### PR TITLE
apps: sweep std::cout to ACE logging across the iot binary

### DIFF
--- a/apps/src/cbor_adapter.cpp
+++ b/apps/src/cbor_adapter.cpp
@@ -3,7 +3,7 @@
 
 #include "cbor_adapter.hpp"
 
-
+#include <ace/Log_Msg.h>
 
 CBORAdapter::CBORAdapter() {
 
@@ -25,8 +25,9 @@ std::int32_t CBORAdapter::json2cbor(const std::string& in, std::string& out) {
         out.assign(cbor.begin(), cbor.end());
         return 0;
     } catch (const std::exception& e) {
-        std::cout << basename(__FILE__) << ":" << __LINE__
-                  << " json2cbor parse error: " << e.what() << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l json2cbor parse error: %C\n"),
+                   e.what()));
         return -1;
     }
 }
@@ -38,7 +39,9 @@ std::string CBORAdapter::getJson(const std::string& fileName) {
     std::stringstream ss;
 
     if(!ifs.is_open()) {
-        std::cout << basename(__FILE__) << ":" << " Error Opening of file: " << fileName << " is Failed" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l failed to open file: %C\n"),
+                   fileName.c_str()));
         return(std::string());
     }
 
@@ -60,7 +63,9 @@ std::string CBORAdapter::getJson(const std::string& fileName) {
 std::int32_t CBORAdapter::getCBOR(const std::string& fname, std::string& cbor) {
     auto data = getJson(fname);
     if(!data.length()) {
-        std::cout << basename(__FILE__) << ":" << " Unable to get the contents of json: " << fname << " is Failed" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l unable to read JSON contents from %C\n"),
+                   fname.c_str()));
         return(-1);
     }
     auto ret = json2cbor(data, cbor);
@@ -74,7 +79,9 @@ bool CBORAdapter::writeIntoFile(const std::string &input, const std::string& fil
     ofs.open(fileName);
 
     if(!ofs.is_open()) {
-        std::cout << basename(__FILE__) << ":" << " Opening of file: " << fileName << " is Failed" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l failed to open file for write: %C\n"),
+                   fileName.c_str()));
         return(false);
     }
 

--- a/apps/src/coap_adapter.cpp
+++ b/apps/src/coap_adapter.cpp
@@ -8,6 +8,7 @@
 #include "lwm2m_registration_client.hpp"
 #include "lwm2m_registration_server.hpp"
 #include "nlohmann/json.hpp"
+#include <ace/Log_Msg.h>
 
 using json = nlohmann::json;
 
@@ -181,7 +182,9 @@ bool CoAPAdapter::serialise(const std::vector<std::string> &uris, const std::vec
         optdelta = (offset & 0xF) /*Uri-Path*/ << 4;
 
         for(const auto& uri: uris) {
-            std::cout << basename(__FILE__) << ":" << __LINE__ << " uri: " << uri << std::endl;
+            ACE_DEBUG((LM_DEBUG,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l uri: %C\n"),
+                       uri.c_str()));
             if(uri.length() >= 0 && uri.length() <= 12) {
                 optdelta |= (uri.length() & 0xF);
                 ss.write (reinterpret_cast <const char *>(&optdelta), sizeof(optdelta));
@@ -206,8 +209,8 @@ bool CoAPAdapter::serialise(const std::vector<std::string> &uris, const std::vec
 
         optdelta = (12 - offset /*Content-Format - Uri-Path*/) << 4;
         offset += (12 - offset);
-            
-        if(cf < 256) { 
+
+        if(cf < 256) {
             optdelta |= 1 /*Length of cf value (1 bytes)*/;
             std::uint8_t ct = cf;
             ss.write (reinterpret_cast <const char *>(&optdelta), sizeof(optdelta));
@@ -223,9 +226,11 @@ bool CoAPAdapter::serialise(const std::vector<std::string> &uris, const std::vec
             optdelta = (15 - offset /* Uri-Query - Uri-Path*/) << 4;
             offset += (15 - offset);
         }
-        
+
         for(const auto& query: queries) {
-            std::cout << basename(__FILE__) << ":" << __LINE__ << " query: " << query << std::endl;
+            ACE_DEBUG((LM_DEBUG,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l query: %C\n"),
+                       query.c_str()));
             if(query.length() > 0 && query.length() <= 12) {
                 optdelta |= query.length();
                 ss.write (reinterpret_cast <const char *>(&optdelta), sizeof(optdelta));
@@ -272,7 +277,9 @@ bool CoAPAdapter::serialise(const std::vector<std::string> &uris, const std::vec
         std::uint8_t optdelta;
         optdelta = (offset & 0xF) /*Uri-Path*/ << 4;
         for(const auto& uri: uris) {
-            std::cout << basename(__FILE__) << ":" << __LINE__ << " uri: " << uri << std::endl;
+            ACE_DEBUG((LM_DEBUG,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l uri: %C\n"),
+                       uri.c_str()));
             if(uri.length() >= 0 && uri.length() <= 12) {
                 optdelta |= (uri.length() & 0xF);
                 ss.write (reinterpret_cast <const char *>(&optdelta), sizeof(optdelta));
@@ -326,7 +333,9 @@ bool CoAPAdapter::serialise(const std::vector<std::string> &uris, const std::vec
         }
         
         for(const auto& query: queries) {
-            std::cout << basename(__FILE__) << ":" << __LINE__ << " query: " << query << std::endl;
+            ACE_DEBUG((LM_DEBUG,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l query: %C\n"),
+                       query.c_str()));
             if(query.length() > 0 && query.length() <= 12) {
                 optdelta |= query.length();
                 ss.write (reinterpret_cast <const char *>(&optdelta), sizeof(optdelta));
@@ -407,7 +416,9 @@ bool CoAPAdapter::serialisePOST(const std::vector<std::string> &uris, const std:
         std::uint8_t optdelta;
         optdelta = (offset & 0xF) /*Uri-Path*/ << 4;
         for(const auto& uri: uris) {
-            std::cout << basename(__FILE__) << ":" << " uri: " << uri << std::endl;
+            ACE_DEBUG((LM_DEBUG,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l uri: %C\n"),
+                       uri.c_str()));
             if(uri.length() >= 0 && uri.length() <= 12) {
                 optdelta |= (uri.length() & 0xF);
                 ss.write (reinterpret_cast <const char *>(&optdelta), sizeof(optdelta));
@@ -452,7 +463,9 @@ bool CoAPAdapter::serialisePOST(const std::vector<std::string> &uris, const std:
         }
         
         for(const auto& query: queries) {
-            std::cout << basename(__FILE__) << ":" << " query: " << query << std::endl;
+            ACE_DEBUG((LM_DEBUG,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l query: %C\n"),
+                       query.c_str()));
             if(query.length() > 0 && query.length() <= 12) {
                 optdelta |= query.length();
                 ss.write (reinterpret_cast <const char *>(&optdelta), sizeof(optdelta));
@@ -686,14 +699,16 @@ std::string CoAPAdapter::buildResponse(const CoAPMessage& message) {
         {
             ///Objects are extracted successfully
             for(const auto& ent: object.m_value) {
-                std::cout << basename(__FILE__) << ":" << __LINE__ <<  " object.m_oid:" << object.m_oid <<" ent.m_oiid:" << ent.m_oiid << " ent.m_riid:" << ent.m_riid
-                          << " ent.m_rid:" << lwm2mAdapter.resourceIDName(oid, ent.m_rid) << " ent.m_ridlength:" << ent.m_ridlength << " ent.m_ridvalue.size:" << ent.m_ridvalue.size()
-                          << " ent.m_ridvalue:";
-        
-                for(const auto& elm: ent.m_ridvalue) {
-                    printf("%0.2X ", (std::uint8_t)elm);
-                }
-                printf("\n");
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l object.m_oid:%u "
+                                    "ent.m_oiid:%u ent.m_riid:%u ent.m_rid:%C "
+                                    "ent.m_ridlength:%u ent.m_ridvalue.size:%u\n"),
+                           static_cast<unsigned>(object.m_oid),
+                           static_cast<unsigned>(ent.m_oiid),
+                           static_cast<unsigned>(ent.m_riid),
+                           lwm2mAdapter.resourceIDName(oid, ent.m_rid).c_str(),
+                           static_cast<unsigned>(ent.m_ridlength),
+                           static_cast<unsigned>(ent.m_ridvalue.size())));
             }
 
             if(RequestType[message.coapheader.type].compare("Acknowledgement")) {
@@ -704,7 +719,8 @@ std::string CoAPAdapter::buildResponse(const CoAPMessage& message) {
         #endif
 
     } else {
-        std::cout <<basename(__FILE__) << ":" << __FILE__ << " This is not an LwM2M Object" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l This is not an LwM2M Object\n")));
     }
     return(std::string());
 }
@@ -720,8 +736,9 @@ std::int32_t CoAPAdapter::parseRequest(const std::string& in, CoAPMessage& coapm
 
     do {
         if(!istrstr.read(reinterpret_cast<char *>(&fourbytes), sizeof(fourbytes)).good()) {
-            std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
-            break;    
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
+            break;
         }
 
         coapmessage.coapheader.tokenlength = fourbytes & 0b00001111;
@@ -734,7 +751,8 @@ std::int32_t CoAPAdapter::parseRequest(const std::string& in, CoAPMessage& coapm
             size_t len = static_cast<size_t>(coapmessage.coapheader.tokenlength);
             coapmessage.tokens.resize(len);
             if(!istrstr.read(reinterpret_cast<char *>(coapmessage.tokens.data()), len).good()) {
-                std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                ACE_ERROR((LM_ERROR,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                 break;
             }
         }
@@ -748,7 +766,8 @@ std::int32_t CoAPAdapter::parseRequest(const std::string& in, CoAPMessage& coapm
             if(opt.optiondelta == 13) {
 
                 if(!istrstr.read(reinterpret_cast<char *>(&onebyte), sizeof(onebyte)).good()) {
-                    std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                     break;
                 }
                 opt.optiondelta = onebyte + 13;
@@ -756,7 +775,8 @@ std::int32_t CoAPAdapter::parseRequest(const std::string& in, CoAPMessage& coapm
             } else if(opt.optiondelta == 14) {
 
                 if(!istrstr.read(reinterpret_cast<char *>(&mid), sizeof(mid)).good()) {
-                    std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                     break;
                 }
 
@@ -784,19 +804,25 @@ std::int32_t CoAPAdapter::parseRequest(const std::string& in, CoAPMessage& coapm
                     if(!istrstr.read(reinterpret_cast<char *>(contents.data()), len).good()) {
                         /// The last block might be less than 1024 bytes while len says it's 1024.
                         if(istrstr.eof()) {
-                            std::cout << basename(__FILE__) << ":" << __LINE__ << " expected length: " << len << std::endl;
+                            ACE_ERROR((LM_ERROR,
+                                       ACE_TEXT("%D [iot:%t] %M %N:%l expected length: %d\n"),
+                                       static_cast<int>(len)));
                             auto len = istrstr.gcount();
-                            std::cout << basename(__FILE__) << ":" << __LINE__ << " actual length: " << len << std::endl;
+                            ACE_DEBUG((LM_DEBUG,
+                                       ACE_TEXT("%D [iot:%t] %M %N:%l actual length: %d\n"),
+                                       static_cast<int>(len)));
                             contents.resize(len);
                         }
                     }
-                    
+
                 } else {
-                    
+
                     if(istrstr.read(reinterpret_cast<char *>(contents.data()), contents.size()).eof()) {
                         /// The last block might be less than 1024 bytes while len says it's 1024.
                         auto len = istrstr.gcount();
-                        std::cout << basename(__FILE__) << ":" << __LINE__ << " actual length: " << len << std::endl;
+                        ACE_DEBUG((LM_DEBUG,
+                                   ACE_TEXT("%D [iot:%t] %M %N:%l actual length: %d\n"),
+                                   static_cast<int>(len)));
                         contents.resize(len);
                     }
                 }
@@ -808,35 +834,40 @@ std::int32_t CoAPAdapter::parseRequest(const std::string& in, CoAPMessage& coapm
 
                 opt.optionvalue.resize(opt.optionlength);
                 if(!istrstr.read(reinterpret_cast<char *>(opt.optionvalue.data()), opt.optionlength).good()) {
-                    std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                     break;
                 }
 
             } else if(opt.optionlength == 13) {
 
                 if(!istrstr.read(reinterpret_cast<char *>(&onebyte), sizeof(onebyte)).good()) {
-                    std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                     break;
                 }
 
                 opt.optionlength = onebyte + 13;
                 opt.optionvalue.resize(opt.optionlength);
                 if(!istrstr.read(reinterpret_cast<char *>(opt.optionvalue.data()), opt.optionlength).good()) {
-                    std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                     break;
                 }
 
             } else if(opt.optionlength == 14) {
 
                 if(!istrstr.read(reinterpret_cast<char *>(&mid), sizeof(mid)).good()) {
-                    std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                     break;
                 }
 
                 opt.optionlength = ntohs(mid) + 269;
                 opt.optionvalue.resize(opt.optionlength);
                 if(!istrstr.read(reinterpret_cast<char *>(opt.optionvalue.data()), opt.optionlength).good()) {
-                    std::cout <<basename(__FILE__) << ":" << __LINE__ << " input buffer is too small to process" << std::endl;
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l input buffer is too small to process\n")));
                     break;
                 }
             }
@@ -863,7 +894,8 @@ bool CoAPAdapter::uncompress(const std::string &input, std::string &output) {
     zStream.opaque = Z_NULL;
 
     if(inflateInit(&zStream) != Z_OK) {
-        std::cout<< basename(__FILE__) << ":" << __LINE__ << " could not initialize uncompression" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l Failed to initialize uncompression\n")));
         inflateEnd(&zStream);
         return false;
     }
@@ -882,7 +914,8 @@ bool CoAPAdapter::uncompress(const std::string &input, std::string &output) {
                 || inflateStatus == Z_NEED_DICT
                 || inflateStatus == Z_DATA_ERROR
                 || inflateStatus == Z_MEM_ERROR) {
-            std::cout << basename(__FILE__) << ":" << __LINE__  << " could not uncompress" << std::endl;
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l Failed to uncompress\n")));
             inflateEnd(&zStream);
             output.clear();
             return false;
@@ -893,16 +926,19 @@ bool CoAPAdapter::uncompress(const std::string &input, std::string &output) {
 
     while(zStream.avail_out == 0);
     if(inflateEnd(&zStream) != Z_OK) {
-        std::cout<<basename(__FILE__) << ":" << __LINE__  << " could not finalize uncompression" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l Failed to finalize uncompression\n")));
         output.clear();
         return false;
     }
 
     if (!output.empty()) {
-        std::cout << basename(__FILE__) << ":" << __LINE__  << " uncompression ratio input/output: " 
-                  << double(input.size())/output.size() << std::endl;
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l uncompression ratio input/output: %C\n"),
+                   std::to_string(double(input.size())/output.size()).c_str()));
     } else {
-        std::cout << basename(__FILE__) << ":" << __LINE__ << " uncompression output empty" << std::endl;
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l uncompression output empty\n")));
     }
     return true;
 }
@@ -941,10 +977,13 @@ bool CoAPAdapter::compress(const std::string &input, std::string &output) {
 
     output.resize(zStream.total_out);
     if (!output.empty()) {
-        std::cout << basename(__FILE__) << ":" << __LINE__  << " compression ratio input/output: "
-            << double(input.size())/output.size() << ", output size: " << output.size() << std::endl;
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l compression ratio input/output: %C, output size: %d\n"),
+                   std::to_string(double(input.size())/output.size()).c_str(),
+                   static_cast<int>(output.size())));
     } else {
-        std::cout << basename(__FILE__) << ":" << __LINE__  << " compression output empty" << std::endl;
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l compression output empty\n")));
     }
     return true;
 }
@@ -955,7 +994,9 @@ bool CoAPAdapter::writeIntoFile(const std::string &input, const std::string& fil
     ofs.open(fileName);
 
     if(!ofs.is_open()) {
-        std::cout << basename(__FILE__) << ":" << " Opening of file: " << fileName << " is Failed" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l Opening of file: %C is Failed\n"),
+                   fileName.c_str()));
         return(false);
     }
 
@@ -1000,12 +1041,19 @@ std::vector<std::string> CoAPAdapter::handleLwM2MObjects(const CoAPAdapter::CoAP
 
         if(!ret) {
             for(const auto& ent: object.m_value) {
-                std::cout << basename(__FILE__) << ":" << __LINE__ <<  " object.m_oid:" << object.m_oid <<" ent.m_oiid:" << ent.m_oiid << " ent.m_riid:" << ent.m_riid
-                          << " ent.m_rid:" << lwm2mAdapter()->resourceIDName(oid, ent.m_rid) << " ent.m_ridlength:" << ent.m_ridlength << " ent.m_ridvalue.size:" << ent.m_ridvalue.size()
-                          << " ent.m_ridvalue:";
-                
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l object.m_oid:%u ent.m_oiid:%u ent.m_riid:%u ent.m_rid:%C ent.m_ridlength:%u ent.m_ridvalue.size:%d ent.m_ridvalue:\n"),
+                           static_cast<unsigned>(object.m_oid),
+                           static_cast<unsigned>(ent.m_oiid),
+                           static_cast<unsigned>(ent.m_riid),
+                           lwm2mAdapter()->resourceIDName(oid, ent.m_rid).c_str(),
+                           static_cast<unsigned>(ent.m_ridlength),
+                           static_cast<int>(ent.m_ridvalue.size())));
+
                 if(oid == 0 && ent.m_rid == 0) {
-                    std::cout << std::string(ent.m_ridvalue.begin(), ent.m_ridvalue.end()) << std::endl;
+                    ACE_DEBUG((LM_DEBUG,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l %C\n"),
+                               std::string(ent.m_ridvalue.begin(), ent.m_ridvalue.end()).c_str()));
                 } else {
                     for(const auto& elm: ent.m_ridvalue) {
                         printf("%0.2X ", (std::uint8_t)elm);
@@ -1089,7 +1137,8 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
         if(isLwm2mUri(coapmessage, uri, oid, oiid, rid, riid)) {
             if("rd" == uri || "bs" == uri) {
                 //rsp = buildResponse(coapmessage);
-                std::cout << basename(__FILE__) << ":" << __LINE__ << " building an ACK" << std::endl;
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l building an ACK\n")));
                 
                 if(!isAmIClient && !uri.compare(0, 2, "bs")) {
                     rsp = buildRegistrationAck(coapmessage);
@@ -1145,7 +1194,9 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
                     ///uncompressed successfully.
                     writeIntoFile(output, "ucborz_cf_12201.txt");
                     auto payload = json::from_cbor(output.c_str());
-                    std::cout << basename(__FILE__) << ":" << __LINE__ << " The Response is\n" << payload.dump() << std::endl;
+                    ACE_DEBUG((LM_DEBUG,
+                               ACE_TEXT("%D [iot:%t] %M %N:%l The Response is\n%C\n"),
+                               payload.dump().c_str()));
                 }
             } else if(12119/*TS*/ == ct) {
                 writeIntoFile(coapmessage.payload, "ts_cf_12119.txt");
@@ -1155,7 +1206,9 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
                 for(auto&[key, value]: payload.items()) {
                     
                 }
-                std::cout << basename(__FILE__) << ":" << __LINE__ << " The Response is\n" << payload.dump() << std::endl;
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l The Response is\n%C\n"),
+                           payload.dump().c_str()));
 
             } else if(12202/*SUCBOR*/ == ct) {
                 writeIntoFile(coapmessage.payload, "sucbor_cf_12202.txt");
@@ -1182,9 +1235,14 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
 
                         ///Objects are extracted successfully
                         for(const auto& ent: object.m_value) {
-                            std::cout << basename(__FILE__) << ":" << __LINE__ <<  " object.m_oid:" << object.m_oid <<" ent.m_oiid:" << ent.m_oiid << " ent.m_riid:" << ent.m_riid
-                                      << " ent.m_rid:" << lwm2mAdapter()->resourceIDName(oid, ent.m_rid) << " ent.m_ridlength:" << ent.m_ridlength << " ent.m_ridvalue.size:" << ent.m_ridvalue.size()
-                                      << " ent.m_ridvalue:";
+                            ACE_DEBUG((LM_DEBUG,
+                                       ACE_TEXT("%D [iot:%t] %M %N:%l object.m_oid:%u ent.m_oiid:%u ent.m_riid:%u ent.m_rid:%C ent.m_ridlength:%u ent.m_ridvalue.size:%d ent.m_ridvalue:\n"),
+                                       static_cast<unsigned>(object.m_oid),
+                                       static_cast<unsigned>(ent.m_oiid),
+                                       static_cast<unsigned>(ent.m_riid),
+                                       lwm2mAdapter()->resourceIDName(oid, ent.m_rid).c_str(),
+                                       static_cast<unsigned>(ent.m_ridlength),
+                                       static_cast<int>(ent.m_ridvalue.size())));
         
                             for(const auto& elm: ent.m_ridvalue) {
                                 printf("%0.2X ", (std::uint8_t)elm);
@@ -1206,7 +1264,9 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
     CoAPMessage coapmessage;
     auto ret = parseRequest(in, coapmessage);
     auto cf = getContentFormat(coapmessage);
-    std::cout << basename(__FILE__) << ":" << __LINE__ << " processRequest with session cf.length: " << cf.length() << std::endl;
+    ACE_DEBUG((LM_DEBUG,
+               ACE_TEXT("%D [iot:%t] %M %N:%l processRequest with session cf.length: %d\n"),
+               static_cast<int>(cf.length())));
 
     // L9 / FUP-2 — Acknowledgement short-circuit + dispatch to
     // RegistrationClient FSM. Same shape as the no-DTLS overload above.
@@ -1271,7 +1331,8 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
         if(isLwm2mUri(coapmessage, uri, oid, oiid, rid, riid)) {
             if("rd" == uri || "bs" == uri) {
                 //rsp = buildResponse(coapmessage);
-                std::cout << basename(__FILE__) << ":" << __LINE__ << " building an ACK" << std::endl;
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l building an ACK\n")));
                 std::string rsp = buildRegistrationAck(coapmessage);
                 out.push_back(rsp);
                 if(!uri.compare(0, 2, "bs") && !isAmIClient) {
@@ -1284,7 +1345,10 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
                     ///@brief The registration or registration update
                 }
             } else {
-                std::cout << basename(__FILE__) << ":" << __LINE__ << " received LwM2M Object" << " oid: " << oid << " oiid: " << oiid << std::endl;
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l received LwM2M Object oid: %u oiid: %u\n"),
+                           static_cast<unsigned>(oid),
+                           static_cast<unsigned>(oiid)));
                 out = handleLwM2MObjects(coapmessage, uri, oid, oiid, rid, riid);
             }
             /// This is LwM2M string URI rd or bs
@@ -1353,9 +1417,14 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
 
                         ///Objects are extracted successfully
                         for(const auto& ent: object.m_value) {
-                            std::cout << basename(__FILE__) << ":" << __LINE__ <<  " object.m_oid:" << object.m_oid <<" ent.m_oiid:" << ent.m_oiid << " ent.m_riid:" << ent.m_riid
-                                      << " ent.m_rid:" << lwm2mAdapter.resourceIDName(oid, ent.m_rid) << " ent.m_ridlength:" << ent.m_ridlength << " ent.m_ridvalue.size:" << ent.m_ridvalue.size()
-                                      << " ent.m_ridvalue:";
+                            ACE_DEBUG((LM_DEBUG,
+                                       ACE_TEXT("%D [iot:%t] %M %N:%l object.m_oid:%u ent.m_oiid:%u ent.m_riid:%u ent.m_rid:%C ent.m_ridlength:%u ent.m_ridvalue.size:%d ent.m_ridvalue:\n"),
+                                       static_cast<unsigned>(object.m_oid),
+                                       static_cast<unsigned>(ent.m_oiid),
+                                       static_cast<unsigned>(ent.m_riid),
+                                       lwm2mAdapter.resourceIDName(oid, ent.m_rid).c_str(),
+                                       static_cast<unsigned>(ent.m_ridlength),
+                                       static_cast<int>(ent.m_ridvalue.size())));
         
                             for(const auto& elm: ent.m_ridvalue) {
                                 printf("%0.2X ", (std::uint8_t)elm);
@@ -1381,19 +1450,20 @@ void CoAPAdapter::dumpCoAPMessage(const CoAPMessage& coapmessage) {
     } else {
         ss << getMethodCode(static_cast<std::uint32_t>(coapmessage.coapheader.code));
     }
-    std::cout << std::endl << basename(__FILE__) << ":" << __LINE__ 
-              << " ver: "         << std::to_string(coapmessage.coapheader.ver)
-              << " type: "        << getRequestType(static_cast<std::uint32_t>(coapmessage.coapheader.type))
-              << " tokenlength: " << std::to_string(coapmessage.coapheader.tokenlength)
-              //<< " code: "        << getMethodCode(static_cast<std::uint32_t>(coapmessage.coapheader.code))
-              << " code: "        << ss.str()
-              << " msgid: "       << coapmessage.coapheader.msgid << std::endl;
+    ACE_DEBUG((LM_DEBUG,
+               ACE_TEXT("%D [iot:%t] %M %N:%l ver: %C type: %C tokenlength: %C code: %C msgid: %u\n"),
+               std::to_string(coapmessage.coapheader.ver).c_str(),
+               getRequestType(static_cast<std::uint32_t>(coapmessage.coapheader.type)).c_str(),
+               std::to_string(coapmessage.coapheader.tokenlength).c_str(),
+               ss.str().c_str(),
+               static_cast<unsigned>(coapmessage.coapheader.msgid)));
 
     for(auto const& opt: coapmessage.uripath) {
-        std::cout << " optiondelta: "  << getOptionNumber(static_cast<std::uint32_t>(opt.optiondelta)) 
-                  << " optionlength: " << std::to_string(opt.optionlength)
-                  << " optionvalue: "  << opt.optionvalue
-                  << std::endl;
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l optiondelta: %C optionlength: %C optionvalue: %C\n"),
+                   getOptionNumber(static_cast<std::uint32_t>(opt.optiondelta)).c_str(),
+                   std::to_string(opt.optionlength).c_str(),
+                   opt.optionvalue.c_str()));
     }
 
     auto it = std::find_if(coapmessage.uripath.begin(), coapmessage.uripath.end(), [&](const auto& ent) -> bool {
@@ -1408,10 +1478,11 @@ void CoAPAdapter::dumpCoAPMessage(const CoAPMessage& coapmessage) {
         auto m = (blk1 >> 3) & 0b1;
         auto num = (blk1 >> 4) & 0b1111;
 
-        std::cout << basename(__FILE__) << ":" << __LINE__ << " Block Number: " << std::to_string(num)
-                  << " More: " << std::to_string(m)
-                  << " Block Size: " << std::to_string(szx)
-                  << std::endl;
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l Block Number: %C More: %C Block Size: %C\n"),
+                   std::to_string(num).c_str(),
+                   std::to_string(m).c_str(),
+                   std::to_string(szx).c_str()));
     }
 }
 

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -3,6 +3,8 @@
 
 #include "dtls_adapter.hpp"
 
+#include <ace/Log_Msg.h>
+
 
 std::int32_t dtlsWriteCb(dtls_context_t *ctx, session_t *session, uint8 *data, size_t len) {
     DTLSAdapter &inst = *static_cast<DTLSAdapter *>(dtls_get_app_data(ctx));
@@ -247,8 +249,9 @@ std::int32_t DTLSAdapter::rx(std::int32_t fd) {
     } else {
         buf.resize(len);
         dtls_debug("got %d bytes from port %d\n", len, ntohs(session.addr.sin.sin_port));
-        std::cout << basename(__FILE__) << ":" << __LINE__ << " got len: " << len << " bytes from port: "
-                  << ntohs(session.addr.sin.sin_port) << std::endl;
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l rx %d bytes from port %u\n"),
+                   len, static_cast<unsigned>(ntohs(session.addr.sin.sin_port))));
 
         if(len <= DTLS_MAX_BUF) {
             dtls_debug_dump("bytes from peer:", buf.data(), len);

--- a/apps/src/lua_config.cpp
+++ b/apps/src/lua_config.cpp
@@ -1,8 +1,9 @@
 #include "lua_config.hpp"
 
 #include <cmath>
-#include <iostream>
 #include <memory>
+
+#include <ace/Log_Msg.h>
 
 extern "C" {
 #include <lauxlib.h>
@@ -94,8 +95,9 @@ ResourceMap load_object_resources(const std::string& path) {
     ResourceMap out;
     LuaStatePtr L(luaL_newstate());
     if (!L) {
-        std::cerr << "[lua_config] " << path
-                  << ": luaL_newstate failed\n";
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l lua_config %C: luaL_newstate failed\n"),
+                   path.c_str()));
         return out;
     }
     luaL_openlibs(L.get());
@@ -106,14 +108,17 @@ ResourceMap load_object_resources(const std::string& path) {
         const char* err = lua_tostring(L.get(), -1);
         std::string msg = err ? err : "(no error message)";
         if (msg.find("cannot open") == std::string::npos) {
-            std::cerr << "[lua_config] " << path << ": " << msg << "\n";
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l lua_config %C: %C\n"),
+                       path.c_str(), msg.c_str()));
         }
         return out;
     }
 
     if (!lua_istable(L.get(), -1)) {
-        std::cerr << "[lua_config] " << path
-                  << ": top-level return is not a table\n";
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l lua_config %C: top-level return is not a table\n"),
+                   path.c_str()));
         return out;
     }
 
@@ -121,14 +126,16 @@ ResourceMap load_object_resources(const std::string& path) {
     // (deviceObject / serverObject / securityObject); we don't enforce.
     lua_pushnil(L.get());
     if (lua_next(L.get(), -2) == 0) {
-        std::cerr << "[lua_config] " << path
-                  << ": top-level table is empty\n";
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l lua_config %C: top-level table is empty\n"),
+                   path.c_str()));
         return out;
     }
     // Stack: top-level table (-3), key (-2), object-table (-1)
     if (!lua_istable(L.get(), -1)) {
-        std::cerr << "[lua_config] " << path
-                  << ": object value is not a table\n";
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l lua_config %C: object value is not a table\n"),
+                   path.c_str()));
         lua_pop(L.get(), 2);
         return out;
     }

--- a/apps/src/lwm2m_adapter.cpp
+++ b/apps/src/lwm2m_adapter.cpp
@@ -2,6 +2,7 @@
 #define __lwm2m_adapter_cpp__
 
 #include "lwm2m_adapter.hpp"
+#include <ace/Log_Msg.h>
 
 LwM2MAdapter::LwM2MAdapter() {
     ///LwM2M Security Object URI --> /0
@@ -354,7 +355,8 @@ std::string LwM2MAdapter::resourceIDName(const std::uint32_t& oid, const std::ui
 std::int32_t LwM2MAdapter::parseLwM2MUri(const std::string& uri, std::uint32_t& oid, std::uint32_t& oiid, std::uint32_t& rid) {
 
     if(uri.empty() || (uri.at(0) != '/')) {
-        std::cout << basename(__FILE__) << ":" << __LINE__ << " Error uri is empty" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l Error uri is empty\n")));
         return(-1);
     }
 
@@ -848,7 +850,8 @@ std::int32_t LwM2MAdapter::serialiseObjects(const json& rid, std::string& out) {
                 ss.write(reinterpret_cast<char *>(out.data()), out.length());
 
             } else {
-                std::cout << basename(__FILE__) << ":" << __LINE__ << " unsupported type" << std::endl;
+                ACE_ERROR((LM_ERROR,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l Error unsupported type\n")));
             }
             riid++;
         }

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -70,7 +70,8 @@ void parsePeerOption(const std::string& in, UDPAdapter::Scheme_t& scheme, std::s
     ///in = coaps://host:port
     if(in.empty()) {
         ///input is empty, 
-        std::cout << basename(__FILE__) << ":" << __LINE__ << " Error input is empty" << std::endl;
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l parsePeerOption: empty input\n")));
         return;
     }
 
@@ -255,8 +256,9 @@ void wire_server(std::shared_ptr<App>& app, const std::string& configDir,
 
         auto expired = registry->expire(now);
         if (!expired.empty()) {
-            std::cout << "[lwm2m] expired " << expired.size()
-                      << " registration(s)\n";
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l expired %u registration(s)\n"),
+                       static_cast<unsigned>(expired.size())));
             // L3 follow-up: forward expired locations to the RegistryMirror
             // when the Mongo schema PR lands.
         }
@@ -368,7 +370,9 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
         auto a = wapp_bs.lock();
         auto r = wreg_bs.lock();
         if (!a || !r) return;
-        std::cout << "[lwm2m] bootstrap commit done; sending Register\n";
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l bootstrap commit done; "
+                            "sending Register\n")));
         auto payload = r->build_register_request(next_msgid(),
                                                  std::string{static_cast<char>(0x01)});
         tx_via(*a, payload, ::UDPAdapter::ServiceType_t::LwM2MClient);
@@ -426,7 +430,9 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
         // the new endpoint (via RegistrationClient::endpoint()) and/or
         // to the freshly-swapped peer above.
         if (reg->state() == ::lwm2m::RegistrationState::Unregistered) {
-            std::cout << "[lwm2m] no bootstrap; sending Register directly\n";
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l no bootstrap; "
+                                "sending Register directly\n")));
             auto payload = reg->build_register_request(
                 next_msgid(),
                 std::string{static_cast<char>(0x10)});
@@ -483,7 +489,9 @@ int main(std::int32_t argc, char *argv[]) {
     parseCommandLineArgument(argc, argv, argValueMap);
     if(!argValueMap.empty()) {
         for(const auto& ent: argValueMap) {
-            std::cout << basename(__FILE__) << ":" << __LINE__ << " ent.first:" << ent.first << " ent.second:" << ent.second << std::endl;
+            ACE_DEBUG((LM_DEBUG,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l arg %C=%C\n"),
+                       ent.first.c_str(), ent.second.c_str()));
         }
     }
 
@@ -491,8 +499,9 @@ int main(std::int32_t argc, char *argv[]) {
     if(!argValueMap["role"].empty() && (argValueMap["role"] == "server" || argValueMap["role"] == "client")) {
         role = roleMap[argValueMap["role"]];
     } else {
-        std::cout << basename(__FILE__) << ":" << __LINE__ << " Error Invalid Option for role" << std::endl;
-        return(-1);
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("%D [iot:%t] %M %N:%l invalid option for role\n")),
+                         -1);
     }
 
     UDPAdapter::Scheme_t scheme;
@@ -501,8 +510,9 @@ int main(std::int32_t argc, char *argv[]) {
     std::uint16_t bsPort;
     if(UDPAdapter::Role_t::CLIENT == role) {
         if(argValueMap["bs"].empty()) {
-            std::cout << basename(__FILE__) << ":" << __LINE__ << " Error bs=value is missing in command line argument" << std::endl;
-            return(-1);
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("%D [iot:%t] %M %N:%l bs=value missing from command line\n")),
+                             -1);
         }
         parsePeerOption(argValueMap["bs"], scheme, bsHost, bsPort);
     }
@@ -510,18 +520,23 @@ int main(std::int32_t argc, char *argv[]) {
     std::string selfHost;
     std::uint16_t selfPort;
     if(argValueMap["local"].empty()) {
-        std::cout << basename(__FILE__) << ":" << __LINE__ << " Error local=value is missing in command line argument" << std::endl;
-        return(-1);
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("%D [iot:%t] %M %N:%l local=value missing from command line\n")),
+                         -1);
     }
     parsePeerOption(argValueMap["local"], scheme, selfHost, selfPort);
 
-    std::cout << basename(__FILE__) << ":" << __LINE__ << " scheme:" << std::to_string(scheme) << " host:" << selfHost << " port:" << std::to_string(selfPort) << std::endl;
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [iot:%t] %M %N:%l scheme=%d host=%C port=%u\n"),
+               static_cast<int>(scheme), selfHost.c_str(),
+               static_cast<unsigned>(selfPort)));
 
     std::string identity("97554878B284CE3B727D8DD06E87659A"), secret("3894beedaa7fe0eae6597dc350a59525");
     if(scheme == UDPAdapter::Scheme_t::CoAPs) {
         ///identity & secret are mandatory argument
         if(argValueMap["identity"].empty() || argValueMap["secret"].empty()) {
-            std::cout << basename(__FILE__) << ":" << __LINE__ << " Error either identity or secret missing for coaps" << std::endl;
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l identity or secret missing for coaps\n")));
             return(-2);
         }
 
@@ -705,8 +720,9 @@ int main(std::int32_t argc, char *argv[]) {
         rline.init();
         rline.start();
     } else {
-        std::cout << "[lwm2m] stdin is not a TTY; running in "
-                  << "non-interactive mode (reactor only).\n";
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [iot:%t] %M %N:%l stdin is not a TTY; "
+                            "running in non-interactive mode (reactor only)\n")));
         // ACE_Task::wait() blocks until svc() returns.
         app->udpAdapter()->wait();
     }


### PR DESCRIPTION
## Summary
Aligns the iot binary with the project's ACE-logging policy (already saved in memory as `feedback_ace_logging`). Active std::cout / std::cerr sites in app-internal code converted to `ACE_DEBUG((LM_*, ACE_TEXT(\"%D [iot:%t] %M %N:%l ...\"), ...))`. CLI command output deliberately kept on stdout (REPL contract).

**Counts of active sites converted**
- \`main.cpp\` 11 · \`lua_config.cpp\` 5 · \`cbor_adapter.cpp\` 4 · \`coap_adapter.cpp\` 40 · \`lwm2m_adapter.cpp\` 2 · \`dtls_adapter.cpp\` 1

**Kept on stdout (deliberate)**
- \`readline.cpp\`, \`cli/coap_dispatch.cpp\`, \`cli/commands/*.cpp\`

**Why it matters**
- Process-death output is no longer lost to stdout buffering (cause of the DsConfig log invisibility I worked around with \`std::endl\` defensively in earlier PRs).
- Same prefix shape as ds-server's logs — easier to correlate.
- Log level tunable at runtime.

## Test plan
- [x] 154/154 lwm2m_test green
- [x] lwm2m binary builds clean under podman \`naushada/iot:latest\`
- [x] Comments + \`#if 0\` legacy code in lwm2m_adapter.cpp untouched
- [x] CLI commands untouched

🤖 Generated with [Claude Code](https://claude.com/claude-code)