### PR TITLE
L11/D1+D2: systemd units + env files

### DIFF
--- a/log/L11/plan.md
+++ b/log/L11/plan.md
@@ -5,7 +5,7 @@
 > on-disk artefacts. As each D closes, the corresponding section
 > moves into `results.md` alongside the evidence.
 >
-> **Status (drafted 2026-05-31):** D1–D6 pending.
+> **Status (2026-05-31):** D1 + D2 done (PR #23). D3–D6 pending.
 
 ---
 
@@ -57,7 +57,9 @@ that `liblua5.3-dev` needs to be on the runtime host.
 
 ## 2. D-items
 
-### D1 — systemd units
+### D1 — systemd units ✅ (PR #23)
+
+Closed 2026-05-31. cmake install rule lands in D4.
 
 **Scope.** Author and install three unit files:
 
@@ -90,7 +92,11 @@ with systemd inside (or a sysvinit-skipping `systemd-nspawn`), runs:
 
 ---
 
-### D2 — Default config layout
+### D2 — Default config layout ✅ (PR #23, partial)
+
+Closed 2026-05-31 for the parts that ship now: env files + tmpfiles.d
+fallback. The `/etc/iot/config/*.lua.example` rename moves to D4 where
+the install rules live.
 
 **Scope.** Decide + ship the on-disk tree:
 

--- a/packaging/etc-iot/lwm2m-client.env
+++ b/packaging/etc-iot/lwm2m-client.env
@@ -1,0 +1,15 @@
+# EnvironmentFile for iot-lwm2m-client.service.
+#
+# Edit LWM2M_ARGS to point at your bootstrap server. The values below
+# match the smoke harness defaults — they boot but will sit in
+# AwaitingRegisterAck if no peer answers on bs=.
+#
+# Hot-reloadable via ds-cli (preferred):
+#   iot.endpoint    — endpoint name (overrides the compiled-in default)
+#   iot.lifetime    — registration lifetime (uint32 seconds)
+#   iot.server.uri  — DM server URI (live re-bind via Deregister-then-
+#                     Register; plain CoAP only, CoAPs logs a warning)
+#
+# See /etc/iot/ds-schemas/iot.lua for type + range constraints.
+
+LWM2M_ARGS=role=client local=coap://0.0.0.0:5684 bs=coap://127.0.0.1:5683 config=/etc/iot/config ds-sock=/run/iot/data_store.sock

--- a/packaging/etc-iot/lwm2m-server.env
+++ b/packaging/etc-iot/lwm2m-server.env
@@ -1,0 +1,10 @@
+# EnvironmentFile for iot-lwm2m-server.service.
+#
+# Server mode binds two ports per the L9 wiring:
+#   - 5683  Device Management server (CoAP) — added by main.cpp
+#   - <local=port>  Bootstrap server — set below
+#
+# Match the default Leshan port pair so a vanilla Leshan client points
+# at the same endpoints without extra config.
+
+LWM2M_ARGS=role=server local=coap://0.0.0.0:5685 config=/etc/iot/config ds-sock=/run/iot/data_store.sock

--- a/packaging/systemd/iot-ds.service
+++ b/packaging/systemd/iot-ds.service
@@ -1,0 +1,45 @@
+[Unit]
+Description=IoT data-store daemon (ds-server, EMP over unix socket)
+Documentation=file:///usr/local/include/data_store/proto.hpp
+# Network not required — the socket is local.
+After=local-fs.target
+# Crash-loop protection: 3 restarts within 30 s → fail so the operator
+# notices, instead of pegging a core. Lives in [Unit] not [Service]
+# in modern systemd (250+).
+StartLimitBurst=3
+StartLimitIntervalSec=30s
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/ds-server \
+    ds-socket=/run/iot/data_store.sock \
+    ds-store=/var/lib/iot/data_store.lua \
+    ds-schema-dir=/etc/iot/ds-schemas
+
+# DynamicUser auto-allocates a system user/group named `iot-ds` for the
+# duration of this service; StateDirectory + RuntimeDirectory end up
+# owned by that uid/gid. Cheaper than maintaining a /etc/passwd entry.
+DynamicUser=yes
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+StateDirectory=iot
+StateDirectoryMode=0750
+
+Restart=on-failure
+RestartSec=2s
+
+# journald handles stdout/stderr (ACE logging writes to stderr) so
+# `journalctl -u iot-ds` works out of the box.
+StandardOutput=journal
+StandardError=journal
+
+# Modest hardening — full lockdown is FUP material (would need cap_net
+# removal, ProtectSystem=strict, etc.).
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/iot-lwm2m-client.service
+++ b/packaging/systemd/iot-lwm2m-client.service
@@ -1,0 +1,42 @@
+[Unit]
+Description=IoT LwM2M client (binds to /run/iot DM server URI)
+Documentation=file:///etc/iot/lwm2m-client.env
+# Needs the data-store socket for live config; ordering ensures
+# DsConfig.connect() doesn't fall through to defaults at boot.
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+# StartLimit* live in [Unit] for modern systemd (250+).
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+# All knobs in the env file so operators edit /etc/iot/lwm2m-client.env,
+# not the unit. Missing file → unit fails fast with "EnvironmentFile not
+# found" (the `-` prefix below makes it optional; we want it required so
+# typos surface, hence no prefix).
+EnvironmentFile=/etc/iot/lwm2m-client.env
+ExecStart=/usr/local/bin/lwm2m $LWM2M_ARGS
+
+DynamicUser=yes
+# Match ds-ds's RuntimeDirectory name so both units see the same
+# /run/iot/ tree (and thus the same socket file). Both units claim the
+# directory; systemd's RuntimeDirectory= semantics make this safe —
+# whichever starts first creates it, the other re-uses it.
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/iot-lwm2m-server.service
+++ b/packaging/systemd/iot-lwm2m-server.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=IoT LwM2M Bootstrap + DM server (Leshan-compatible)
+Documentation=file:///etc/iot/lwm2m-server.env
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+# Mutually-exclusive use case with the client unit: typical deploys
+# enable one or the other. Both can coexist on disjoint ports if
+# someone really wants client + server on the same host.
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/lwm2m-server.env
+ExecStart=/usr/local/bin/lwm2m $LWM2M_ARGS
+
+DynamicUser=yes
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/iot.conf
+++ b/packaging/systemd/iot.conf
@@ -1,0 +1,11 @@
+# tmpfiles.d entry for the iot socket directory.
+#
+# Belt-and-braces: the systemd units in this package use
+# `RuntimeDirectory=iot` which already creates and chowns /run/iot/.
+# This file exists for hosts where the service starts before
+# systemd-tmpfiles (rare) and for non-DynamicUser= overrides where the
+# owner needs to be a fixed uid/gid.
+#
+# Type Path                Mode UID  GID   Age Argument
+d      /run/iot            0755 root root  -   -
+d      /var/lib/iot        0750 root root  -   -


### PR DESCRIPTION
## Summary
First slice of L11 (packaging + deployment). Authors the systemd unit files + env files needed for \`systemctl enable --now iot-ds iot-lwm2m-client\` to work after D4's install rules land.

**D1 — systemd units** (under \`packaging/systemd/\`)
- \`iot-ds.service\` — ds-server; DynamicUser; RuntimeDirectory=iot; StateDirectory=iot; crash-loop protection in [Unit] for modern systemd.
- \`iot-lwm2m-client.service\` — After/Wants iot-ds.service so DsConfig connect succeeds at boot.
- \`iot-lwm2m-server.service\` — same shape, server role.

All three: Type=simple, NoNewPrivileges, PrivateTmp, ProtectKernelTunables, ProtectControlGroups, RestrictRealtime. Journal logging.

**D2 — env files + tmpfiles.d fallback** (under \`packaging/etc-iot/\` and \`packaging/systemd/iot.conf\`)
- Smoke-harness-compatible defaults; comment points at the hot-reloadable iot.* keys + schema.

## Test plan
- [x] \`systemd-analyze verify\` clean on all three units (validated in podman + systemd container)
- [x] cmake install rules deferred to D4 (per the L11 plan sequencing)
- [x] End-to-end \`systemctl start\` smoke deferred to D6

🤖 Generated with [Claude Code](https://claude.com/claude-code)