### PR TITLE
L12/D1+D2: vpn.* schema + openvpn-client module scaffold

### DIFF
--- a/log/L12/plan.md
+++ b/log/L12/plan.md
@@ -5,7 +5,7 @@
 > binary via its management interface. Config in + state out flows
 > through the same `ds-server` that the lwm2m binary integrates with.
 >
-> **Status (drafted 2026-05-31):** all D-items pending.
+> **Status (2026-05-31):** D1 + D2 done (PR #29). D3–D6 pending.
 
 ---
 
@@ -57,7 +57,13 @@ uses.
 
 ## 2. D-items
 
-### D1 — `vpn.*` schema
+### D1 — `vpn.*` schema ✅ (PR #29)
+
+Closed 2026-05-31. Schema lands at
+`modules/openvpn-client/schemas/vpn.lua` with 9 read + 7 write keys
++ defaults for the optional ones. cmake install rule drops it at
+`/etc/iot/ds-schemas/vpn.lua`. Smoke verified `vpn.remote.port=99999`
+rejected with `schema(vpn.remote.port): 99999 above max 65535`.
 
 **Scope.** Add `modules/openvpn-client/schemas/vpn.lua`. ds-server
 auto-loads it from `/etc/iot/ds-schemas/` (FUP-DS-6 default dir).
@@ -94,7 +100,14 @@ schema parses + the type / range / default expectations hold.
 
 ---
 
-### D2 — Module scaffold
+### D2 — Module scaffold ✅ (PR #29)
+
+Closed 2026-05-31. Module tree under `modules/openvpn-client/`
+mirrors data-store. v0 binary connects to ds-server, dumps every
+known vpn.* key via libdatastore_client, exits. Internal lib
+(`openvpn_client_lib`) split out so future test targets link the
+same code the binary runs. Schema install rule lands at
+`/etc/iot/ds-schemas/vpn.lua`. Module README at `docs/design.md`.
 
 **Scope.** Create `modules/openvpn-client/` mirroring data-store's
 shape:

--- a/modules/openvpn-client/CMakeLists.txt
+++ b/modules/openvpn-client/CMakeLists.txt
@@ -1,0 +1,53 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(openvpn_client CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ACE_TAO install prefix — same idiom as the data-store + apps cmake.
+if(NOT DEFINED ACE_ROOT)
+    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
+endif()
+
+set(OVPN_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Pull in the sibling data-store module so we get libdatastore_client +
+# its public headers. Same pattern apps/CMakeLists.txt uses for the
+# lwm2m binary. If data-store has already been added (e.g. by a parent
+# project), skip the re-add to avoid the cmake "already exists" error.
+if(NOT TARGET datastore_client)
+    add_subdirectory(${OVPN_MODULE_DIR}/../data-store
+                     ${CMAKE_BINARY_DIR}/data-store)
+endif()
+
+include_directories(
+    ${OVPN_MODULE_DIR}/inc
+    ${OVPN_MODULE_DIR}/../data-store/inc
+    ${ACE_ROOT}/include
+)
+
+link_directories(${ACE_ROOT}/lib)
+
+# Internal lib so future test targets can link the same code that
+# the binary uses. v0 — only main.cpp; D3+ add client/ds_bridge/etc.
+add_library(openvpn_client_lib STATIC
+    src/main_impl.cpp)
+
+target_link_libraries(openvpn_client_lib
+    PUBLIC datastore_client ACE pthread)
+
+add_executable(openvpn-client src/main.cpp)
+target_link_libraries(openvpn-client PRIVATE openvpn_client_lib)
+
+# Install rule. Skip if IOT_PACKAGING_INSTALL is OFF (set by the
+# parent apps/CMakeLists.txt for dev-builds that shouldn't touch
+# /etc/iot or system paths).
+include(GNUInstallDirs)
+if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+    install(TARGETS openvpn-client
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    # Ship the canonical vpn.* schema alongside iot.lua so ds-server
+    # auto-loads it from its default /etc/iot/ds-schemas/ dir.
+    install(FILES schemas/vpn.lua
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+endif()

--- a/modules/openvpn-client/docs/design.md
+++ b/modules/openvpn-client/docs/design.md
@@ -1,0 +1,122 @@
+# openvpn-client — module design (L12)
+
+> **Status (2026-05-31):** D1 + D2 scaffold landed. D3 (DsBridge),
+> D4 (mgmt parser), D5 (ACE_Process wrapper), D6 (lifecycle glue +
+> e2e smoke) pending.
+
+## What this module is
+
+A daemon that owns the lifecycle of an `openvpn(8)` subprocess and
+mirrors its state into the data store. Operators configure via
+`ds-cli set vpn.*`; the daemon spawns openvpn with a generated
+config, watches its management interface, and publishes the assigned
+virtual IP + state back to the same store.
+
+```
+┌──────────────────────────────────────────────────────────────┐
+│                       Operator / Other apps                  │
+│        ds-cli set vpn.*       ds-cli get vpn.assigned.ip     │
+└──────────────────────┬───────────────────────────────────────┘
+                       │ EMP over /run/iot/data_store.sock
+                  ┌────▼─────┐
+                  │ ds-server│  (schemas: iot.lua, vpn.lua)
+                  └────┬─────┘
+                       │ libdatastore_client (watch + get + set)
+                  ┌────▼──────────┐
+                  │ openvpn-client│  this module
+                  │  (ACE_Reactor)│
+                  └───┬───────┬───┘
+        ACE_Process   │       │  ACE_SOCK_Stream
+                      │       └──────────┐
+                      ▼                  ▼
+                ┌──────────┐       ┌──────────────────┐
+                │ openvpn  │◀──────│ mgmt 127.0.0.1   │
+                │ binary   │       │   :<vpn.mgmt.port│
+                └────┬─────┘       └──────────────────┘
+                     │ TUN device
+                     ▼
+                  remote VPN
+```
+
+## Why ACE (not libevent like grace-server)
+
+The rest of this repo (lwm2m, ds-server, ds-cli) all run on
+`ACE_Reactor` + `ACE_Task`. Using ACE here keeps the threading
+story uniform and reuses primitives the codebase already has
+under test:
+
+- `ACE_Reactor` — one event loop per process
+- `ACE_Event_Handler` — wraps the mgmt socket fd
+- `ACE_SOCK_Stream` + `ACE_INET_Addr` — connects to `localhost:<mgmt-port>`
+- `ACE_Process` + `ACE_Process_Manager` — fork/exec openvpn, wait on SIGCHLD
+
+## Schema layout
+
+`schemas/vpn.lua` (installed to `/etc/iot/ds-schemas/vpn.lua` by the
+module's cmake install rule) declares every readable + writable key
+with type + range constraints. ds-server validates at set time —
+`ds-cli set vpn.remote.port 99999` is rejected as `SchemaRejected`
+before the daemon ever sees the value. Full key list in the schema
+file itself; quick reference in [L12 plan §2 D1](../../../log/L12/plan.md).
+
+## Module layout
+
+```
+modules/openvpn-client/
+├── CMakeLists.txt
+├── inc/openvpn_client/
+│   └── client.hpp            v0 public API
+├── src/
+│   ├── main.cpp              CLI parse + entry
+│   ├── main_impl.cpp         v0 dump-vpn-keys (D2)
+│   ├── ds_bridge.{hpp,cpp}   (D3 — pending)
+│   ├── mgmt_protocol.{hpp,cpp}  (D4 — pending)
+│   ├── process.{hpp,cpp}     (D5 — pending)
+│   └── client.cpp            lifecycle FSM (D6 — pending)
+├── schemas/vpn.lua
+├── test/                     gtest suite (D3 onward)
+└── docs/design.md            this file
+```
+
+## State machine (D6)
+
+Same `vpn.state` values the schema declares. Wire shape:
+
+```
+            ┌──────────────┐
+            │ disconnected │   ◀── start state
+            └──────┬───────┘
+                   │ (spawn openvpn)
+            ┌──────▼───────┐
+            │ resolving    │   ◀── >STATE:RESOLVE
+            └──────┬───────┘
+                   │
+            ┌──────▼───────┐
+            │ connecting   │   ◀── >STATE:TCP_CONNECT / WAIT
+            └──────┬───────┘
+                   │
+            ┌──────▼───────┐
+            │ auth         │   ◀── >STATE:AUTH
+            └──────┬───────┘
+                   │
+            ┌──────▼───────┐
+            │ wait         │   ◀── >STATE:GET_CONFIG
+            └──────┬───────┘
+                   │
+            ┌──────▼───────┐
+            │ connected    │   ◀── >STATE:CONNECTED  +  >PUSH_REPLY:…
+            └──────┬───────┘  (we write vpn.assigned.* here)
+                   │ (SIGCHLD or SIGINT)
+            ┌──────▼───────┐
+            │ exited       │   ◀── ACE_Process::wait() returns
+            └──────────────┘
+```
+
+First-cut (L12/D6) quiesces at `connected`. Reconnect is FUP-L12-1.
+
+## Related docs
+
+- [L12 plan](../../../log/L12/plan.md) — phase plan + risk register
+- [data-store protocol](../../data-store/docs/protocol.md) — EMP framing
+- [data-store client API](../../data-store/docs/client_api.md) — the lib we link
+- [apps/src/ds_config.cpp](../../../apps/src/ds_config.cpp) — DsBridge's template

--- a/modules/openvpn-client/inc/openvpn_client/client.hpp
+++ b/modules/openvpn-client/inc/openvpn_client/client.hpp
@@ -1,0 +1,38 @@
+#ifndef __openvpn_client_client_hpp__
+#define __openvpn_client_client_hpp__
+
+/// Public-ish header for the openvpn-client module. Only really
+/// "public" in the sense that the in-tree test target links against
+/// the same lib (openvpn_client_lib) the binary uses — there is no
+/// API stability contract for external consumers.
+///
+/// L12/D2 scaffold: holds the bare interface needed by main.cpp.
+/// D3..D6 add DsBridge, mgmt protocol parser, process wrapper, and
+/// the lifecycle FSM.
+
+#include <cstdint>
+#include <string>
+
+namespace openvpn_client {
+
+/// Status surfaced by the v0 main. Mirrors data_store::Status shape
+/// so callers can switch on `.ok` + read `.err`.
+struct Status {
+    bool        ok = true;
+    int         code = 0;
+    std::string err;
+};
+
+/// v0 entry point: connect to ds-server at `socketPath` (empty →
+/// default `/var/run/iot/data_store.sock`), `get` the known vpn.*
+/// keys, dump them to stderr (ACE logging), exit. No openvpn
+/// subprocess yet — D5+D6 add it.
+///
+/// Returns Status{ok=true} on success even when a key is unset
+/// (an unset key is just absent from the output). ok=false on
+/// connect failure or wire-level error.
+Status v0_dump_vpn_keys(const std::string& socketPath);
+
+} // namespace openvpn_client
+
+#endif /* __openvpn_client_client_hpp__ */

--- a/modules/openvpn-client/schemas/vpn.lua
+++ b/modules/openvpn-client/schemas/vpn.lua
@@ -1,0 +1,59 @@
+-- vpn.* schema for openvpn-client (L12).
+--
+-- Read keys (operator configures via ds-cli):
+--   vpn.remote.host   - server hostname or IP (required)
+--   vpn.remote.port   - server port            (default 1194, 1..65535)
+--   vpn.remote.proto  - "udp" or "tcp"         (default "udp")
+--   vpn.cert.path     - client X.509 cert      (required, absolute path)
+--   vpn.key.path      - client X.509 priv key  (required, absolute path)
+--   vpn.ca.path       - server CA              (required, absolute path)
+--   vpn.cipher        - data-channel cipher    (default "AES-256-GCM")
+--   vpn.dev           - "tun" or "tap"         (default "tun")
+--   vpn.mgmt.port     - mgmt iface port        (default 7505, 1024..65535)
+--
+-- Write keys (openvpn-client publishes back):
+--   vpn.state             - "disconnected" / "resolving" / "connecting" /
+--                           "auth" / "wait" / "connected" / "exited"
+--   vpn.assigned.ip       - pushed virtual IP
+--   vpn.assigned.gateway  - pushed VPN gateway
+--   vpn.assigned.netmask  - pushed netmask
+--   vpn.assigned.dns      - comma-joined DNS list (array variant: FUP)
+--   vpn.pid               - live openvpn subprocess pid
+--   vpn.exit_code         - last openvpn exit code (set when state=exited)
+--
+-- Drop this file alongside iot.lua at ds-server's `ds-schema-dir=`
+-- path (defaults to /etc/iot/ds-schemas/). ds-server auto-loads it
+-- on boot; missing dir is silently treated as no-schemas.
+--
+-- Note: paths (cert/key/ca) are STRING-validated here. Filesystem
+-- existence is checked by the daemon at start time, not at set time
+-- (the schema can't stat() the host filesystem).
+
+return {
+  namespace = "vpn",
+  keys = {
+    -- ───────── Read keys (operator → daemon) ─────────
+    ["vpn.remote.host"]  = { type = "string"  },
+    ["vpn.remote.port"]  = { type = "integer", default = 1194,
+                             min = 1, max = 65535 },
+    ["vpn.remote.proto"] = { type = "string",  default = "udp" },
+
+    ["vpn.cert.path"]    = { type = "string"  },
+    ["vpn.key.path"]     = { type = "string"  },
+    ["vpn.ca.path"]      = { type = "string"  },
+
+    ["vpn.cipher"]       = { type = "string",  default = "AES-256-GCM" },
+    ["vpn.dev"]          = { type = "string",  default = "tun" },
+    ["vpn.mgmt.port"]    = { type = "integer", default = 7505,
+                             min = 1024, max = 65535 },
+
+    -- ───────── Write keys (daemon → operator) ─────────
+    ["vpn.state"]            = { type = "string" },
+    ["vpn.assigned.ip"]      = { type = "string" },
+    ["vpn.assigned.gateway"] = { type = "string" },
+    ["vpn.assigned.netmask"] = { type = "string" },
+    ["vpn.assigned.dns"]     = { type = "string" },
+    ["vpn.pid"]              = { type = "integer", min = 0 },
+    ["vpn.exit_code"]        = { type = "integer" },
+  },
+}

--- a/modules/openvpn-client/src/main.cpp
+++ b/modules/openvpn-client/src/main.cpp
@@ -1,0 +1,55 @@
+/// openvpn-client — v0 scaffold (L12/D2).
+///
+/// Usage:
+///   openvpn-client [--ds-sock=PATH] [--help]
+///
+/// Today: connects to ds-server, dumps every known vpn.* key (whether
+/// set or unset), exits. D3 layers a proper DsBridge + watch over
+/// the bare get; D4/D5/D6 add the mgmt protocol parser, openvpn(8)
+/// subprocess, and the connect → first-PUSH_REPLY → write-back loop.
+
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include <string>
+
+#include "openvpn_client/client.hpp"
+
+namespace {
+
+void usage() {
+    std::cout <<
+        "openvpn-client (L12/D2 scaffold)\n"
+        "\n"
+        "Usage: openvpn-client [--ds-sock=PATH] [--help]\n"
+        "\n"
+        "  --ds-sock=PATH   ds-server unix socket; defaults to ds-server's\n"
+        "                   built-in default (/var/run/iot/data_store.sock).\n"
+        "  --help           show this and exit.\n"
+        "\n"
+        "Today this binary connects to ds-server, dumps every known vpn.*\n"
+        "key, and exits. The full lifecycle lands in L12/D3..D6.\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::string sock;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if (a.rfind("--ds-sock=", 0) == 0) {
+            sock = a.substr(10);
+        } else if (a == "--help" || a == "-h") {
+            usage();
+            return 0;
+        } else {
+            std::cerr << "openvpn-client: unknown argument '" << a << "'\n";
+            usage();
+            return 2;
+        }
+    }
+
+    auto rs = openvpn_client::v0_dump_vpn_keys(sock);
+    return rs.ok ? 0 : 1;
+}

--- a/modules/openvpn-client/src/main_impl.cpp
+++ b/modules/openvpn-client/src/main_impl.cpp
@@ -1,0 +1,110 @@
+#include "openvpn_client/client.hpp"
+
+#include <sstream>
+#include <string>
+#include <type_traits>
+#include <variant>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+
+#include "data_store/client.hpp"
+#include "data_store/value.hpp"
+
+namespace openvpn_client {
+
+namespace {
+
+/// Stringify a Value for a single ACE_DEBUG log line. Keeps the
+/// dump human-readable without dragging in nlohmann::json.
+std::string value_to_display(const data_store::Value& v) {
+    return std::visit([](auto&& a) -> std::string {
+        using T = std::decay_t<decltype(a)>;
+        if constexpr (std::is_same_v<T, std::monostate>) return "(null)";
+        else if constexpr (std::is_same_v<T, bool>)
+            return a ? "true" : "false";
+        else if constexpr (std::is_same_v<T, std::string>) return a;
+        else if constexpr (std::is_same_v<T, double>) {
+            char buf[32];
+            std::snprintf(buf, sizeof(buf), "%g", a);
+            return buf;
+        } else {
+            return std::to_string(a);
+        }
+    }, v);
+}
+
+/// All vpn.* keys the schema (L12/D1) declares. Order matches the
+/// schema file's read-then-write grouping so the dump reads naturally.
+const std::vector<std::string>& known_keys() {
+    static const std::vector<std::string> ks = {
+        "vpn.remote.host",
+        "vpn.remote.port",
+        "vpn.remote.proto",
+        "vpn.cert.path",
+        "vpn.key.path",
+        "vpn.ca.path",
+        "vpn.cipher",
+        "vpn.dev",
+        "vpn.mgmt.port",
+        "vpn.state",
+        "vpn.assigned.ip",
+        "vpn.assigned.gateway",
+        "vpn.assigned.netmask",
+        "vpn.assigned.dns",
+        "vpn.pid",
+        "vpn.exit_code",
+    };
+    return ks;
+}
+
+} // namespace
+
+Status v0_dump_vpn_keys(const std::string& socketPath) {
+    data_store::Client cli;
+    auto cs = cli.connect(socketPath);
+    if (!cs.ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [ovpn:%t] %M %N:%l data-store connect "
+                            "failed: %C\n"),
+                   cs.err.c_str()));
+        Status s;
+        s.ok = false;
+        s.code = cs.code;
+        s.err = cs.err;
+        return s;
+    }
+
+    std::vector<data_store::Client::GetResult> got;
+    auto gs = cli.get(known_keys(), got);
+    if (!gs.ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [ovpn:%t] %M %N:%l get(vpn.*) failed: %C\n"),
+                   gs.err.c_str()));
+        Status s;
+        s.ok = false;
+        s.code = gs.code;
+        s.err = gs.err;
+        return s;
+    }
+
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [ovpn:%t] %M %N:%l vpn.* snapshot "
+                        "(%u keys) from %C:\n"),
+               static_cast<unsigned>(got.size()),
+               socketPath.empty() ? "(default socket)" : socketPath.c_str()));
+    for (const auto& r : got) {
+        if (!r.has_value) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l   %C = <unset>\n"),
+                       r.key.c_str()));
+        } else {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l   %C = %C\n"),
+                       r.key.c_str(), value_to_display(r.value).c_str()));
+        }
+    }
+    return {};
+}
+
+} // namespace openvpn_client


### PR DESCRIPTION
## Summary
First slice of L12 (OpenVPN client + data-store integration).

**D1 — \`vpn.*\` schema**
- 9 read keys (\`vpn.remote.{host,port,proto}\`, \`vpn.cert.path\`, \`vpn.key.path\`, \`vpn.ca.path\`, \`vpn.cipher\`, \`vpn.dev\`, \`vpn.mgmt.port\`) + 7 write keys (\`vpn.state\`, \`vpn.assigned.{ip,gateway,netmask,dns}\`, \`vpn.pid\`, \`vpn.exit_code\`)
- Types + ranges constrained; defaults for optionals (port=1194, proto=udp, cipher=AES-256-GCM, dev=tun, mgmt.port=7505)
- cmake install rule drops at \`/etc/iot/ds-schemas/vpn.lua\` so ds-server auto-loads it

**D2 — module scaffold**
- \`modules/openvpn-client/\` mirroring \`modules/data-store/\`
- \`openvpn_client_lib\` (static) split out so future test targets link the same code
- v0 binary: \`openvpn-client --ds-sock=PATH\` connects to ds-server, dumps every known vpn.* key, exits
- Module README at \`docs/design.md\` covers the planned ACE architecture + state machine

## Test plan
- [x] Build clean under podman
- [x] \`--help\` works
- [x] \`./openvpn-client\` dumps 16 keys against a live ds-server: explicit values, schema defaults, unset markers all render correctly
- [x] \`ds-cli set vpn.remote.port 99999\` rejected with \`schema(vpn.remote.port): 99999 above max 65535\`

## Next
- D3 (DsBridge — proper watch + write-back)
- D4 (mgmt protocol parser)
- D5 (ACE_Process wrapper)
- D6 (lifecycle glue + end-to-end smoke against a real openvpn server)

🤖 Generated with [Claude Code](https://claude.com/claude-code)