### PR TITLE
L11/D3: OCI runtime image (~119 MB) + dispatcher entrypoint

### DIFF
--- a/log/L11/plan.md
+++ b/log/L11/plan.md
@@ -5,8 +5,8 @@
 > on-disk artefacts. As each D closes, the corresponding section
 > moves into `results.md` alongside the evidence.
 >
-> **Status (2026-05-31):** D1 + D2 done (PR #23); D4 done (PR #24).
-> D3 + D5 + D6 pending.
+> **Status (2026-05-31):** D1 + D2 (PR #23), D4 (PR #24), D3 (PR #25)
+> done. D5 + D6 pending. FUP-L11-1 opened to track image-size shrink.
 
 ---
 
@@ -137,7 +137,13 @@ under `/etc/iot/config/`.
 
 ---
 
-### D3 — OCI image build
+### D3 — OCI image build ✅ (PR #25)
+
+Closed 2026-05-31. Image size landed at **119 MB** vs the 100 MB
+soft target — over by ~18%; routes to shrink documented in
+`packaging/README.md` and tracked as **FUP-L11-1**. All smokes pass
+end-to-end inside the container (ds-server + ds-cli + lwm2m client
+picking up live config).
 
 **Scope.** A `packaging/Containerfile` (podman-first; works under
 Docker too) producing a runtime image:
@@ -244,6 +250,14 @@ container and proves it works:
 
 - `log/L11/e2e-smoke.sh`
 - `log/L11/e2e-smoke.txt` (captured run)
+
+---
+
+## 2.5. Follow-ups opened during execution
+
+| ID         | Item                                                                                                                                          |
+|------------|------------------------------------------------------------------------------------------------------------------------------------------------|
+| FUP-L11-1  | OCI image size 119 MB vs 100 MB soft target. Routes documented in `packaging/README.md` §"Image size" (debian-slim base, drop mongo runtime, upx). Not blocking. |
 
 ---
 

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -1,0 +1,102 @@
+# Multi-stage runtime image for ds-server + lwm2m.
+#
+# Stage 1 (build) re-uses the existing dev image — naushada/iot:latest —
+# which already has ACE_TAO 7.0.0, mongocxx, OpenSSL 3.1.1, tinydtls,
+# and Lua 5.3 dev set up at the paths apps/CMakeLists.txt expects.
+#
+# Stage 2 (runtime) starts from Ubuntu 22.04 minimal and copies in only
+# the binaries + shared libs the ldd inventory says are needed:
+#   - libACE.so.7.0.0          (from /usr/local/ACE_TAO-7.0.0/lib)
+#   - libmongocxx + libbsoncxx + libmongoc + libbson  (lwm2m only)
+#   - libssl/libcrypto 3       (from base ubuntu)
+#   - libreadline/libtinfo/libz (from base ubuntu)
+#   - Lua + tinydtls are STATICALLY linked into the binaries — no runtime needed
+#
+# Target image size ≤ 100 MB. Last measured: see packaging/README.md.
+
+ARG BUILD_IMAGE=naushada/iot:latest
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage 1: build
+# ──────────────────────────────────────────────────────────────────────
+FROM ${BUILD_IMAGE} AS build
+
+# liblua5.3-dev isn't baked into the dev image; install it once here so
+# the make invocation finds lauxlib.h. The dev image ships without /tmp
+# so apt-key's temp-file creation fails — mkdir it first.
+RUN mkdir -p /tmp && chmod 1777 /tmp && \
+    apt-get update -qq && apt-get install -y -qq liblua5.3-dev && \
+    rm -rf /var/lib/apt/lists/*
+
+WORKDIR /src
+COPY . /src
+
+RUN rm -rf /src/apps/build /src/modules/data-store/build && \
+    mkdir -p /src/apps/build && \
+    cd /src/apps/build && \
+    cmake -DCMAKE_INSTALL_PREFIX=/usr .. && \
+    make -j"$(nproc)" && \
+    make install DESTDIR=/staging
+
+# Container deploys don't care about copy-on-edit safety for the config
+# templates — the image is the unit of upgrade. Rename .example back to
+# .lua so the lwm2m binary's `config=/etc/iot/config` boots out of the
+# box. Operators override by mounting their own /etc/iot/config tree.
+RUN find /staging/etc/iot/config -name '*.lua.example' \
+        -exec sh -c 'mv "$1" "${1%.example}"' _ {} \;
+
+# Strip the binaries — saves ~20 MB across the three.
+RUN strip /staging/usr/bin/ds-server \
+          /staging/usr/bin/ds-cli \
+          /staging/usr/bin/lwm2m
+
+# ──────────────────────────────────────────────────────────────────────
+# Stage 2: runtime
+# ──────────────────────────────────────────────────────────────────────
+FROM ubuntu:22.04 AS runtime
+
+# Runtime apt: only the libs the binaries actually link against per ldd.
+# --no-install-recommends keeps the layer small.
+RUN apt-get update -qq && \
+    apt-get install -y --no-install-recommends -qq \
+        libreadline8 \
+        libssl3 \
+        zlib1g \
+        ca-certificates && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/* /usr/share/doc/* /usr/share/man/*
+
+# Bring in ACE 7.0.0 shared lib only (not the full SDK).
+COPY --from=build /usr/local/ACE_TAO-7.0.0/lib/libACE.so* /usr/local/ACE_TAO-7.0.0/lib/
+
+# Bring in mongocxx + bsoncxx + mongoc + bson runtime libs (lwm2m links them).
+COPY --from=build /usr/local/lib/libbson-1.0.so*    /usr/local/lib/
+COPY --from=build /usr/local/lib/libbsoncxx.so*     /usr/local/lib/
+COPY --from=build /usr/local/lib/libmongoc-1.0.so*  /usr/local/lib/
+COPY --from=build /usr/local/lib/libmongocxx.so*    /usr/local/lib/
+
+# ld.so cache update so the binaries find these.
+RUN echo /usr/local/ACE_TAO-7.0.0/lib > /etc/ld.so.conf.d/ace-tao.conf && \
+    echo /usr/local/lib              > /etc/ld.so.conf.d/iot-runtime.conf && \
+    ldconfig
+
+# Binaries + config + entrypoint.
+COPY --from=build /staging/usr/bin/ds-server   /usr/local/bin/
+COPY --from=build /staging/usr/bin/ds-cli      /usr/local/bin/
+COPY --from=build /staging/usr/bin/lwm2m       /usr/local/bin/
+COPY --from=build /staging/etc/iot             /etc/iot
+
+COPY packaging/iot-entrypoint.sh /usr/local/bin/iot-entrypoint
+RUN chmod +x /usr/local/bin/iot-entrypoint
+
+# RuntimeDirectory= equivalent inside the container — ds-server binds
+# its socket here. Operators can `--volume host:/run/iot` to share the
+# socket between sibling containers.
+RUN mkdir -p /run/iot /var/lib/iot && \
+    chmod 0755 /run/iot && \
+    chmod 0750 /var/lib/iot
+
+# Smoke probe: `podman run --rm iot:l11 ds-cli --help` should land in
+# the help path (exit 0 or 2).
+ENTRYPOINT ["/usr/local/bin/iot-entrypoint"]
+CMD []

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -1,0 +1,146 @@
+# packaging/ — L11 deploy artefacts
+
+Multi-target runtime packaging for `ds-server` + `lwm2m`. Two paths:
+
+| Target          | Authoring artefact                                | Install vehicle              |
+|-----------------|---------------------------------------------------|------------------------------|
+| Bare metal / VM | `systemd/iot-*.service`, `etc-iot/*.env`, `systemd/iot.conf` | cmake install rules (L11/D4) |
+| Container       | `Containerfile`, `iot-entrypoint.sh`              | OCI image (this dir, L11/D3) |
+
+The wire spec (data-store EMP) and the application API (libdatastore_client)
+are documented separately under [`modules/data-store/docs/`](../modules/data-store/docs/).
+
+---
+
+## OCI image (D3)
+
+### Build
+
+```sh
+podman build -f packaging/Containerfile -t iot:l11 .
+```
+
+The build is a **two-stage**:
+
+- **Stage 1** re-uses the dev image `naushada/iot:latest` (ACE_TAO 7.0.0,
+  mongocxx, OpenSSL 3.1.1, tinydtls). Compiles + `make install
+  DESTDIR=/staging`. Renames `*.lua.example` back to `*.lua` for in-image
+  defaults (no copy-on-edit safety needed — image *is* the upgrade unit).
+  Strips the binaries to save ~20 MB.
+- **Stage 2** starts from `ubuntu:22.04` with only `libreadline8 libssl3
+  zlib1g ca-certificates --no-install-recommends`. Copies in:
+  - `libACE.so.7.0.0` from `/usr/local/ACE_TAO-7.0.0/lib/`
+  - `lib{bson,bsoncxx,mongoc,mongocxx}*` from `/usr/local/lib/`
+  - The three binaries + `/etc/iot/`
+- `ldconfig` indexes both lib trees via two files in `/etc/ld.so.conf.d/`.
+
+### Run
+
+The entrypoint dispatches on `IOT_ROLE`:
+
+```sh
+# ds-server
+podman run -d --name iot-ds -e IOT_ROLE=ds iot:l11
+
+# lwm2m client (needs ds-server reachable on /run/iot)
+podman run -d --name iot-client -e IOT_ROLE=client \
+    --volumes-from iot-ds iot:l11
+
+# lwm2m server (Leshan-style bootstrap + DM)
+podman run -d --name iot-server -e IOT_ROLE=server \
+    --volumes-from iot-ds -p 5683:5683/udp -p 5685:5685/udp iot:l11
+```
+
+The entrypoint also accepts a binary name as the first arg — useful
+for debugging:
+
+```sh
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock get iot.endpoint
+podman run --rm iot:l11 ds-cli --help
+```
+
+### Image size
+
+| Stage                          | Approx size |
+|--------------------------------|------------:|
+| Build stage                    | ~3.5 GB     |
+| Runtime stage (this image)     | **~119 MB** |
+
+Above the soft 100 MB target. Routes to shrink, in rough effort order:
+
+1. **Use `debian:bookworm-slim` base instead of `ubuntu:22.04`** — saves
+   ~40 MB but introduces an apt-source switch.
+2. **Drop mongocxx/bsoncxx/mongoc/bson runtime** — only the lwm2m binary
+   links them, and only because db_adapter.cpp is still in the build.
+   Removing the mongo-mirror stubs would save ~15 MB.
+3. **`upx --best` on the binaries** — saves ~5–10 MB; trades startup
+   speed and complicates core-dump triage.
+
+None of these are blocking for v1. Filed as `FUP-L11-1` (see [L11
+plan](../log/L11/plan.md)).
+
+### Verified smokes
+
+Both run inside the same container against the embedded ds-server.
+
+| Smoke                                                         | Result                                               |
+|---------------------------------------------------------------|------------------------------------------------------|
+| `ds-server` boots, listens on `/run/iot/data_store.sock`      | "listening on /run/iot/data_store.sock (mode 0660)"  |
+| `ds-cli set iot.endpoint '"…"'` round-trips                   | `ok` + `get` returns the value                       |
+| `ds-cli set iot.lifetime -1` rejected by schema               | `schema(iot.lifetime): -1 below min 0`               |
+| `lwm2m role=client` (via `IOT_ROLE=client`) picks up live cfg | `endpoint from data-store: urn:dev:oci-client`       |
+|                                                               | `Registration lifetime from data-store: 3600`        |
+
+---
+
+## Bare-metal install (D1 + D2 + D4)
+
+```sh
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr   # use --prefix=/usr/local for /usr/local layout
+make -C build -j"$(nproc)"
+sudo make -C build install                   # use DESTDIR=… for packaging
+sudo systemctl daemon-reload
+sudo systemctl enable --now iot-ds.service iot-lwm2m-client.service
+```
+
+Layout the install lands (under `--prefix=/usr`):
+
+```
+/usr/bin/{ds-server, ds-cli, lwm2m}
+/usr/lib/<triplet>/libdatastore_client.a
+/usr/include/data_store/{client,proto,value}.hpp
+/usr/lib/systemd/system/iot-{ds, lwm2m-client, lwm2m-server}.service
+/usr/lib/tmpfiles.d/iot.conf
+/etc/iot/ds-schemas/iot.lua
+/etc/iot/{lwm2m-client,lwm2m-server}.env
+/etc/iot/config/{security,server,device,accessControl,firmware}Object/*.lua.example
+```
+
+`.lua.example` files: operators copy to `.lua` + edit. Package upgrades
+won't clobber edited copies. The OCI image skips this convention (see
+above).
+
+### Disable packaging install (dev workflow)
+
+```sh
+cmake -B build -DIOT_PACKAGING_INSTALL=OFF
+make -C build install                        # binaries + lib + headers only
+```
+
+---
+
+## Live config from `ds-cli`
+
+Once a deployment is running, operators tune via `ds-cli`:
+
+```sh
+ds-cli --socket=/run/iot/data_store.sock set iot.endpoint '"urn:dev:prod-1"'
+ds-cli --socket=/run/iot/data_store.sock set iot.lifetime 600
+ds-cli --socket=/run/iot/data_store.sock set iot.server.uri '"coap://10.0.0.5:5683"'
+ds-cli --socket=/run/iot/data_store.sock get iot.endpoint iot.lifetime iot.server.uri
+```
+
+Changes hot-apply via `DsConfig::on_change` → `RegistrationClient`
+setters (FUP-DS-9, FUP-DS-10, FUP-DS-11). See
+[`modules/data-store/docs/protocol.md`](../modules/data-store/docs/protocol.md)
+for full schema + rejection semantics.

--- a/packaging/etc-iot/lwm2m-client.env
+++ b/packaging/etc-iot/lwm2m-client.env
@@ -12,4 +12,4 @@
 #
 # See /etc/iot/ds-schemas/iot.lua for type + range constraints.
 
-LWM2M_ARGS=role=client local=coap://0.0.0.0:5684 bs=coap://127.0.0.1:5683 config=/etc/iot/config ds-sock=/run/iot/data_store.sock
+LWM2M_ARGS="role=client local=coap://0.0.0.0:5684 bs=coap://127.0.0.1:5683 config=/etc/iot/config ds-sock=/run/iot/data_store.sock"

--- a/packaging/etc-iot/lwm2m-server.env
+++ b/packaging/etc-iot/lwm2m-server.env
@@ -7,4 +7,4 @@
 # Match the default Leshan port pair so a vanilla Leshan client points
 # at the same endpoints without extra config.
 
-LWM2M_ARGS=role=server local=coap://0.0.0.0:5685 config=/etc/iot/config ds-sock=/run/iot/data_store.sock
+LWM2M_ARGS="role=server local=coap://0.0.0.0:5685 config=/etc/iot/config ds-sock=/run/iot/data_store.sock"

--- a/packaging/iot-entrypoint.sh
+++ b/packaging/iot-entrypoint.sh
@@ -1,0 +1,59 @@
+#!/bin/sh
+# Container entrypoint: dispatch on IOT_ROLE env var.
+#
+#   IOT_ROLE=ds      → run ds-server
+#   IOT_ROLE=client  → run lwm2m role=client
+#   IOT_ROLE=server  → run lwm2m role=server
+#
+# Per-role default args live in /etc/iot/lwm2m-*.env (sourced via
+# . , so they end up as shell vars). Operators override by:
+#   * mounting their own /etc/iot/ tree, OR
+#   * passing `--env LWM2M_ARGS=...` on `podman run`, OR
+#   * passing literal argv to the container (becomes "$@").
+#
+# Argv passed to the container goes through to the underlying binary,
+# which lets you do:
+#   podman run iot:l11 ds-cli set iot.endpoint '"urn:dev:c-7"'
+
+set -e
+
+# If the first arg is one of our binaries, forward verbatim — supports
+# `podman run iot:l11 ds-cli get foo`.
+case "${1:-}" in
+    ds-cli|ds-server|lwm2m)
+        exec "$@"
+        ;;
+esac
+
+case "${IOT_ROLE:-}" in
+    ds)
+        exec /usr/local/bin/ds-server \
+            ds-socket=/run/iot/data_store.sock \
+            ds-store=/var/lib/iot/data_store.lua \
+            ds-schema-dir=/etc/iot/ds-schemas \
+            "$@"
+        ;;
+    client)
+        # shellcheck disable=SC1091
+        [ -f /etc/iot/lwm2m-client.env ] && . /etc/iot/lwm2m-client.env
+        : "${LWM2M_ARGS:?lwm2m-client.env missing LWM2M_ARGS}"
+        # shellcheck disable=SC2086  # word-splitting is intentional
+        exec /usr/local/bin/lwm2m $LWM2M_ARGS "$@"
+        ;;
+    server)
+        # shellcheck disable=SC1091
+        [ -f /etc/iot/lwm2m-server.env ] && . /etc/iot/lwm2m-server.env
+        : "${LWM2M_ARGS:?lwm2m-server.env missing LWM2M_ARGS}"
+        # shellcheck disable=SC2086
+        exec /usr/local/bin/lwm2m $LWM2M_ARGS "$@"
+        ;;
+    "")
+        echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server" >&2
+        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m" >&2
+        exit 64
+        ;;
+    *)
+        echo "iot-entrypoint: unknown IOT_ROLE='$IOT_ROLE' (expected ds|client|server)" >&2
+        exit 64
+        ;;
+esac


### PR DESCRIPTION
## Summary
Multi-stage \`packaging/Containerfile\` producing a runtime image. Stage 1 reuses \`naushada/iot:latest\` for the build; stage 2 is \`ubuntu:22.04\` + only the runtime deps \`ldd\` shows (libreadline, libssl3, zlib1g + the custom libACE + mongo* libs lwm2m links).

\`iot-entrypoint.sh\` dispatches on \`IOT_ROLE={ds,client,server}\` and also forwards bare binary names for debugging (\`podman run iot:l11 ds-cli get foo\`).

\`packaging/README.md\` documents both OCI and bare-metal install paths in one place so D5's DEPLOY.md can cross-link.

## Test plan
End-to-end smokes inside the container:
- [x] ds-server boots; \`listening on /run/iot/data_store.sock (mode 0660)\`
- [x] \`ds-cli set/get\` round-trips typed values
- [x] \`ds-cli set iot.lifetime -1\` rejected by schema
- [x] \`IOT_ROLE=client\` picks up \`endpoint from data-store: urn:dev:oci-client\` + lifetime=3600 live from ds-server

## Caveat
Image size landed at **119 MB** vs the 100 MB soft target — ~18% over. Routes to shrink documented in \`packaging/README.md\` (debian-slim base, drop mongo runtime, upx). Tracked as **FUP-L11-1**, not blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)