### PR TITLE
data-store: Mihini-style EMP framing (binary header + JSON payload)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ log/L9/cli-zip-smoke-*.log
 log/L9/probe-readline.*
 log/L9/run-cli-smoke.run.log
 log/L9/.cli-zip-big.json
+
+# CMake test build artifacts
+apps/test/build/

--- a/apps/src/ds_config.cpp
+++ b/apps/src/ds_config.cpp
@@ -49,10 +49,8 @@ DsConfig::DsConfig(std::string socketPath)
                    m_path.c_str(), cs.err.c_str()));
         return;
     }
-    // Read+discard the welcome line so the listener thread's first
-    // demuxed line isn't sitting in the welcome bookkeeping.
-    std::string w;
-    m_impl->client.recv_welcome(w, /*timeout_ms=*/500);
+    // EMP has no welcome handshake — the connection is usable as soon
+    // as connect() returns ok.
     m_ok = true;
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("%D [iot:%t] %M %N:%l data-store ready at %C\n"),

--- a/modules/data-store/docs/protocol.md
+++ b/modules/data-store/docs/protocol.md
@@ -1,0 +1,285 @@
+# Data-Store Wire Protocol (EMP)
+
+> Modelled on Eclipse Mihini's
+> [Embedded Micro Protocol](https://wiki.eclipse.org/Mihini/Embedded_Micro_Protocol).
+> Same framing shape; smaller, KV-shaped opcode set tailored to this
+> module's contract.
+
+The data-store speaks a binary, framed RPC protocol over `AF_UNIX`
+SOCK_STREAM (default socket `/var/run/iot/data_store.sock`). Every
+exchange is one or more EMP frames; payloads carry UTF-8 JSON.
+
+The framing is symmetric — both client → server commands and
+server → client responses + pushes use the same 8-byte header.
+
+---
+
+## 1. Frame layout
+
+```
+ 0               1               2               3
+ 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7 0 1 2 3 4 5 6 7
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|             cmdID             |      type     |     reqID     |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                         payload_size                          |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+|                                                               |
+|                  payload  (payload_size bytes)                |
+|                                                               |
++-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+```
+
+All integers are **big-endian**.
+
+| Field          | Size  | Description                                       |
+|----------------|------:|---------------------------------------------------|
+| `cmdID`        | 2 B   | opcode (see §2)                                   |
+| `type`         | 1 B   | frame-kind bits (see §3)                          |
+| `reqID`        | 1 B   | request correlator, 0..255                        |
+| `payload_size` | 4 B   | bytes of payload that follow (≤ 1 MiB ceiling)    |
+| `payload`      | N B   | request/response/push body (see §4)               |
+
+The implementation header layout: `modules/data-store/inc/data_store/proto.hpp`.
+
+---
+
+## 2. Opcodes
+
+| cmdID    | Name             | Direction        | Purpose                                       |
+|---------:|------------------|------------------|-----------------------------------------------|
+| `0x0001` | `Set`            | client → server  | Write one or more keys (atomic per request)   |
+| `0x0002` | `Get`            | client → server  | Read one or more keys                         |
+| `0x0003` | `RegisterWatch`  | client → server  | Subscribe to value-change notifications       |
+| `0x0004` | `RemoveWatch`    | client → server  | Unsubscribe one or more watched keys          |
+| `0x0064` | `NotifyEvent`    | server → client  | Push: value of a watched key changed          |
+
+Any opcode the server doesn't recognise is answered with a response
+carrying status `BadOpcode` (§5).
+
+The full Mihini opcode space (52 commands covering SMS / FOTA / data
+consolidation) is **not** implemented — those concepts don't map onto a
+generic KV store. The five opcodes above are the data-store's complete
+public surface.
+
+---
+
+## 3. Type byte
+
+The `type` byte tells the receiver what kind of frame it is.
+
+| bit | Mnemonic   | Set when…                                                 |
+|----:|------------|-----------------------------------------------------------|
+| 0   | `Response` | server → client reply, correlated by `reqID`              |
+| 1   | `Push`     | server → client unsolicited push (`reqID = 0`)            |
+| 2-7 | reserved   | MUST be zero                                              |
+
+Encoding rules:
+- **Command** (client → server): `type = 0x00`, `reqID > 0`.
+- **Response** (server → client): `type = 0x01`, `reqID` echoed from
+  the originating command.
+- **Push** (server → client): `type = 0x02`, `reqID = 0`.
+
+Mihini's EMP reserves bits 1-7; we repurpose **bit 1** for server-
+initiated push so that change-notifications fit the same framing as
+everything else. This is a local extension — Mihini-pure peers would
+treat such a frame as malformed, but no Mihini-pure peer ever connects
+to ds-server.
+
+---
+
+## 4. Payload
+
+### Commands
+
+The command body is the JSON object (or empty for opcodes that take no
+arguments). Every current opcode carries a single field `keys`:
+
+```json
+// Op::Set        — array of single-key objects, value is JSON-typed.
+{"keys":[{"foo":"bar"}, {"counter":42}, {"enabled":true}]}
+
+// Op::Get        — array of strings.
+{"keys":["foo","missing"]}
+
+// Op::RegisterWatch / Op::RemoveWatch  — array of strings.
+{"keys":["foo","bar"]}
+```
+
+Value types round-trip through `data_store::Value`:
+
+| JSON in           | Stored as                         |
+|-------------------|-----------------------------------|
+| `null`            | `std::monostate`                  |
+| `true` / `false`  | `bool`                            |
+| `"text"`          | `std::string`                     |
+| `42` (≥ 0, ≤ 2³²) | `std::uint32_t`                   |
+| `-1`              | `std::int32_t`                    |
+| `1.5`             | `double`                          |
+| out-of-range int  | spilled to `double`               |
+
+### Responses
+
+The payload's first 2 bytes are the big-endian `Status` code (§5);
+the rest, if any, is a JSON body.
+
+```text
++--------+---------------+
+| status |   JSON body   |
+| 2 B BE |   (optional)  |
++--------+---------------+
+```
+
+| Op              | Body on success                                    | Body on failure                   |
+|-----------------|----------------------------------------------------|-----------------------------------|
+| `Set`           | empty                                              | `{"err":"..."}`                   |
+| `Get`           | `{"data":[{"k":"…","v":<typed-or-null>}, …]}`      | `{"err":"..."}`                   |
+| `RegisterWatch` | empty                                              | `{"err":"..."}`                   |
+| `RemoveWatch`   | empty                                              | `{"err":"..."}`                   |
+
+For `Get`, every requested key produces one entry in `data` in the
+same order; `v == null` means the key is absent from the store **and**
+the (optional) schema has no default for it.
+
+### Pushes
+
+`NotifyEvent` (only push opcode today) carries no status prefix —
+the payload IS the JSON body:
+
+```json
+{"k":"foo","v":"bar","prev":"old"}
+```
+
+`prev` is `null` when the key was newly created. `v` is `null` when
+the change was a removal (currently no opcode emits this — `Set` only
+fires for actual writes — but the field is reserved).
+
+---
+
+## 5. Status codes
+
+`Status` is the 2-byte big-endian integer that prefixes every response
+payload. **Zero is success**, every other value is a failure.
+
+| Code     | Name             | Meaning                                                                   |
+|---------:|------------------|---------------------------------------------------------------------------|
+| `0x0000` | `Ok`             | Success                                                                   |
+| `0x8001` | `BadFrame`       | Malformed header, payload truncated, oversized, or wrong direction        |
+| `0x8002` | `BadOpcode`      | Unknown / unsupported `cmdID`                                             |
+| `0x8003` | `BadPayload`     | JSON parse failure or payload not in the expected shape for this opcode   |
+| `0x8004` | `SchemaRejected` | `SchemaRegistry::validate_set` rejected the value                         |
+| `0x8005` | `NotFound`       | Reserved for future single-key reads                                      |
+| `0x8006` | `InternalError`  | Caught exception on the server side                                       |
+
+The high bit distinguishes implementation status codes (`0x8xxx`) from
+the reserved low range (`0x0000-0x7FFF`) used by transport / OS errors
+in Mihini's original `swi_status_t` mapping.
+
+---
+
+## 6. Request lifecycle
+
+1. **Connect.** Client opens the unix socket. There is no welcome
+   handshake — the connection is usable immediately.
+2. **Issue commands.** Client picks the next `reqID` (round-robin in
+   1..255; the lib's correlator combines `(op << 8) | reqID` so two
+   different opcodes can share a `reqID` slot in flight).
+3. **Receive responses.** Server replies on the same socket with a
+   frame whose `type` has bit 0 set and `reqID` matches the request.
+   Order between commands on different reqIDs is **not** guaranteed.
+4. **Receive pushes.** Independently of any request, the server may
+   push `NotifyEvent` frames for keys this session has registered.
+   Pushes have `reqID = 0` and don't correlate with any request.
+
+The per-session `reqID` namespace is 8-bit, so a client must wait for
+the response before reusing the same `(op, reqID)` pair. The client
+library handles this transparently with a monotonic counter that wraps.
+
+---
+
+## 7. Worked example — `Set foo=42`
+
+Wire bytes the client sends (28 B total):
+
+```
+00 01    ← cmdID = Set
+00       ← type  = command
+07       ← reqID = 7
+00 00 00 14 ← payload_size = 20
+{"keys":[{"foo":42}]}    ← 20 B JSON body
+```
+
+Wire bytes the server sends back (10 B total):
+
+```
+00 01    ← cmdID = Set (echo)
+01       ← type  = response (bit 0)
+07       ← reqID = 7 (echo)
+00 00 00 02 ← payload_size = 2 (status prefix only, empty body)
+00 00    ← Status::Ok
+```
+
+If a peer is currently watching `foo`, the server also emits a push to
+that peer in parallel (28 B):
+
+```
+00 64    ← cmdID = NotifyEvent
+02       ← type  = push (bit 1)
+00       ← reqID = 0
+00 00 00 14 ← payload_size = 20
+{"k":"foo","v":42,"prev":null}  ← 20 B JSON body
+```
+
+---
+
+## 8. Client API surface
+
+`libdatastore_client` exposes one method per opcode plus convenience
+wrappers. Per [feedback_ace_logging] the server logs go through ACE;
+clients keep the call surface POSIX-clean.
+
+| Method                                                | Opcode            |
+|-------------------------------------------------------|-------------------|
+| `Client::connect(path)`                               | (transport)       |
+| `Client::set(vector<KV>, timeout)`                    | `0x0001 Set`      |
+| `Client::set(key, Value, timeout)` (convenience)      | `0x0001 Set`      |
+| `Client::get(vector<string>, vector<GetResult>&, …)`  | `0x0002 Get`      |
+| `Client::watch(vector<string>, cb, *handle, …)`       | `0x0003 Register` |
+| `Client::watch(vector<string>, …)` (pull-style)       | `0x0003 Register` |
+| `Client::unwatch(WatchHandle, …)`                     | `0x0004 Remove`   |
+| `Client::unwatch(vector<string>, …)`                  | `0x0004 Remove`   |
+| `Client::recv_event(Event&, …)`                       | (consumes push)   |
+| `EventCallback` invoked from listener thread          | `0x0064 Notify`   |
+
+Each call serialises the appropriate command frame, waits up to
+`timeout_ms` for the matching response, and lifts the wire `Status`
+into the returned `Status{ok, code, err}`.
+
+---
+
+## 9. Sanity ceilings and failure modes
+
+- **Maximum payload**: 1 MiB. A header claiming more is treated as
+  corrupt and the connection is dropped (`BadFrame`).
+- **Truncated recv**: client and server both buffer partial frames and
+  retry on next read — never block.
+- **Cross-opcode reqID collisions**: avoided client-side by combining
+  `(op, reqID)` into a 16-bit correlator key.
+- **Listener thread crash**: client's outstanding promises are failed
+  with `runtime_error("listener exited")`; future requests get
+  `Status::ok = false` with `code = ECONNRESET`-equivalent diagnostic.
+
+---
+
+## 10. Divergences from Mihini EMP
+
+| Aspect              | Mihini EMP                              | Data-store EMP                                |
+|---------------------|-----------------------------------------|-----------------------------------------------|
+| Transport           | TCP `localhost:9999`                    | `AF_UNIX` SOCK_STREAM, default `/var/run/iot/data_store.sock` |
+| Opcode set          | 52 commands (SMS, FOTA, tables, …)      | 5 commands (`Set`/`Get`/`Reg`/`Rem`/`Notify`) |
+| Push mechanism      | Implicit per command-pair (e.g. `NewSMS`) | Explicit type-byte bit 1                    |
+| Status codes        | `swi_status_t`                           | Custom 0x8xxx range                          |
+| Welcome             | n/a                                      | n/a                                          |
+| Payload type        | JSON                                    | JSON, with typed values via `data_store::Value` |
+| reqID width         | 8 bits                                   | 8 bits (matched)                            |
+| Endian              | Big-endian                              | Big-endian (matched)                         |

--- a/modules/data-store/inc/data_store/client.hpp
+++ b/modules/data-store/inc/data_store/client.hpp
@@ -56,12 +56,10 @@ public:
     Client(Client&&) noexcept;
     Client& operator=(Client&&) noexcept;
 
-    /// Open the connection and start the listener thread.
+    /// Open the connection and start the listener thread. EMP has no
+    /// welcome handshake — the server is ready to receive frames as
+    /// soon as `connect()` returns ok.
     Status connect(std::string path = "");
-
-    /// Read the welcome line. Convenience: also consumable as the
-    /// first recv_event-style line if not called explicitly.
-    Status recv_welcome(std::string& out, std::int32_t timeout_ms = 1000);
 
     // --- ops --------------------------------------------------------
 

--- a/modules/data-store/inc/data_store/proto.hpp
+++ b/modules/data-store/inc/data_store/proto.hpp
@@ -1,40 +1,123 @@
 #ifndef __data_store_proto_hpp__
 #define __data_store_proto_hpp__
 
-/// Shared by client + server. Wire-protocol constants and string
-/// helpers per modules/data-store/docs/design.md §3.
+/// Embedded Micro Protocol (EMP) framing for the data-store wire.
 ///
-/// One JSON document per `\n`-terminated line, both directions.
-/// Helpers in this header avoid pulling nlohmann::json into every
-/// translation unit — see proto.cpp for the parsers.
+/// Modelled on Eclipse Mihini's EMP
+/// (https://wiki.eclipse.org/Mihini/Embedded_Micro_Protocol):
+/// fixed 8-byte big-endian header followed by a JSON payload.
+///
+///   offset  size  field
+///   ──────  ────  ─────────────────────────────────────────────
+///   0       2     cmdID            opcode (see Op below)
+///   2       1     type             frame kind, see FrameTypeBit
+///   3       1     reqID            request correlator, 0..255
+///   4       4     payload_size     big-endian, bytes of body
+///   8       N     payload          UTF-8 JSON document (or empty)
+///
+/// Type byte:
+///   bit 0 = 0  → Command  (client → server)
+///   bit 0 = 1  → Response (server → client, correlated by reqID)
+///   bit 1 = 1  → Push     (server → client, reqID = 0, no correlation;
+///                          repurposes Mihini's reserved bit 1 for
+///                          server-initiated notify, see protocol.md)
+///   bits 2..7 reserved (must be 0).
+///
+/// Responses carry a 2-byte big-endian `status` prefix INSIDE the
+/// payload (i.e. the JSON body, if any, starts at payload offset 2).
+/// status == 0 → success; any other value indicates failure, with the
+/// JSON body OPTIONALLY carrying `{"err":"..."}`. Pushes do NOT carry
+/// a status prefix — their full payload is JSON.
 
+#include <cstddef>
+#include <cstdint>
 #include <string>
-#include <vector>
+#include <string_view>
 
 namespace data_store::proto {
 
-/// All supported request operations.
-enum class Op {
-    Set,
-    Get,
-    Register,
-    Remove,
-    Unknown,
+// ─────────────────────────────── Opcodes ────────────────────────────
+
+enum class Op : std::uint16_t {
+    Unknown       = 0x0000,
+    Set           = 0x0001,   ///< Client → Server: write keys
+    Get           = 0x0002,   ///< Client → Server: read keys
+    RegisterWatch = 0x0003,   ///< Client → Server: subscribe keys
+    RemoveWatch   = 0x0004,   ///< Client → Server: unsubscribe keys
+    NotifyEvent   = 0x0064,   ///< Server → Client (push): value changed
 };
 
-/// Parse op-name strings the server is willing to accept. Unknown
-/// strings map to Op::Unknown so the dispatcher can reject them
-/// uniformly (REQ-DS-014).
-Op parse_op(const std::string& s);
+Op          parse_op(std::uint16_t raw);
 std::string op_name(Op op);
 
-/// Welcome line sent by the server on connect. Single line, ends
-/// with '\n'. D1 risk-gate uses this exact string.
-constexpr const char* kWelcomeLine =
-    "{\"ok\":true,\"hello\":\"data-store-server\",\"v\":1}\n";
+// ─────────────────────────────── Frame type ─────────────────────────
 
-/// Default unix-socket path and persistence file location, both
-/// overridable via CLI flags on the server.
+enum FrameTypeBit : std::uint8_t {
+    Response = 0x01,    ///< bit 0
+    Push     = 0x02,    ///< bit 1 — our extension of Mihini's reserved
+};
+
+inline bool is_command (std::uint8_t t) { return (t & (Response | Push)) == 0; }
+inline bool is_response(std::uint8_t t) { return (t & Response) != 0; }
+inline bool is_push    (std::uint8_t t) { return (t & Push)     != 0; }
+
+// ─────────────────────────────── Status codes ───────────────────────
+
+enum class Status : std::uint16_t {
+    Ok              = 0,
+    BadFrame        = 0x8001,   ///< malformed header / truncated payload
+    BadOpcode       = 0x8002,   ///< unknown / unsupported cmdID
+    BadPayload      = 0x8003,   ///< payload is not the JSON shape we expect
+    SchemaRejected  = 0x8004,   ///< SchemaRegistry::validate_set said no
+    NotFound        = 0x8005,   ///< (reserved for future single-key reads)
+    InternalError   = 0x8006,   ///< caught exception on the server side
+};
+
+const char* status_name(Status s);
+
+// ─────────────────────────────── Header (POD) ───────────────────────
+
+struct Header {
+    std::uint16_t cmdID        = 0;
+    std::uint8_t  type         = 0;
+    std::uint8_t  reqID        = 0;
+    std::uint32_t payload_size = 0;
+};
+
+constexpr std::size_t kHeaderSize = 8;
+
+/// Big-endian encode/decode of the 8-byte header. The helpers assume
+/// `out` has room for kHeaderSize bytes and `in` has at least
+/// kHeaderSize bytes available — callers gate on `buf.size() >= 8`.
+void encode_header(const Header& h, char* out);
+void decode_header(const char* in, Header& h);
+
+/// Append a complete frame (header + status-prefix-if-response + body)
+/// to `out`. `body` is the JSON document (or "") to ship. Responses
+/// stamp the 2-byte status BEFORE the body inside the payload.
+void encode_frame_command (Op op, std::uint8_t reqID,
+                           std::string_view body, std::string& out);
+void encode_frame_response(Op op, std::uint8_t reqID, Status st,
+                           std::string_view body, std::string& out);
+void encode_frame_push    (Op op,
+                           std::string_view body, std::string& out);
+
+/// Pull one complete frame off the front of `buf`. Returns:
+///   * true  — `header` + `payload` filled, frame removed from `buf`
+///   * false — not enough bytes yet (caller waits for more recv)
+/// On a malformed header (oversized payload past kMaxPayloadBytes)
+/// throws std::runtime_error so the caller can drop the connection.
+bool try_decode_frame(std::string& buf,
+                      Header& header,
+                      std::string& payload);
+
+/// Maximum accepted payload size. Hard ceiling so a malicious / buggy
+/// peer can't make us allocate gigabytes. 1 MiB is far more than any
+/// real Set/Get carrying a handful of keys needs.
+constexpr std::uint32_t kMaxPayloadBytes = 1u << 20;
+
+// ─────────────────────────────── Endpoint defaults ──────────────────
+
 constexpr const char* kDefaultSocketPath = "/var/run/iot/data_store.sock";
 constexpr const char* kDefaultStorePath  = "/var/lib/iot/data_store.lua";
 

--- a/modules/data-store/src/cli/ds_cli.cpp
+++ b/modules/data-store/src/cli/ds_cli.cpp
@@ -1,7 +1,6 @@
-/// ds-cli — debugging client for ds-server.
+/// ds-cli — debugging client for ds-server (EMP protocol).
 ///
 /// Usage:
-///   ds-cli [--socket=PATH] [welcome]
 ///   ds-cli [--socket=PATH] set <key> <value>
 ///   ds-cli [--socket=PATH] get <key> [<key>...]
 ///   ds-cli [--socket=PATH] watch [--count=N] <key> [<key>...]
@@ -40,7 +39,6 @@ void on_signal(int) { g_stop.store(true); }
 void usage() {
     std::cerr <<
         "Usage:\n"
-        "  ds-cli [--socket=PATH] [welcome]\n"
         "  ds-cli [--socket=PATH] set <key> <value>\n"
         "  ds-cli [--socket=PATH] get <key> [<key>...]\n"
         "  ds-cli [--socket=PATH] watch [--count=N] <key> [<key>...]\n"
@@ -49,7 +47,7 @@ void usage() {
 
 struct Args {
     std::string                 socket;
-    std::string                 cmd = "welcome";
+    std::string                 cmd;
     int                         count = 1;
     std::vector<std::string>    rest;
 };
@@ -75,14 +73,6 @@ Args parse(int argc, char** argv) {
         else                              a.rest.emplace_back(std::move(s));
     }
     return a;
-}
-
-int do_welcome(data_store::Client& cli) {
-    std::string w;
-    auto rs = cli.recv_welcome(w);
-    if (!rs.ok) { std::cerr << "[ds-cli] " << rs.err << "\n"; return 2; }
-    std::cout << w;
-    return 0;
 }
 
 /// Parse a CLI-supplied value into a Value. We try JSON first
@@ -136,7 +126,6 @@ std::string value_to_display(const data_store::Value& v) {
 
 int do_set(data_store::Client& cli, const std::vector<std::string>& a) {
     if (a.size() != 2) { usage(); return 2; }
-    std::string w; cli.recv_welcome(w);
     auto rs = cli.set(a[0], parse_cli_value(a[1]));
     if (!rs.ok) { std::cerr << "[ds-cli] set: " << rs.err << "\n"; return 2; }
     std::cout << "ok\n";
@@ -145,7 +134,6 @@ int do_set(data_store::Client& cli, const std::vector<std::string>& a) {
 
 int do_get(data_store::Client& cli, const std::vector<std::string>& keys) {
     if (keys.empty()) { usage(); return 2; }
-    std::string w; cli.recv_welcome(w);
     std::vector<data_store::Client::GetResult> got;
     auto rs = cli.get(keys, got);
     if (!rs.ok) { std::cerr << "[ds-cli] get: " << rs.err << "\n"; return 2; }
@@ -159,7 +147,6 @@ int do_get(data_store::Client& cli, const std::vector<std::string>& keys) {
 int do_watch(data_store::Client& cli, const std::vector<std::string>& keys,
              int count) {
     if (keys.empty()) { usage(); return 2; }
-    std::string w; cli.recv_welcome(w);
 
     // Use the callback API so the wire-level demo matches the
     // production pattern: an app registers a handler and keeps going;
@@ -197,7 +184,6 @@ int do_watch(data_store::Client& cli, const std::vector<std::string>& keys,
 
 int do_unwatch(data_store::Client& cli, const std::vector<std::string>& keys) {
     if (keys.empty()) { usage(); return 2; }
-    std::string w; cli.recv_welcome(w);
     auto rs = cli.unwatch(keys);
     if (!rs.ok) { std::cerr << "[ds-cli] unwatch: " << rs.err << "\n"; return 2; }
     std::cout << "ok\n";
@@ -217,8 +203,7 @@ int main(int argc, char** argv) {
         return 1;
     }
 
-    if      (a.cmd == "welcome") return do_welcome(cli);
-    else if (a.cmd == "set")     return do_set(cli, a.rest);
+    if      (a.cmd == "set")     return do_set(cli, a.rest);
     else if (a.cmd == "get")     return do_get(cli, a.rest);
     else if (a.cmd == "watch")   return do_watch(cli, a.rest, a.count);
     else if (a.cmd == "unwatch") return do_unwatch(cli, a.rest);

--- a/modules/data-store/src/client/client.cpp
+++ b/modules/data-store/src/client/client.cpp
@@ -11,6 +11,7 @@
 #include <future>
 #include <mutex>
 #include <stdexcept>
+#include <string_view>
 #include <sys/socket.h>
 #include <sys/un.h>
 #include <thread>
@@ -41,13 +42,29 @@ Status protocol_err(const std::string& what) {
     Status s; s.ok = false; s.err = what; return s;
 }
 
-std::atomic<std::uint64_t> g_next_id{1};
+/// reqID is the EMP correlator; 8 bits → 256 slots → wrap every 256
+/// requests. Listener thread uses 16-bit (op<<8 | reqID) so concurrent
+/// reqs on different opcodes don't collide.
+std::atomic<std::uint8_t>  g_next_reqid{1};
 std::atomic<std::uint64_t> g_next_handle{1};
 
 struct WatchEntry {
     std::vector<std::string>      keys;
     Client::EventCallback         cb;
 };
+
+struct PendingValue {
+    proto::Status status = proto::Status::Ok;
+    json          body;
+};
+
+/// 16-bit correlator combines opcode + reqID so two in-flight ops on
+/// the same reqID slot don't collide. We never queue >256 of any one
+/// opcode in flight; that's the EMP / Mihini ceiling.
+inline std::uint16_t corr_key(proto::Op op, std::uint8_t reqID) {
+    return static_cast<std::uint16_t>(
+        (static_cast<std::uint16_t>(op) << 8) | reqID);
+}
 
 } // namespace
 
@@ -61,15 +78,9 @@ public:
     std::thread          listener;
     std::atomic<bool>    stop_listener{false};
 
-    // id → pending promise (fulfilled by the listener thread).
-    std::mutex                                            pending_mtx;
-    std::unordered_map<std::uint64_t, std::promise<json>> pending;
-
-    // Welcome line bookkeeping.
-    std::mutex                  welcome_mtx;
-    std::condition_variable     welcome_cv;
-    std::string                 welcome_line;
-    bool                        welcome_received = false;
+    // corr_key → pending promise (fulfilled by the listener thread).
+    std::mutex                                                  pending_mtx;
+    std::unordered_map<std::uint16_t, std::promise<PendingValue>> pending;
 
     // Pull-style event queue.
     std::mutex                  events_mtx;
@@ -81,53 +92,59 @@ public:
     std::unordered_map<WatchHandle, WatchEntry>             watches;
     std::unordered_map<std::string, std::size_t>            key_refcount;
 
-    Status send_json(const std::string& body);
-    Status round_trip(json& req, json& resp, std::int32_t timeout_ms);
+    Status send_frame(const std::string& frame);
+    Status round_trip(proto::Op op, std::string_view body,
+                      PendingValue& out, std::int32_t timeout_ms);
     void   run_listener();
     void   fail_all_pending(const std::string& why);
 };
 
-Status Client::Impl::send_json(const std::string& body) {
-    std::string line = body + "\n";
-    ssize_t n = stream.send_n(line.data(), line.size());
-    if (n < 0 || static_cast<std::size_t>(n) != line.size()) {
+Status Client::Impl::send_frame(const std::string& frame) {
+    if (frame.empty()) return {};
+    ssize_t n = stream.send_n(frame.data(), frame.size());
+    if (n < 0 || static_cast<std::size_t>(n) != frame.size()) {
         return sys_err("send_n");
     }
     return {};
 }
 
-Status Client::Impl::round_trip(json& req, json& resp,
+Status Client::Impl::round_trip(proto::Op op,
+                                std::string_view body,
+                                PendingValue& out,
                                 std::int32_t timeout_ms) {
     if (!connected.load()) return protocol_err("not connected");
 
-    const std::uint64_t id = g_next_id.fetch_add(1);
-    req["id"] = id;
+    const std::uint8_t  reqID = g_next_reqid.fetch_add(1);
+    const std::uint16_t key   = corr_key(op, reqID);
 
-    std::promise<json>  prom;
-    std::future<json>   fut = prom.get_future();
+    std::promise<PendingValue>  prom;
+    std::future<PendingValue>   fut = prom.get_future();
     {
         std::lock_guard<std::mutex> g(pending_mtx);
-        pending.emplace(id, std::move(prom));
+        pending.emplace(key, std::move(prom));
     }
 
-    auto ss = send_json(req.dump());
+    std::string frame;
+    proto::encode_frame_command(op, reqID, body, frame);
+    auto ss = send_frame(frame);
     if (!ss.ok) {
         std::lock_guard<std::mutex> g(pending_mtx);
-        pending.erase(id);
+        pending.erase(key);
         return ss;
     }
 
     using namespace std::chrono;
     if (fut.wait_for(milliseconds(timeout_ms)) != std::future_status::ready) {
         std::lock_guard<std::mutex> g(pending_mtx);
-        pending.erase(id);
+        pending.erase(key);
         Status s; s.ok=false; s.code=ETIMEDOUT;
-        s.err = "request timeout (id=" + std::to_string(id) + ")";
+        s.err = "request timeout (op=" + proto::op_name(op) +
+                " reqID=" + std::to_string(reqID) + ")";
         return s;
     }
 
     try {
-        resp = fut.get();
+        out = fut.get();
     } catch (const std::exception& e) {
         return protocol_err(std::string("promise broken: ") + e.what());
     }
@@ -149,31 +166,28 @@ void Client::Impl::run_listener() {
 
         buf.append(chunk, static_cast<std::size_t>(n));
 
-        for (;;) {
-            auto pos = buf.find('\n');
-            if (pos == std::string::npos) break;
-            std::string line = buf.substr(0, pos);
-            buf.erase(0, pos + 1);
-            if (line.empty()) continue;
-
-            json p;
-            try { p = json::parse(line); } catch (...) { continue; }
-
-            // Welcome (server's first line — `hello` field).
-            {
-                std::lock_guard<std::mutex> g(welcome_mtx);
-                if (!welcome_received && p.contains("hello")) {
-                    welcome_line     = line + "\n";
-                    welcome_received = true;
-                    welcome_cv.notify_all();
-                    continue;
-                }
+        // Drain as many complete EMP frames as the recv buffer holds.
+        while (true) {
+            proto::Header h;
+            std::string   payload;
+            try {
+                if (!proto::try_decode_frame(buf, h, payload)) break;
+            } catch (const std::exception&) {
+                // Corrupt header → drop connection.
+                stop_listener.store(true);
+                break;
             }
 
-            // Notify push.
-            if (p.contains("ev")) {
+            const proto::Op op = proto::parse_op(h.cmdID);
+
+            if (proto::is_push(h.type)) {
+                // Push: payload is the JSON body (no status prefix).
+                if (op != proto::Op::NotifyEvent) continue;
+                json p;
+                try { p = json::parse(payload); } catch (...) { continue; }
+
                 Event ev;
-                ev.key   = p.value("k", "");
+                ev.key = p.value("k", "");
                 if (p.contains("v")) ev.value = value_from_json(p["v"]);
                 if (p.contains("prev") && !p["prev"].is_null()) {
                     ev.prev           = value_from_json(p["prev"]);
@@ -185,11 +199,10 @@ void Client::Impl::run_listener() {
                     events.push_back(ev);
                     events_cv.notify_one();
                 }
-
                 std::vector<EventCallback> cbs;
                 {
                     std::lock_guard<std::mutex> g(watches_mtx);
-                    for (const auto& [h, w] : watches) {
+                    for (const auto& [hnd, w] : watches) {
                         for (const auto& k : w.keys) {
                             if (k == ev.key) { cbs.push_back(w.cb); break; }
                         }
@@ -201,23 +214,41 @@ void Client::Impl::run_listener() {
                 continue;
             }
 
-            // Response: ok + id → fulfill promise.
-            if (p.contains("ok") && p.contains("id")) {
-                std::uint64_t id = p["id"].get<std::uint64_t>();
-                std::promise<json> prom;
-                bool found = false;
-                {
-                    std::lock_guard<std::mutex> g(pending_mtx);
-                    auto it = pending.find(id);
-                    if (it != pending.end()) {
-                        prom  = std::move(it->second);
-                        pending.erase(it);
-                        found = true;
+            if (!proto::is_response(h.type)) continue;  // ignore
+
+            // Response: first 2 payload bytes = status, rest = JSON body.
+            PendingValue v;
+            if (payload.size() < 2) {
+                v.status = proto::Status::BadFrame;
+            } else {
+                v.status = static_cast<proto::Status>(
+                    (static_cast<std::uint8_t>(payload[0]) << 8) |
+                     static_cast<std::uint8_t>(payload[1]));
+                if (payload.size() > 2) {
+                    try {
+                        v.body = json::parse(payload.data() + 2,
+                                             payload.data() + payload.size());
+                    } catch (...) {
+                        // Tolerate empty / unparseable body — status
+                        // already conveys success/failure.
                     }
                 }
-                if (found) {
-                    try { prom.set_value(std::move(p)); } catch (...) {}
+            }
+
+            const std::uint16_t key = corr_key(op, h.reqID);
+            std::promise<PendingValue> prom;
+            bool found = false;
+            {
+                std::lock_guard<std::mutex> g(pending_mtx);
+                auto it = pending.find(key);
+                if (it != pending.end()) {
+                    prom  = std::move(it->second);
+                    pending.erase(it);
+                    found = true;
                 }
+            }
+            if (found) {
+                try { prom.set_value(std::move(v)); } catch (...) {}
             }
         }
     }
@@ -225,18 +256,13 @@ void Client::Impl::run_listener() {
     fail_all_pending("listener exited");
 
     {
-        std::lock_guard<std::mutex> g(welcome_mtx);
-        welcome_received = true;
-        welcome_cv.notify_all();
-    }
-    {
         std::lock_guard<std::mutex> g(events_mtx);
         events_cv.notify_all();
     }
 }
 
 void Client::Impl::fail_all_pending(const std::string& why) {
-    std::unordered_map<std::uint64_t, std::promise<json>> snapshot;
+    std::unordered_map<std::uint16_t, std::promise<PendingValue>> snapshot;
     {
         std::lock_guard<std::mutex> g(pending_mtx);
         snapshot.swap(pending);
@@ -277,73 +303,80 @@ Status Client::connect(std::string path) {
     return {};
 }
 
-Status Client::recv_welcome(std::string& out, std::int32_t timeout_ms) {
-    if (!m_impl->connected.load()) return protocol_err("not connected");
-    std::unique_lock<std::mutex> g(m_impl->welcome_mtx);
-    if (!m_impl->welcome_cv.wait_for(g,
-            std::chrono::milliseconds(timeout_ms),
-            [&]() { return m_impl->welcome_received; })) {
-        Status s; s.ok=false; s.code=ETIMEDOUT;
-        s.err = "welcome timeout"; return s;
+namespace {
+
+/// Translate a wire-level status + optional error body into a
+/// caller-friendly Status. Ok → empty Status{}, anything else gets
+/// the err string lifted from the body when present.
+Status status_from(const PendingValue& v, const char* op_label) {
+    if (v.status == proto::Status::Ok) return {};
+    Status s; s.ok = false;
+    s.code = static_cast<int>(v.status);
+    if (v.body.is_object() && v.body.contains("err") &&
+        v.body["err"].is_string()) {
+        s.err = v.body["err"].get<std::string>();
+    } else {
+        s.err = std::string(op_label) + " failed (status=" +
+                proto::status_name(v.status) + ")";
     }
-    if (m_impl->welcome_line.empty()) {
-        return protocol_err("connection closed before welcome");
-    }
-    out = m_impl->welcome_line;
-    return {};
+    return s;
 }
+
+} // namespace
 
 Status Client::set(const std::vector<KV>& pairs, std::int32_t timeout_ms) {
     json req;
-    req["op"]   = "set";
     req["keys"] = json::array();
     for (const auto& kv : pairs) {
-        // Wire shape: each entry is a single-key object whose value
-        // round-trips through JSON's native type system.
+        // Wire shape per opcode 0x0001 Set: keys is an array of
+        // single-key objects so each value round-trips through JSON's
+        // native type system.
         json e;
         e[kv.first] = value_to_json(kv.second);
         req["keys"].push_back(e);
     }
-    json resp;
-    auto rs = m_impl->round_trip(req, resp, timeout_ms);
+    const std::string body = req.dump();
+    PendingValue out;
+    auto rs = m_impl->round_trip(proto::Op::Set,
+                                 std::string_view(body.data(), body.size()),
+                                 out, timeout_ms);
     if (!rs.ok) return rs;
-    if (!resp.value("ok", false)) {
-        return protocol_err(resp.value("err", "set failed"));
-    }
-    return {};
+    return status_from(out, "set");
 }
 
 Status Client::get(const std::vector<std::string>& keys,
-                   std::vector<GetResult>&         out,
+                   std::vector<GetResult>&         out_results,
                    std::int32_t                    timeout_ms) {
-    out.clear();
+    out_results.clear();
     json req;
-    req["op"]   = "get";
     req["keys"] = keys;
-    json resp;
-    auto rs = m_impl->round_trip(req, resp, timeout_ms);
+    const std::string body = req.dump();
+    PendingValue out;
+    auto rs = m_impl->round_trip(proto::Op::Get,
+                                 std::string_view(body.data(), body.size()),
+                                 out, timeout_ms);
     if (!rs.ok) return rs;
-    if (!resp.value("ok", false)) {
-        return protocol_err(resp.value("err", "get failed"));
-    }
-    if (!resp.contains("data") || !resp["data"].is_array()) {
+    auto err = status_from(out, "get");
+    if (!err.ok) return err;
+    if (!out.body.is_object() || !out.body.contains("data") ||
+        !out.body["data"].is_array()) {
         return protocol_err("get response missing data array");
     }
-    for (const auto& item : resp["data"]) {
+    for (const auto& item : out.body["data"]) {
         GetResult g;
         g.key = item.value("k", "");
         if (item.contains("v") && !item["v"].is_null()) {
             g.value     = value_from_json(item["v"]);
             g.has_value = true;
         }
-        out.push_back(std::move(g));
+        out_results.push_back(std::move(g));
     }
     return {};
 }
 
 Status Client::watch(const std::vector<std::string>& keys,
                      std::int32_t                    timeout_ms) {
-    // Pull-style: bump local refcount, only send wire `register`
+    // Pull-style: bump local refcount, only send wire RegisterWatch
     // for keys that just transitioned 0 → 1.
     std::vector<std::string> wireKeys;
     {
@@ -355,10 +388,12 @@ Status Client::watch(const std::vector<std::string>& keys,
     if (wireKeys.empty()) return {};
 
     json req;
-    req["op"]   = "register";
     req["keys"] = wireKeys;
-    json resp;
-    auto rs = m_impl->round_trip(req, resp, timeout_ms);
+    const std::string body = req.dump();
+    PendingValue out;
+    auto rs = m_impl->round_trip(proto::Op::RegisterWatch,
+                                 std::string_view(body.data(), body.size()),
+                                 out, timeout_ms);
     if (!rs.ok) {
         std::lock_guard<std::mutex> g(m_impl->watches_mtx);
         for (const auto& k : wireKeys) {
@@ -369,10 +404,7 @@ Status Client::watch(const std::vector<std::string>& keys,
         }
         return rs;
     }
-    if (!resp.value("ok", false)) {
-        return protocol_err(resp.value("err", "watch failed"));
-    }
-    return {};
+    return status_from(out, "watch");
 }
 
 Status Client::watch(const std::vector<std::string>& keys,
@@ -429,15 +461,14 @@ Status Client::unwatch(const std::vector<std::string>& keys,
     if (wireKeys.empty()) return {};
 
     json req;
-    req["op"]   = "remove";
     req["keys"] = wireKeys;
-    json resp;
-    auto rs = m_impl->round_trip(req, resp, timeout_ms);
+    const std::string body = req.dump();
+    PendingValue out;
+    auto rs = m_impl->round_trip(proto::Op::RemoveWatch,
+                                 std::string_view(body.data(), body.size()),
+                                 out, timeout_ms);
     if (!rs.ok) return rs;
-    if (!resp.value("ok", false)) {
-        return protocol_err(resp.value("err", "unwatch failed"));
-    }
-    return {};
+    return status_from(out, "unwatch");
 }
 
 Status Client::recv_event(Event& out, std::int32_t timeout_ms) {
@@ -463,11 +494,6 @@ void Client::close() {
         if (m_impl->listener.joinable()) m_impl->listener.join();
         m_impl->stream.close();
         m_impl->fail_all_pending("client closed");
-        {
-            std::lock_guard<std::mutex> g(m_impl->welcome_mtx);
-            m_impl->welcome_received = true;
-            m_impl->welcome_cv.notify_all();
-        }
         {
             std::lock_guard<std::mutex> g(m_impl->events_mtx);
             m_impl->events_cv.notify_all();

--- a/modules/data-store/src/proto/proto.cpp
+++ b/modules/data-store/src/proto/proto.cpp
@@ -1,24 +1,150 @@
 #include "data_store/proto.hpp"
 
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+
 namespace data_store::proto {
 
-Op parse_op(const std::string& s) {
-    if (s == "set")      return Op::Set;
-    if (s == "get")      return Op::Get;
-    if (s == "register") return Op::Register;
-    if (s == "remove")   return Op::Remove;
-    return Op::Unknown;
+// ─────────────────────────────── opcodes ────────────────────────────
+
+Op parse_op(std::uint16_t raw) {
+    switch (raw) {
+        case static_cast<std::uint16_t>(Op::Set):           return Op::Set;
+        case static_cast<std::uint16_t>(Op::Get):           return Op::Get;
+        case static_cast<std::uint16_t>(Op::RegisterWatch): return Op::RegisterWatch;
+        case static_cast<std::uint16_t>(Op::RemoveWatch):   return Op::RemoveWatch;
+        case static_cast<std::uint16_t>(Op::NotifyEvent):   return Op::NotifyEvent;
+        default:                                            return Op::Unknown;
+    }
 }
 
 std::string op_name(Op op) {
     switch (op) {
-        case Op::Set:      return "set";
-        case Op::Get:      return "get";
-        case Op::Register: return "register";
-        case Op::Remove:   return "remove";
-        case Op::Unknown:  break;
+        case Op::Set:           return "Set";
+        case Op::Get:           return "Get";
+        case Op::RegisterWatch: return "RegisterWatch";
+        case Op::RemoveWatch:   return "RemoveWatch";
+        case Op::NotifyEvent:   return "NotifyEvent";
+        case Op::Unknown:       break;
     }
-    return "unknown";
+    return "Unknown";
+}
+
+const char* status_name(Status s) {
+    switch (s) {
+        case Status::Ok:             return "Ok";
+        case Status::BadFrame:       return "BadFrame";
+        case Status::BadOpcode:      return "BadOpcode";
+        case Status::BadPayload:     return "BadPayload";
+        case Status::SchemaRejected: return "SchemaRejected";
+        case Status::NotFound:       return "NotFound";
+        case Status::InternalError:  return "InternalError";
+    }
+    return "Unknown";
+}
+
+// ─────────────────────────────── header codec ───────────────────────
+
+namespace {
+
+inline void write_u16_be(std::uint16_t v, char* out) {
+    out[0] = static_cast<char>((v >> 8) & 0xff);
+    out[1] = static_cast<char>( v       & 0xff);
+}
+
+inline void write_u32_be(std::uint32_t v, char* out) {
+    out[0] = static_cast<char>((v >> 24) & 0xff);
+    out[1] = static_cast<char>((v >> 16) & 0xff);
+    out[2] = static_cast<char>((v >>  8) & 0xff);
+    out[3] = static_cast<char>( v        & 0xff);
+}
+
+inline std::uint16_t read_u16_be(const char* in) {
+    return static_cast<std::uint16_t>(
+        (static_cast<std::uint8_t>(in[0]) << 8) |
+         static_cast<std::uint8_t>(in[1]));
+}
+
+inline std::uint32_t read_u32_be(const char* in) {
+    return (static_cast<std::uint32_t>(static_cast<std::uint8_t>(in[0])) << 24) |
+           (static_cast<std::uint32_t>(static_cast<std::uint8_t>(in[1])) << 16) |
+           (static_cast<std::uint32_t>(static_cast<std::uint8_t>(in[2])) <<  8) |
+            static_cast<std::uint32_t>(static_cast<std::uint8_t>(in[3]));
+}
+
+void append_header(Op op, std::uint8_t type, std::uint8_t reqID,
+                   std::uint32_t payload_size, std::string& out) {
+    char hdr[kHeaderSize];
+    write_u16_be(static_cast<std::uint16_t>(op), hdr);
+    hdr[2] = static_cast<char>(type);
+    hdr[3] = static_cast<char>(reqID);
+    write_u32_be(payload_size, hdr + 4);
+    out.append(hdr, kHeaderSize);
+}
+
+} // namespace
+
+void encode_header(const Header& h, char* out) {
+    write_u16_be(h.cmdID, out);
+    out[2] = static_cast<char>(h.type);
+    out[3] = static_cast<char>(h.reqID);
+    write_u32_be(h.payload_size, out + 4);
+}
+
+void decode_header(const char* in, Header& h) {
+    h.cmdID        = read_u16_be(in);
+    h.type         = static_cast<std::uint8_t>(in[2]);
+    h.reqID        = static_cast<std::uint8_t>(in[3]);
+    h.payload_size = read_u32_be(in + 4);
+}
+
+// ─────────────────────────────── frame encode ───────────────────────
+
+void encode_frame_command(Op op, std::uint8_t reqID,
+                          std::string_view body, std::string& out) {
+    append_header(op, /*type=*/0, reqID,
+                  static_cast<std::uint32_t>(body.size()), out);
+    out.append(body.data(), body.size());
+}
+
+void encode_frame_response(Op op, std::uint8_t reqID, Status st,
+                           std::string_view body, std::string& out) {
+    // Responses prefix the 2-byte big-endian status INSIDE the payload.
+    const std::uint32_t plen = static_cast<std::uint32_t>(2 + body.size());
+    append_header(op, /*type=*/Response, reqID, plen, out);
+    char st_bytes[2];
+    write_u16_be(static_cast<std::uint16_t>(st), st_bytes);
+    out.append(st_bytes, 2);
+    out.append(body.data(), body.size());
+}
+
+void encode_frame_push(Op op,
+                       std::string_view body, std::string& out) {
+    // No reqID correlation, no status prefix — payload IS the JSON body.
+    append_header(op, /*type=*/Push, /*reqID=*/0,
+                  static_cast<std::uint32_t>(body.size()), out);
+    out.append(body.data(), body.size());
+}
+
+// ─────────────────────────────── frame decode ───────────────────────
+
+bool try_decode_frame(std::string& buf,
+                      Header& header,
+                      std::string& payload) {
+    if (buf.size() < kHeaderSize) return false;
+    decode_header(buf.data(), header);
+    if (header.payload_size > kMaxPayloadBytes) {
+        throw std::runtime_error(
+            "EMP payload_size " + std::to_string(header.payload_size) +
+            " exceeds ceiling " + std::to_string(kMaxPayloadBytes));
+    }
+    const std::size_t need = kHeaderSize + header.payload_size;
+    if (buf.size() < need) return false;
+    payload.assign(buf.data() + kHeaderSize, header.payload_size);
+    buf.erase(0, need);
+    return true;
 }
 
 } // namespace data_store::proto

--- a/modules/data-store/src/server/server.cpp
+++ b/modules/data-store/src/server/server.cpp
@@ -134,11 +134,8 @@ int Server::handle_input(ACE_HANDLE /*fd*/) {
         m_sessions.insert(s);
     }
 
-    // Send welcome inline so the client knows the connection is live
-    // before issuing any request. ProcessRequest messages can already
-    // follow asynchronously.
-    s->send(proto::kWelcomeLine);
-
+    // EMP has no welcome handshake — the server is ready to receive
+    // frames as soon as the socket is registered with the reactor.
     if (ACE_Reactor::instance()->register_handler(
             s, ACE_Event_Handler::READ_MASK) == -1) {
         ACE_ERROR((LM_ERROR,

--- a/modules/data-store/src/server/session.cpp
+++ b/modules/data-store/src/server/session.cpp
@@ -1,11 +1,13 @@
 #include "session.hpp"
 
 #include "data_store.hpp"
+#include "data_store/proto.hpp"
 #include "server.hpp"
 #include "worker.hpp"
 
 #include <cerrno>
 #include <cstring>
+#include <stdexcept>
 
 #include <ace/Log_Msg.h>
 #include <ace/Reactor.h>
@@ -27,8 +29,11 @@ ACE_HANDLE Session::get_handle() const {
 }
 
 int Session::handle_input(ACE_HANDLE /*fd*/) {
-    // Reactor thread: read what's available, split on '\n', enqueue
-    // each complete line as a ProcessRequest to the owner Worker.
+    // Reactor thread: read what's available, extract complete EMP
+    // frames (header + payload), and enqueue each as a ProcessRequest
+    // for the owner Worker. The worker decodes the header to dispatch
+    // — keeping the reactor path bytes-only minimises lock/parse work
+    // on the shared thread.
     char buf[4096];
     ssize_t n = m_stream.recv(buf, sizeof(buf));
     if (n <= 0) {
@@ -39,15 +44,34 @@ int Session::handle_input(ACE_HANDLE /*fd*/) {
     m_recvBuf.append(buf, static_cast<std::size_t>(n));
 
     for (;;) {
-        auto pos = m_recvBuf.find('\n');
-        if (pos == std::string::npos) break;
-        std::string line = m_recvBuf.substr(0, pos);
-        m_recvBuf.erase(0, pos + 1);
-        if (line.empty()) continue;
+        proto::Header h;
+        std::string   payload;
+        bool got = false;
+        try {
+            // Peek at the header without consuming, so we can compute
+            // the full frame length, then carve out [header || body]
+            // as a single contiguous blob for the worker to redecode.
+            if (m_recvBuf.size() < proto::kHeaderSize) break;
+            proto::decode_header(m_recvBuf.data(), h);
+            if (h.payload_size > proto::kMaxPayloadBytes) {
+                throw std::runtime_error("oversized payload");
+            }
+            const std::size_t need = proto::kHeaderSize + h.payload_size;
+            if (m_recvBuf.size() < need) break;
+            payload.assign(m_recvBuf.data(), need);
+            m_recvBuf.erase(0, need);
+            got = true;
+        } catch (const std::exception& e) {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [Session:%t] %M %N:%l bad EMP frame: "
+                                "%C — dropping connection\n"),
+                       e.what()));
+            return -1;
+        }
 
-        if (m_owner) {
+        if (got && m_owner) {
             auto* msg = new WorkMsg{
-                WorkKind::ProcessRequest, this, std::move(line)};
+                WorkKind::ProcessRequest, this, std::move(payload)};
             if (m_owner->enqueue(msg) == -1) {
                 ACE_ERROR((LM_ERROR,
                            ACE_TEXT("%D [Session:%t] %M %N:%l enqueue "

--- a/modules/data-store/src/server/worker.cpp
+++ b/modules/data-store/src/server/worker.cpp
@@ -10,6 +10,7 @@
 
 #include <algorithm>
 #include <cstring>
+#include <string_view>
 
 #include <ace/Log_Msg.h>
 #include <ace/Message_Block.h>
@@ -33,26 +34,43 @@ WorkMsg* unwrap_block(ACE_Message_Block* mb) {
     return *reinterpret_cast<WorkMsg**>(mb->rd_ptr());
 }
 
-/// Build a `{"ok":false,"id":...,"err":"..."}` response line.
-std::string error_response(const json& reqId, const std::string& msg) {
-    json r;
-    r["ok"]  = false;
-    if (!reqId.is_null()) r["id"] = reqId;
-    r["err"] = msg;
-    return r.dump() + "\n";
+/// Encode an EMP response carrying optional JSON body and a status.
+/// Body of "" + status Ok is a bare ack; non-Ok statuses are paired
+/// with `{"err":"..."}` for human-readable diagnostics.
+std::string encode_response(proto::Op    op,
+                            std::uint8_t reqID,
+                            proto::Status st,
+                            const json&  body) {
+    std::string out;
+    const std::string s = body.is_null() ? std::string{} : body.dump();
+    proto::encode_frame_response(op, reqID, st,
+                                 std::string_view(s.data(), s.size()), out);
+    return out;
 }
 
-/// Build a `{"ev":"changed","k":"...","v":<typed>,"prev":<typed>}` line.
-std::string notify_line(const std::string& key,
-                        const Value& newValue,
-                        const std::optional<Value>& prev) {
-    json r;
-    r["ev"] = "changed";
-    r["k"]  = key;
-    r["v"]  = value_to_json(newValue);
-    if (prev.has_value()) r["prev"] = value_to_json(*prev);
-    else                  r["prev"] = nullptr;
-    return r.dump() + "\n";
+std::string encode_error(proto::Op    op,
+                         std::uint8_t reqID,
+                         proto::Status st,
+                         const std::string& msg) {
+    json b;
+    b["err"] = msg;
+    return encode_response(op, reqID, st, b);
+}
+
+/// Encode a NotifyEvent push frame (server → client, no correlation).
+std::string encode_notify_push(const std::string& key,
+                               const Value&       newValue,
+                               const std::optional<Value>& prev) {
+    json b;
+    b["k"] = key;
+    b["v"] = value_to_json(newValue);
+    if (prev.has_value()) b["prev"] = value_to_json(*prev);
+    else                  b["prev"] = nullptr;
+    std::string out;
+    const std::string s = b.dump();
+    proto::encode_frame_push(proto::Op::NotifyEvent,
+                             std::string_view(s.data(), s.size()), out);
+    return out;
 }
 
 } // namespace
@@ -146,35 +164,57 @@ void Worker::handle_process_request(WorkMsg* msg) {
     Session* s = msg->session;
     if (!s) return;
 
+    // msg->payload holds the FULL raw EMP frame (header || body).
+    // session.cpp already validated payload_size against
+    // kMaxPayloadBytes; here we trust the bounds.
+    if (msg->payload.size() < proto::kHeaderSize) {
+        return; // pathological — drop quietly, reactor will close on next read
+    }
+    proto::Header h{};
+    proto::decode_header(msg->payload.data(), h);
+    const char*  body_ptr = msg->payload.data() + proto::kHeaderSize;
+    const std::size_t body_len = msg->payload.size() - proto::kHeaderSize;
+
+    // EMP requests carry no status prefix — the JSON body starts at
+    // payload offset 0.
     json req;
-    json reqId;
-    try {
-        req = json::parse(msg->payload);
-        if (req.contains("id")) reqId = req["id"];
-    } catch (const std::exception& e) {
-        s->send(error_response(reqId, std::string("bad json: ") + e.what()));
-        return;
+    if (body_len > 0) {
+        try {
+            req = json::parse(body_ptr, body_ptr + body_len);
+        } catch (const std::exception& e) {
+            s->send(encode_error(proto::parse_op(h.cmdID), h.reqID,
+                                 proto::Status::BadPayload,
+                                 std::string("bad json: ") + e.what()));
+            return;
+        }
     }
 
-    if (!req.is_object() || !req.contains("op") || !req["op"].is_string()) {
-        s->send(error_response(reqId, "missing op"));
-        return;
-    }
-
-    const std::string opStr = req["op"].get<std::string>();
-    const proto::Op   op    = proto::parse_op(opStr);
+    const proto::Op op = proto::parse_op(h.cmdID);
     if (op == proto::Op::Unknown) {
-        s->send(error_response(reqId, "unknown op '" + opStr + "'"));
-        return;
-    }
-    if (!req.contains("keys") || !req["keys"].is_array()) {
-        s->send(error_response(reqId, "missing keys array"));
+        s->send(encode_error(op, h.reqID, proto::Status::BadOpcode,
+                             "unknown opcode 0x" +
+                             [&]{
+                                 char b[8];
+                                 std::snprintf(b, sizeof(b), "%04x", h.cmdID);
+                                 return std::string(b);
+                             }()));
         return;
     }
 
-    json resp;
-    resp["ok"] = true;
-    if (!reqId.is_null()) resp["id"] = reqId;
+    if (!proto::is_command(h.type)) {
+        // Server only consumes commands. Responses / pushes from a
+        // client violate the protocol — drop with BadFrame.
+        s->send(encode_error(op, h.reqID, proto::Status::BadFrame,
+                             "expected command frame"));
+        return;
+    }
+
+    // All four request opcodes carry `keys: [...]` in the body.
+    if (!req.is_object() || !req.contains("keys") || !req["keys"].is_array()) {
+        s->send(encode_error(op, h.reqID, proto::Status::BadPayload,
+                             "missing keys array"));
+        return;
+    }
 
     switch (op) {
         case proto::Op::Set: {
@@ -183,15 +223,16 @@ void Worker::handle_process_request(WorkMsg* msg) {
             // the wire so the initiating client sees its ack before
             // peers see the push.
             struct Push {
-                Session*                 watcher;
-                std::string              line;
+                Session*     watcher;
+                std::string  frame;
             };
             std::vector<Push> pushes;
 
             for (const auto& e : req["keys"]) {
                 if (!e.is_object() || e.size() != 1) {
-                    s->send(error_response(
-                        reqId, "set entry must be a single-key object"));
+                    s->send(encode_error(op, h.reqID,
+                                         proto::Status::BadPayload,
+                                         "set entry must be a single-key object"));
                     return;
                 }
                 auto it = e.begin();
@@ -203,28 +244,31 @@ void Worker::handle_process_request(WorkMsg* msg) {
                 if (m_schema) {
                     auto err = m_schema->validate_set(k, v);
                     if (err) {
-                        s->send(error_response(reqId, *err));
+                        s->send(encode_error(op, h.reqID,
+                                             proto::Status::SchemaRejected,
+                                             *err));
                         return;
                     }
                 }
                 auto r = m_store->set(k, v);
                 if (!r.changed) continue;
-                std::string line = notify_line(k, v, r.prev);
+                std::string frame = encode_notify_push(k, v, r.prev);
                 for (Session* w : r.watchers) {
                     if (!w) continue;
-                    pushes.push_back({w, line});
+                    pushes.push_back({w, frame});
                 }
             }
-            s->send(resp.dump() + "\n");
+            s->send(encode_response(op, h.reqID, proto::Status::Ok, json{}));
 
             // Notify fan-out: same-Worker → write directly; cross-Worker
-            // → enqueue DeliverNotify on the watcher's owner Worker.
+            // → enqueue DeliverNotify on the watcher's owner Worker
+            // carrying the pre-encoded push frame.
             for (auto& p : pushes) {
                 if (p.watcher->owner() == this) {
-                    p.watcher->send(p.line);
+                    p.watcher->send(p.frame);
                 } else if (p.watcher->owner()) {
                     auto* m = new WorkMsg{
-                        WorkKind::DeliverNotify, p.watcher, p.line};
+                        WorkKind::DeliverNotify, p.watcher, p.frame};
                     p.watcher->owner()->enqueue(m);
                 }
             }
@@ -232,10 +276,13 @@ void Worker::handle_process_request(WorkMsg* msg) {
         }
 
         case proto::Op::Get: {
+            json resp;
             resp["data"] = json::array();
             for (const auto& e : req["keys"]) {
                 if (!e.is_string()) {
-                    s->send(error_response(reqId, "get keys must be strings"));
+                    s->send(encode_error(op, h.reqID,
+                                         proto::Status::BadPayload,
+                                         "get keys must be strings"));
                     return;
                 }
                 const std::string k = e.get<std::string>();
@@ -255,47 +302,55 @@ void Worker::handle_process_request(WorkMsg* msg) {
                 }
                 resp["data"].push_back(item);
             }
-            s->send(resp.dump() + "\n");
+            s->send(encode_response(op, h.reqID, proto::Status::Ok, resp));
             return;
         }
 
-        case proto::Op::Register: {
+        case proto::Op::RegisterWatch: {
             for (const auto& e : req["keys"]) {
                 if (!e.is_string()) {
-                    s->send(error_response(reqId, "register keys must be strings"));
+                    s->send(encode_error(op, h.reqID,
+                                         proto::Status::BadPayload,
+                                         "register keys must be strings"));
                     return;
                 }
                 const std::string k = e.get<std::string>();
                 m_store->watch(s, k);
                 s->note_watch(k);
             }
-            s->send(resp.dump() + "\n");
+            s->send(encode_response(op, h.reqID, proto::Status::Ok, json{}));
             return;
         }
 
-        case proto::Op::Remove: {
+        case proto::Op::RemoveWatch: {
             for (const auto& e : req["keys"]) {
                 if (!e.is_string()) {
-                    s->send(error_response(reqId, "remove keys must be strings"));
+                    s->send(encode_error(op, h.reqID,
+                                         proto::Status::BadPayload,
+                                         "remove keys must be strings"));
                     return;
                 }
                 const std::string k = e.get<std::string>();
                 m_store->unwatch(s, k);
                 s->note_unwatch(k);
             }
-            s->send(resp.dump() + "\n");
+            s->send(encode_response(op, h.reqID, proto::Status::Ok, json{}));
             return;
         }
 
+        case proto::Op::NotifyEvent:
         case proto::Op::Unknown:
-            // Unreachable — already handled above.
+            // Server doesn't accept these as commands.
+            s->send(encode_error(op, h.reqID, proto::Status::BadOpcode,
+                                 "opcode not valid as a request"));
             return;
     }
 }
 
 void Worker::handle_deliver_notify(WorkMsg* msg) {
-    // Caller (any Worker) packaged a notify destined for one of OUR
-    // sessions. We're the sole writer to its socket, so send inline.
+    // Caller (any Worker) packaged an already-encoded EMP push frame
+    // destined for one of OUR sessions. We're the sole writer to its
+    // socket, so send inline.
     if (msg->session) {
         msg->session->send(msg->payload);
     }

--- a/modules/data-store/test/callback_test.cpp
+++ b/modules/data-store/test/callback_test.cpp
@@ -84,7 +84,6 @@ TEST(Callback, single_watch_with_callback_fires_on_event) {
     auto cli_fut = std::async(std::launch::async, [&]() {
         ds::Client cli;
         auto cs = cli.connect(srv.sock); if (!cs.ok) return cs;
-        std::string w; cli.recv_welcome(w, 2000);
 
         ds::Client::WatchHandle h = ds::Client::kInvalidHandle;
         std::vector<std::string> keys = {"foo"};
@@ -138,7 +137,6 @@ TEST(Callback, multiple_watches_with_overlapping_keys_all_fire) {
     auto cli_fut = std::async(std::launch::async, [&]() {
         ds::Client cli;
         auto cs = cli.connect(srv.sock); if (!cs.ok) return cs;
-        std::string w; cli.recv_welcome(w, 2000);
 
         ds::Client::WatchHandle ha, hb;
         std::vector<std::string> aKeys = {"foo", "shared"};

--- a/modules/data-store/test/data_store_test.cpp
+++ b/modules/data-store/test/data_store_test.cpp
@@ -12,28 +12,96 @@ namespace proto = data_store::proto;
 
 /* ───────────────────────────── proto ──────────────────────────────── */
 
-TEST(Proto, parse_op_round_trip) {
-    EXPECT_EQ(proto::Op::Set,      proto::parse_op("set"));
-    EXPECT_EQ(proto::Op::Get,      proto::parse_op("get"));
-    EXPECT_EQ(proto::Op::Register, proto::parse_op("register"));
-    EXPECT_EQ(proto::Op::Remove,   proto::parse_op("remove"));
-    EXPECT_EQ(proto::Op::Unknown,  proto::parse_op("fetch"));
-    EXPECT_EQ(proto::Op::Unknown,  proto::parse_op(""));
+TEST(Proto, parse_op_round_trips_known_opcodes) {
+    EXPECT_EQ(proto::Op::Set,           proto::parse_op(0x0001));
+    EXPECT_EQ(proto::Op::Get,           proto::parse_op(0x0002));
+    EXPECT_EQ(proto::Op::RegisterWatch, proto::parse_op(0x0003));
+    EXPECT_EQ(proto::Op::RemoveWatch,   proto::parse_op(0x0004));
+    EXPECT_EQ(proto::Op::NotifyEvent,   proto::parse_op(0x0064));
+    EXPECT_EQ(proto::Op::Unknown,       proto::parse_op(0x9999));
+    EXPECT_EQ(proto::Op::Unknown,       proto::parse_op(0));
 }
 
-TEST(Proto, op_name_matches_parser) {
-    for (auto op : {proto::Op::Set, proto::Op::Get,
-                    proto::Op::Register, proto::Op::Remove}) {
-        EXPECT_EQ(op, proto::parse_op(proto::op_name(op)));
-    }
+TEST(Proto, encode_decode_header_round_trip) {
+    proto::Header in;
+    in.cmdID        = 0x1234;
+    in.type         = proto::Response;
+    in.reqID        = 42;
+    in.payload_size = 1024;
+    char buf[proto::kHeaderSize];
+    proto::encode_header(in, buf);
+    proto::Header out;
+    proto::decode_header(buf, out);
+    EXPECT_EQ(in.cmdID,        out.cmdID);
+    EXPECT_EQ(in.type,         out.type);
+    EXPECT_EQ(in.reqID,        out.reqID);
+    EXPECT_EQ(in.payload_size, out.payload_size);
 }
 
-TEST(Proto, welcome_line_is_one_json_doc_ending_in_newline) {
-    std::string w{proto::kWelcomeLine};
-    ASSERT_FALSE(w.empty());
-    EXPECT_EQ('\n', w.back());
-    EXPECT_NE(std::string::npos, w.find("\"ok\":true"));
-    EXPECT_NE(std::string::npos, w.find("data-store-server"));
+TEST(Proto, encode_command_then_decode_frame) {
+    std::string wire;
+    proto::encode_frame_command(proto::Op::Get, 7, R"({"keys":["a"]})", wire);
+    proto::Header h;
+    std::string body;
+    ASSERT_TRUE(proto::try_decode_frame(wire, h, body));
+    EXPECT_EQ(static_cast<std::uint16_t>(proto::Op::Get), h.cmdID);
+    EXPECT_EQ(0u, h.type);
+    EXPECT_EQ(7u, h.reqID);
+    EXPECT_EQ(R"({"keys":["a"]})", body);
+    EXPECT_TRUE(wire.empty());
+}
+
+TEST(Proto, encode_response_carries_status_prefix) {
+    std::string wire;
+    proto::encode_frame_response(proto::Op::Set, 3, proto::Status::Ok,
+                                 std::string_view{}, wire);
+    proto::Header h;
+    std::string body;
+    ASSERT_TRUE(proto::try_decode_frame(wire, h, body));
+    EXPECT_EQ(proto::Response, h.type);
+    ASSERT_GE(body.size(), 2u);
+    EXPECT_EQ(0, static_cast<std::uint8_t>(body[0]));
+    EXPECT_EQ(0, static_cast<std::uint8_t>(body[1]));
+}
+
+TEST(Proto, encode_push_has_push_bit_and_no_status_prefix) {
+    std::string wire;
+    proto::encode_frame_push(proto::Op::NotifyEvent,
+                             R"({"k":"foo","v":1})", wire);
+    proto::Header h;
+    std::string body;
+    ASSERT_TRUE(proto::try_decode_frame(wire, h, body));
+    EXPECT_TRUE(proto::is_push(h.type));
+    EXPECT_FALSE(proto::is_response(h.type));
+    EXPECT_EQ(0u, h.reqID);
+    EXPECT_EQ(R"({"k":"foo","v":1})", body);
+}
+
+TEST(Proto, try_decode_returns_false_when_buffer_short) {
+    std::string wire;
+    proto::encode_frame_command(proto::Op::Set, 1, R"({"keys":[]})", wire);
+    // Snip the last 3 bytes to simulate an incomplete recv.
+    std::string truncated = wire.substr(0, wire.size() - 3);
+    proto::Header h;
+    std::string body;
+    EXPECT_FALSE(proto::try_decode_frame(truncated, h, body));
+    EXPECT_EQ(wire.size() - 3, truncated.size());
+}
+
+TEST(Proto, try_decode_rejects_oversized_payload) {
+    // Hand-craft a header claiming payload_size > kMaxPayloadBytes.
+    proto::Header h;
+    h.cmdID        = 0x0001;
+    h.type         = 0;
+    h.reqID        = 1;
+    h.payload_size = proto::kMaxPayloadBytes + 1;
+    char buf[proto::kHeaderSize];
+    proto::encode_header(h, buf);
+    std::string wire(buf, proto::kHeaderSize);
+    proto::Header out;
+    std::string body;
+    EXPECT_THROW(proto::try_decode_frame(wire, out, body),
+                 std::runtime_error);
 }
 
 /* ───────────────────────────── store ──────────────────────────────── */

--- a/modules/data-store/test/protocol_test.cpp
+++ b/modules/data-store/test/protocol_test.cpp
@@ -96,7 +96,6 @@ TEST(Protocol, DS_REQ_DS_003_set_then_get_returns_latest) {
     auto cli_fut = std::async(std::launch::async, [&]() {
         ds::Client cli;
         auto cs = cli.connect(srv.sock); if (!cs.ok) return cs;
-        std::string w; cli.recv_welcome(w, 2000);
         auto ss = cli.set("foo", ds::Value{std::string("bar")}, 2000);
         if (!ss.ok) return ss;
         std::vector<ds::Client::GetResult> got;
@@ -127,7 +126,6 @@ TEST(Protocol, DS_REQ_DS_007_register_then_set_emits_notify_to_watcher) {
     auto watch_fut = std::async(std::launch::async, [&]() {
         ds::Client w;
         auto cs = w.connect(srv.sock); if (!cs.ok) return cs;
-        std::string welcome; w.recv_welcome(welcome, 2000);
         auto rs = w.watch("foo", 2000); if (!rs.ok) return rs;
 
         ds::Client::Event ev;
@@ -145,7 +143,6 @@ TEST(Protocol, DS_REQ_DS_007_register_then_set_emits_notify_to_watcher) {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
         ds::Client s;
         auto cs = s.connect(srv.sock); if (!cs.ok) return cs;
-        std::string welcome; s.recv_welcome(welcome, 2000);
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
         return s.set("foo", ds::Value{std::string("bar")}, 2000);
     });
@@ -171,7 +168,6 @@ TEST(Protocol, DS_REQ_DS_006_unchanged_value_no_notify) {
     auto seed_fut = std::async(std::launch::async, [&]() {
         ds::Client s;
         auto cs = s.connect(srv.sock); if (!cs.ok) return cs;
-        std::string w; s.recv_welcome(w, 2000);
         return s.set("foo", ds::Value{std::string("bar")}, 2000);
     });
     pump_until(seed_fut);
@@ -181,7 +177,6 @@ TEST(Protocol, DS_REQ_DS_006_unchanged_value_no_notify) {
     auto watch_fut = std::async(std::launch::async, [&]() {
         ds::Client w;
         auto cs = w.connect(srv.sock); if (!cs.ok) return cs;
-        std::string welcome; w.recv_welcome(welcome, 2000);
         auto rs = w.watch("foo", 2000); if (!rs.ok) return rs;
         ds::Client::Event ev;
         auto es = w.recv_event(ev, 300);
@@ -199,7 +194,6 @@ TEST(Protocol, DS_REQ_DS_006_unchanged_value_no_notify) {
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
         ds::Client s;
         auto cs = s.connect(srv.sock); if (!cs.ok) return cs;
-        std::string welcome; s.recv_welcome(welcome, 2000);
         std::this_thread::sleep_for(std::chrono::milliseconds(50));
         return s.set("foo", ds::Value{std::string("bar")}, 2000);   // same value
     });

--- a/modules/data-store/test/server_integration_test.cpp
+++ b/modules/data-store/test/server_integration_test.cpp
@@ -58,7 +58,7 @@ void pump(int times = 4) {
 
 /* ────────────────────────────── REQ-DS-011 ───────────────────────── */
 
-TEST(ServerIntegration, DS_REQ_DS_011_one_client_gets_welcome) {
+TEST(ServerIntegration, DS_REQ_DS_011_one_client_connects_and_gets_response) {
     std::string dir = make_temp_dir();
     if (dir.empty()) GTEST_SKIP() << "no writable /tmp or cwd";
     std::string sock = dir + "/ds.sock";
@@ -69,23 +69,24 @@ TEST(ServerIntegration, DS_REQ_DS_011_one_client_gets_welcome) {
     ds::server::Server server(store, &pool, sock);
     ASSERT_EQ(0, server.open());
 
-    // Connect from the test thread; the reactor pump below services
-    // the accept. We give the client a generous timeout in case the
-    // first pump tick lands after recv_welcome blocks.
+    // EMP has no welcome — to prove the wire works, issue a get on a
+    // missing key and assert ok+empty data.
     auto fut = std::async(std::launch::async, [&]() {
         ds::Client cli;
         auto cs = cli.connect(sock);
         if (!cs.ok) return std::string("CONNECT_FAILED:") + cs.err;
-        std::string w;
-        auto rs = cli.recv_welcome(w, /*timeout_ms=*/2000);
-        if (!rs.ok) return std::string("RECV_FAILED:") + rs.err;
-        return w;
+        std::vector<ds::Client::GetResult> got;
+        auto rs = cli.get({"nope"}, got, /*timeout_ms=*/2000);
+        if (!rs.ok) return std::string("GET_FAILED:") + rs.err;
+        if (got.size() != 1) return std::string("BAD_SIZE");
+        if (got[0].has_value) return std::string("UNEXPECTED_VALUE");
+        return std::string("ok");
     });
 
     pump(20);                       // service the connect
     std::string got = fut.get();
 
-    EXPECT_EQ(std::string(ds::proto::kWelcomeLine), got);
+    EXPECT_EQ("ok", got);
     server.close();
     pool.close();
     ::unlink(sock.c_str());
@@ -115,10 +116,11 @@ TEST(ServerIntegration, DS_REQ_DS_011_concurrent_sessions) {
             ds::Client cli;
             auto cs = cli.connect(sock);
             if (!cs.ok) return std::string("CONNECT:") + cs.err;
-            std::string w;
-            auto rs = cli.recv_welcome(w, 3000);
-            if (!rs.ok) return std::string("RECV:") + rs.err;
-            return w;
+            // Each session does one Get to prove the wire is alive.
+            std::vector<ds::Client::GetResult> got;
+            auto rs = cli.get({"nope"}, got, 3000);
+            if (!rs.ok) return std::string("GET:") + rs.err;
+            return std::string("ok");
         }));
     }
 
@@ -129,7 +131,7 @@ TEST(ServerIntegration, DS_REQ_DS_011_concurrent_sessions) {
     int ok = 0;
     for (auto& f : clients) {
         std::string got = f.get();
-        if (got == ds::proto::kWelcomeLine) ++ok;
+        if (got == "ok") ++ok;
         else ADD_FAILURE() << "session result: " << got;
     }
     EXPECT_EQ(N, ok);


### PR DESCRIPTION
## Summary
- Replace the \\n-delimited JSON-line wire with **Embedded Micro Protocol (EMP)** framing modelled on Eclipse Mihini.
- 8-byte big-endian header: \`cmdID(2) | type(1) | reqID(1) | payload_size(4)\`; payload is UTF-8 JSON.
- 5 KV-scoped opcodes: \`Set\` / \`Get\` / \`RegisterWatch\` / \`RemoveWatch\` / \`NotifyEvent\` (push).
- Type byte bit 0 = response, bit 1 = push (our extension of a Mihini-reserved bit so server-initiated notify shares the framing).
- Responses prefix a 2-byte big-endian \`Status\` (Ok=0; 0x8xxx for protocol errors).
- libdatastore_client API surface unchanged; reqID correlation via \`(op << 8 | reqID)\` so two opcodes can share a reqID slot in flight.
- Welcome handshake removed — EMP has none.
- **Hard cut**: no compat shim. All ds-tests rewritten for the new wire.
- Documented end-to-end in \`modules/data-store/docs/protocol.md\` (layout, opcodes, statuses, lifecycle, worked example, Mihini divergences).

## Test plan
- [x] 39/39 ds-tests green under podman \`naushada/iot:latest\` (proto unit tests for header round-trip, frame encode/decode, status prefix, push bit, oversized-payload rejection)
- [x] ds-cli set/get round-trips strings, uints, bools end-to-end
- [x] watch + notify push verified (set fires the watcher's callback)
- [x] lwm2m binary still builds + reads iot.endpoint/iot.lifetime via EMP from ds-server

🤖 Generated with [Claude Code](https://claude.com/claude-code)