### PR TITLE
data-store: typed values (grace-server variant shape) end-to-end

### DIFF
--- a/modules/data-store/CMakeLists.txt
+++ b/modules/data-store/CMakeLists.txt
@@ -34,6 +34,7 @@ endif()
 
 include_directories(
     ${DS_MODULE_DIR}/inc
+    ${DS_MODULE_DIR}/src
     ${ACE_ROOT}/include
     ${NLOHMANN_JSON_INCLUDE}
     ${LUA_INCLUDE_DIR})
@@ -111,8 +112,8 @@ if(BUILD_DATA_STORE_TESTS)
         src/client/client.cpp)
 
     target_link_libraries(ds-tests
-        gtest_main
-        gtest
+        GTest::gtest_main
+        GTest::gtest
         ACE
         pthread
         ${LUA_LINK_LIBS})

--- a/modules/data-store/inc/data_store/client.hpp
+++ b/modules/data-store/inc/data_store/client.hpp
@@ -33,9 +33,11 @@
 #include <utility>
 #include <vector>
 
+#include "data_store/value.hpp"
+
 namespace data_store {
 
-using KV = std::pair<std::string, std::string>;
+using KV = std::pair<std::string, Value>;
 
 /// Result of a connect() / set() / get() / ... call.
 struct Status {
@@ -65,14 +67,14 @@ public:
 
     /// `set` one or more key/value pairs atomically.
     Status set(const std::vector<KV>& pairs, std::int32_t timeout_ms = 1000);
-    Status set(const std::string& k, const std::string& v,
+    Status set(const std::string& k, Value v,
                std::int32_t timeout_ms = 1000) {
-        return set(std::vector<KV>{{k, v}}, timeout_ms);
+        return set(std::vector<KV>{{k, std::move(v)}}, timeout_ms);
     }
 
     struct GetResult {
         std::string key;
-        std::string value;
+        Value       value;
         bool        has_value = false;
     };
     /// `get` one or more keys. `out` is filled in the same order as
@@ -87,8 +89,8 @@ public:
     /// real previous value from a freshly-created key.
     struct Event {
         std::string key;
-        std::string value;
-        std::string prev;
+        Value       value;
+        Value       prev;
         bool        prev_has_value = false;
     };
 

--- a/modules/data-store/inc/data_store/value.hpp
+++ b/modules/data-store/inc/data_store/value.hpp
@@ -1,0 +1,46 @@
+#ifndef __data_store_value_hpp__
+#define __data_store_value_hpp__
+
+/// Typed values carried by the data-store protocol.
+///
+/// Same variant shape as grace-server's lua_engine value_type
+/// (modules/data-store/docs/design.md §3 + DS-D11). The wire
+/// protocol now carries JSON values directly (no string coercion),
+/// the in-memory store keys onto a `Value`, and the Lua persistor
+/// writes the matching Lua-native type to disk.
+///
+/// `std::monostate` rather than `std::nullptr_t` is used for the
+/// "absent" / "null" alternative so the variant is default-
+/// constructible and `std::get<std::monostate>` reads cleanly.
+
+#include <cstdint>
+#include <string>
+#include <variant>
+
+namespace data_store {
+
+using Value = std::variant<
+    std::monostate,     // JSON null
+    std::string,
+    bool,
+    std::uint32_t,
+    std::int32_t,
+    double>;
+
+/// Convenience kind enum for readable dispatch on Value::index().
+enum class ValueKind : std::uint8_t {
+    Null    = 0,
+    String  = 1,
+    Boolean = 2,
+    Uint    = 3,
+    Int     = 4,
+    Double  = 5,
+};
+
+inline ValueKind kind_of(const Value& v) {
+    return static_cast<ValueKind>(v.index());
+}
+
+} // namespace data_store
+
+#endif /* __data_store_value_hpp__ */

--- a/modules/data-store/src/cli/ds_cli.cpp
+++ b/modules/data-store/src/cli/ds_cli.cpp
@@ -14,6 +14,7 @@
 
 #include "data_store/client.hpp"
 #include "data_store/proto.hpp"
+#include "data_store/value.hpp"
 
 #include <atomic>
 #include <cerrno>
@@ -22,9 +23,14 @@
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
+#include <limits>
 #include <string>
+#include <type_traits>
 #include <unistd.h>
+#include <variant>
 #include <vector>
+
+#include "nlohmann/json.hpp"
 
 namespace {
 
@@ -79,10 +85,59 @@ int do_welcome(data_store::Client& cli) {
     return 0;
 }
 
+/// Parse a CLI-supplied value into a Value. We try JSON first
+/// (catches numbers, booleans, null, quoted strings); on parse
+/// failure we fall through to a plain string. This means
+/// `set foo 42` stores integer 42, `set foo true` stores bool true,
+/// and `set foo hello` stores the string "hello".
+data_store::Value parse_cli_value(const std::string& raw) {
+    try {
+        auto j = nlohmann::json::parse(raw);
+        if (j.is_null())            return std::monostate{};
+        if (j.is_boolean())         return j.get<bool>();
+        if (j.is_string())          return j.get<std::string>();
+        if (j.is_number_float())    return j.get<double>();
+        if (j.is_number_unsigned()) {
+            auto u = j.get<std::uint64_t>();
+            if (u <= std::numeric_limits<std::uint32_t>::max())
+                return static_cast<std::uint32_t>(u);
+            return static_cast<double>(u);
+        }
+        if (j.is_number_integer()) {
+            auto i = j.get<std::int64_t>();
+            if (i >= std::numeric_limits<std::int32_t>::min() &&
+                i <= std::numeric_limits<std::int32_t>::max())
+                return static_cast<std::int32_t>(i);
+            return static_cast<double>(i);
+        }
+    } catch (...) {
+        // Not valid JSON → treat as a bare string.
+    }
+    return raw;
+}
+
+/// Render a Value for human-readable CLI output.
+std::string value_to_display(const data_store::Value& v) {
+    return std::visit([](auto&& a) -> std::string {
+        using T = std::decay_t<decltype(a)>;
+        if constexpr (std::is_same_v<T, std::monostate>) return "(null)";
+        else if constexpr (std::is_same_v<T, bool>)
+            return a ? "true" : "false";
+        else if constexpr (std::is_same_v<T, std::string>) return a;
+        else if constexpr (std::is_same_v<T, double>) {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%g", a);
+            return buf;
+        } else {
+            return std::to_string(a);
+        }
+    }, v);
+}
+
 int do_set(data_store::Client& cli, const std::vector<std::string>& a) {
     if (a.size() != 2) { usage(); return 2; }
     std::string w; cli.recv_welcome(w);
-    auto rs = cli.set(a[0], a[1]);
+    auto rs = cli.set(a[0], parse_cli_value(a[1]));
     if (!rs.ok) { std::cerr << "[ds-cli] set: " << rs.err << "\n"; return 2; }
     std::cout << "ok\n";
     return 0;
@@ -95,7 +150,7 @@ int do_get(data_store::Client& cli, const std::vector<std::string>& keys) {
     auto rs = cli.get(keys, got);
     if (!rs.ok) { std::cerr << "[ds-cli] get: " << rs.err << "\n"; return 2; }
     for (const auto& g : got) {
-        if (g.has_value) std::cout << g.key << "=" << g.value << "\n";
+        if (g.has_value) std::cout << g.key << "=" << value_to_display(g.value) << "\n";
         else             std::cout << g.key << "=(null)\n";
     }
     return 0;
@@ -115,8 +170,10 @@ int do_watch(data_store::Client& cli, const std::vector<std::string>& keys,
     data_store::Client::WatchHandle h = data_store::Client::kInvalidHandle;
     auto rs = cli.watch(keys,
         [&](const data_store::Client::Event& ev) {
-            std::cout << "[event] " << ev.key << " = " << ev.value;
-            if (ev.prev_has_value) std::cout << "  (prev=" << ev.prev << ")";
+            std::cout << "[event] " << ev.key << " = "
+                      << value_to_display(ev.value);
+            if (ev.prev_has_value)
+                std::cout << "  (prev=" << value_to_display(ev.prev) << ")";
             std::cout << "\n";
             std::cout.flush();
             received.fetch_add(1);

--- a/modules/data-store/src/client/client.cpp
+++ b/modules/data-store/src/client/client.cpp
@@ -1,6 +1,7 @@
 #include "data_store/client.hpp"
 
 #include "data_store/proto.hpp"
+#include "proto/value_json.hpp"
 
 #include <atomic>
 #include <cerrno>
@@ -173,9 +174,9 @@ void Client::Impl::run_listener() {
             if (p.contains("ev")) {
                 Event ev;
                 ev.key   = p.value("k", "");
-                ev.value = p.value("v", "");
+                if (p.contains("v")) ev.value = value_from_json(p["v"]);
                 if (p.contains("prev") && !p["prev"].is_null()) {
-                    ev.prev           = p["prev"].get<std::string>();
+                    ev.prev           = value_from_json(p["prev"]);
                     ev.prev_has_value = true;
                 }
 
@@ -297,7 +298,10 @@ Status Client::set(const std::vector<KV>& pairs, std::int32_t timeout_ms) {
     req["op"]   = "set";
     req["keys"] = json::array();
     for (const auto& kv : pairs) {
-        json e; e["k"] = kv.first; e["v"] = kv.second;
+        // Wire shape: each entry is a single-key object whose value
+        // round-trips through JSON's native type system.
+        json e;
+        e[kv.first] = value_to_json(kv.second);
         req["keys"].push_back(e);
     }
     json resp;
@@ -329,7 +333,7 @@ Status Client::get(const std::vector<std::string>& keys,
         GetResult g;
         g.key = item.value("k", "");
         if (item.contains("v") && !item["v"].is_null()) {
-            g.value     = item["v"].get<std::string>();
+            g.value     = value_from_json(item["v"]);
             g.has_value = true;
         }
         out.push_back(std::move(g));

--- a/modules/data-store/src/proto/value_json.hpp
+++ b/modules/data-store/src/proto/value_json.hpp
@@ -1,0 +1,59 @@
+#ifndef __data_store_proto_value_json_hpp__
+#define __data_store_proto_value_json_hpp__
+
+/// Server-internal: JSON ↔ Value conversion. Lives under src/proto
+/// (not in the public inc/ tree) because it pulls in nlohmann::json,
+/// which the client library deliberately avoids in its public ABI.
+///
+/// The client lib reaches into this header only from its .cpp, never
+/// from inc/data_store/client.hpp.
+
+#include "data_store/value.hpp"
+
+#include <limits>
+#include <type_traits>
+
+#include "nlohmann/json.hpp"
+
+namespace data_store {
+
+inline Value value_from_json(const nlohmann::json& j) {
+    using nlohmann::json;
+    if (j.is_null())    return std::monostate{};
+    if (j.is_boolean()) return j.get<bool>();
+    if (j.is_string())  return j.get<std::string>();
+    if (j.is_number_float()) return j.get<double>();
+    if (j.is_number_unsigned()) {
+        auto u = j.get<std::uint64_t>();
+        if (u <= std::numeric_limits<std::uint32_t>::max()) {
+            return static_cast<std::uint32_t>(u);
+        }
+        // Wider than uint32 → spill to double (we keep the variant
+        // grace-shaped; no int64 alternative).
+        return static_cast<double>(u);
+    }
+    if (j.is_number_integer()) {
+        auto i = j.get<std::int64_t>();
+        if (i >= std::numeric_limits<std::int32_t>::min() &&
+            i <= std::numeric_limits<std::int32_t>::max()) {
+            return static_cast<std::int32_t>(i);
+        }
+        return static_cast<double>(i);
+    }
+    // Arrays / objects → not a scalar value; collapse to monostate.
+    // Callers should reject these before reaching here.
+    return std::monostate{};
+}
+
+inline nlohmann::json value_to_json(const Value& v) {
+    using nlohmann::json;
+    return std::visit([](auto&& arg) -> json {
+        using T = std::decay_t<decltype(arg)>;
+        if constexpr (std::is_same_v<T, std::monostate>) return nullptr;
+        else return arg;
+    }, v);
+}
+
+} // namespace data_store
+
+#endif /* __data_store_proto_value_json_hpp__ */

--- a/modules/data-store/src/server/data_store.cpp
+++ b/modules/data-store/src/server/data_store.cpp
@@ -6,18 +6,17 @@
 
 namespace data_store::server {
 
-void DataStore::load_from(std::unordered_map<std::string, std::string> data) {
+void DataStore::load_from(std::unordered_map<std::string, Value> data) {
     std::lock_guard<std::mutex> g(m_mtx);
     m_data = std::move(data);
 }
 
 void DataStore::flush_locked_release(
-        std::unordered_map<std::string, std::string> snapshot) {
+        std::unordered_map<std::string, Value> snapshot) {
     if (!m_persistor) return;
     try {
         m_persistor->save(snapshot);
     } catch (const std::exception& e) {
-        // In-memory map IS updated. Log loud + carry on per design §7.
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%D [DS:%t] %M %N:%l persist failed: %C\n"),
                    e.what()));
@@ -29,44 +28,39 @@ std::size_t DataStore::size() const {
     return m_data.size();
 }
 
-std::optional<std::string> DataStore::get(const std::string& key) const {
+std::optional<Value> DataStore::get(const std::string& key) const {
     std::lock_guard<std::mutex> g(m_mtx);
     auto it = m_data.find(key);
     if (it == m_data.end()) return std::nullopt;
     return it->second;
 }
 
-SetResult DataStore::set(const std::string& key, const std::string& value) {
+SetResult DataStore::set(const std::string& key, Value value) {
     SetResult out;
-    std::unordered_map<std::string, std::string> snapshot;
+    std::unordered_map<std::string, Value> snapshot;
     {
         std::lock_guard<std::mutex> g(m_mtx);
 
         auto it = m_data.find(key);
         if (it == m_data.end()) {
-            m_data.emplace(key, value);
+            m_data.emplace(key, std::move(value));
             out.changed = true;
         } else {
             if (it->second == value) {
                 // REQ-DS-006: unchanged value → no notification + no flush.
                 return out;
             }
-            out.prev    = it->second;
+            out.prev    = std::move(it->second);
             out.changed = true;
-            it->second  = value;
+            it->second  = std::move(value);
         }
 
-        // Snapshot the watcher set for this key so the caller can
-        // dispatch notifications without holding the lock.
         auto wit = m_watchers.find(key);
         if (wit != m_watchers.end()) {
             out.watchers.reserve(wit->second.size());
             for (Session* s : wit->second) out.watchers.push_back(s);
         }
 
-        // Snapshot data for the persistor — copy under the lock so
-        // the disk image is consistent with the in-memory state at
-        // exactly this set's commit point.
         if (m_persistor) snapshot = m_data;
     }
     flush_locked_release(std::move(snapshot));
@@ -75,7 +69,7 @@ SetResult DataStore::set(const std::string& key, const std::string& value) {
 
 bool DataStore::remove(const std::string& key) {
     bool existed = false;
-    std::unordered_map<std::string, std::string> snapshot;
+    std::unordered_map<std::string, Value> snapshot;
     {
         std::lock_guard<std::mutex> g(m_mtx);
         existed = m_data.erase(key) > 0;

--- a/modules/data-store/src/server/data_store.hpp
+++ b/modules/data-store/src/server/data_store.hpp
@@ -3,14 +3,10 @@
 
 /// Server-internal in-memory key-value store + per-key watch table.
 ///
+/// Values are typed via `data_store::Value` (variant of null /
+/// string / bool / uint32 / int32 / double — grace-server shape).
 /// Shared across all Worker threads, so every public method takes
-/// the internal mutex. Workers call into this when servicing a
-/// session request; the reactor thread never touches it.
-///
-/// The watch table maps `key → set of Session*`. `set()` returns the
-/// snapshot of watchers so the caller can dispatch DeliverNotify
-/// messages to each watcher's owning Worker without holding the
-/// mutex across socket writes.
+/// the internal mutex.
 
 #include <cstddef>
 #include <mutex>
@@ -20,20 +16,17 @@
 #include <unordered_set>
 #include <vector>
 
+#include "data_store/value.hpp"
+
 namespace data_store::server {
 
 class LuaPersistor;
 class Session;   // fwd; defined in session.hpp
 
-/// Result of a `set` call. `changed` is true iff the new value
-/// differed from the prior one (or the key was absent). `prev` is
-/// nullopt when the key was new. `watchers` is the snapshot of
-/// Sessions subscribed to this key at write time — safe to use
-/// after the store mutex is released.
 struct SetResult {
-    bool                      changed = false;
-    std::optional<std::string> prev;
-    std::vector<Session*>     watchers;
+    bool                  changed = false;
+    std::optional<Value>  prev;
+    std::vector<Session*> watchers;
 };
 
 class DataStore {
@@ -43,23 +36,21 @@ public:
     DataStore& operator=(const DataStore&) = delete;
 
     /// Attach an (optional) Lua-backed persistor. set() / remove()
-    /// will flush to disk after every successful state-changing call.
-    /// Pass nullptr (or skip) for an in-memory-only store.
+    /// flush after every successful state change.
     void set_persistor(LuaPersistor* p) { m_persistor = p; }
 
     /// Bulk replace — called at startup after LuaPersistor::load().
-    void load_from(std::unordered_map<std::string, std::string> data);
+    void load_from(std::unordered_map<std::string, Value> data);
 
     std::size_t size() const;
 
     /// Read. Returns nullopt for missing keys.
-    std::optional<std::string> get(const std::string& key) const;
+    std::optional<Value> get(const std::string& key) const;
 
     /// Write. Returns SetResult describing the change + watchers.
-    SetResult set(const std::string& key, const std::string& value);
+    SetResult set(const std::string& key, Value value);
 
-    /// Remove. Returns true if the key existed. No notifications
-    /// fired today per DS-D5 (reserved for v2).
+    /// Remove. Returns true if the key existed.
     bool remove(const std::string& key);
 
     // ---- Watch table ----------------------------------------------------
@@ -69,12 +60,11 @@ public:
     void unwatch_all(Session* s);
 
 private:
-    /// Persist the current map to disk (called from set/remove after
-    /// the in-memory mutation, with the mutex released).
-    void flush_locked_release(std::unordered_map<std::string, std::string> snapshot);
+    void flush_locked_release(
+        std::unordered_map<std::string, Value> snapshot);
 
     mutable std::mutex                                              m_mtx;
-    std::unordered_map<std::string, std::string>                    m_data;
+    std::unordered_map<std::string, Value>                          m_data;
     std::unordered_map<std::string, std::unordered_set<Session*>>   m_watchers;
     LuaPersistor*                                                   m_persistor = nullptr;
 };

--- a/modules/data-store/src/server/lua_persistor.cpp
+++ b/modules/data-store/src/server/lua_persistor.cpp
@@ -1,14 +1,19 @@
 #include "lua_persistor.hpp"
 
 #include <cerrno>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <fcntl.h>
 #include <fstream>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <sstream>
 #include <sys/stat.h>
+#include <type_traits>
 #include <unistd.h>
+#include <variant>
 
 extern "C" {
 #include <lauxlib.h>
@@ -19,6 +24,8 @@ extern "C" {
 namespace data_store::server {
 
 namespace {
+
+constexpr int kSchemaVersion = 2;
 
 struct LuaStateDeleter {
     void operator()(lua_State* L) const { if (L) lua_close(L); }
@@ -53,12 +60,70 @@ std::string lua_quote(const std::string& s) {
     return out;
 }
 
+/// Render a Value as its Lua literal form.
+std::string serialise_value(const Value& v) {
+    return std::visit([](auto&& a) -> std::string {
+        using T = std::decay_t<decltype(a)>;
+        if constexpr (std::is_same_v<T, std::monostate>) {
+            return "nil";
+        } else if constexpr (std::is_same_v<T, bool>) {
+            return a ? "true" : "false";
+        } else if constexpr (std::is_same_v<T, std::string>) {
+            return lua_quote(a);
+        } else if constexpr (std::is_same_v<T, std::uint32_t> ||
+                             std::is_same_v<T, std::int32_t>) {
+            return std::to_string(a);
+        } else if constexpr (std::is_same_v<T, double>) {
+            // Lua 5.3+ accepts e-notation; round-trip with %.17g.
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%.17g", a);
+            return std::string(buf);
+        } else {
+            return "nil";
+        }
+    }, v);
+}
+
+/// Pull a single Lua-stack value (idx is absolute) into a Value.
+/// Returns std::nullopt when the type isn't representable in Value
+/// (tables, functions, userdata) — caller skips those entries.
+std::optional<Value> read_value(lua_State* L, int idx) {
+    switch (lua_type(L, idx)) {
+        case LUA_TNIL:
+            return Value(std::monostate{});
+        case LUA_TBOOLEAN:
+            return Value(lua_toboolean(L, idx) != 0);
+        case LUA_TSTRING: {
+            std::size_t len = 0;
+            const char* s = lua_tolstring(L, idx, &len);
+            return Value(std::string(s, len));
+        }
+        case LUA_TNUMBER:
+            if (lua_isinteger(L, idx)) {
+                lua_Integer n = lua_tointeger(L, idx);
+                if (n >= 0 &&
+                    n <= static_cast<lua_Integer>(
+                             std::numeric_limits<std::uint32_t>::max())) {
+                    return Value(static_cast<std::uint32_t>(n));
+                }
+                if (n >= std::numeric_limits<std::int32_t>::min() &&
+                    n <= std::numeric_limits<std::int32_t>::max()) {
+                    return Value(static_cast<std::int32_t>(n));
+                }
+                return Value(static_cast<double>(n));
+            }
+            return Value(lua_tonumber(L, idx));
+        default:
+            return std::nullopt;
+    }
+}
+
 } // namespace
 
 LuaPersistor::LuaPersistor(std::string path) : m_path(std::move(path)) {}
 
-std::unordered_map<std::string, std::string> LuaPersistor::load() {
-    std::unordered_map<std::string, std::string> out;
+std::unordered_map<std::string, Value> LuaPersistor::load() {
+    std::unordered_map<std::string, Value> out;
 
     // Missing file is fine — start with an empty map.
     if (::access(m_path.c_str(), R_OK) != 0) return out;
@@ -76,8 +141,8 @@ std::unordered_map<std::string, std::string> LuaPersistor::load() {
         throw CorruptStoreError("top-level return is not a table");
     }
 
-    // Pull the schema_version (currently informational; we accept
-    // any version since v1 is forward-compatible with v0).
+    // schema_version is informational — both v1 (string-only) and v2
+    // (typed) parse correctly through the value-type switch below.
     lua_getfield(L.get(), -1, "schema_version");
     lua_pop(L.get(), 1);
 
@@ -86,15 +151,13 @@ std::unordered_map<std::string, std::string> LuaPersistor::load() {
         throw CorruptStoreError("missing or non-table `data` field");
     }
 
-    // Walk `data` — keys + values both strings.
     lua_pushnil(L.get());
     while (lua_next(L.get(), -2) != 0) {
-        if (lua_type(L.get(), -2) == LUA_TSTRING &&
-            lua_type(L.get(), -1) == LUA_TSTRING) {
-            std::size_t klen = 0, vlen = 0;
+        if (lua_type(L.get(), -2) == LUA_TSTRING) {
+            std::size_t klen = 0;
             const char* k = lua_tolstring(L.get(), -2, &klen);
-            const char* v = lua_tolstring(L.get(), -1, &vlen);
-            out.emplace(std::string(k, klen), std::string(v, vlen));
+            auto val = read_value(L.get(), lua_gettop(L.get()));
+            if (val) out.emplace(std::string(k, klen), std::move(*val));
         }
         lua_pop(L.get(), 1);
     }
@@ -102,15 +165,19 @@ std::unordered_map<std::string, std::string> LuaPersistor::load() {
 }
 
 void LuaPersistor::save(
-        const std::unordered_map<std::string, std::string>& data) {
+        const std::unordered_map<std::string, Value>& data) {
     // Build the serialised text first so a serialise error doesn't
     // leave a half-written tmp file behind.
     std::ostringstream ss;
     ss << "return {\n";
-    ss << "  schema_version = 1,\n";
+    ss << "  schema_version = " << kSchemaVersion << ",\n";
     ss << "  data = {\n";
     for (const auto& [k, v] : data) {
-        ss << "    [" << lua_quote(k) << "] = " << lua_quote(v) << ",\n";
+        // monostate keys serialise to `nil` — Lua would drop them on
+        // load, so we skip them here for a smaller, cleaner file.
+        if (std::holds_alternative<std::monostate>(v)) continue;
+        ss << "    [" << lua_quote(k) << "] = "
+           << serialise_value(v) << ",\n";
     }
     ss << "  },\n";
     ss << "}\n";

--- a/modules/data-store/src/server/lua_persistor.hpp
+++ b/modules/data-store/src/server/lua_persistor.hpp
@@ -1,38 +1,35 @@
 #ifndef __data_store_server_lua_persistor_hpp__
 #define __data_store_server_lua_persistor_hpp__
 
-/// Loads + flushes the persistent key-value store as a Lua chunk.
+/// Loads + flushes the persistent key-value store as a Lua chunk
+/// of TYPED values (DS-D11).
 ///
-/// On-disk shape per design.md §4.1:
+/// On-disk shape:
 ///
 ///   return {
-///     schema_version = 1,
+///     schema_version = 2,
 ///     data = {
-///       ["foo"] = "bar",
-///       ["counter"] = "42",
-///       ...
+///       ["foo"]     = "bar",       -- string
+///       ["counter"] = 42,          -- integer
+///       ["ratio"]   = 1.5,         -- float
+///       ["enabled"] = true,        -- boolean
+///       ["unset"]   = nil,         -- absent (serialiser skips nils)
+///       -- ...
 ///     },
 ///   }
 ///
-/// Mirrors the `apps/config/**/*.lua` convention so the same loader
-/// (`iot::lua_config`) can be pointed at the file for inspection,
-/// though the data-store module ships its own minimal loader instead
-/// of cross-linking apps/.
-///
-/// load() runs once on daemon startup; save() runs after every
-/// successful set/remove that changes state (write-through per
-/// DS-D2). save() is crash-safe via temp + fsync + rename.
+/// Each value lands in the right `data_store::Value` variant
+/// alternative on load. Schema-version 1 (string-only) files still
+/// load — every value comes back as Value::string.
 
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
 
+#include "data_store/value.hpp"
+
 namespace data_store::server {
 
-/// Distinguishes "file simply isn't there yet" (recoverable: start
-/// with empty map) from "file exists but we can't parse it"
-/// (REQ-DS-016: must log + exit 3, not silently start with stale
-/// state).
 class CorruptStoreError : public std::runtime_error {
 public:
     using std::runtime_error::runtime_error;
@@ -42,13 +39,11 @@ class LuaPersistor {
 public:
     explicit LuaPersistor(std::string path);
 
-    /// Read the file. Returns an empty map if it doesn't exist.
-    /// Throws CorruptStoreError on parse / schema problems.
-    std::unordered_map<std::string, std::string> load();
+    /// Read the file. Empty map when missing; throws on parse failure.
+    std::unordered_map<std::string, Value> load();
 
-    /// Atomic write: serialise → write to `<path>.tmp` → fsync →
-    /// rename to `<path>`. Throws std::runtime_error on disk error.
-    void save(const std::unordered_map<std::string, std::string>& data);
+    /// Atomic write: serialise → write `<path>.tmp` → fsync → rename.
+    void save(const std::unordered_map<std::string, Value>& data);
 
     const std::string& path() const { return m_path; }
 

--- a/modules/data-store/src/server/schema.cpp
+++ b/modules/data-store/src/server/schema.cpp
@@ -4,9 +4,12 @@
 #include <cstdio>
 #include <cstring>
 #include <dirent.h>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #include <sys/stat.h>
+#include <type_traits>
+#include <variant>
 
 #include <ace/Log_Msg.h>
 
@@ -34,50 +37,72 @@ SchemaType parse_type(const std::string& s) {
     return SchemaType::Any;
 }
 
-/// Stringify a Lua value at stack index `idx` to the wire form
-/// (everything in the store is a std::string).
-std::string lua_value_to_string(lua_State* L, int idx) {
+/// Pull a Lua value at stack index `idx` into a Value, picking the
+/// narrowest variant alternative that fits. Returns monostate for
+/// unsupported types (tables, functions, userdata).
+Value lua_value_to_value(lua_State* L, int idx) {
     switch (lua_type(L, idx)) {
-        case LUA_TBOOLEAN: return lua_toboolean(L, idx) ? "1" : "0";
-        case LUA_TNUMBER: {
-            double n = lua_tonumber(L, idx);
-            // Integer-friendly print when the value is a whole number.
-            if (n == static_cast<double>(static_cast<long long>(n))) {
-                return std::to_string(static_cast<long long>(n));
+        case LUA_TBOOLEAN:
+            return Value(lua_toboolean(L, idx) != 0);
+        case LUA_TNUMBER:
+            if (lua_isinteger(L, idx)) {
+                lua_Integer n = lua_tointeger(L, idx);
+                if (n >= 0 &&
+                    n <= static_cast<lua_Integer>(
+                             std::numeric_limits<std::uint32_t>::max())) {
+                    return Value(static_cast<std::uint32_t>(n));
+                }
+                if (n >= std::numeric_limits<std::int32_t>::min() &&
+                    n <= std::numeric_limits<std::int32_t>::max()) {
+                    return Value(static_cast<std::int32_t>(n));
+                }
+                return Value(static_cast<double>(n));
             }
-            char buf[32];
-            std::snprintf(buf, sizeof(buf), "%g", n);
-            return buf;
-        }
+            return Value(lua_tonumber(L, idx));
         case LUA_TSTRING: {
             std::size_t len = 0;
             const char* s = lua_tolstring(L, idx, &len);
-            return std::string(s, len);
+            return Value(std::string(s, len));
         }
-        default: return {};
+        default:
+            return Value(std::monostate{});
     }
 }
 
-bool parse_long(const std::string& s, long long& out) {
-    if (s.empty()) return false;
-    try {
-        std::size_t pos = 0;
-        out = std::stoll(s, &pos);
-        return pos == s.size();
-    } catch (...) {
-        return false;
-    }
+/// Best-effort: stringify a Value for inclusion in a diagnostic
+/// message. Booleans → true/false; numbers → decimal; strings bare.
+std::string value_diag(const Value& v) {
+    return std::visit([](auto&& a) -> std::string {
+        using T = std::decay_t<decltype(a)>;
+        if constexpr (std::is_same_v<T, std::monostate>) return "null";
+        else if constexpr (std::is_same_v<T, bool>)      return a ? "true" : "false";
+        else if constexpr (std::is_same_v<T, std::string>) return a;
+        else if constexpr (std::is_same_v<T, double>) {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%g", a);
+            return buf;
+        } else {
+            return std::to_string(a);
+        }
+    }, v);
 }
 
-bool parse_double(const std::string& s, double& out) {
-    if (s.empty()) return false;
-    try {
-        std::size_t pos = 0;
-        out = std::stod(s, &pos);
-        return pos == s.size();
-    } catch (...) {
-        return false;
+/// Pull an integer out of a numeric Value (uint32/int32/double in
+/// integer range). Returns nullopt for strings / bools / fractional
+/// doubles.
+std::optional<long long> value_as_integer(const Value& v) {
+    if (std::holds_alternative<std::uint32_t>(v)) {
+        return static_cast<long long>(std::get<std::uint32_t>(v));
     }
+    if (std::holds_alternative<std::int32_t>(v)) {
+        return static_cast<long long>(std::get<std::int32_t>(v));
+    }
+    if (std::holds_alternative<double>(v)) {
+        double d = std::get<double>(v);
+        long long n = static_cast<long long>(d);
+        if (static_cast<double>(n) == d) return n;
+    }
+    return std::nullopt;
 }
 
 } // namespace
@@ -125,7 +150,7 @@ void SchemaRegistry::load_one(const std::string& path) {
 
         lua_getfield(L.get(), -1, "default");
         if (!lua_isnil(L.get(), -1)) {
-            e.default_value = lua_value_to_string(L.get(), -1);
+            e.default_value = lua_value_to_value(L.get(), lua_gettop(L.get()));
         }
         lua_pop(L.get(), 1);
 
@@ -186,47 +211,59 @@ const SchemaEntry* SchemaRegistry::find(const std::string& key) const {
 }
 
 std::optional<std::string> SchemaRegistry::validate_set(
-        const std::string& key, const std::string& value) const {
+        const std::string& key, const Value& value) const {
     auto it = m_entries.find(key);
     if (it == m_entries.end()) return std::nullopt;  // passthrough
     const SchemaEntry& e = it->second;
+
+    // monostate (null) is always accepted — used to clear a key.
+    if (std::holds_alternative<std::monostate>(value)) return std::nullopt;
+
     switch (e.type) {
         case SchemaType::Any:
+            return std::nullopt;
+
         case SchemaType::String:
         case SchemaType::Opaque:
-            return std::nullopt;
-        case SchemaType::Boolean: {
-            if (value == "0" || value == "1" ||
-                value == "true" || value == "false") return std::nullopt;
-            return "schema(" + key + "): expected boolean, got '" + value + "'";
-        }
+            if (std::holds_alternative<std::string>(value)) return std::nullopt;
+            return "schema(" + key + "): expected string, got " +
+                   value_diag(value);
+
+        case SchemaType::Boolean:
+            if (std::holds_alternative<bool>(value)) return std::nullopt;
+            return "schema(" + key + "): expected boolean, got " +
+                   value_diag(value);
+
         case SchemaType::Integer: {
-            long long n;
-            if (!parse_long(value, n)) {
-                return "schema(" + key + "): expected integer, got '" + value + "'";
+            auto n = value_as_integer(value);
+            if (!n) {
+                return "schema(" + key + "): expected integer, got " +
+                       value_diag(value);
             }
-            if (e.min_int && n < *e.min_int) {
-                return "schema(" + key + "): " + std::to_string(n) +
+            if (e.min_int && *n < *e.min_int) {
+                return "schema(" + key + "): " + std::to_string(*n) +
                        " below min " + std::to_string(*e.min_int);
             }
-            if (e.max_int && n > *e.max_int) {
-                return "schema(" + key + "): " + std::to_string(n) +
+            if (e.max_int && *n > *e.max_int) {
+                return "schema(" + key + "): " + std::to_string(*n) +
                        " above max " + std::to_string(*e.max_int);
             }
             return std::nullopt;
         }
-        case SchemaType::Float: {
-            double f;
-            if (!parse_double(value, f)) {
-                return "schema(" + key + "): expected float, got '" + value + "'";
+
+        case SchemaType::Float:
+            if (std::holds_alternative<double>(value) ||
+                std::holds_alternative<std::uint32_t>(value) ||
+                std::holds_alternative<std::int32_t>(value)) {
+                return std::nullopt;
             }
-            return std::nullopt;
-        }
+            return "schema(" + key + "): expected float, got " +
+                   value_diag(value);
     }
     return std::nullopt;
 }
 
-std::optional<std::string> SchemaRegistry::default_for(
+std::optional<Value> SchemaRegistry::default_for(
         const std::string& key) const {
     auto it = m_entries.find(key);
     if (it == m_entries.end()) return std::nullopt;

--- a/modules/data-store/src/server/schema.hpp
+++ b/modules/data-store/src/server/schema.hpp
@@ -34,6 +34,8 @@
 #include <string>
 #include <unordered_map>
 
+#include "data_store/value.hpp"
+
 namespace data_store::server {
 
 enum class SchemaType : std::uint8_t {
@@ -47,7 +49,7 @@ enum class SchemaType : std::uint8_t {
 
 struct SchemaEntry {
     SchemaType                  type = SchemaType::Any;
-    std::optional<std::string>  default_value;   ///< stringified
+    std::optional<Value>        default_value;
     std::optional<long long>    min_int;
     std::optional<long long>    max_int;
 };
@@ -69,11 +71,11 @@ public:
     /// Validate a set value against the schema. Returns an empty
     /// optional on success; a diagnostic string on rejection.
     std::optional<std::string> validate_set(const std::string& key,
-                                            const std::string& value) const;
+                                            const Value& value) const;
 
     /// Default for an absent key, or nullopt when the schema has
     /// no default (or no entry at all).
-    std::optional<std::string> default_for(const std::string& key) const;
+    std::optional<Value> default_for(const std::string& key) const;
 
     std::size_t size() const { return m_entries.size(); }
 

--- a/modules/data-store/src/server/worker.cpp
+++ b/modules/data-store/src/server/worker.cpp
@@ -2,6 +2,7 @@
 
 #include "data_store.hpp"
 #include "data_store/proto.hpp"
+#include "proto/value_json.hpp"
 #include "schema.hpp"
 #include "server.hpp"
 #include "session.hpp"
@@ -41,15 +42,15 @@ std::string error_response(const json& reqId, const std::string& msg) {
     return r.dump() + "\n";
 }
 
-/// Build a `{"ev":"changed","k":"...","v":"...","prev":...}` line.
+/// Build a `{"ev":"changed","k":"...","v":<typed>,"prev":<typed>}` line.
 std::string notify_line(const std::string& key,
-                        const std::string& newValue,
-                        const std::optional<std::string>& prev) {
+                        const Value& newValue,
+                        const std::optional<Value>& prev) {
     json r;
     r["ev"] = "changed";
     r["k"]  = key;
-    r["v"]  = newValue;
-    if (prev.has_value()) r["prev"] = *prev;
+    r["v"]  = value_to_json(newValue);
+    if (prev.has_value()) r["prev"] = value_to_json(*prev);
     else                  r["prev"] = nullptr;
     return r.dump() + "\n";
 }
@@ -177,9 +178,10 @@ void Worker::handle_process_request(WorkMsg* msg) {
 
     switch (op) {
         case proto::Op::Set: {
-            // Each element is `{"k":"...","v":"..."}`. Collect notify
-            // dispatches; emit after the response is on the wire so the
-            // initiating client sees its ack before peers see the push.
+            // Each element is a single-key object `{"keyname": <typed-value>}`.
+            // Collect notify dispatches; emit after the response is on
+            // the wire so the initiating client sees its ack before
+            // peers see the push.
             struct Push {
                 Session*                 watcher;
                 std::string              line;
@@ -187,13 +189,14 @@ void Worker::handle_process_request(WorkMsg* msg) {
             std::vector<Push> pushes;
 
             for (const auto& e : req["keys"]) {
-                if (!e.is_object() || !e.contains("k") || !e.contains("v") ||
-                    !e["k"].is_string() || !e["v"].is_string()) {
-                    s->send(error_response(reqId, "set entry needs k+v strings"));
+                if (!e.is_object() || e.size() != 1) {
+                    s->send(error_response(
+                        reqId, "set entry must be a single-key object"));
                     return;
                 }
-                const std::string k = e["k"].get<std::string>();
-                const std::string v = e["v"].get<std::string>();
+                auto it = e.begin();
+                const std::string k = it.key();
+                Value v = value_from_json(it.value());
                 // REQ-DS-014 / schema check: reject type mismatches
                 // before touching the store. Schema is optional; an
                 // unknown key returns nullopt → passthrough.
@@ -240,12 +243,12 @@ void Worker::handle_process_request(WorkMsg* msg) {
                 json item;
                 item["k"] = k;
                 if (v.has_value()) {
-                    item["v"] = *v;
+                    item["v"] = value_to_json(*v);
                 } else if (m_schema) {
                     // Fall back to the schema default when the
                     // key is unset.
                     auto def = m_schema->default_for(k);
-                    if (def) item["v"] = *def;
+                    if (def) item["v"] = value_to_json(*def);
                     else     item["v"] = nullptr;
                 } else {
                     item["v"] = nullptr;

--- a/modules/data-store/test/callback_test.cpp
+++ b/modules/data-store/test/callback_test.cpp
@@ -98,7 +98,7 @@ TEST(Callback, single_watch_with_callback_fires_on_event) {
 
         // Set from the same client — server fans the notify back to
         // every watcher on the key, including us.
-        auto ss = cli.set("foo", "bar", 2000);
+        auto ss = cli.set("foo", ds::Value{std::string("bar")}, 2000);
         if (!ss.ok) return ss;
 
         // Wait up to 3s for the callback.
@@ -119,7 +119,7 @@ TEST(Callback, single_watch_with_callback_fires_on_event) {
     if (rs.ok) {
         auto ev = fut.get();
         EXPECT_EQ("foo", ev.key);
-        EXPECT_EQ("bar", ev.value);
+        EXPECT_EQ(std::string("bar"), std::get<std::string>(ev.value));
         EXPECT_FALSE(ev.prev_has_value);
     }
     ::rmdir(dir.c_str());
@@ -152,9 +152,12 @@ TEST(Callback, multiple_watches_with_overlapping_keys_all_fire) {
             &hb, 2000);
         if (!rb.ok) return rb;
 
-        if (auto s = cli.set("foo",    "1", 2000); !s.ok) return s;
-        if (auto s = cli.set("bar",    "2", 2000); !s.ok) return s;
-        if (auto s = cli.set("shared", "3", 2000); !s.ok) return s;
+        if (auto s = cli.set("foo",
+                ds::Value{std::string("1")}, 2000); !s.ok) return s;
+        if (auto s = cli.set("bar",
+                ds::Value{std::string("2")}, 2000); !s.ok) return s;
+        if (auto s = cli.set("shared",
+                ds::Value{std::string("3")}, 2000); !s.ok) return s;
 
         // Wait for listener to dispatch.
         for (int i = 0; i < 100; ++i) {
@@ -167,7 +170,8 @@ TEST(Callback, multiple_watches_with_overlapping_keys_all_fire) {
 
         // Drop A; another set on shared should fire ONLY B.
         if (auto s = cli.unwatch(ha, 2000); !s.ok) return s;
-        if (auto s = cli.set("shared", "4", 2000); !s.ok) return s;
+        if (auto s = cli.set("shared",
+                ds::Value{std::string("4")}, 2000); !s.ok) return s;
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         EXPECT_EQ(2, a_fires.load());
         EXPECT_EQ(3, b_fires.load());

--- a/modules/data-store/test/data_store_test.cpp
+++ b/modules/data-store/test/data_store_test.cpp
@@ -3,9 +3,11 @@
 #include <gtest/gtest.h>
 
 #include "data_store/proto.hpp"
+#include "data_store/value.hpp"
 #include "../src/server/data_store.hpp"
 
 using data_store::server::DataStore;
+using data_store::Value;
 namespace proto = data_store::proto;
 
 /* ───────────────────────────── proto ──────────────────────────────── */
@@ -44,31 +46,31 @@ TEST(DataStore, empty_get_returns_nullopt) {
 
 TEST(DataStore, set_then_get_returns_value) {
     DataStore s;
-    auto r = s.set("k", "v");
+    auto r = s.set("k", Value{std::string("v")});
     EXPECT_TRUE(r.changed);
     EXPECT_FALSE(r.prev.has_value());        // new key
     EXPECT_TRUE(r.watchers.empty());
     EXPECT_EQ(1u, s.size());
     auto v = s.get("k");
     ASSERT_TRUE(v.has_value());
-    EXPECT_EQ("v", *v);
+    EXPECT_EQ(std::string("v"), std::get<std::string>(*v));
 }
 
 TEST(DataStore, second_set_returns_previous) {
     DataStore s;
-    s.set("k", "v1");
-    auto r = s.set("k", "v2");
+    s.set("k", Value{std::string("v1")});
+    auto r = s.set("k", Value{std::string("v2")});
     EXPECT_TRUE(r.changed);
     ASSERT_TRUE(r.prev.has_value());
-    EXPECT_EQ("v1", *r.prev);
-    EXPECT_EQ("v2", *s.get("k"));
+    EXPECT_EQ(std::string("v1"), std::get<std::string>(*r.prev));
+    EXPECT_EQ(std::string("v2"), std::get<std::string>(*s.get("k")));
     EXPECT_EQ(1u, s.size());
 }
 
 TEST(DataStore, unchanged_set_reports_not_changed) {
     DataStore s;
-    s.set("k", "v");
-    auto r = s.set("k", "v");
+    s.set("k", Value{std::string("v")});
+    auto r = s.set("k", Value{std::string("v")});
     EXPECT_FALSE(r.changed);                 // REQ-DS-006
     EXPECT_FALSE(r.prev.has_value());        // no notify, no snapshot
     EXPECT_TRUE(r.watchers.empty());
@@ -76,8 +78,32 @@ TEST(DataStore, unchanged_set_reports_not_changed) {
 
 TEST(DataStore, remove_returns_true_only_when_present) {
     DataStore s;
-    s.set("k", "v");
+    s.set("k", Value{std::string("v")});
     EXPECT_TRUE(s.remove("k"));
     EXPECT_FALSE(s.remove("k"));
     EXPECT_FALSE(s.get("k").has_value());
+}
+
+TEST(DataStore, integer_value_round_trips) {
+    DataStore s;
+    auto r = s.set("counter", Value{static_cast<std::uint32_t>(42)});
+    EXPECT_TRUE(r.changed);
+    auto v = s.get("counter");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_EQ(42u, std::get<std::uint32_t>(*v));
+}
+
+TEST(DataStore, boolean_value_round_trips) {
+    DataStore s;
+    s.set("enabled", Value{true});
+    auto v = s.get("enabled");
+    ASSERT_TRUE(v.has_value());
+    EXPECT_TRUE(std::get<bool>(*v));
+}
+
+TEST(DataStore, typed_unchanged_set_is_noop) {
+    DataStore s;
+    s.set("x", Value{static_cast<std::int32_t>(-7)});
+    auto r = s.set("x", Value{static_cast<std::int32_t>(-7)});
+    EXPECT_FALSE(r.changed);
 }

--- a/modules/data-store/test/lua_persistor_test.cpp
+++ b/modules/data-store/test/lua_persistor_test.cpp
@@ -11,10 +11,12 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "data_store/value.hpp"
 #include "../src/server/data_store.hpp"
 #include "../src/server/lua_persistor.hpp"
 
 namespace ds = data_store::server;
+using data_store::Value;
 
 namespace {
 
@@ -45,16 +47,45 @@ TEST(LuaPersistor, save_then_load_round_trips) {
     std::string path = dir + "/store.lua";
 
     ds::LuaPersistor p(path);
-    std::unordered_map<std::string, std::string> in {
-        {"foo", "bar"},
-        {"counter", "42"},
-        {"k.with.dots", "v"},
-        {"tricky", "has \"quotes\" and\nnewline"},
+    std::unordered_map<std::string, Value> in {
+        {"foo",          Value{std::string("bar")}},
+        {"counter",      Value{static_cast<std::uint32_t>(42)}},
+        {"signed",       Value{static_cast<std::int32_t>(-7)}},
+        {"ratio",        Value{1.5}},
+        {"enabled",      Value{true}},
+        {"k.with.dots",  Value{std::string("v")}},
+        {"tricky",       Value{std::string("has \"quotes\" and\nnewline")}},
     };
     p.save(in);
 
     auto out = p.load();
     EXPECT_EQ(in, out);
+
+    ::unlink(path.c_str());
+    ::rmdir(dir.c_str());
+}
+
+TEST(LuaPersistor, v1_string_only_file_loads_as_strings) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    std::string path = dir + "/v1.lua";
+
+    // Hand-crafted v1 file — every value is a Lua string literal,
+    // schema_version=1. Must load cleanly under the new typed code.
+    std::ofstream(path) <<
+        "return {\n"
+        "  schema_version = 1,\n"
+        "  data = {\n"
+        "    [\"foo\"] = \"bar\",\n"
+        "    [\"baz\"] = \"qux\",\n"
+        "  },\n"
+        "}\n";
+
+    ds::LuaPersistor p(path);
+    auto out = p.load();
+    ASSERT_EQ(2u, out.size());
+    EXPECT_EQ(std::string("bar"), std::get<std::string>(out.at("foo")));
+    EXPECT_EQ(std::string("qux"), std::get<std::string>(out.at("baz")));
 
     ::unlink(path.c_str());
     ::rmdir(dir.c_str());
@@ -96,12 +127,12 @@ TEST(DataStorePersist, set_flushes_to_disk_and_load_restores) {
         ds::DataStore s;
         s.set_persistor(&p);
 
-        s.set("a", "1");
-        s.set("b", "2");
+        s.set("a", Value{std::string("1")});
+        s.set("b", Value{static_cast<std::uint32_t>(2)});
         s.remove("a");
         // s.set with unchanged value MUST NOT add a flush — but
         // since the flush is best-effort we just check final state.
-        s.set("b", "2");
+        s.set("b", Value{static_cast<std::uint32_t>(2)});
     }
 
     {
@@ -111,7 +142,7 @@ TEST(DataStorePersist, set_flushes_to_disk_and_load_restores) {
         EXPECT_EQ(1u, s.size());
         auto b = s.get("b");
         ASSERT_TRUE(b.has_value());
-        EXPECT_EQ("2", *b);
+        EXPECT_EQ(2u, std::get<std::uint32_t>(*b));
         EXPECT_FALSE(s.get("a").has_value());
     }
 

--- a/modules/data-store/test/protocol_test.cpp
+++ b/modules/data-store/test/protocol_test.cpp
@@ -97,13 +97,14 @@ TEST(Protocol, DS_REQ_DS_003_set_then_get_returns_latest) {
         ds::Client cli;
         auto cs = cli.connect(srv.sock); if (!cs.ok) return cs;
         std::string w; cli.recv_welcome(w, 2000);
-        auto ss = cli.set("foo", "bar", 2000); if (!ss.ok) return ss;
+        auto ss = cli.set("foo", ds::Value{std::string("bar")}, 2000);
+        if (!ss.ok) return ss;
         std::vector<ds::Client::GetResult> got;
         auto gs = cli.get({"foo", "missing"}, got, 2000); if (!gs.ok) return gs;
         EXPECT_EQ(2u, got.size());
         EXPECT_EQ("foo", got[0].key);
         EXPECT_TRUE(got[0].has_value);
-        EXPECT_EQ("bar", got[0].value);
+        EXPECT_EQ(std::string("bar"), std::get<std::string>(got[0].value));
         EXPECT_EQ("missing", got[1].key);
         EXPECT_FALSE(got[1].has_value);
         return ds::Status{};
@@ -133,7 +134,7 @@ TEST(Protocol, DS_REQ_DS_007_register_then_set_emits_notify_to_watcher) {
         auto es = w.recv_event(ev, 5000);
         if (!es.ok) return es;
         EXPECT_EQ("foo",  ev.key);
-        EXPECT_EQ("bar",  ev.value);
+        EXPECT_EQ(std::string("bar"), std::get<std::string>(ev.value));
         EXPECT_FALSE(ev.prev_has_value);   // foo was new
         return ds::Status{};
     });
@@ -146,7 +147,7 @@ TEST(Protocol, DS_REQ_DS_007_register_then_set_emits_notify_to_watcher) {
         auto cs = s.connect(srv.sock); if (!cs.ok) return cs;
         std::string welcome; s.recv_welcome(welcome, 2000);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
-        return s.set("foo", "bar", 2000);
+        return s.set("foo", ds::Value{std::string("bar")}, 2000);
     });
 
     pump_until(watch_fut, set_fut);
@@ -171,7 +172,7 @@ TEST(Protocol, DS_REQ_DS_006_unchanged_value_no_notify) {
         ds::Client s;
         auto cs = s.connect(srv.sock); if (!cs.ok) return cs;
         std::string w; s.recv_welcome(w, 2000);
-        return s.set("foo", "bar", 2000);
+        return s.set("foo", ds::Value{std::string("bar")}, 2000);
     });
     pump_until(seed_fut);
     auto seed = seed_fut.get();
@@ -189,7 +190,7 @@ TEST(Protocol, DS_REQ_DS_006_unchanged_value_no_notify) {
         ds::Status fail;
         fail.ok = false;
         fail.err = es.ok
-            ? "unexpected notify k=" + ev.key + " v=" + ev.value
+            ? "unexpected notify k=" + ev.key
             : "unexpected error: " + es.err;
         return fail;
     });
@@ -200,7 +201,7 @@ TEST(Protocol, DS_REQ_DS_006_unchanged_value_no_notify) {
         auto cs = s.connect(srv.sock); if (!cs.ok) return cs;
         std::string welcome; s.recv_welcome(welcome, 2000);
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
-        return s.set("foo", "bar", 2000);   // same value
+        return s.set("foo", ds::Value{std::string("bar")}, 2000);   // same value
     });
 
     pump_until(watch_fut, set_fut);

--- a/modules/data-store/test/schema_test.cpp
+++ b/modules/data-store/test/schema_test.cpp
@@ -9,9 +9,11 @@
 #include <sys/stat.h>
 #include <unistd.h>
 
+#include "data_store/value.hpp"
 #include "../src/server/schema.hpp"
 
 namespace ds = data_store::server;
+using data_store::Value;
 
 namespace {
 
@@ -56,7 +58,7 @@ return {
     ASSERT_NE(nullptr, e);
     EXPECT_EQ(ds::SchemaType::Integer, e->type);
     ASSERT_TRUE(e->default_value.has_value());
-    EXPECT_EQ("86400", *e->default_value);
+    EXPECT_EQ(86400u, std::get<std::uint32_t>(*e->default_value));
     EXPECT_EQ(0LL, e->min_int.value_or(-1));
 
     EXPECT_EQ(nullptr, r.find("not.in.schema"));
@@ -66,7 +68,8 @@ return {
 TEST(Schema, validate_set_passes_unknown_keys_through) {
     ds::SchemaRegistry r;
     // No schema loaded → every set passes.
-    EXPECT_FALSE(r.validate_set("anything", "v").has_value());
+    EXPECT_FALSE(r.validate_set("anything",
+        Value{std::string("v")}).has_value());
 }
 
 TEST(Schema, validate_set_rejects_type_mismatch) {
@@ -77,14 +80,38 @@ return { keys = { ["n"] = { type="integer", min=0, max=10 } } })");
 
     ds::SchemaRegistry r;
     r.load_directory(dir);
-    EXPECT_FALSE(r.validate_set("n", "5").has_value());   // ok
-    EXPECT_TRUE (r.validate_set("n", "foo").has_value()); // not integer
-    EXPECT_TRUE (r.validate_set("n", "-1").has_value());  // below min
-    EXPECT_TRUE (r.validate_set("n", "99").has_value());  // above max
+    EXPECT_FALSE(r.validate_set("n",
+        Value{static_cast<std::uint32_t>(5)}).has_value());     // ok
+    EXPECT_TRUE (r.validate_set("n",
+        Value{std::string("foo")}).has_value());                 // not integer
+    EXPECT_TRUE (r.validate_set("n",
+        Value{static_cast<std::int32_t>(-1)}).has_value());      // below min
+    EXPECT_TRUE (r.validate_set("n",
+        Value{static_cast<std::uint32_t>(99)}).has_value());     // above max
     ::unlink((dir + "/x.lua").c_str()); ::rmdir(dir.c_str());
 }
 
-TEST(Schema, default_for_returns_stringified_default) {
+TEST(Schema, validate_set_typed_string_and_boolean) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
+    write_file(dir + "/t.lua", R"(
+return { keys = {
+    ["name"]    = { type="string"  },
+    ["enabled"] = { type="boolean" },
+} })");
+    ds::SchemaRegistry r;
+    r.load_directory(dir);
+    EXPECT_FALSE(r.validate_set("name",
+        Value{std::string("ok")}).has_value());
+    EXPECT_TRUE (r.validate_set("name",
+        Value{static_cast<std::uint32_t>(1)}).has_value());
+    EXPECT_FALSE(r.validate_set("enabled", Value{true}).has_value());
+    EXPECT_TRUE (r.validate_set("enabled",
+        Value{std::string("true")}).has_value());
+    ::unlink((dir + "/t.lua").c_str()); ::rmdir(dir.c_str());
+}
+
+TEST(Schema, default_for_returns_typed_default) {
     auto dir = make_tmpdir();
     if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
     write_file(dir + "/d.lua", R"(
@@ -99,9 +126,15 @@ return {
 
     ds::SchemaRegistry r;
     r.load_directory(dir);
-    EXPECT_EQ("42",    r.default_for("a").value_or(""));
-    EXPECT_EQ("1",     r.default_for("b").value_or(""));
-    EXPECT_EQ("hello", r.default_for("c").value_or(""));
+    auto a = r.default_for("a");
+    ASSERT_TRUE(a.has_value());
+    EXPECT_EQ(42u, std::get<std::uint32_t>(*a));
+    auto b = r.default_for("b");
+    ASSERT_TRUE(b.has_value());
+    EXPECT_TRUE(std::get<bool>(*b));
+    auto c = r.default_for("c");
+    ASSERT_TRUE(c.has_value());
+    EXPECT_EQ(std::string("hello"), std::get<std::string>(*c));
     EXPECT_FALSE(r.default_for("d").has_value());
     EXPECT_FALSE(r.default_for("nope").has_value());
     ::unlink((dir + "/d.lua").c_str()); ::rmdir(dir.c_str());
@@ -122,7 +155,8 @@ return { keys = { ["dup"] = { type="integer", default=2 } } })");
     ASSERT_TRUE(e->default_value.has_value());
     // Last-loaded wins; filesystem readdir order isn't guaranteed,
     // so just assert it's one of the two.
-    EXPECT_TRUE(*e->default_value == "1" || *e->default_value == "2");
+    auto n = std::get<std::uint32_t>(*e->default_value);
+    EXPECT_TRUE(n == 1u || n == 2u);
 
     ::unlink((dir + "/a.lua").c_str());
     ::unlink((dir + "/b.lua").c_str());


### PR DESCRIPTION
## Summary
- Replace string-only data-store values with `data_store::Value`, a `std::variant<monostate, string, bool, uint32_t, int32_t, double>` mirroring grace-server's shape.
- New wire shape for `set`: `keys: [{\"foo\": <typed-value>}, {\"counter\": 42}, ...]` — each entry a single-key object, value JSON-typed.
- Notify push, GetResult, Event, KV, LuaPersistor, SchemaRegistry all carry Value through. v1 (string-only) persistor files still load.
- ds-cli's `set` parses each value as JSON best-effort (`42` → uint32, `true` → bool, plain text → string).

## Test plan
- [x] 35/35 ds-tests green under podman (`naushada/iot:latest`)
- [x] Added coverage for typed round-trip (uint/int/bool/double), v1 string-only backward-compat load, per-alternative schema validation
- [x] ds-server + ds-cli + lwm2m binary all build clean
- [ ] PR 2 (separate branch): wire libdatastore_client into the iot binary as a real consumer (FUP-DS-5 from L10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)