### PR TITLE
data-store: per-watch callbacks + per-client Lua schemas

### DIFF
--- a/modules/data-store/CMakeLists.txt
+++ b/modules/data-store/CMakeLists.txt
@@ -97,6 +97,7 @@ if(BUILD_DATA_STORE_TESTS)
         test/worker_pool_test.cpp
         test/protocol_test.cpp
         test/lua_persistor_test.cpp
+        test/callback_test.cpp
         src/server/server.cpp
         src/server/session.cpp
         src/server/data_store.cpp

--- a/modules/data-store/CMakeLists.txt
+++ b/modules/data-store/CMakeLists.txt
@@ -64,6 +64,7 @@ add_executable(ds-server
     src/server/session.cpp
     src/server/data_store.cpp
     src/server/lua_persistor.cpp
+    src/server/schema.cpp
     src/server/worker.cpp
     src/server/worker_pool.cpp
     src/proto/proto.cpp)
@@ -98,10 +99,12 @@ if(BUILD_DATA_STORE_TESTS)
         test/protocol_test.cpp
         test/lua_persistor_test.cpp
         test/callback_test.cpp
+        test/schema_test.cpp
         src/server/server.cpp
         src/server/session.cpp
         src/server/data_store.cpp
         src/server/lua_persistor.cpp
+        src/server/schema.cpp
         src/server/worker.cpp
         src/server/worker_pool.cpp
         src/proto/proto.cpp

--- a/modules/data-store/inc/data_store/client.hpp
+++ b/modules/data-store/inc/data_store/client.hpp
@@ -12,8 +12,22 @@
 ///
 /// Wire details live in proto.hpp; the design is in
 /// modules/data-store/docs/design.md.
+///
+/// Threading model
+/// ---------------
+/// `connect()` spawns an internal listener thread. The listener
+/// owns the read side of the socket: every '\n'-terminated line is
+/// demuxed into either (a) a notify push (`{"ev":"changed",...}`)
+/// fanned out to per-watch callbacks AND a pull-style event queue,
+/// or (b) a response (`{"ok":...,"id":...}`) fulfilling the matching
+/// pending-request promise.
+///
+/// Public methods (`set`/`get`/`watch`/`unwatch`/`recv_event`) are
+/// safe to call from any thread; the listener thread is the sole
+/// reader, request methods just send + wait on their promise.
 
 #include <cstdint>
+#include <functional>
 #include <memory>
 #include <string>
 #include <utility>
@@ -23,23 +37,13 @@ namespace data_store {
 
 using KV = std::pair<std::string, std::string>;
 
-/// Result of a connect() / recv_welcome() / send_request() call.
-/// `ok` is true when the call completed successfully. On failure
-/// `err` carries a single-line reason; `code` carries an errno when
-/// the failure was a syscall error, or 0 for protocol/parse errors.
+/// Result of a connect() / set() / get() / ... call.
 struct Status {
     bool        ok = true;
     int         code = 0;       // errno or 0
     std::string err;
 };
 
-/// Stream-socket client. Single-connection per instance; not
-/// thread-safe. Internally uses ACE_LSOCK_Stream + ACE_Time_Value
-/// for I/O so it shares the same timeout semantics as the rest of
-/// the iot stack; the public ABI stays POSIX-clean via pimpl.
-///
-/// D1 exposes `connect()` + `recv_welcome()`; D2/D3/D5 add `set()`,
-/// `get()`, `watch()`, `unwatch()`, and the async push receive loop.
 class Client {
 public:
     Client();
@@ -50,58 +54,34 @@ public:
     Client(Client&&) noexcept;
     Client& operator=(Client&&) noexcept;
 
-    /// Open the connection. `path` is the server's listening socket
-    /// (defaults to data_store::proto::kDefaultSocketPath when empty).
+    /// Open the connection and start the listener thread.
     Status connect(std::string path = "");
 
-    /// Read the single welcome line the server emits on accept.
-    /// Returns the line (including trailing '\n') in `out`. Times
-    /// out after `timeout_ms`.
+    /// Read the welcome line. Convenience: also consumable as the
+    /// first recv_event-style line if not called explicitly.
     Status recv_welcome(std::string& out, std::int32_t timeout_ms = 1000);
-
-    /// Read one '\n'-terminated line from the socket. Useful for
-    /// consuming notify events (and for tests). Returns the line
-    /// without the trailing newline in `out`.
-    Status recv_line(std::string& out, std::int32_t timeout_ms = 1000);
 
     // --- ops --------------------------------------------------------
 
-    /// `set` one or more key/value pairs atomically. Returns when
-    /// the server's `{"ok":...}` ack is received; `id` correlates
-    /// the response with the request.
+    /// `set` one or more key/value pairs atomically.
     Status set(const std::vector<KV>& pairs, std::int32_t timeout_ms = 1000);
     Status set(const std::string& k, const std::string& v,
                std::int32_t timeout_ms = 1000) {
         return set(std::vector<KV>{{k, v}}, timeout_ms);
     }
 
-    /// `get` one or more keys. `out` is filled in the same order as
-    /// `keys`; missing keys come back with `has_value=false`.
     struct GetResult {
         std::string key;
         std::string value;
         bool        has_value = false;
     };
+    /// `get` one or more keys. `out` is filled in the same order as
+    /// `keys`; missing keys come back with `has_value=false`.
     Status get(const std::vector<std::string>& keys,
                std::vector<GetResult>&         out,
                std::int32_t                    timeout_ms = 1000);
 
-    /// `register` for change notifications on one or more keys.
-    /// Notifications arrive asynchronously and are read via
-    /// `recv_line` / `recv_event` after the ack.
-    Status watch(const std::vector<std::string>& keys,
-                 std::int32_t                    timeout_ms = 1000);
-    Status watch(const std::string& key, std::int32_t timeout_ms = 1000) {
-        return watch(std::vector<std::string>{key}, timeout_ms);
-    }
-
-    /// `remove` one or more keys from the calling session's watch
-    /// set (other sessions' watches on the same keys are unaffected).
-    Status unwatch(const std::vector<std::string>& keys,
-                   std::int32_t                    timeout_ms = 1000);
-    Status unwatch(const std::string& key, std::int32_t timeout_ms = 1000) {
-        return unwatch(std::vector<std::string>{key}, timeout_ms);
-    }
+    // --- watch + callback ------------------------------------------
 
     /// Parsed notification event. `prev_has_value` distinguishes a
     /// real previous value from a freshly-created key.
@@ -111,15 +91,68 @@ public:
         std::string prev;
         bool        prev_has_value = false;
     };
-    /// Read the next notify line and parse it. Returns ok=false with
-    /// err="not an event" if the line was a response, not a push.
+
+    using EventCallback = std::function<void(const Event&)>;
+
+    /// Opaque handle returned by `watch(keys, cb)`. Hand back to
+    /// `unwatch(handle)` to drop this specific registration. The
+    /// same set of keys can be watched many times (each call gets
+    /// its own handle + callback); a key is unregistered on the
+    /// wire only when the last local watcher drops it.
+    using WatchHandle = std::uint64_t;
+    static constexpr WatchHandle kInvalidHandle = 0;
+
+    /// Register `cb` for value-change notifications on `keys`. The
+    /// callback fires on the listener thread for every matching
+    /// `ev=changed` event the server pushes. Returns the wire-level
+    /// ack status; `*out_handle` is set on success.
+    ///
+    /// The same Client can call watch() multiple times with different
+    /// keys + callbacks; all callbacks subscribed to a given key fire
+    /// for every change to that key.
+    Status watch(const std::vector<std::string>& keys,
+                 EventCallback                   cb,
+                 WatchHandle*                    out_handle = nullptr,
+                 std::int32_t                    timeout_ms = 1000);
+    Status watch(const std::string& key,
+                 EventCallback      cb,
+                 WatchHandle*       out_handle = nullptr,
+                 std::int32_t       timeout_ms = 1000) {
+        return watch(std::vector<std::string>{key},
+                     std::move(cb), out_handle, timeout_ms);
+    }
+
+    /// Pull-style watch (no callback). Use `recv_event()` to drain
+    /// the queued events. May be combined with callback-style watches
+    /// on the same Client — events arrive on both paths.
+    Status watch(const std::vector<std::string>& keys,
+                 std::int32_t                    timeout_ms = 1000);
+    Status watch(const std::string& key, std::int32_t timeout_ms = 1000) {
+        return watch(std::vector<std::string>{key}, timeout_ms);
+    }
+
+    /// Drop a specific callback-style watch. The server-side `remove`
+    /// fires only when this handle was the last local watcher for
+    /// any of its keys.
+    Status unwatch(WatchHandle handle, std::int32_t timeout_ms = 1000);
+
+    /// Drop a pull-style watch (or any local registration on these
+    /// keys, including callback ones if they were the only watchers).
+    Status unwatch(const std::vector<std::string>& keys,
+                   std::int32_t                    timeout_ms = 1000);
+    Status unwatch(const std::string& key, std::int32_t timeout_ms = 1000) {
+        return unwatch(std::vector<std::string>{key}, timeout_ms);
+    }
+
+    /// Pull one buffered event (filled by the listener thread). Use
+    /// alongside the pull-style watch(); callback-style watches do
+    /// NOT block this — events go to BOTH paths.
     Status recv_event(Event& out, std::int32_t timeout_ms = 1000);
 
-    /// Close the connection. Idempotent.
+    /// Close the connection + join the listener thread. Idempotent.
     void close();
 
-    /// Underlying ACE_HANDLE / fd. `-1` when not connected. Tests
-    /// use this; production code should not need it.
+    /// Underlying ACE_HANDLE / fd. `-1` when not connected.
     int fd() const;
 
 private:

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -1,0 +1,34 @@
+-- Example schema published by the iot client. Drop this file (or
+-- any sibling *.lua) under the ds-server's `ds-schema-dir=` path
+-- and ds-server will validate every set/get against it.
+--
+-- Each schema entry's `keys` table is keyed by the FULL key name
+-- (the optional `namespace` field is informational). When two
+-- files claim the same key, last-loaded wins — ds-server logs a
+-- WARNING so silent ownership collisions are visible.
+
+return {
+  namespace = "iot",
+  keys = {
+    ["iot.lifetime"]   = {
+      type    = "integer",
+      default = 86400,
+      min     = 0,
+    },
+    ["iot.endpoint"]   = {
+      type    = "string",
+      default = "urn:dev:client-1",
+    },
+    ["iot.binding"]    = {
+      type    = "string",
+      default = "U",
+    },
+    ["iot.identity"]   = {
+      type    = "opaque",
+    },
+    ["iot.observable"] = {
+      type    = "boolean",
+      default = true,
+    },
+  },
+}

--- a/modules/data-store/src/client/client.cpp
+++ b/modules/data-store/src/client/client.cpp
@@ -4,8 +4,16 @@
 
 #include <atomic>
 #include <cerrno>
+#include <condition_variable>
 #include <cstring>
+#include <deque>
+#include <future>
+#include <mutex>
+#include <stdexcept>
+#include <sys/socket.h>
 #include <sys/un.h>
+#include <thread>
+#include <unordered_map>
 
 #include <ace/LSOCK_Connector.h>
 #include <ace/LSOCK_Stream.h>
@@ -33,59 +41,53 @@ Status protocol_err(const std::string& what) {
 }
 
 std::atomic<std::uint64_t> g_next_id{1};
+std::atomic<std::uint64_t> g_next_handle{1};
+
+struct WatchEntry {
+    std::vector<std::string>      keys;
+    Client::EventCallback         cb;
+};
 
 } // namespace
 
-// --- pimpl --------------------------------------------------------------
+// ─────────────────────────────── Impl ───────────────────────────────
 
 class Client::Impl {
 public:
-    ACE_LSOCK_Stream stream;
-    std::string      recvBuf;
-    bool             connected = false;
+    ACE_LSOCK_Stream     stream;
+    std::atomic<bool>    connected{false};
 
-    Status recv_one_line(std::string& out, std::int32_t timeout_ms);
-    Status send_json(const std::string& req);
+    std::thread          listener;
+    std::atomic<bool>    stop_listener{false};
+
+    // id → pending promise (fulfilled by the listener thread).
+    std::mutex                                            pending_mtx;
+    std::unordered_map<std::uint64_t, std::promise<json>> pending;
+
+    // Welcome line bookkeeping.
+    std::mutex                  welcome_mtx;
+    std::condition_variable     welcome_cv;
+    std::string                 welcome_line;
+    bool                        welcome_received = false;
+
+    // Pull-style event queue.
+    std::mutex                  events_mtx;
+    std::condition_variable     events_cv;
+    std::deque<Event>           events;
+
+    // Callback-style watches + per-key local refcount.
+    std::mutex                                              watches_mtx;
+    std::unordered_map<WatchHandle, WatchEntry>             watches;
+    std::unordered_map<std::string, std::size_t>            key_refcount;
+
+    Status send_json(const std::string& body);
     Status round_trip(json& req, json& resp, std::int32_t timeout_ms);
+    void   run_listener();
+    void   fail_all_pending(const std::string& why);
 };
 
-Status Client::Impl::recv_one_line(std::string& out, std::int32_t timeout_ms) {
-    // Service from recvBuf first.
-    auto pos = recvBuf.find('\n');
-    if (pos != std::string::npos) {
-        out = recvBuf.substr(0, pos);
-        recvBuf.erase(0, pos + 1);
-        return {};
-    }
-
-    char buf[1024];
-    ACE_Time_Value timeout(timeout_ms / 1000,
-                           (timeout_ms % 1000) * 1000);
-    for (;;) {
-        ssize_t n = stream.recv(buf, sizeof(buf), &timeout);
-        if (n < 0) {
-            if (errno == ETIME || errno == ETIMEDOUT) {
-                Status s; s.ok=false; s.code=ETIMEDOUT;
-                s.err = "recv timeout"; return s;
-            }
-            return sys_err("recv");
-        }
-        if (n == 0) return protocol_err("server closed");
-        recvBuf.append(buf, static_cast<std::size_t>(n));
-        pos = recvBuf.find('\n');
-        if (pos != std::string::npos) {
-            out = recvBuf.substr(0, pos);
-            recvBuf.erase(0, pos + 1);
-            return {};
-        }
-        // No newline yet — loop and read more (timeout applies per
-        // recv call; cumulative wait may exceed it slightly, which
-        // is fine for our use case).
-    }
-}
-
-Status Client::Impl::send_json(const std::string& req) {
-    std::string line = req + "\n";
+Status Client::Impl::send_json(const std::string& body) {
+    std::string line = body + "\n";
     ssize_t n = stream.send_n(line.data(), line.size());
     if (n < 0 || static_cast<std::size_t>(n) != line.size()) {
         return sys_err("send_n");
@@ -95,35 +97,158 @@ Status Client::Impl::send_json(const std::string& req) {
 
 Status Client::Impl::round_trip(json& req, json& resp,
                                 std::int32_t timeout_ms) {
+    if (!connected.load()) return protocol_err("not connected");
+
     const std::uint64_t id = g_next_id.fetch_add(1);
     req["id"] = id;
-    auto ss = send_json(req.dump());
-    if (!ss.ok) return ss;
 
-    // Read lines until we find one with our id. Skip notify pushes
-    // (`ev=changed`) so the caller's set/get/watch ack arrives
-    // without interference. Callers needing pushes should use
-    // recv_event AFTER the round-trip completes.
-    for (;;) {
-        std::string line;
-        auto rs = recv_one_line(line, timeout_ms);
-        if (!rs.ok) return rs;
-        json p;
-        try { p = json::parse(line); }
-        catch (const std::exception& e) {
-            return protocol_err(std::string("bad response json: ") + e.what());
+    std::promise<json>  prom;
+    std::future<json>   fut = prom.get_future();
+    {
+        std::lock_guard<std::mutex> g(pending_mtx);
+        pending.emplace(id, std::move(prom));
+    }
+
+    auto ss = send_json(req.dump());
+    if (!ss.ok) {
+        std::lock_guard<std::mutex> g(pending_mtx);
+        pending.erase(id);
+        return ss;
+    }
+
+    using namespace std::chrono;
+    if (fut.wait_for(milliseconds(timeout_ms)) != std::future_status::ready) {
+        std::lock_guard<std::mutex> g(pending_mtx);
+        pending.erase(id);
+        Status s; s.ok=false; s.code=ETIMEDOUT;
+        s.err = "request timeout (id=" + std::to_string(id) + ")";
+        return s;
+    }
+
+    try {
+        resp = fut.get();
+    } catch (const std::exception& e) {
+        return protocol_err(std::string("promise broken: ") + e.what());
+    }
+    return {};
+}
+
+void Client::Impl::run_listener() {
+    std::string buf;
+    char        chunk[1024];
+
+    while (!stop_listener.load()) {
+        ACE_Time_Value timeout(0, 200 * 1000);
+        ssize_t n = stream.recv(chunk, sizeof(chunk), &timeout);
+        if (n < 0) {
+            if (errno == ETIME || errno == ETIMEDOUT || errno == EAGAIN) continue;
+            break;
         }
-        if (p.contains("ev")) continue;     // push — ignore here
-        if (!p.contains("ok")) {
-            return protocol_err("response missing ok");
+        if (n == 0) break;     // EOF
+
+        buf.append(chunk, static_cast<std::size_t>(n));
+
+        for (;;) {
+            auto pos = buf.find('\n');
+            if (pos == std::string::npos) break;
+            std::string line = buf.substr(0, pos);
+            buf.erase(0, pos + 1);
+            if (line.empty()) continue;
+
+            json p;
+            try { p = json::parse(line); } catch (...) { continue; }
+
+            // Welcome (server's first line — `hello` field).
+            {
+                std::lock_guard<std::mutex> g(welcome_mtx);
+                if (!welcome_received && p.contains("hello")) {
+                    welcome_line     = line + "\n";
+                    welcome_received = true;
+                    welcome_cv.notify_all();
+                    continue;
+                }
+            }
+
+            // Notify push.
+            if (p.contains("ev")) {
+                Event ev;
+                ev.key   = p.value("k", "");
+                ev.value = p.value("v", "");
+                if (p.contains("prev") && !p["prev"].is_null()) {
+                    ev.prev           = p["prev"].get<std::string>();
+                    ev.prev_has_value = true;
+                }
+
+                {
+                    std::lock_guard<std::mutex> g(events_mtx);
+                    events.push_back(ev);
+                    events_cv.notify_one();
+                }
+
+                std::vector<EventCallback> cbs;
+                {
+                    std::lock_guard<std::mutex> g(watches_mtx);
+                    for (const auto& [h, w] : watches) {
+                        for (const auto& k : w.keys) {
+                            if (k == ev.key) { cbs.push_back(w.cb); break; }
+                        }
+                    }
+                }
+                for (auto& cb : cbs) {
+                    try { cb(ev); } catch (...) { /* swallow */ }
+                }
+                continue;
+            }
+
+            // Response: ok + id → fulfill promise.
+            if (p.contains("ok") && p.contains("id")) {
+                std::uint64_t id = p["id"].get<std::uint64_t>();
+                std::promise<json> prom;
+                bool found = false;
+                {
+                    std::lock_guard<std::mutex> g(pending_mtx);
+                    auto it = pending.find(id);
+                    if (it != pending.end()) {
+                        prom  = std::move(it->second);
+                        pending.erase(it);
+                        found = true;
+                    }
+                }
+                if (found) {
+                    try { prom.set_value(std::move(p)); } catch (...) {}
+                }
+            }
         }
-        if (p.contains("id") && p["id"] != id) continue;  // mismatched
-        resp = std::move(p);
-        return {};
+    }
+
+    fail_all_pending("listener exited");
+
+    {
+        std::lock_guard<std::mutex> g(welcome_mtx);
+        welcome_received = true;
+        welcome_cv.notify_all();
+    }
+    {
+        std::lock_guard<std::mutex> g(events_mtx);
+        events_cv.notify_all();
     }
 }
 
-// --- Client -------------------------------------------------------------
+void Client::Impl::fail_all_pending(const std::string& why) {
+    std::unordered_map<std::uint64_t, std::promise<json>> snapshot;
+    {
+        std::lock_guard<std::mutex> g(pending_mtx);
+        snapshot.swap(pending);
+    }
+    for (auto& [id, prom] : snapshot) {
+        try {
+            prom.set_exception(std::make_exception_ptr(
+                std::runtime_error(why)));
+        } catch (...) {}
+    }
+}
+
+// ─────────────────────────── Client ───────────────────────────
 
 Client::Client() : m_impl(std::make_unique<Impl>()) {}
 Client::~Client() { close(); }
@@ -143,33 +268,36 @@ Status Client::connect(std::string path) {
     if (connector.connect(m_impl->stream, addr, &timeout) == -1) {
         return sys_err("ACE_LSOCK_Connector::connect(" + path + ")");
     }
-    m_impl->connected = true;
+    m_impl->connected.store(true);
+    m_impl->stop_listener.store(false);
+    m_impl->listener = std::thread([impl = m_impl.get()]() {
+        impl->run_listener();
+    });
     return {};
 }
 
 Status Client::recv_welcome(std::string& out, std::int32_t timeout_ms) {
-    if (!m_impl->connected) return protocol_err("not connected");
-    std::string line;
-    auto rs = m_impl->recv_one_line(line, timeout_ms);
-    if (!rs.ok) return rs;
-    out = line + "\n";   // restore newline for byte-equality tests
+    if (!m_impl->connected.load()) return protocol_err("not connected");
+    std::unique_lock<std::mutex> g(m_impl->welcome_mtx);
+    if (!m_impl->welcome_cv.wait_for(g,
+            std::chrono::milliseconds(timeout_ms),
+            [&]() { return m_impl->welcome_received; })) {
+        Status s; s.ok=false; s.code=ETIMEDOUT;
+        s.err = "welcome timeout"; return s;
+    }
+    if (m_impl->welcome_line.empty()) {
+        return protocol_err("connection closed before welcome");
+    }
+    out = m_impl->welcome_line;
     return {};
 }
 
-Status Client::recv_line(std::string& out, std::int32_t timeout_ms) {
-    if (!m_impl->connected) return protocol_err("not connected");
-    return m_impl->recv_one_line(out, timeout_ms);
-}
-
 Status Client::set(const std::vector<KV>& pairs, std::int32_t timeout_ms) {
-    if (!m_impl->connected) return protocol_err("not connected");
     json req;
     req["op"]   = "set";
     req["keys"] = json::array();
     for (const auto& kv : pairs) {
-        json e;
-        e["k"] = kv.first;
-        e["v"] = kv.second;
+        json e; e["k"] = kv.first; e["v"] = kv.second;
         req["keys"].push_back(e);
     }
     json resp;
@@ -185,7 +313,6 @@ Status Client::get(const std::vector<std::string>& keys,
                    std::vector<GetResult>&         out,
                    std::int32_t                    timeout_ms) {
     out.clear();
-    if (!m_impl->connected) return protocol_err("not connected");
     json req;
     req["op"]   = "get";
     req["keys"] = keys;
@@ -212,25 +339,94 @@ Status Client::get(const std::vector<std::string>& keys,
 
 Status Client::watch(const std::vector<std::string>& keys,
                      std::int32_t                    timeout_ms) {
-    if (!m_impl->connected) return protocol_err("not connected");
+    // Pull-style: bump local refcount, only send wire `register`
+    // for keys that just transitioned 0 → 1.
+    std::vector<std::string> wireKeys;
+    {
+        std::lock_guard<std::mutex> g(m_impl->watches_mtx);
+        for (const auto& k : keys) {
+            if (m_impl->key_refcount[k]++ == 0) wireKeys.push_back(k);
+        }
+    }
+    if (wireKeys.empty()) return {};
+
     json req;
     req["op"]   = "register";
-    req["keys"] = keys;
+    req["keys"] = wireKeys;
     json resp;
     auto rs = m_impl->round_trip(req, resp, timeout_ms);
-    if (!rs.ok) return rs;
+    if (!rs.ok) {
+        std::lock_guard<std::mutex> g(m_impl->watches_mtx);
+        for (const auto& k : wireKeys) {
+            auto it = m_impl->key_refcount.find(k);
+            if (it != m_impl->key_refcount.end() && it->second > 0) {
+                if (--it->second == 0) m_impl->key_refcount.erase(it);
+            }
+        }
+        return rs;
+    }
     if (!resp.value("ok", false)) {
         return protocol_err(resp.value("err", "watch failed"));
     }
     return {};
 }
 
+Status Client::watch(const std::vector<std::string>& keys,
+                     EventCallback                   cb,
+                     WatchHandle*                    out_handle,
+                     std::int32_t                    timeout_ms) {
+    if (!cb) return protocol_err("watch: callback is null");
+
+    auto pull = watch(keys, timeout_ms);
+    if (!pull.ok) return pull;
+
+    WatchHandle h = g_next_handle.fetch_add(1);
+    {
+        std::lock_guard<std::mutex> g(m_impl->watches_mtx);
+        WatchEntry w;
+        w.keys = keys;
+        w.cb   = std::move(cb);
+        m_impl->watches.emplace(h, std::move(w));
+    }
+    if (out_handle) *out_handle = h;
+    return {};
+}
+
+Status Client::unwatch(WatchHandle handle, std::int32_t timeout_ms) {
+    if (handle == kInvalidHandle) return protocol_err("invalid handle");
+
+    std::vector<std::string> keys;
+    {
+        std::lock_guard<std::mutex> g(m_impl->watches_mtx);
+        auto it = m_impl->watches.find(handle);
+        if (it == m_impl->watches.end()) {
+            return protocol_err("unknown watch handle");
+        }
+        keys = it->second.keys;
+        m_impl->watches.erase(it);
+    }
+    return unwatch(keys, timeout_ms);
+}
+
 Status Client::unwatch(const std::vector<std::string>& keys,
                        std::int32_t                    timeout_ms) {
-    if (!m_impl->connected) return protocol_err("not connected");
+    std::vector<std::string> wireKeys;
+    {
+        std::lock_guard<std::mutex> g(m_impl->watches_mtx);
+        for (const auto& k : keys) {
+            auto it = m_impl->key_refcount.find(k);
+            if (it == m_impl->key_refcount.end()) continue;
+            if (--it->second == 0) {
+                m_impl->key_refcount.erase(it);
+                wireKeys.push_back(k);
+            }
+        }
+    }
+    if (wireKeys.empty()) return {};
+
     json req;
     req["op"]   = "remove";
-    req["keys"] = keys;
+    req["keys"] = wireKeys;
     json resp;
     auto rs = m_impl->round_trip(req, resp, timeout_ms);
     if (!rs.ok) return rs;
@@ -241,37 +437,47 @@ Status Client::unwatch(const std::vector<std::string>& keys,
 }
 
 Status Client::recv_event(Event& out, std::int32_t timeout_ms) {
-    if (!m_impl->connected) return protocol_err("not connected");
-    std::string line;
-    auto rs = m_impl->recv_one_line(line, timeout_ms);
-    if (!rs.ok) return rs;
-    json p;
-    try { p = json::parse(line); }
-    catch (const std::exception& e) {
-        return protocol_err(std::string("bad event json: ") + e.what());
+    std::unique_lock<std::mutex> g(m_impl->events_mtx);
+    if (!m_impl->events_cv.wait_for(g,
+            std::chrono::milliseconds(timeout_ms),
+            [&]() { return !m_impl->events.empty() ||
+                           !m_impl->connected.load(); })) {
+        Status s; s.ok=false; s.code=ETIMEDOUT;
+        s.err = "no event within timeout"; return s;
     }
-    if (!p.contains("ev")) return protocol_err("not an event");
-    out.key   = p.value("k", "");
-    out.value = p.value("v", "");
-    if (p.contains("prev") && !p["prev"].is_null()) {
-        out.prev           = p["prev"].get<std::string>();
-        out.prev_has_value = true;
-    } else {
-        out.prev_has_value = false;
-    }
+    if (m_impl->events.empty()) return protocol_err("connection closed");
+    out = m_impl->events.front();
+    m_impl->events.pop_front();
     return {};
 }
 
 void Client::close() {
-    if (m_impl && m_impl->connected) {
+    if (!m_impl) return;
+    if (m_impl->connected.exchange(false)) {
+        m_impl->stop_listener.store(true);
+        ::shutdown(m_impl->stream.get_handle(), SHUT_RDWR);
+        if (m_impl->listener.joinable()) m_impl->listener.join();
         m_impl->stream.close();
-        m_impl->connected = false;
-        m_impl->recvBuf.clear();
+        m_impl->fail_all_pending("client closed");
+        {
+            std::lock_guard<std::mutex> g(m_impl->welcome_mtx);
+            m_impl->welcome_received = true;
+            m_impl->welcome_cv.notify_all();
+        }
+        {
+            std::lock_guard<std::mutex> g(m_impl->events_mtx);
+            m_impl->events_cv.notify_all();
+        }
+        {
+            std::lock_guard<std::mutex> g(m_impl->watches_mtx);
+            m_impl->watches.clear();
+            m_impl->key_refcount.clear();
+        }
     }
 }
 
 int Client::fd() const {
-    if (!m_impl || !m_impl->connected) return -1;
+    if (!m_impl || !m_impl->connected.load()) return -1;
     return const_cast<ACE_LSOCK_Stream&>(m_impl->stream).get_handle();
 }
 

--- a/modules/data-store/src/server/main.cpp
+++ b/modules/data-store/src/server/main.cpp
@@ -9,6 +9,7 @@
 /// kDefaultStorePath. Both are operator-overridable.
 
 #include "lua_persistor.hpp"
+#include "schema.hpp"
 #include "server.hpp"
 #include "worker_pool.hpp"
 
@@ -56,8 +57,21 @@ int main(int argc, char** argv) {
     std::string storePath = arg_value(argc, argv, "ds-store");
     if (storePath.empty())  storePath = data_store::proto::kDefaultStorePath;
 
+    std::string schemaDir = arg_value(argc, argv, "ds-schema-dir");
+
     std::cout << "[ds-server] socket=" << socketPath
-              << " store=" << storePath << "\n";
+              << " store=" << storePath;
+    if (!schemaDir.empty()) std::cout << " schemas=" << schemaDir;
+    std::cout << "\n";
+
+    // Schema (optional) — load every *.lua under ds-schema-dir/.
+    // Empty dir or missing files are tolerated (no validation kicks in).
+    auto schema = std::make_shared<data_store::server::SchemaRegistry>();
+    if (!schemaDir.empty()) {
+        auto n = schema->load_directory(schemaDir);
+        std::cout << "[ds-server] loaded " << n
+                  << " schema key(s) from " << schemaDir << "\n";
+    }
 
     auto store = std::make_shared<data_store::server::DataStore>();
 
@@ -81,7 +95,7 @@ int main(int argc, char** argv) {
     // shape as xpmile MicroService pool. Must be open()ed before the
     // server starts accepting so the first handle_input has a place
     // to enqueue.
-    data_store::server::WorkerPool pool(store);
+    data_store::server::WorkerPool pool(store, schema);
     if (pool.open() != 0) {
         std::cerr << "[ds-server] worker pool open failed; exit 1\n";
         return 1;

--- a/modules/data-store/src/server/schema.cpp
+++ b/modules/data-store/src/server/schema.cpp
@@ -1,0 +1,234 @@
+#include "schema.hpp"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstring>
+#include <dirent.h>
+#include <iostream>
+#include <memory>
+#include <sstream>
+#include <stdexcept>
+#include <sys/stat.h>
+
+extern "C" {
+#include <lauxlib.h>
+#include <lua.h>
+#include <lualib.h>
+}
+
+namespace data_store::server {
+
+namespace {
+
+struct LuaStateDeleter {
+    void operator()(lua_State* L) const { if (L) lua_close(L); }
+};
+using LuaStatePtr = std::unique_ptr<lua_State, LuaStateDeleter>;
+
+SchemaType parse_type(const std::string& s) {
+    if (s == "string")  return SchemaType::String;
+    if (s == "integer") return SchemaType::Integer;
+    if (s == "float")   return SchemaType::Float;
+    if (s == "boolean") return SchemaType::Boolean;
+    if (s == "opaque")  return SchemaType::Opaque;
+    return SchemaType::Any;
+}
+
+/// Stringify a Lua value at stack index `idx` to the wire form
+/// (everything in the store is a std::string).
+std::string lua_value_to_string(lua_State* L, int idx) {
+    switch (lua_type(L, idx)) {
+        case LUA_TBOOLEAN: return lua_toboolean(L, idx) ? "1" : "0";
+        case LUA_TNUMBER: {
+            double n = lua_tonumber(L, idx);
+            // Integer-friendly print when the value is a whole number.
+            if (n == static_cast<double>(static_cast<long long>(n))) {
+                return std::to_string(static_cast<long long>(n));
+            }
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%g", n);
+            return buf;
+        }
+        case LUA_TSTRING: {
+            std::size_t len = 0;
+            const char* s = lua_tolstring(L, idx, &len);
+            return std::string(s, len);
+        }
+        default: return {};
+    }
+}
+
+bool parse_long(const std::string& s, long long& out) {
+    if (s.empty()) return false;
+    try {
+        std::size_t pos = 0;
+        out = std::stoll(s, &pos);
+        return pos == s.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+bool parse_double(const std::string& s, double& out) {
+    if (s.empty()) return false;
+    try {
+        std::size_t pos = 0;
+        out = std::stod(s, &pos);
+        return pos == s.size();
+    } catch (...) {
+        return false;
+    }
+}
+
+} // namespace
+
+void SchemaRegistry::load_one(const std::string& path) {
+    LuaStatePtr L(luaL_newstate());
+    if (!L) throw std::runtime_error("luaL_newstate failed");
+    luaL_openlibs(L.get());
+
+    if (luaL_dofile(L.get(), path.c_str()) != LUA_OK) {
+        std::string err = lua_tostring(L.get(), -1);
+        throw std::runtime_error("luaL_dofile: " + err);
+    }
+    if (!lua_istable(L.get(), -1)) {
+        throw std::runtime_error("top-level return is not a table");
+    }
+
+    lua_getfield(L.get(), -1, "keys");
+    if (!lua_istable(L.get(), -1)) {
+        throw std::runtime_error("schema missing `keys` table");
+    }
+
+    // Iterate `keys`.
+    lua_pushnil(L.get());
+    while (lua_next(L.get(), -2) != 0) {
+        // key at -2, spec table at -1
+        if (lua_type(L.get(), -2) != LUA_TSTRING ||
+            !lua_istable(L.get(), -1)) {
+            lua_pop(L.get(), 1);
+            continue;
+        }
+        std::size_t klen = 0;
+        const char* kc = lua_tolstring(L.get(), -2, &klen);
+        std::string key(kc, klen);
+
+        SchemaEntry e;
+
+        lua_getfield(L.get(), -1, "type");
+        if (lua_isstring(L.get(), -1)) {
+            std::size_t tlen = 0;
+            const char* ts = lua_tolstring(L.get(), -1, &tlen);
+            e.type = parse_type(std::string(ts, tlen));
+        }
+        lua_pop(L.get(), 1);
+
+        lua_getfield(L.get(), -1, "default");
+        if (!lua_isnil(L.get(), -1)) {
+            e.default_value = lua_value_to_string(L.get(), -1);
+        }
+        lua_pop(L.get(), 1);
+
+        lua_getfield(L.get(), -1, "min");
+        if (lua_isnumber(L.get(), -1)) {
+            e.min_int = static_cast<long long>(lua_tointeger(L.get(), -1));
+        }
+        lua_pop(L.get(), 1);
+
+        lua_getfield(L.get(), -1, "max");
+        if (lua_isnumber(L.get(), -1)) {
+            e.max_int = static_cast<long long>(lua_tointeger(L.get(), -1));
+        }
+        lua_pop(L.get(), 1);
+
+        auto [it, inserted] = m_entries.emplace(key, e);
+        if (!inserted) {
+            std::cerr << "[schema] WARNING: duplicate key '" << key
+                      << "' in " << path
+                      << " — overriding previous definition\n";
+            it->second = e;
+        }
+        lua_pop(L.get(), 1);    // spec table
+    }
+}
+
+std::size_t SchemaRegistry::load_directory(const std::string& dir) {
+    DIR* d = ::opendir(dir.c_str());
+    if (!d) return 0;       // missing dir is fine
+
+    while (auto* ent = ::readdir(d)) {
+        std::string name = ent->d_name;
+        if (name.size() < 5) continue;
+        if (name.compare(name.size() - 4, 4, ".lua") != 0) continue;
+        std::string path = dir;
+        if (!path.empty() && path.back() != '/') path.push_back('/');
+        path += name;
+
+        struct stat st{};
+        if (::stat(path.c_str(), &st) != 0 || !S_ISREG(st.st_mode)) continue;
+
+        try {
+            load_one(path);
+        } catch (const std::exception& e) {
+            std::cerr << "[schema] WARNING: skipping " << path
+                      << ": " << e.what() << "\n";
+        }
+    }
+    ::closedir(d);
+    return m_entries.size();
+}
+
+const SchemaEntry* SchemaRegistry::find(const std::string& key) const {
+    auto it = m_entries.find(key);
+    return (it == m_entries.end()) ? nullptr : &it->second;
+}
+
+std::optional<std::string> SchemaRegistry::validate_set(
+        const std::string& key, const std::string& value) const {
+    auto it = m_entries.find(key);
+    if (it == m_entries.end()) return std::nullopt;  // passthrough
+    const SchemaEntry& e = it->second;
+    switch (e.type) {
+        case SchemaType::Any:
+        case SchemaType::String:
+        case SchemaType::Opaque:
+            return std::nullopt;
+        case SchemaType::Boolean: {
+            if (value == "0" || value == "1" ||
+                value == "true" || value == "false") return std::nullopt;
+            return "schema(" + key + "): expected boolean, got '" + value + "'";
+        }
+        case SchemaType::Integer: {
+            long long n;
+            if (!parse_long(value, n)) {
+                return "schema(" + key + "): expected integer, got '" + value + "'";
+            }
+            if (e.min_int && n < *e.min_int) {
+                return "schema(" + key + "): " + std::to_string(n) +
+                       " below min " + std::to_string(*e.min_int);
+            }
+            if (e.max_int && n > *e.max_int) {
+                return "schema(" + key + "): " + std::to_string(n) +
+                       " above max " + std::to_string(*e.max_int);
+            }
+            return std::nullopt;
+        }
+        case SchemaType::Float: {
+            double f;
+            if (!parse_double(value, f)) {
+                return "schema(" + key + "): expected float, got '" + value + "'";
+            }
+            return std::nullopt;
+        }
+    }
+    return std::nullopt;
+}
+
+std::optional<std::string> SchemaRegistry::default_for(
+        const std::string& key) const {
+    auto it = m_entries.find(key);
+    if (it == m_entries.end()) return std::nullopt;
+    return it->second.default_value;
+}
+
+} // namespace data_store::server

--- a/modules/data-store/src/server/schema.hpp
+++ b/modules/data-store/src/server/schema.hpp
@@ -1,0 +1,90 @@
+#ifndef __data_store_server_schema_hpp__
+#define __data_store_server_schema_hpp__
+
+/// Optional client-published schema for the data store.
+///
+/// Operators / packagers drop *.lua files under a directory (default
+/// `/etc/iot/ds-schemas/`); ds-server scans the directory at startup,
+/// indexes every key spec by full key name. Schemas are immutable
+/// after load — no locks needed on the read path.
+///
+/// Each client / app owns one .lua file in the directory; the
+/// registry merges every file into a single key→spec map. Two
+/// files claiming the same key get a stderr warning (last-loaded
+/// wins) so silent ownership collisions don't slip past.
+///
+/// On-disk shape (one file per client/user):
+///
+///   return {
+///     namespace = "iot",
+///     keys = {
+///       ["iot.lifetime"]  = { type="integer", default=86400, min=0 },
+///       ["iot.endpoint"]  = { type="string",  default="urn:dev:client-1" },
+///       ["iot.identity"]  = { type="opaque" },
+///     },
+///   }
+///
+/// Validation rules:
+///   - set rejects type mismatches (`{ok:false, err:"..."}`)
+///   - get returns the schema default when the key is absent
+///   - unknown keys (no schema entry) pass through unchanged
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+
+namespace data_store::server {
+
+enum class SchemaType : std::uint8_t {
+    String,
+    Integer,
+    Float,
+    Boolean,
+    Opaque,
+    Any,        ///< no schema entry / no type field — anything goes
+};
+
+struct SchemaEntry {
+    SchemaType                  type = SchemaType::Any;
+    std::optional<std::string>  default_value;   ///< stringified
+    std::optional<long long>    min_int;
+    std::optional<long long>    max_int;
+};
+
+class SchemaRegistry {
+public:
+    SchemaRegistry() = default;
+
+    /// Load every *.lua under `dir`. Returns the number of keys
+    /// indexed. Missing directory → 0 (not an error). A malformed
+    /// individual file is logged to stderr and skipped so one bad
+    /// schema doesn't take the daemon down.
+    std::size_t load_directory(const std::string& dir);
+
+    /// Lookup a spec for `key`. Returns nullptr when the key isn't
+    /// in any loaded schema — the caller treats this as "passthrough".
+    const SchemaEntry* find(const std::string& key) const;
+
+    /// Validate a set value against the schema. Returns an empty
+    /// optional on success; a diagnostic string on rejection.
+    std::optional<std::string> validate_set(const std::string& key,
+                                            const std::string& value) const;
+
+    /// Default for an absent key, or nullopt when the schema has
+    /// no default (or no entry at all).
+    std::optional<std::string> default_for(const std::string& key) const;
+
+    std::size_t size() const { return m_entries.size(); }
+
+private:
+    /// Parse one schema file. Throws std::runtime_error on
+    /// fundamental problems; caller catches + skips.
+    void load_one(const std::string& path);
+
+    std::unordered_map<std::string, SchemaEntry> m_entries;
+};
+
+} // namespace data_store::server
+
+#endif /* __data_store_server_schema_hpp__ */

--- a/modules/data-store/src/server/worker.cpp
+++ b/modules/data-store/src/server/worker.cpp
@@ -2,6 +2,7 @@
 
 #include "data_store.hpp"
 #include "data_store/proto.hpp"
+#include "schema.hpp"
 #include "server.hpp"
 #include "session.hpp"
 #include "worker_pool.hpp"
@@ -55,8 +56,12 @@ std::string notify_line(const std::string& key,
 
 } // namespace
 
-Worker::Worker(std::shared_ptr<DataStore> store, int id)
-  : m_store(std::move(store)), m_id(id) {
+Worker::Worker(std::shared_ptr<DataStore>      store,
+               std::shared_ptr<SchemaRegistry> schema,
+               int                             id)
+  : m_store(std::move(store)),
+    m_schema(std::move(schema)),
+    m_id(id) {
 }
 
 Worker::~Worker() {
@@ -189,6 +194,16 @@ void Worker::handle_process_request(WorkMsg* msg) {
                 }
                 const std::string k = e["k"].get<std::string>();
                 const std::string v = e["v"].get<std::string>();
+                // REQ-DS-014 / schema check: reject type mismatches
+                // before touching the store. Schema is optional; an
+                // unknown key returns nullopt → passthrough.
+                if (m_schema) {
+                    auto err = m_schema->validate_set(k, v);
+                    if (err) {
+                        s->send(error_response(reqId, *err));
+                        return;
+                    }
+                }
                 auto r = m_store->set(k, v);
                 if (!r.changed) continue;
                 std::string line = notify_line(k, v, r.prev);
@@ -224,8 +239,17 @@ void Worker::handle_process_request(WorkMsg* msg) {
                 auto v = m_store->get(k);
                 json item;
                 item["k"] = k;
-                if (v.has_value()) item["v"] = *v;
-                else               item["v"] = nullptr;
+                if (v.has_value()) {
+                    item["v"] = *v;
+                } else if (m_schema) {
+                    // Fall back to the schema default when the
+                    // key is unset.
+                    auto def = m_schema->default_for(k);
+                    if (def) item["v"] = *def;
+                    else     item["v"] = nullptr;
+                } else {
+                    item["v"] = nullptr;
+                }
                 resp["data"].push_back(item);
             }
             s->send(resp.dump() + "\n");

--- a/modules/data-store/src/server/worker.hpp
+++ b/modules/data-store/src/server/worker.hpp
@@ -20,6 +20,7 @@
 namespace data_store::server {
 
 class DataStore;
+class SchemaRegistry;
 class Session;
 
 enum class WorkKind : std::uint8_t {
@@ -36,7 +37,9 @@ struct WorkMsg {
 
 class Worker : public ACE_Task<ACE_MT_SYNCH> {
 public:
-    Worker(std::shared_ptr<DataStore> store, int id);
+    Worker(std::shared_ptr<DataStore>      store,
+           std::shared_ptr<SchemaRegistry> schema,   // may be nullptr
+           int                             id);
     ~Worker() override;
 
     int open(void* args = nullptr) override;
@@ -55,8 +58,9 @@ private:
     void handle_deliver_notify(WorkMsg* msg);
     void handle_session_closed(WorkMsg* msg);
 
-    std::shared_ptr<DataStore> m_store;
-    int                        m_id;
+    std::shared_ptr<DataStore>      m_store;
+    std::shared_ptr<SchemaRegistry> m_schema;
+    int                             m_id;
 };
 
 } // namespace data_store::server

--- a/modules/data-store/src/server/worker_pool.cpp
+++ b/modules/data-store/src/server/worker_pool.cpp
@@ -4,12 +4,13 @@
 
 namespace data_store::server {
 
-WorkerPool::WorkerPool(std::shared_ptr<DataStore> store,
-                       std::size_t poolSize) {
+WorkerPool::WorkerPool(std::shared_ptr<DataStore>      store,
+                       std::shared_ptr<SchemaRegistry> schema,
+                       std::size_t                     poolSize) {
     m_workers.reserve(poolSize);
     for (std::size_t i = 0; i < poolSize; ++i) {
         m_workers.emplace_back(
-            std::make_unique<Worker>(store, static_cast<int>(i)));
+            std::make_unique<Worker>(store, schema, static_cast<int>(i)));
     }
 }
 

--- a/modules/data-store/src/server/worker_pool.hpp
+++ b/modules/data-store/src/server/worker_pool.hpp
@@ -18,12 +18,15 @@
 
 namespace data_store::server {
 
+class SchemaRegistry;
+
 class WorkerPool {
 public:
     static constexpr std::size_t kDefaultSize = 5;
 
-    WorkerPool(std::shared_ptr<DataStore> store,
-               std::size_t poolSize = kDefaultSize);
+    WorkerPool(std::shared_ptr<DataStore>      store,
+               std::shared_ptr<SchemaRegistry> schema = nullptr,
+               std::size_t                     poolSize = kDefaultSize);
     ~WorkerPool();
 
     int  open();

--- a/modules/data-store/test/callback_test.cpp
+++ b/modules/data-store/test/callback_test.cpp
@@ -58,7 +58,7 @@ struct LiveServer {
 
     explicit LiveServer(const std::string& dir)
       : store(std::make_shared<ds::server::DataStore>()),
-        pool(store, 3),
+        pool(store, /*schema=*/nullptr, 3),
         sock(dir + "/ds.sock") {
         EXPECT_EQ(0, pool.open());
         server = std::make_unique<ds::server::Server>(store, &pool, sock);

--- a/modules/data-store/test/callback_test.cpp
+++ b/modules/data-store/test/callback_test.cpp
@@ -1,0 +1,184 @@
+/// Per-watch callback API tests. Same Client instance, multiple
+/// register calls with overlapping + distinct keys, each with its
+/// own callback. The listener thread fans events out to every
+/// matching callback.
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <cstring>
+#include <future>
+#include <mutex>
+#include <string>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+#include <unordered_map>
+#include <vector>
+
+#include <ace/Reactor.h>
+#include <ace/Time_Value.h>
+
+#include "data_store/client.hpp"
+#include "../src/server/data_store.hpp"
+#include "../src/server/server.hpp"
+#include "../src/server/worker_pool.hpp"
+
+namespace ds = data_store;
+
+namespace {
+
+std::string make_tmpdir() {
+    char tmpl[64] = "/tmp/ds-cb-XXXXXX";
+    if (char* d = mkdtemp(tmpl)) return d;
+    ::mkdir("/tmp", 01777);
+    std::strcpy(tmpl, "/tmp/ds-cb-XXXXXX");
+    if (char* d = mkdtemp(tmpl)) return d;
+    std::strcpy(tmpl, "./ds-cb-XXXXXX");
+    if (char* d = mkdtemp(tmpl)) return d;
+    return {};
+}
+
+/// Pump the test thread's reactor for `ms` total in 20 ms slices.
+void pump_ms(int ms) {
+    int slices = (ms + 19) / 20;
+    for (int i = 0; i < slices; ++i) {
+        ACE_Time_Value tv(0, 20 * 1000);
+        ACE_Reactor::instance()->handle_events(tv);
+    }
+}
+
+struct LiveServer {
+    std::shared_ptr<ds::server::DataStore> store;
+    ds::server::WorkerPool                 pool;
+    std::unique_ptr<ds::server::Server>    server;
+    std::string                            sock;
+
+    explicit LiveServer(const std::string& dir)
+      : store(std::make_shared<ds::server::DataStore>()),
+        pool(store, 3),
+        sock(dir + "/ds.sock") {
+        EXPECT_EQ(0, pool.open());
+        server = std::make_unique<ds::server::Server>(store, &pool, sock);
+        EXPECT_EQ(0, server->open());
+    }
+    ~LiveServer() {
+        server->close();
+        pool.close();
+        ::unlink(sock.c_str());
+    }
+};
+
+} // namespace
+
+TEST(Callback, single_watch_with_callback_fires_on_event) {
+    std::string dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    LiveServer srv(dir);
+
+    std::promise<ds::Client::Event> got;
+    auto fut = got.get_future();
+
+    auto cli_fut = std::async(std::launch::async, [&]() {
+        ds::Client cli;
+        auto cs = cli.connect(srv.sock); if (!cs.ok) return cs;
+        std::string w; cli.recv_welcome(w, 2000);
+
+        ds::Client::WatchHandle h = ds::Client::kInvalidHandle;
+        std::vector<std::string> keys = {"foo"};
+        auto rs = cli.watch(keys,
+            [&](const ds::Client::Event& e) {
+                try { got.set_value(e); } catch (...) {}
+            },
+            &h, 2000);
+        if (!rs.ok) return rs;
+        EXPECT_NE(ds::Client::kInvalidHandle, h);
+
+        // Set from the same client — server fans the notify back to
+        // every watcher on the key, including us.
+        auto ss = cli.set("foo", "bar", 2000);
+        if (!ss.ok) return ss;
+
+        // Wait up to 3s for the callback.
+        if (fut.wait_for(std::chrono::seconds(3))
+                != std::future_status::ready) {
+            ds::Status s; s.ok=false; s.err="callback not invoked";
+            return s;
+        }
+        return ds::Status{};
+    });
+
+    while (cli_fut.wait_for(std::chrono::milliseconds(0))
+            != std::future_status::ready) {
+        pump_ms(40);
+    }
+    auto rs = cli_fut.get();
+    EXPECT_TRUE(rs.ok) << rs.err;
+    if (rs.ok) {
+        auto ev = fut.get();
+        EXPECT_EQ("foo", ev.key);
+        EXPECT_EQ("bar", ev.value);
+        EXPECT_FALSE(ev.prev_has_value);
+    }
+    ::rmdir(dir.c_str());
+}
+
+TEST(Callback, multiple_watches_with_overlapping_keys_all_fire) {
+    std::string dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    LiveServer srv(dir);
+
+    // Per-callback counters. Callback A watches {foo, shared};
+    // callback B watches {bar, shared}. A `set shared=x` MUST fire
+    // both A and B; a `set foo=...` MUST fire only A.
+    std::atomic<int> a_fires{0}, b_fires{0};
+
+    auto cli_fut = std::async(std::launch::async, [&]() {
+        ds::Client cli;
+        auto cs = cli.connect(srv.sock); if (!cs.ok) return cs;
+        std::string w; cli.recv_welcome(w, 2000);
+
+        ds::Client::WatchHandle ha, hb;
+        std::vector<std::string> aKeys = {"foo", "shared"};
+        std::vector<std::string> bKeys = {"bar", "shared"};
+        auto ra = cli.watch(aKeys,
+            [&](const ds::Client::Event&) { a_fires.fetch_add(1); },
+            &ha, 2000);
+        if (!ra.ok) return ra;
+        auto rb = cli.watch(bKeys,
+            [&](const ds::Client::Event&) { b_fires.fetch_add(1); },
+            &hb, 2000);
+        if (!rb.ok) return rb;
+
+        if (auto s = cli.set("foo",    "1", 2000); !s.ok) return s;
+        if (auto s = cli.set("bar",    "2", 2000); !s.ok) return s;
+        if (auto s = cli.set("shared", "3", 2000); !s.ok) return s;
+
+        // Wait for listener to dispatch.
+        for (int i = 0; i < 100; ++i) {
+            if (a_fires.load() >= 2 && b_fires.load() >= 2) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        EXPECT_EQ(2, a_fires.load()) << "A should see foo + shared";
+        EXPECT_EQ(2, b_fires.load()) << "B should see bar + shared";
+
+        // Drop A; another set on shared should fire ONLY B.
+        if (auto s = cli.unwatch(ha, 2000); !s.ok) return s;
+        if (auto s = cli.set("shared", "4", 2000); !s.ok) return s;
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        EXPECT_EQ(2, a_fires.load());
+        EXPECT_EQ(3, b_fires.load());
+        return ds::Status{};
+    });
+
+    while (cli_fut.wait_for(std::chrono::milliseconds(0))
+            != std::future_status::ready) {
+        pump_ms(40);
+    }
+    auto rs = cli_fut.get();
+    EXPECT_TRUE(rs.ok) << rs.err;
+    ::rmdir(dir.c_str());
+}

--- a/modules/data-store/test/protocol_test.cpp
+++ b/modules/data-store/test/protocol_test.cpp
@@ -70,7 +70,7 @@ struct LiveServer {
 
     LiveServer(const std::string& dir)
       : store(std::make_shared<ds::server::DataStore>()),
-        pool(store, 3),
+        pool(store, /*schema=*/nullptr, 3),
         sock(dir + "/ds.sock") {
         EXPECT_EQ(0, pool.open());
         server = std::make_unique<ds::server::Server>(store, &pool, sock);

--- a/modules/data-store/test/schema_test.cpp
+++ b/modules/data-store/test/schema_test.cpp
@@ -1,0 +1,130 @@
+/// SchemaRegistry + Worker integration tests.
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "../src/server/schema.hpp"
+
+namespace ds = data_store::server;
+
+namespace {
+
+std::string make_tmpdir() {
+    char tmpl[64] = "/tmp/ds-schema-XXXXXX";
+    if (char* d = mkdtemp(tmpl)) return d;
+    ::mkdir("/tmp", 01777);
+    std::strcpy(tmpl, "/tmp/ds-schema-XXXXXX");
+    if (char* d = mkdtemp(tmpl)) return d;
+    std::strcpy(tmpl, "./ds-schema-XXXXXX");
+    if (char* d = mkdtemp(tmpl)) return d;
+    return {};
+}
+
+void write_file(const std::string& path, const std::string& body) {
+    std::ofstream(path) << body;
+}
+
+} // namespace
+
+TEST(Schema, missing_dir_yields_empty_registry) {
+    ds::SchemaRegistry r;
+    EXPECT_EQ(0u, r.load_directory("/no/such/dir"));
+    EXPECT_EQ(0u, r.size());
+}
+
+TEST(Schema, loads_single_file_and_indexes_keys) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    write_file(dir + "/iot.lua", R"(
+return {
+  namespace = "iot",
+  keys = {
+    ["iot.lifetime"]  = { type="integer", default=86400, min=0 },
+    ["iot.endpoint"]  = { type="string",  default="urn:dev:client-1" },
+  },
+})");
+
+    ds::SchemaRegistry r;
+    EXPECT_EQ(2u, r.load_directory(dir));
+    auto* e = r.find("iot.lifetime");
+    ASSERT_NE(nullptr, e);
+    EXPECT_EQ(ds::SchemaType::Integer, e->type);
+    ASSERT_TRUE(e->default_value.has_value());
+    EXPECT_EQ("86400", *e->default_value);
+    EXPECT_EQ(0LL, e->min_int.value_or(-1));
+
+    EXPECT_EQ(nullptr, r.find("not.in.schema"));
+    ::unlink((dir + "/iot.lua").c_str()); ::rmdir(dir.c_str());
+}
+
+TEST(Schema, validate_set_passes_unknown_keys_through) {
+    ds::SchemaRegistry r;
+    // No schema loaded → every set passes.
+    EXPECT_FALSE(r.validate_set("anything", "v").has_value());
+}
+
+TEST(Schema, validate_set_rejects_type_mismatch) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    write_file(dir + "/x.lua", R"(
+return { keys = { ["n"] = { type="integer", min=0, max=10 } } })");
+
+    ds::SchemaRegistry r;
+    r.load_directory(dir);
+    EXPECT_FALSE(r.validate_set("n", "5").has_value());   // ok
+    EXPECT_TRUE (r.validate_set("n", "foo").has_value()); // not integer
+    EXPECT_TRUE (r.validate_set("n", "-1").has_value());  // below min
+    EXPECT_TRUE (r.validate_set("n", "99").has_value());  // above max
+    ::unlink((dir + "/x.lua").c_str()); ::rmdir(dir.c_str());
+}
+
+TEST(Schema, default_for_returns_stringified_default) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    write_file(dir + "/d.lua", R"(
+return {
+  keys = {
+    ["a"] = { type="integer", default=42 },
+    ["b"] = { type="boolean", default=true },
+    ["c"] = { type="string",  default="hello" },
+    ["d"] = { type="integer" },     -- no default
+  },
+})");
+
+    ds::SchemaRegistry r;
+    r.load_directory(dir);
+    EXPECT_EQ("42",    r.default_for("a").value_or(""));
+    EXPECT_EQ("1",     r.default_for("b").value_or(""));
+    EXPECT_EQ("hello", r.default_for("c").value_or(""));
+    EXPECT_FALSE(r.default_for("d").has_value());
+    EXPECT_FALSE(r.default_for("nope").has_value());
+    ::unlink((dir + "/d.lua").c_str()); ::rmdir(dir.c_str());
+}
+
+TEST(Schema, duplicate_key_across_files_last_wins) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    write_file(dir + "/a.lua", R"(
+return { keys = { ["dup"] = { type="integer", default=1 } } })");
+    write_file(dir + "/b.lua", R"(
+return { keys = { ["dup"] = { type="integer", default=2 } } })");
+
+    ds::SchemaRegistry r;
+    EXPECT_EQ(1u, r.load_directory(dir));      // one unique key
+    auto* e = r.find("dup");
+    ASSERT_NE(nullptr, e);
+    ASSERT_TRUE(e->default_value.has_value());
+    // Last-loaded wins; filesystem readdir order isn't guaranteed,
+    // so just assert it's one of the two.
+    EXPECT_TRUE(*e->default_value == "1" || *e->default_value == "2");
+
+    ::unlink((dir + "/a.lua").c_str());
+    ::unlink((dir + "/b.lua").c_str());
+    ::rmdir(dir.c_str());
+}

--- a/modules/data-store/test/worker_pool_test.cpp
+++ b/modules/data-store/test/worker_pool_test.cpp
@@ -17,7 +17,7 @@ TEST(WorkerPool, default_size_is_five) {
 
 TEST(WorkerPool, round_robin_visits_every_worker_then_wraps) {
     auto store = std::make_shared<ds::DataStore>();
-    ds::WorkerPool pool(store, 3);
+    ds::WorkerPool pool(store, /*schema=*/nullptr, 3);
     ASSERT_EQ(0, pool.open());
 
     // 6 picks across a 3-pool: indices 0,1,2,0,1,2.
@@ -39,6 +39,6 @@ TEST(WorkerPool, round_robin_visits_every_worker_then_wraps) {
 
 TEST(WorkerPool, next_before_open_returns_nullptr_when_pool_size_zero) {
     auto store = std::make_shared<ds::DataStore>();
-    ds::WorkerPool pool(store, 0);
+    ds::WorkerPool pool(store, /*schema=*/nullptr, /*poolSize=*/0);
     EXPECT_EQ(nullptr, pool.next());
 }


### PR DESCRIPTION
## Summary

Two follow-on features on the data-store module:

1. **Callback-style watch** (`1fb4909`). `connect()` spawns an internal
   listener thread that owns the read side of the socket; every line
   is demuxed into either (a) a notify push, fanned out to per-watch
   `EventCallback`s AND a pull-style event queue, or (b) a response
   fulfilling the matching pending-request promise by `id`.

   Same Client can call `watch(keys, cb)` many times with different
   key sets; per-key local refcount means the wire-level `register`
   fires only on 0→1 and `remove` only on N→0.

   ```cpp
   data_store::Client cli;
   cli.connect("/var/run/iot/data_store.sock");

   data_store::Client::WatchHandle ha, hb;
   cli.watch({"foo", "shared"}, cbA, &ha);   // wire: register {foo, shared}
   cli.watch({"bar", "shared"}, cbB, &hb);   // wire: register {bar}

   cli.set("shared", "x");                   // cbA + cbB both fire
   cli.unwatch(ha);                          // wire: remove {foo}
                                             //   (shared still has cbB)
   cli.set("shared", "y");                   // only cbB fires
   ```

2. **Per-client Lua schemas** (`25a4e4b`). New `ds-schema-dir=PATH`
   CLI flag on ds-server. Each client/app drops one `*.lua` schema
   file in the directory:

   ```lua
   return {
     namespace = \"iot\",
     keys = {
       [\"iot.lifetime\"]  = { type=\"integer\", default=86400, min=0 },
       [\"iot.endpoint\"]  = { type=\"string\",  default=\"urn:dev:client-1\" },
       [\"iot.identity\"]  = { type=\"opaque\" },
     },
   }
   ```

   Worker dispatch consults the registry on every set/get:
   - set with type/range mismatch → `{ok:false, err:\"schema(K): ...\"}`
   - get on absent key → falls back to schema default
   - unknown keys pass through (schema is opt-in)
   - duplicate keys across files log a WARNING (last-loaded wins)

   Sample schema at `modules/data-store/schemas/iot.lua`.

## Test plan

- [x] `ds-tests` — 30/30 pass
  - +2 Callback (single watch + multi-overlapping with ref-counted unwatch)
  - +6 Schema (load + validate + default + duplicate-warning)
- [x] Manual wire smoke against `ds-server ds-schema-dir=…`:
  - `set iot.lifetime 3600` → `ok`
  - `set iot.lifetime abc` → `schema(iot.lifetime): expected integer, got 'abc'`
  - `set iot.lifetime -1` → `schema(iot.lifetime): -1 below min 0`
  - `get iot.endpoint` (unset) → `urn:dev:client-1` (schema default)
  - `get iot.unknown` → `(null)` (no schema entry, no value)

To build + run locally:

```
cd modules/data-store && mkdir -p build && cd build
cmake .. -DBUILD_DATA_STORE_TESTS=ON
make -j2
./ds-tests
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)