### PR TITLE
docs: README + architecture.md refresh for L10/L11

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ One binary, `lwm2m`, plays either role:
 | `server` | `local=` Bootstrap port + `:5683` DM port   | LwM2M Server + Bootstrap-Server |
 | `client` | `local=` LwM2M Client port                  | LwM2M Client (device)        |
 
-## Status (2026-05-29)
+## Status (2026-05-31)
 
 | Phase | Closes (RDD §6) | State |
 |------:|-----------------|-------|
@@ -24,6 +24,8 @@ One binary, `lwm2m`, plays either role:
 | L7 | Observe / Notify + threshold engine (D4 NON-default / CON-on-demand) | ✅ |
 | L8 | Canonical objects + Linux platform readers + JSON-backed Device | ✅ |
 | L9 | App-level wiring + Leshan interop harness + first pcap pass | ✅ |
+| L10 | Data-store: typed values (variant), EMP framing, schema, live watch + hot-apply for `iot.{endpoint, lifetime, server.uri}` | ✅ |
+| L11 | Packaging: systemd units, GNUInstallDirs install rules, OCI runtime image, end-to-end smoke, [`DEPLOY.md`](DEPLOY.md) | ✅ |
 
 All six binding decisions (D1–D6) are recorded in
 [`apps/docs/lwm2m-rdd.md`](apps/docs/lwm2m-rdd.md#11-decisions-log) and
@@ -31,21 +33,23 @@ mirrored in [`apps/docs/lwm2m-design.md`](apps/docs/lwm2m-design.md#12-decisions
 
 ## Build
 
-The supported build path is the container image. The local (non-container)
-build needs ACE_TAO 7.0.0 at `/usr/local/ACE_TAO-7.0.0`, OpenSSL 3.1.1,
-mongo-cxx-driver v3.6, tinydtls (vendored under `apps/3rdparty/tinydtls`),
-and `nlohmann/json` (vendored under `apps/3rdparty/json`).
+Two paths land everything (`lwm2m` + `ds-server` + `ds-cli` +
+`libdatastore_client.a` + tests):
 
-### Container (podman or docker)
+- **Dev image** (`docker/Dockerfile` → `naushada/iot:latest`) — fat
+  build environment with ACE_TAO 7.0.0, OpenSSL 3.1.1, mongo-c/cxx,
+  tinydtls, gtest. Use this for compiling and running tests.
+- **Runtime image** (`packaging/Containerfile` → `iot:l11`) — thin
+  multi-stage image for deployment. ~119 MB. See
+  [`packaging/README.md`](packaging/README.md).
+
+For a full deploy walkthrough (container + bare-metal paths +
+operator cookbook), see [`DEPLOY.md`](DEPLOY.md).
+
+### Dev image (podman or docker)
 
 ```sh
 podman build -t naushada/iot:latest -f docker/Dockerfile .
-```
-
-To pin a specific commit (useful for cache busting between rebuilds):
-
-```sh
-podman build --build-arg GIT_REF=<sha> -t naushada/iot:latest -f docker/Dockerfile .
 ```
 
 The image:
@@ -56,14 +60,26 @@ The image:
 - Steps 12–13 clone googletest + the project, build tinydtls via
   autoconf, then `cmake .. && make` for the `lwm2m` + `lwm2m_test`
   targets.
-- The binaries land at `/opt/app/lwm2m` and `/opt/app/lwm2m_test`.
 
-### Local
+### Local (no container)
+
+Needs the same deps installed on the host:
 
 ```sh
 cd apps/3rdparty/tinydtls && autoconf && autoheader && ./configure && make
 cd ../.. && mkdir -p build && cd build && cmake .. && make
 ```
+
+For a packageable install:
+
+```sh
+cmake -B build -DCMAKE_INSTALL_PREFIX=/usr
+make -C build -j"$(nproc)"
+make -C build install DESTDIR=/tmp/staging   # or sudo make install for /
+```
+
+See [`DEPLOY.md`](DEPLOY.md) for the resulting layout + systemd
+integration.
 
 ## Quick-start
 
@@ -142,26 +158,50 @@ to be built from source. See `apps/docs/leshan-interop.md` §2.
 ## Layout
 
 ```
-apps/
-├── inc/           public headers (LwM2M, codecs, registration / bootstrap / observe)
-├── src/           implementation files
-├── test/          GoogleTest suites
-├── config/        JSON config for Security (OID 0), Server (OID 1), Device (OID 3)
-├── 3rdparty/      vendored tinydtls + nlohmann::json
-├── docs/          design + RDD + interop docs
-│   ├── architecture.md       pre- and post-L9 layout
-│   ├── ace-refactor.md       I/O design
-│   ├── lwm2m-design.md       module map + state machines + decisions
-│   ├── lwm2m-rdd.md          requirements catalogue + traceability + defects
-│   └── leshan-interop.md     L9 interop runbook
+apps/                          LwM2M client + server binary
+├── inc/                       public headers (LwM2M, codecs, registration / bootstrap / observe / DsConfig)
+├── src/                       implementation files (+ cli/ for the REPL)
+├── test/                      GoogleTest suites (154 tests)
+├── config/                    Lua templates for Security/Server/Device/...
+├── 3rdparty/                  vendored tinydtls + nlohmann::json
+├── docs/
+│   ├── architecture.md        post-L11 layout
+│   ├── ace-refactor.md        I/O refactor history
+│   ├── cli.md                 REPL commands
+│   ├── lwm2m-design.md        module map + FSMs + decisions
+│   ├── lwm2m-rdd.md           requirements catalogue + traceability
+│   └── leshan-interop.md      L9 interop runbook
 └── CMakeLists.txt
 
+modules/
+└── data-store/                AF_UNIX KV store (ds-server + ds-cli + libdatastore_client.a)
+    ├── inc/data_store/        public client headers (POSIX-clean)
+    ├── src/                   server + client + cli + proto
+    ├── test/                  39 tests (proto framing, schema, persistence, watch)
+    ├── schemas/iot.lua        canonical iot.* schema (installed to /etc/iot/ds-schemas/)
+    └── docs/
+        ├── design.md          design + history
+        ├── protocol.md        EMP wire spec + opcodes + ds-cli examples
+        ├── client_api.md      libdatastore_client integration guide
+        └── tdd.md             D1–D10 phase plan + closures
+
+packaging/                     L11 deploy artefacts
+├── systemd/                   iot-{ds,lwm2m-client,lwm2m-server}.service + iot.conf (tmpfiles.d)
+├── etc-iot/                   lwm2m-{client,server}.env templates
+├── Containerfile              multi-stage OCI runtime build (~119 MB)
+├── iot-entrypoint.sh          IOT_ROLE dispatcher
+└── README.md                  packaging internals + size budget
+
 docker/
-├── Dockerfile
-└── docker-compose.leshan.yml four-service compose harness
+├── Dockerfile                 dev build image (naushada/iot:latest)
+└── docker-compose.leshan.yml  Leshan interop harness
 
 log/
-└── L9/            pcap captures + interop run scripts
+├── L9/                        pcap captures + interop run scripts
+├── L10/                       data-store phase closure + smokes
+└── L11/                       packaging phase plan + e2e smoke
+
+DEPLOY.md                      top-level deploy walkthrough (container + bare metal)
 ```
 
 ## Decisions (D1–D6)
@@ -181,15 +221,20 @@ Full rationale: [`apps/docs/lwm2m-rdd.md`](apps/docs/lwm2m-rdd.md#11-decisions-l
 
 ## Known follow-ups
 
-- **Wire FSM-level ACK handling** — Acknowledgement-typed inbound frames
-  are currently short-circuited at the top of
-  `CoAPAdapter::processRequest` to suppress the wire-spurious echo. The
-  proper consumer (`RegistrationClient::on_response`, `DmClient` response
-  paths) needs to be wired in.
+L10 / L11 leftovers (data-store + packaging):
+
+- **FUP-DS-1** — Profile the persistor's fsync cost under load. Move to
+  a dedicated ACE_Task worker if it shows up in CoAP latency.
+- **FUP-DS-12** — Live CoAPs DTLS rebind on `iot.server.uri` change.
+  Today the peer is swapped but the DTLS session isn't re-handshaked.
+  Opens only if a CoAPs deployment surfaces.
+- **FUP-L11-1** — OCI image size shrink (119 MB → < 100 MB target).
+  Routes in [`packaging/README.md`](packaging/README.md) §"Image size".
+
+Older items still open from L9:
+
 - **RegistryMirror activation** — the worker is built but not started by
   `main.cpp` because the Mongo schema PR is pending.
 - **Leshan client-side interop** — needs the `leshan-client-demo` JAR
-  built from source; no canonical image on Docker Hub.
-
-See [`apps/docs/leshan-interop.md`](apps/docs/leshan-interop.md) §8 for
-the full follow-up list.
+  built from source; no canonical image on Docker Hub. See
+  [`apps/docs/leshan-interop.md`](apps/docs/leshan-interop.md) §8.

--- a/apps/docs/architecture.md
+++ b/apps/docs/architecture.md
@@ -1,8 +1,11 @@
-# IoT LwM2M Stack — Current Architecture
+# IoT LwM2M Stack — Architecture
 
-Status: **as-implemented snapshot** (pre-ACE refactor). This document captures
-the codebase as it stands so we have a fixed baseline to compare against
-during the ACE refactor and the LwM2M design work that follows.
+> **Status (2026-05-31).** §1–§12 capture the *pre-ACE-refactor* baseline
+> from the early phases of the project — kept as historical context.
+> §13 onward documents the *current* shape after L9 (LwM2M wiring) and
+> L10 (data-store integration) landed. §14 covers L11 packaging. When
+> the current behaviour diverges from §1–§12, the later sections are
+> authoritative.
 
 ## 1. What the binary does
 
@@ -308,30 +311,87 @@ six binding decisions (D1 spec version, D2 short-server-id keying,
 D3 registry storage, D4 notify transport, D5 push plane, D6 device
 backing).
 
-## Data-store module
+## 14. Data-store integration (L10) + Packaging (L11)
+
+### Data-store module (L10)
 
 Sibling at `modules/data-store/`. A standalone persistent
 key-value store delivered as three targets:
 
-- `ds-server` — AF_UNIX daemon. ACE reactor on the main thread, pool
-  of 5 `ACE_Task<ACE_MT_SYNCH>` workers (xpmile MicroService shape)
-  draining work via `getq/putq`. Backed by a Lua chunk on disk
-  (`return { schema_version = 1, data = {...} }`) with write-through
-  on every set/remove via temp + fsync + rename.
+- `ds-server` — AF_UNIX daemon. ACE reactor accepts; pool of 5
+  `ACE_Task<ACE_MT_SYNCH>` workers (xpmile MicroService shape) drains
+  per-session work via `getq/putq`. Backed by a Lua chunk on disk
+  (`return { schema_version = 2, data = {...} }`) with write-through
+  on every set/remove via temp + fsync + rename. Auto-loads
+  `/etc/iot/ds-schemas/*.lua` for type + range validation at set time.
 - `libdatastore_client.a` — POSIX-clean public header (pimpl over
   ACE internally). Apps link this and talk over the unix socket;
   there is **no in-process accessor** — clean blast-radius
   separation between iot and the store.
-- `ds-cli` — operator debug client, supports
-  `welcome / set / get / watch / unwatch` subcommands.
+- `ds-cli` — operator debug client: `set / get / watch / unwatch`.
 
-Wire protocol is line-delimited JSON
-(`{"op":"set","keys":[...],"id":N}` / `{"ok":true,...}` /
-`{"ev":"changed","k":"...","v":"...","prev":...}`); per-key watch
-fan-out is dispatched cross-Worker via the same `WorkMsg` queue used
-for requests, so the only socket writer is always the session's
-owning Worker — no socket locking anywhere.
+**Wire** is binary EMP framing (Mihini-style 8-byte big-endian header
++ JSON payload), not line-delimited JSON. Five opcodes —
+`Set / Get / RegisterWatch / RemoveWatch / NotifyEvent` — with a
+2-byte status prefix on every response. Push notifications use a
+distinct `type` bit so the listener thread can demux them without
+reqID correlation. Spec: [`modules/data-store/docs/protocol.md`](../../modules/data-store/docs/protocol.md).
 
-Docs: [`modules/data-store/docs/design.md`](../../modules/data-store/docs/design.md)
-+ [`tdd.md`](../../modules/data-store/docs/tdd.md). L10 closure
-record: [`log/L10/results.md`](../../log/L10/results.md).
+**Values** are a `std::variant<monostate, string, bool, uint32, int32,
+double>` matching grace-server's `value_type`. JSON's native type
+system round-trips through `value_to_json` / `value_from_json` helpers.
+
+**Per-key watch fan-out** is dispatched cross-Worker via the same
+`WorkMsg` queue used for requests, so the only socket writer is
+always the session's owning Worker — no socket locking anywhere.
+
+### iot binary integration (L10 cont'd)
+
+The lwm2m binary holds a `DsConfig` for its process lifetime:
+
+- At startup, primes a thread-safe cache via a single `Get` of
+  `iot.endpoint`/`iot.lifetime`/`iot.server.uri`, then registers a
+  callback-style `watch` for the same keys.
+- On every NotifyEvent, the listener thread updates the cache and
+  fires per-key apply policies via `RegistrationClient` setters:
+  - `iot.lifetime` → atomic `set_lifetime` → next Update tick uses it
+  - `iot.endpoint` → `set_endpoint` flips `pending_reregister` →
+    reactor tick sends Deregister; on Unregistered the existing
+    Register branch fires with the new endpoint
+  - `iot.server.uri` → fills a `Rebind` mailbox + flips
+    `pending_reregister` → after Unregistered, reactor swaps the
+    ServiceContext peer + auto-Registers to the new server
+- DsConfig is optional: connect failures log once at LM_INFO and
+  every accessor returns nullopt → caller's compiled defaults run.
+
+Wire trace + apply policy worked out in PRs #16/#17/#18 (L10 follow-
+ups DS-9/10/11). End-to-end smoke at `log/L11/e2e-smoke.sh`.
+
+### Packaging (L11)
+
+`packaging/` lands two deploy paths off the same cmake build:
+
+- **OCI runtime image** (`packaging/Containerfile`) — multi-stage
+  build off `naushada/iot:latest`; runtime is `ubuntu:22.04` + only
+  the libs `ldd` actually demands. `iot-entrypoint.sh` dispatches on
+  `IOT_ROLE={ds,client,server}`. ~119 MB.
+- **Bare-metal install** — `make install` (GNUInstallDirs idiom)
+  drops binaries + headers + lib under `${CMAKE_INSTALL_PREFIX}`,
+  schema/configs under `/etc/iot/`, systemd units under
+  `/usr/lib/systemd/system/`, tmpfiles.d entry under
+  `/usr/lib/tmpfiles.d/`. Three units: `iot-ds.service`,
+  `iot-lwm2m-client.service`, `iot-lwm2m-server.service`. The lwm2m
+  units `After=iot-ds.service Wants=iot-ds.service` so DsConfig
+  connects on the first try.
+
+Operator-facing walkthrough: [`DEPLOY.md`](../../DEPLOY.md).
+Packaging internals + size budget: [`packaging/README.md`](../../packaging/README.md).
+Phase plan + closures: [`log/L11/plan.md`](../../log/L11/plan.md).
+
+### Related docs
+
+- [`modules/data-store/docs/design.md`](../../modules/data-store/docs/design.md) — historical design + superseded markers
+- [`modules/data-store/docs/protocol.md`](../../modules/data-store/docs/protocol.md) — current wire spec (EMP)
+- [`modules/data-store/docs/client_api.md`](../../modules/data-store/docs/client_api.md) — `libdatastore_client` application guide
+- [`log/L10/results.md`](../../log/L10/results.md) — L10 closure record
+- [`log/L11/plan.md`](../../log/L11/plan.md) — L11 packaging phase


### PR DESCRIPTION
## Summary
Bring the two top-level human-facing docs back into alignment with what's actually shipped after L10 (data-store) + L11 (packaging).

**README.md**
- Status table picks up L10 + L11
- Build section distinguishes dev image vs runtime image; points at DEPLOY.md + packaging/README.md
- Layout tree adds modules/data-store/, packaging/, DEPLOY.md, log/L10 + log/L11
- Known follow-ups pruned (FSM-ACK closed) + extended (FUP-DS-1, FUP-DS-12, FUP-L11-1)

**apps/docs/architecture.md**
- Top banner reframes §1–§12 as historical baseline; §13 + §14 are current truth
- Replaces the stale "Data-store module" appendix with a full §14:
  - Corrects wire description: EMP framing (not line-delimited JSON), schema_version=2, typed Value variant
  - Adds "iot binary integration" subsection: DsConfig watch + per-key apply policies (PRs #16-#18)
  - Adds "Packaging (L11)" subsection: OCI + bare-metal paths
  - Cross-links to design.md / protocol.md / client_api.md / DEPLOY.md / packaging/README.md / L10 + L11 logs

Historical sections kept (not deleted) with a "later sections are authoritative" banner so old PR review threads still resolve.

## Test plan
- [x] Markdown-only; cross-links resolve from `git`'s root
- [x] No code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)