### PR TITLE
L11/D5+D6: DEPLOY.md + e2e smoke harness (closes L11)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,0 +1,239 @@
+# Deploying iot
+
+Two paths, your choice:
+
+| Path        | When                                                                                    | Time-to-first-`get`  |
+|-------------|------------------------------------------------------------------------------------------|----------------------|
+| **Container** | Cloud, edge devices that already run a container engine, local hacking                | 5 min                |
+| **Bare metal** | Single-purpose appliances, embedded Linux without container runtime                  | 15 min               |
+
+After install both paths boot `ds-server` (the typed-value config plane)
+plus one of the `lwm2m` roles (client or server). Live config flows
+through `ds-cli` — no service restarts needed for endpoint, lifetime,
+or DM server URI changes.
+
+For the wire spec, application API, and ds-cli cookbook see:
+
+- [modules/data-store/docs/protocol.md](modules/data-store/docs/protocol.md) — EMP framing
+- [modules/data-store/docs/client_api.md](modules/data-store/docs/client_api.md) — `libdatastore_client` API
+- [packaging/README.md](packaging/README.md) — build/install internals + image size budget
+
+---
+
+## Path A — Container (recommended for first run)
+
+### 1. Build the runtime image
+
+```sh
+podman build -f packaging/Containerfile -t iot:l11 .
+```
+
+(~5 min cold, < 30 s warm thanks to layer caching. Final image
+~119 MB; see [`packaging/README.md`](packaging/README.md) for the
+size budget routes if you need it smaller.)
+
+### 2. Start ds-server + lwm2m client
+
+The two containers share `/run/iot` via a named volume so the lwm2m
+client can connect to ds-server's unix socket:
+
+```sh
+podman volume create iot-run
+podman run -d --name iot-ds     -e IOT_ROLE=ds     -v iot-run:/run/iot iot:l11
+podman run -d --name iot-client -e IOT_ROLE=client -v iot-run:/run/iot iot:l11
+```
+
+For the server role (Bootstrap + DM), substitute `IOT_ROLE=server` and
+expose UDP ports:
+
+```sh
+podman run -d --name iot-server -e IOT_ROLE=server \
+    -v iot-run:/run/iot \
+    -p 5683:5683/udp -p 5685:5685/udp \
+    iot:l11
+```
+
+### 3. Tune config via ds-cli
+
+```sh
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock \
+    set iot.endpoint '"urn:dev:my-device-1"'
+
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock \
+    set iot.lifetime 600
+
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock \
+    get iot.endpoint iot.lifetime
+```
+
+The lwm2m container picks these up via its `DsConfig` watch +
+on_change handlers (FUP-DS-9..11). Watch the log:
+
+```sh
+podman logs -f iot-client | grep "applied iot"
+# applied iot.endpoint=urn:dev:my-device-1 — re-register cycle queued ...
+# applied iot.lifetime=600 to live RegistrationClient — next Update tick uses it
+```
+
+### 4. Verify the full pipeline
+
+Run the end-to-end smoke that this repo ships:
+
+```sh
+sh log/L11/e2e-smoke.sh
+```
+
+It builds the image, starts both containers, mutates a key, asserts
+the hot-apply landed, and confirms schema rejection still gates. The
+last run is captured at [`log/L11/e2e-smoke.txt`](log/L11/e2e-smoke.txt).
+
+---
+
+## Path B — Bare metal / VM
+
+### 1. Build + install
+
+```sh
+# Dependencies (Ubuntu 22.04 reference)
+sudo apt install -y cmake g++ libssl-dev zlib1g-dev libreadline-dev \
+                    liblua5.3-dev libace-dev libmongocxx-dev libbsoncxx-dev
+
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+make -C build -j"$(nproc)"
+sudo make -C build install
+```
+
+Layout (under `--prefix=/usr`):
+
+```
+/usr/bin/{ds-server, ds-cli, lwm2m}
+/usr/lib/<triplet>/libdatastore_client.a
+/usr/lib/systemd/system/iot-{ds, lwm2m-client, lwm2m-server}.service
+/usr/lib/tmpfiles.d/iot.conf
+/etc/iot/ds-schemas/iot.lua
+/etc/iot/{lwm2m-client, lwm2m-server}.env
+/etc/iot/config/<object>/*.lua.example
+```
+
+### 2. Copy + edit your config templates
+
+The packaged `.lua.example` files exist so `sudo apt upgrade` (or your
+equivalent) never silently clobbers your real config. Copy one to
+`.lua` and edit:
+
+```sh
+cd /etc/iot/config/securityObject
+sudo cp 0.lua.example 0.lua
+sudoedit 0.lua             # set serverUri, identity, secretKey
+```
+
+Repeat for `serverObject/0.lua`, `deviceObject/0.lua` as needed for
+your role.
+
+### 3. Enable + start
+
+```sh
+sudo systemctl daemon-reload
+sudo systemctl enable --now iot-ds.service iot-lwm2m-client.service
+sudo systemctl status iot-ds iot-lwm2m-client
+```
+
+The lwm2m-client unit `After=iot-ds.service Wants=iot-ds.service` so
+DsConfig connects on the first try without falling back to defaults.
+
+### 4. Same ds-cli tuning as the container path
+
+```sh
+ds-cli --socket=/run/iot/data_store.sock set iot.endpoint '"urn:dev:my-device-1"'
+ds-cli --socket=/run/iot/data_store.sock set iot.lifetime 600
+journalctl -u iot-lwm2m-client.service -f | grep "applied iot"
+```
+
+---
+
+## Common operator tasks
+
+### Inspect the schema
+
+```sh
+cat /etc/iot/ds-schemas/iot.lua
+# Defines: iot.endpoint, iot.lifetime, iot.server.uri,
+#          iot.binding, iot.identity, iot.observable
+```
+
+### See what's in the store right now
+
+```sh
+ds-cli --socket=/run/iot/data_store.sock get \
+    iot.endpoint iot.lifetime iot.server.uri \
+    iot.binding iot.identity iot.observable
+```
+
+### Watch for live changes (e.g. from another operator)
+
+```sh
+ds-cli --socket=/run/iot/data_store.sock watch --count=10 \
+    iot.endpoint iot.lifetime iot.server.uri
+```
+
+### Drop the persistent store (start clean)
+
+```sh
+sudo systemctl stop iot-ds
+sudo rm /var/lib/iot/data_store.lua
+sudo systemctl start iot-ds
+```
+
+### Run with a non-default socket path
+
+Both `ds-server` and `ds-cli` accept `--socket=PATH`. The lwm2m binary
+takes `ds-sock=PATH` in its `LWM2M_ARGS`. Edit
+`/etc/iot/lwm2m-client.env` (bare metal) or pass via env
+(`podman run --env LWM2M_ARGS=...`).
+
+---
+
+## Troubleshooting
+
+### "data-store not available at /run/iot/data_store.sock"
+
+ds-server isn't running, or the socket path differs from what the
+lwm2m client expects.
+
+- Container: `podman logs iot-ds` — look for "listening on" log line.
+- Bare metal: `systemctl status iot-ds.service` — look for the same.
+- Both paths: confirm both processes see the same `/run/iot/`
+  (named volume / `RuntimeDirectory=`).
+
+### "schema(iot.X): expected Y, got Z"
+
+The ds-cli value didn't match the schema type. See
+`/etc/iot/ds-schemas/iot.lua` for the spec. Quote string values:
+`'"urn:dev:..."'` (the outer single + inner double quotes survive
+shell parsing).
+
+### lwm2m client logs the change but doesn't act
+
+`iot.endpoint` and `iot.server.uri` only trigger their FSM cycle when
+the client is in `Registered` state. If the bootstrap / register is
+still in flight when the change arrives, the flag stays set; the next
+tick after the state stabilises consumes it. Wait one full Update
+interval (default 30 s margin under 86400 s lifetime).
+
+CoAPs server-URI rebind is best-effort: the peer swap happens but the
+DTLS session isn't re-handshaked. Tracked as FUP-DS-12 if a CoAPs
+deployment needs it.
+
+---
+
+## What's NOT in this deploy story (yet)
+
+- **Multi-arch container images.** Builds for whatever arch the host
+  has. Cross-builds are a follow-up.
+- **TLS / mTLS to ds-server.** The unix socket DAC perms are the
+  authentication boundary.
+- **`.deb` / `.rpm` packages.** The cmake `install` rule produces a
+  packageable tree under `DESTDIR=`; wrapping that into a distro
+  package is downstream-specific.
+- **systemd-managed container orchestration.** The OCI image bypasses
+  systemd; for bare-metal systemd-managed deploys, use the unit files.

--- a/log/L11/e2e-smoke.sh
+++ b/log/L11/e2e-smoke.sh
@@ -1,0 +1,106 @@
+#!/bin/sh
+# L11/D6 — end-to-end deploy smoke.
+#
+# Boots the OCI image from PR #25 as two sibling containers (ds + client)
+# sharing a /run/iot volume, mutates iot.lifetime via ds-cli, asserts
+# the client container picks up the hot-applied value.
+#
+# Run from the repo root:
+#   ./log/L11/e2e-smoke.sh
+# Or after `git pull` from a fresh clone:
+#   sh ./log/L11/e2e-smoke.sh
+#
+# Exit 0 on success; non-zero with a message on failure.
+
+set -eu
+
+PODMAN="${PODMAN:-/opt/homebrew/bin/podman}"
+IMAGE="${IMAGE:-iot:l11}"
+
+DS_NAME=iot-ds-e2e
+CLIENT_NAME=iot-client-e2e
+VOLUME=iot-run-e2e
+
+cleanup() {
+    "$PODMAN" rm -f "$DS_NAME" "$CLIENT_NAME" >/dev/null 2>&1 || true
+    "$PODMAN" volume rm "$VOLUME" >/dev/null 2>&1 || true
+}
+trap cleanup EXIT INT TERM
+
+cleanup
+
+echo "=== 1. Build the OCI image (no-op if cached) ==="
+"$PODMAN" build -f packaging/Containerfile -t "$IMAGE" . 2>&1 | tail -3
+
+echo
+echo "=== 2. Start ds-server container ==="
+"$PODMAN" volume create "$VOLUME" >/dev/null
+"$PODMAN" run -d \
+    --name "$DS_NAME" \
+    -e IOT_ROLE=ds \
+    -v "$VOLUME":/run/iot \
+    "$IMAGE" >/dev/null
+sleep 0.5
+"$PODMAN" logs "$DS_NAME" 2>&1 | grep -F "listening on" || {
+    echo "FAIL: ds-server didn't log 'listening on'" >&2
+    "$PODMAN" logs "$DS_NAME" >&2
+    exit 1
+}
+echo "OK ds-server bound /run/iot/data_store.sock"
+
+echo
+echo "=== 3. Seed initial iot.* keys via ds-cli (from inside the ds container) ==="
+"$PODMAN" exec "$DS_NAME" \
+    ds-cli --socket=/run/iot/data_store.sock \
+    set iot.endpoint '"urn:dev:e2e-initial"' >/dev/null
+"$PODMAN" exec "$DS_NAME" \
+    ds-cli --socket=/run/iot/data_store.sock \
+    set iot.lifetime 7200 >/dev/null
+"$PODMAN" exec "$DS_NAME" \
+    ds-cli --socket=/run/iot/data_store.sock \
+    get iot.endpoint iot.lifetime
+
+echo
+echo "=== 4. Start lwm2m client container sharing /run/iot ==="
+"$PODMAN" run -d \
+    --name "$CLIENT_NAME" \
+    -e IOT_ROLE=client \
+    -v "$VOLUME":/run/iot \
+    "$IMAGE" >/dev/null
+sleep 1.0
+"$PODMAN" logs "$CLIENT_NAME" 2>&1 | grep -F "endpoint from data-store: urn:dev:e2e-initial" || {
+    echo "FAIL: client didn't pick up initial endpoint from data-store" >&2
+    "$PODMAN" logs "$CLIENT_NAME" >&2
+    exit 1
+}
+echo "OK client picked up initial iot.endpoint + iot.lifetime via DsConfig"
+
+echo
+echo "=== 5. Hot-apply: mutate iot.lifetime; expect 'applied iot.lifetime=...' on client ==="
+"$PODMAN" exec "$DS_NAME" \
+    ds-cli --socket=/run/iot/data_store.sock \
+    set iot.lifetime 1800 >/dev/null
+sleep 0.5
+"$PODMAN" logs "$CLIENT_NAME" 2>&1 | grep -F "applied iot.lifetime=1800" || {
+    echo "FAIL: client didn't log the hot-applied lifetime" >&2
+    "$PODMAN" logs "$CLIENT_NAME" 2>&1 | tail -20 >&2
+    exit 1
+}
+echo "OK client hot-applied iot.lifetime=1800 from listener thread"
+
+echo
+echo "=== 6. Schema rejection still gates at the wire ==="
+if "$PODMAN" exec "$DS_NAME" \
+    ds-cli --socket=/run/iot/data_store.sock \
+    set iot.lifetime -1 >/dev/null 2>&1; then
+    echo "FAIL: ds-cli set iot.lifetime -1 unexpectedly succeeded" >&2
+    exit 1
+fi
+echo "OK schema rejected iot.lifetime=-1 with SchemaRejected"
+
+echo
+echo "=== Summary ==="
+echo "All 6 checks passed."
+echo "DS image size: $("$PODMAN" image inspect "$IMAGE" --format '{{.Size}}' | awk '{printf "%.1f MB", $1/1024/1024}')"
+echo "ds container exit: $("$PODMAN" inspect "$DS_NAME" --format '{{.State.Status}}')"
+echo "client container exit: $("$PODMAN" inspect "$CLIENT_NAME" --format '{{.State.Status}}')"

--- a/log/L11/e2e-smoke.txt
+++ b/log/L11/e2e-smoke.txt
@@ -1,0 +1,29 @@
+=== 1. Build the OCI image (no-op if cached) ===
+--> ccd8bfb76901
+Successfully tagged localhost/iot:l11
+ccd8bfb76901f624ce60f38259c597667812340f039b389309a3606acf23610e
+
+=== 2. Start ds-server container ===
+2026-05-31 07:55:35.478327 [DS:1] LM_DEBUG /src/modules/data-store/src/server/server.cpp:74 listening on /run/iot/data_store.sock (mode 0660)
+OK ds-server bound /run/iot/data_store.sock
+
+=== 3. Seed initial iot.* keys via ds-cli (from inside the ds container) ===
+iot.endpoint=urn:dev:e2e-initial
+iot.lifetime=7200
+
+=== 4. Start lwm2m client container sharing /run/iot ===
+2026-05-31 07:55:36.525154 [iot:1] LM_INFO /src/apps/src/main.cpp:603 endpoint from data-store: urn:dev:e2e-initial
+OK client picked up initial iot.endpoint + iot.lifetime via DsConfig
+
+=== 5. Hot-apply: mutate iot.lifetime; expect 'applied iot.lifetime=...' on client ===
+2026-05-31 07:55:37.678118 [iot:2] LM_INFO /src/apps/src/main.cpp:636 applied iot.lifetime=1800 to live RegistrationClient — next Update tick uses it
+OK client hot-applied iot.lifetime=1800 from listener thread
+
+=== 6. Schema rejection still gates at the wire ===
+OK schema rejected iot.lifetime=-1 with SchemaRejected
+
+=== Summary ===
+All 6 checks passed.
+DS image size: 118.6 MB
+ds container exit: running
+client container exit: running

--- a/log/L11/plan.md
+++ b/log/L11/plan.md
@@ -5,8 +5,8 @@
 > on-disk artefacts. As each D closes, the corresponding section
 > moves into `results.md` alongside the evidence.
 >
-> **Status (2026-05-31):** D1 + D2 (PR #23), D4 (PR #24), D3 (PR #25)
-> done. D5 + D6 pending. FUP-L11-1 opened to track image-size shrink.
+> **Status (2026-05-31):** All six D-items closed (PRs #23, #24, #25, #26).
+> FUP-L11-1 (image-size shrink) opened during D3, not blocking.
 
 ---
 
@@ -210,7 +210,13 @@ tree and no missing files / dangling rpaths.
 
 ---
 
-### D5 — README: deploy walkthrough
+### D5 — README: deploy walkthrough ✅ (PR #26)
+
+Closed 2026-05-31. Top-level `DEPLOY.md` lands with both container
++ bare-metal paths, an operator-task cookbook, and a troubleshooting
+section. Cross-links to `packaging/README.md` for internals and to
+`modules/data-store/docs/{protocol,client_api}.md` for the wire +
+API references.
 
 **Scope.** Top-level `DEPLOY.md` (or a section in `README.md`) with
 two paths:
@@ -233,7 +239,12 @@ item; visible quality bar).
 
 ---
 
-### D6 — End-to-end smoke
+### D6 — End-to-end smoke ✅ (PR #26)
+
+Closed 2026-05-31. `log/L11/e2e-smoke.sh` runs the full path —
+build image → start ds + client containers sharing a named
+volume → seed + read + hot-apply → schema rejection. All 6 checks
+pass; evidence at `log/L11/e2e-smoke.txt`.
 
 **Scope.** A single script that runs the full deploy path on a clean
 container and proves it works:


### PR DESCRIPTION
## Summary
Final two L11 D-items, closing the phase.

**D6 — \`log/L11/e2e-smoke.sh\`**
Runs the full deploy path on a clean podman host: build OCI image → start ds-server + lwm2m client as sibling containers sharing a named \`iot-run\` volume → seed via \`ds-cli\` → assert client picks up config via DsConfig → mutate \`iot.lifetime\` → assert hot-apply log fires → confirm schema rejection still gates. All 6 checks pass; evidence at \`log/L11/e2e-smoke.txt\`.

**D5 — Top-level \`DEPLOY.md\`**
Operator-facing walkthrough. Two paths (container + bare-metal). Cookbook for common tasks (inspect schema, watch live changes, drop store, non-default socket). Troubleshooting for the three common failure modes. Cross-links to \`packaging/README.md\` + \`modules/data-store/docs/{protocol,client_api}.md\` — no duplication.

## Test plan
- [x] e2e smoke: 6/6 checks pass; output captured at \`log/L11/e2e-smoke.txt\`
- [x] L11 plan marks D5 + D6 done; all six D-items closed
- [x] Cross-links validated

## L11 status post-merge
- D1 + D2 (PR #23): systemd units + env files
- D3 (PR #25): OCI runtime image
- D4 (PR #24): cmake install rules + DESTDIR smoke
- D5 + D6 (this PR): DEPLOY.md + e2e smoke
- FUP-L11-1: image-size shrink (119 MB vs 100 MB soft target), not blocking

🤖 Generated with [Claude Code](https://claude.com/claude-code)