### PR TITLE
apps: header-level std::cout cleanup + missing return fix

### DIFF
--- a/apps/inc/coap_adapter.hpp
+++ b/apps/inc/coap_adapter.hpp
@@ -8,6 +8,8 @@
 #include <algorithm>
 #include <fstream>
 
+#include <ace/Log_Msg.h>
+
 #include "cbor_adapter.hpp"
 #include "lwm2m_adapter.hpp"
 
@@ -288,7 +290,10 @@ class CoAPAdapter {
             });
 
             if(it != coapmessage.uripath.end()) {
-                std::cout << basename(__FILE__) << ":" << __LINE__ <<  " value:" << it->optionvalue << " cf: " << ::ntohs(atoi(it->optionvalue.c_str())) << std::endl;
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l value=%C cf=%u\n"),
+                           it->optionvalue.c_str(),
+                           static_cast<unsigned>(::ntohs(atoi(it->optionvalue.c_str())))));
                 return(getContentFormat(::ntohs(atoi(it->optionvalue.c_str()))));
             }
 

--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -155,7 +155,8 @@ class DTLSAdapter {
          */
         void add_credential(const std::string& identity, const std::string& secret) {
             if(!device_credentials.insert(std::pair<std::string, std::string>(identity, secret)).second) {
-                std::cout << "add_credential-> identity & secret can't be inserted into STL" << std::endl;
+                ACE_ERROR((LM_ERROR,
+                           ACE_TEXT("%D [iot:%t] %M %N:%l add_credential: identity already registered\n")));
             }
         }
 

--- a/apps/src/lwm2m_adapter.cpp
+++ b/apps/src/lwm2m_adapter.cpp
@@ -830,6 +830,7 @@ std::int32_t LwM2MAdapter::buildLwM2MPayload(const ObjectId_t& oid, std::string 
     default:
         break;
     }
+    return 0;
 }
 
 


### PR DESCRIPTION
## Summary
Tail end of PR #19's ACE-logging sweep. Two stragglers in headers (\`coap_adapter.hpp\`, \`dtls_adapter.hpp\`) — headers matter more because every TU pulls them in.

- \`coap_adapter.hpp:getContentFormat()\` trace — eliminates the per-TU \`-Wwrite-strings\` warning from \`basename(__FILE__)\` under libgen.h semantics.
- \`dtls_adapter.hpp:add_credential()\` insertion-failure log.

Also fixes the line-shifted \`-Wreturn-type\` warning in \`LwM2MAdapter::buildLwM2MPayload\` (pre-existing, surfaced because PR #20 shortened the file by 400 lines and moved the offending function's closing brace up).

## Test plan
- [x] 154/154 lwm2m_test green
- [x] All targets (lwm2m, ds-server, ds-cli, ds-tests, lwm2m_test) build clean under podman

🤖 Generated with [Claude Code](https://claude.com/claude-code)