### PR TITLE
L11/D4: cmake install rules + DESTDIR smoke

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -76,7 +76,61 @@ target_link_libraries(lwm2m
 
 add_subdirectory(test)
 
+include(GNUInstallDirs)
+
+# Drop the CONFIGURATIONS Release filter so `make install` works in
+# Debug builds too — packagers don't always rebuild as Release.
 install(TARGETS lwm2m
-        CONFIGURATIONS Release
-        RUNTIME DESTINATION /usr/local/bin
-)
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# ──────────────────────────── packaging assets ─────────────────────────
+# IOT_PACKAGING_INSTALL toggles the systemd + /etc/iot/* install. Default
+# ON so a `make install` produces a deployable tree; flip to OFF for
+# dev installs that should not touch /lib/systemd or /etc/iot.
+option(IOT_PACKAGING_INSTALL "Install systemd units, env files, config examples" ON)
+
+if(IOT_PACKAGING_INSTALL)
+    # systemd unit files. /lib/systemd/system is the conventional
+    # vendor path; distros' own units live at /etc/systemd/system
+    # and override us, which is fine.
+    install(FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-ds.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-lwm2m-client.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-lwm2m-server.service
+            DESTINATION lib/systemd/system)
+
+    # tmpfiles.d fallback for hosts where RuntimeDirectory= doesn't
+    # fire (older systemd, sysvinit shims). MUST land under plain
+    # `lib/tmpfiles.d`, NOT `${CMAKE_INSTALL_LIBDIR}/tmpfiles.d` —
+    # multi-arch hosts make LIBDIR=lib/<triplet> which systemd-tmpfiles
+    # doesn't scan.
+    install(FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot.conf
+            DESTINATION lib/tmpfiles.d)
+
+    # EnvironmentFile for each lwm2m unit. Use FULL_SYSCONFDIR so the
+    # files land at /etc/iot/ when --prefix=/usr (cmake's GNUInstallDirs
+    # special-cases /usr to make sysconfdir an absolute /etc). The
+    # relative CMAKE_INSTALL_SYSCONFDIR would have placed these at
+    # /usr/etc/iot/ which no service reads.
+    install(FILES
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/lwm2m-client.env
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/lwm2m-server.env
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot)
+
+    # Object-resource config templates. Land each .lua as .lua.example
+    # so an operator copy + edit is required — packaging upgrades won't
+    # silently clobber edited config. Renaming has to be per-file
+    # because cmake's install(FILES RENAME) only takes one source.
+    set(IOT_CONFIG_DIR ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/config)
+    foreach(subdir securityObject serverObject deviceObject accessControlObject firmwareObject)
+        file(GLOB _lua_files
+             RELATIVE ${CMAKE_CURRENT_SOURCE_DIR}/config/${subdir}
+             ${CMAKE_CURRENT_SOURCE_DIR}/config/${subdir}/*.lua)
+        foreach(_f ${_lua_files})
+            install(FILES ${CMAKE_CURRENT_SOURCE_DIR}/config/${subdir}/${_f}
+                    DESTINATION ${IOT_CONFIG_DIR}/${subdir}
+                    RENAME ${_f}.example)
+        endforeach()
+    endforeach()
+endif()

--- a/log/L11/plan.md
+++ b/log/L11/plan.md
@@ -5,7 +5,8 @@
 > on-disk artefacts. As each D closes, the corresponding section
 > moves into `results.md` alongside the evidence.
 >
-> **Status (2026-05-31):** D1 + D2 done (PR #23). D3–D6 pending.
+> **Status (2026-05-31):** D1 + D2 done (PR #23); D4 done (PR #24).
+> D3 + D5 + D6 pending.
 
 ---
 
@@ -170,7 +171,15 @@ Target size ≤ 100 MB.
 
 ---
 
-### D4 — cmake install rules pass smoke
+### D4 — cmake install rules pass smoke ✅ (PR #24)
+
+Closed 2026-05-31. Switched both CMakeLists.txt files to GNUInstallDirs
+so packagers can override via `--prefix=/usr`. Added install rules for
+the D1+D2 artefacts behind `IOT_PACKAGING_INSTALL=ON` (default). Used
+`CMAKE_INSTALL_FULL_SYSCONFDIR` (not the relative variant) so `/etc/iot`
+lands absolute under `--prefix=/usr`, and hardcoded `lib/tmpfiles.d`
+(not `LIBDIR/tmpfiles.d`) so multi-arch hosts don't bury it under
+`lib/aarch64-linux-gnu/`. Smoke evidence in PR description.
 
 **Scope.** Audit current `install(...)` rules across
 `apps/CMakeLists.txt` + `modules/data-store/CMakeLists.txt`. Add what's

--- a/modules/data-store/CMakeLists.txt
+++ b/modules/data-store/CMakeLists.txt
@@ -121,16 +121,23 @@ if(BUILD_DATA_STORE_TESTS)
     add_test(NAME ds-tests COMMAND ds-tests)
 endif()
 
-install(TARGETS ds-server ds-cli
-        RUNTIME DESTINATION /usr/local/bin)
-install(TARGETS datastore_client
-        ARCHIVE DESTINATION /usr/local/lib)
-install(DIRECTORY inc/data_store
-        DESTINATION /usr/local/include)
+include(GNUInstallDirs)
 
-# Ship the canonical iot.* schema to the default ds-schema-dir so
-# packaged installs validate iot.endpoint / iot.lifetime / etc. out
-# of the box. Operators can drop additional *.lua siblings in the
-# same directory.
+# Use GNUInstallDirs so packagers can override per the standard
+# autotools-style flow:
+#   cmake -DCMAKE_INSTALL_PREFIX=/usr     → bin → /usr/bin
+#   cmake -DCMAKE_INSTALL_PREFIX=/usr/local (default) → bin → /usr/local/bin
+# Pair with `make install DESTDIR=/staging` for clean per-tree installs.
+install(TARGETS ds-server ds-cli
+        RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+install(TARGETS datastore_client
+        ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR})
+install(DIRECTORY inc/data_store
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+# Ship the canonical iot.* schema to the ds-server default schema dir.
+# FULL_SYSCONFDIR is /etc when --prefix=/usr (cmake's special case);
+# the relative SYSCONFDIR would land at /usr/etc which ds-server won't
+# scan.
 install(FILES schemas/iot.lua
-        DESTINATION /etc/iot/ds-schemas/)
+        DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)


### PR DESCRIPTION
## Summary
Switch both \`CMakeLists.txt\` files to \`GNUInstallDirs\` so packagers can run the standard \`cmake --prefix=/usr && make install DESTDIR=...\`. Adds install rules for the D1+D2 assets behind \`IOT_PACKAGING_INSTALL=ON\` (default).

**Install layout (\`--prefix=/usr\`)**
- \`/usr/bin/{ds-server, ds-cli, lwm2m}\`
- \`/usr/lib/<triplet>/libdatastore_client.a\`
- \`/usr/include/data_store/{client,proto,value}.hpp\`
- \`/usr/lib/systemd/system/iot-{ds,lwm2m-client,lwm2m-server}.service\`
- \`/usr/lib/tmpfiles.d/iot.conf\` (plain lib/, not multi-arch)
- \`/etc/iot/ds-schemas/iot.lua\`
- \`/etc/iot/{lwm2m-client,lwm2m-server}.env\`
- \`/etc/iot/config/{security,server,device,accessControl,firmware}Object/*.lua.example\`

**Gotchas captured in comments**
- \`CMAKE_INSTALL_SYSCONFDIR\` is relative (\"etc\"); use \`CMAKE_INSTALL_FULL_SYSCONFDIR\` for absolute \`/etc\` under \`--prefix=/usr\`
- \`tmpfiles.d\` MUST be \`/usr/lib/tmpfiles.d\`, NOT under multi-arch \`LIBDIR/tmpfiles.d\`

## Test plan
- [x] DESTDIR smoke under podman: \`cmake --prefix=/usr && make install DESTDIR=/tmp/staging\` lands all 10 expected paths
- [x] \`ldd lwm2m\` shows no missing libs
- [x] 154/154 lwm2m_test green
- [x] 39/39 ds-tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)