### PR TITLE
L12/D3: openvpn-client DsBridge (snapshot + watch + write-back)

### DIFF
--- a/log/L12/plan.md
+++ b/log/L12/plan.md
@@ -5,7 +5,8 @@
 > binary via its management interface. Config in + state out flows
 > through the same `ds-server` that the lwm2m binary integrates with.
 >
-> **Status (2026-05-31):** D1 + D2 done (PR #29). D3–D6 pending.
+> **Status (2026-05-31):** D1 + D2 (PR #29), D3 (PR #30) done.
+> D4–D6 pending.
 
 ---
 
@@ -143,7 +144,26 @@ and exits.
 
 ---
 
-### D3 — DsBridge: read vpn.* from data-store + connect/watch
+### D3 — DsBridge: read vpn.* from data-store + connect/watch ✅ (PR #30)
+
+Closed 2026-05-31. `src/ds_bridge.{hpp,cpp}` lands with read
+accessors + setters per the L12 plan key list, plus
+`missing_required()` that returns the 4 required keys absent (host,
+cert.path, key.path, ca.path). Listener-thread watch logs
+"needs restart" on every change (R4 first-cut policy); FUP-L12-1
+will replace with live re-application.
+
+5 unit tests in `test/ds_bridge_test.cpp` cover the don't-need-a-
+live-ds-server paths (construct against bad socket, accessors return
+nullopt, missing_required shape, setters no-op when disconnected,
+on_change accepts nullptr). Build behind
+`-DBUILD_OPENVPN_CLIENT_TESTS=ON`. Smoke against a real ds-server
+verifies the "ready for D6" handoff message fires only when all 4
+required keys are present.
+
+`v0_dump_vpn_keys` refactored to use DsBridge instead of bare
+Client::get so the binary now exercises the bridge end-to-end on
+every run.
 
 **Scope.** `ds_bridge.{hpp,cpp}` — analog of `apps/src/ds_config.cpp`,
 adapted for vpn keys:

--- a/modules/openvpn-client/CMakeLists.txt
+++ b/modules/openvpn-client/CMakeLists.txt
@@ -28,16 +28,40 @@ include_directories(
 
 link_directories(${ACE_ROOT}/lib)
 
-# Internal lib so future test targets can link the same code that
-# the binary uses. v0 — only main.cpp; D3+ add client/ds_bridge/etc.
+# Internal lib so test targets can link the same code that the
+# binary uses. D3 added ds_bridge.cpp; D4/D5/D6 will append.
 add_library(openvpn_client_lib STATIC
-    src/main_impl.cpp)
+    src/main_impl.cpp
+    src/ds_bridge.cpp)
+
+target_include_directories(openvpn_client_lib PUBLIC src)
 
 target_link_libraries(openvpn_client_lib
     PUBLIC datastore_client ACE pthread)
 
 add_executable(openvpn-client src/main.cpp)
 target_link_libraries(openvpn-client PRIVATE openvpn_client_lib)
+
+# ─────────────────────────── Tests ─────────────────────────────
+# Light unit tests for the bits of openvpn_client that DON'T need a
+# live ds-server (DsBridge construct-against-bad-socket path,
+# missing_required() shape). Live ds-server smokes stay as
+# log/L12/*-smoke.sh scripts run on demand.
+option(BUILD_OPENVPN_CLIENT_TESTS "Build openvpn-client gtest suite" OFF)
+if(BUILD_OPENVPN_CLIENT_TESTS)
+    find_package(GTest REQUIRED)
+    enable_testing()
+
+    add_executable(openvpn-client-tests
+        test/ds_bridge_test.cpp)
+
+    target_link_libraries(openvpn-client-tests
+        openvpn_client_lib
+        GTest::gtest_main
+        GTest::gtest)
+
+    add_test(NAME openvpn-client-tests COMMAND openvpn-client-tests)
+endif()
 
 # Install rule. Skip if IOT_PACKAGING_INSTALL is OFF (set by the
 # parent apps/CMakeLists.txt for dev-builds that shouldn't touch

--- a/modules/openvpn-client/src/ds_bridge.cpp
+++ b/modules/openvpn-client/src/ds_bridge.cpp
@@ -1,0 +1,290 @@
+#include "ds_bridge.hpp"
+
+#include <mutex>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include <ace/Log_Msg.h>
+
+#include "data_store/client.hpp"
+#include "data_store/proto.hpp"
+#include "data_store/value.hpp"
+
+namespace openvpn_client {
+
+const char* DsBridge::kDefaultSocketPath = data_store::proto::kDefaultSocketPath;
+
+namespace {
+
+// ─────────────────────── Key constants ──────────────────────────────
+// Single source of truth for the wire-level key strings so accessors,
+// the watch list, the listener-thread router, and missing_required()
+// can't drift apart.
+constexpr const char* kRemoteHost  = "vpn.remote.host";
+constexpr const char* kRemotePort  = "vpn.remote.port";
+constexpr const char* kRemoteProto = "vpn.remote.proto";
+constexpr const char* kCertPath    = "vpn.cert.path";
+constexpr const char* kKeyPath     = "vpn.key.path";
+constexpr const char* kCaPath      = "vpn.ca.path";
+constexpr const char* kCipher      = "vpn.cipher";
+constexpr const char* kDev         = "vpn.dev";
+constexpr const char* kMgmtPort    = "vpn.mgmt.port";
+
+constexpr const char* kState           = "vpn.state";
+constexpr const char* kAssignedIp      = "vpn.assigned.ip";
+constexpr const char* kAssignedGateway = "vpn.assigned.gateway";
+constexpr const char* kAssignedNetmask = "vpn.assigned.netmask";
+constexpr const char* kAssignedDns     = "vpn.assigned.dns";
+constexpr const char* kPid             = "vpn.pid";
+constexpr const char* kExitCode        = "vpn.exit_code";
+
+/// Variant→T lift with int32→uint32 promotion for non-negative ints
+/// (schema's min=0 catches the negative case at set time so this is
+/// just defensive). Otherwise nullopt for type mismatch.
+template <class T>
+std::optional<T> as(const data_store::Value& v) {
+    if (auto* p = std::get_if<T>(&v)) return *p;
+    if constexpr (std::is_same_v<T, std::uint32_t>) {
+        if (auto* p = std::get_if<std::int32_t>(&v); p && *p >= 0) {
+            return static_cast<std::uint32_t>(*p);
+        }
+    }
+    return std::nullopt;
+}
+
+} // namespace
+
+// ───────────────────────────── Impl ─────────────────────────────────
+
+struct DsBridge::Impl {
+    data_store::Client              client;
+    data_store::Client::WatchHandle watch_handle =
+        data_store::Client::kInvalidHandle;
+
+    mutable std::mutex            mtx;
+    // Snapshots updated by the listener thread + initial prime.
+    std::optional<std::string>    remote_host;
+    std::optional<std::uint32_t>  remote_port;
+    std::optional<std::string>    remote_proto;
+    std::optional<std::string>    cert_path;
+    std::optional<std::string>    key_path;
+    std::optional<std::string>    ca_path;
+    std::optional<std::string>    cipher;
+    std::optional<std::string>    dev;
+    std::optional<std::uint32_t>  mgmt_port;
+    ChangeCallback                cb;
+};
+
+// ─────────────────────── ctor / dtor ────────────────────────────────
+
+DsBridge::DsBridge(std::string socketPath)
+  : m_impl(std::make_unique<Impl>()),
+    m_path(socketPath.empty() ? std::string(kDefaultSocketPath)
+                              : std::move(socketPath)) {
+    auto cs = m_impl->client.connect(m_path);
+    if (!cs.ok) {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [ovpn:%t] %M %N:%l data-store not available "
+                            "at %C (%C); openvpn-client cannot start\n"),
+                   m_path.c_str(), cs.err.c_str()));
+        return;
+    }
+    m_ok = true;
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [ovpn:%t] %M %N:%l data-store ready at %C\n"),
+               m_path.c_str()));
+
+    // Prime the snapshot with one initial get. Missing values stay
+    // nullopt; the caller checks missing_required() before spawning
+    // openvpn so a half-configured store can't start a half-broken
+    // tunnel.
+    const std::vector<std::string> read_keys = {
+        kRemoteHost, kRemotePort, kRemoteProto,
+        kCertPath, kKeyPath, kCaPath,
+        kCipher, kDev, kMgmtPort,
+    };
+    std::vector<data_store::Client::GetResult> got;
+    auto gs = m_impl->client.get(read_keys, got);
+    if (gs.ok) {
+        std::lock_guard<std::mutex> g(m_impl->mtx);
+        for (auto& r : got) {
+            if (!r.has_value) continue;
+            if      (r.key == kRemoteHost)  m_impl->remote_host  = as<std::string>(r.value);
+            else if (r.key == kRemotePort)  m_impl->remote_port  = as<std::uint32_t>(r.value);
+            else if (r.key == kRemoteProto) m_impl->remote_proto = as<std::string>(r.value);
+            else if (r.key == kCertPath)    m_impl->cert_path    = as<std::string>(r.value);
+            else if (r.key == kKeyPath)     m_impl->key_path     = as<std::string>(r.value);
+            else if (r.key == kCaPath)      m_impl->ca_path      = as<std::string>(r.value);
+            else if (r.key == kCipher)      m_impl->cipher       = as<std::string>(r.value);
+            else if (r.key == kDev)         m_impl->dev          = as<std::string>(r.value);
+            else if (r.key == kMgmtPort)    m_impl->mgmt_port    = as<std::uint32_t>(r.value);
+        }
+    }
+
+    // Register the watch. Same 9 keys; the listener thread routes by
+    // string match into the snapshot + the per-key Key enum the
+    // caller's on_change handler sees.
+    auto ws = m_impl->client.watch(
+        read_keys,
+        [this](const data_store::Client::Event& ev) {
+            std::optional<Key> changed;
+            {
+                std::lock_guard<std::mutex> g(m_impl->mtx);
+                if      (ev.key == kRemoteHost)  { m_impl->remote_host  = as<std::string>(ev.value);   changed = Key::RemoteHost;  }
+                else if (ev.key == kRemotePort)  { m_impl->remote_port  = as<std::uint32_t>(ev.value); changed = Key::RemotePort;  }
+                else if (ev.key == kRemoteProto) { m_impl->remote_proto = as<std::string>(ev.value);   changed = Key::RemoteProto; }
+                else if (ev.key == kCertPath)    { m_impl->cert_path    = as<std::string>(ev.value);   changed = Key::CertPath;    }
+                else if (ev.key == kKeyPath)     { m_impl->key_path     = as<std::string>(ev.value);   changed = Key::KeyPath;     }
+                else if (ev.key == kCaPath)      { m_impl->ca_path      = as<std::string>(ev.value);   changed = Key::CaPath;      }
+                else if (ev.key == kCipher)      { m_impl->cipher       = as<std::string>(ev.value);   changed = Key::Cipher;      }
+                else if (ev.key == kDev)         { m_impl->dev          = as<std::string>(ev.value);   changed = Key::Dev;         }
+                else if (ev.key == kMgmtPort)    { m_impl->mgmt_port    = as<std::uint32_t>(ev.value); changed = Key::MgmtPort;    }
+            }
+            if (!changed) return;
+            // First-cut policy (L12 R4): log "needs restart"; live
+            // re-application lives in FUP-L12-1.
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l vpn config key "
+                                "'%C' changed — restart openvpn-client to "
+                                "apply (live hot-reload is FUP-L12-1)\n"),
+                       ev.key.c_str()));
+            ChangeCallback cbcopy;
+            {
+                std::lock_guard<std::mutex> g(m_impl->mtx);
+                cbcopy = m_impl->cb;
+            }
+            if (cbcopy) cbcopy(*changed);
+        },
+        &m_impl->watch_handle);
+    if (!ws.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [ovpn:%t] %M %N:%l watch register failed: "
+                            "%C — cache primed but hot-reload notifications "
+                            "disabled\n"),
+                   ws.err.c_str()));
+    }
+}
+
+DsBridge::~DsBridge() {
+    if (!m_impl) return;
+    if (m_impl->watch_handle != data_store::Client::kInvalidHandle) {
+        m_impl->client.unwatch(m_impl->watch_handle, /*timeout_ms=*/200);
+    }
+    m_impl->client.close();
+}
+
+// ─────────────────────── Read accessors ─────────────────────────────
+
+std::optional<std::string> DsBridge::remote_host() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->remote_host;
+}
+std::optional<std::uint32_t> DsBridge::remote_port() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->remote_port;
+}
+std::optional<std::string> DsBridge::remote_proto() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->remote_proto;
+}
+std::optional<std::string> DsBridge::cert_path() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->cert_path;
+}
+std::optional<std::string> DsBridge::key_path() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->key_path;
+}
+std::optional<std::string> DsBridge::ca_path() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->ca_path;
+}
+std::optional<std::string> DsBridge::cipher() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->cipher;
+}
+std::optional<std::string> DsBridge::dev() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->dev;
+}
+std::optional<std::uint32_t> DsBridge::mgmt_port() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->mgmt_port;
+}
+
+std::optional<std::vector<std::string>>
+DsBridge::missing_required() const {
+    if (!m_ok) {
+        // Not even connected → everything is missing; surface as the
+        // four required keys rather than the connection error so the
+        // caller's "missing config" path is uniform.
+        return std::vector<std::string>{
+            kRemoteHost, kCertPath, kKeyPath, kCaPath};
+    }
+    std::vector<std::string> missing;
+    {
+        std::lock_guard<std::mutex> g(m_impl->mtx);
+        if (!m_impl->remote_host.has_value()) missing.emplace_back(kRemoteHost);
+        if (!m_impl->cert_path.has_value())   missing.emplace_back(kCertPath);
+        if (!m_impl->key_path.has_value())    missing.emplace_back(kKeyPath);
+        if (!m_impl->ca_path.has_value())     missing.emplace_back(kCaPath);
+    }
+    if (missing.empty()) return std::nullopt;
+    return missing;
+}
+
+// ─────────────────────── Write side ─────────────────────────────────
+
+void DsBridge::set_state(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kState, s);
+    if (!rs.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [ovpn:%t] %M %N:%l set %C='%C' failed: %C\n"),
+                   kState, s.c_str(), rs.err.c_str()));
+    }
+}
+void DsBridge::set_assigned_ip(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kAssignedIp, s);
+}
+void DsBridge::set_assigned_gateway(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kAssignedGateway, s);
+}
+void DsBridge::set_assigned_netmask(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kAssignedNetmask, s);
+}
+void DsBridge::set_assigned_dns(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kAssignedDns, s);
+}
+void DsBridge::set_pid(std::uint32_t p) {
+    if (!m_ok) return;
+    m_impl->client.set(kPid, p);
+}
+void DsBridge::set_exit_code(std::int32_t c) {
+    if (!m_ok) return;
+    m_impl->client.set(kExitCode, c);
+}
+
+// ─────────────────────── on_change registration ─────────────────────
+
+void DsBridge::on_change(ChangeCallback cb) {
+    if (!m_impl) return;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    m_impl->cb = std::move(cb);
+}
+
+} // namespace openvpn_client

--- a/modules/openvpn-client/src/ds_bridge.hpp
+++ b/modules/openvpn-client/src/ds_bridge.hpp
@@ -1,0 +1,117 @@
+#ifndef __openvpn_client_ds_bridge_hpp__
+#define __openvpn_client_ds_bridge_hpp__
+
+/// Bridge between openvpn-client and ds-server.
+///
+/// Mirrors the pattern in apps/src/ds_config.cpp (iot.* keys) but
+/// for the vpn.* namespace. Holds a data_store::Client for the
+/// daemon lifetime; primes a thread-safe snapshot of the readable
+/// keys on startup; registers a callback-style watch so subsequent
+/// `ds-cli set vpn.*` mutations land in the cache and fire the
+/// caller's on_change handler.
+///
+/// L12/D3 — first-cut hot-reload policy per R4 in log/L12/plan.md:
+/// the watch logs "needs restart" on every change. Live re-application
+/// (regenerating the openvpn .conf + restarting the subprocess) is
+/// FUP-L12-1 once the lifecycle FSM (D6) is in place.
+///
+/// Threading: all read accessors and the missing_required() check
+/// are thread-safe (internal mutex). The data_store::Client's
+/// listener thread is the source of cache updates; main-thread
+/// callers take the same mutex for read.
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace openvpn_client {
+
+class DsBridge {
+public:
+    /// Which key did the on_change() callback fire for? Exposing the
+    /// raw string would work too, but an enum makes switch-statements
+    /// in the consumer exhaustive-warnings-friendly.
+    enum class Key {
+        RemoteHost,
+        RemotePort,
+        RemoteProto,
+        CertPath,
+        KeyPath,
+        CaPath,
+        Cipher,
+        Dev,
+        MgmtPort,
+    };
+
+    using ChangeCallback = std::function<void(Key)>;
+
+    /// Connect to `socketPath` (empty → default
+    /// /var/run/iot/data_store.sock), prime the snapshot, register the
+    /// watch. Connection failures are silently absorbed — call
+    /// connected() to check before exercising the accessors.
+    explicit DsBridge(std::string socketPath = {});
+    ~DsBridge();
+
+    DsBridge(const DsBridge&)            = delete;
+    DsBridge& operator=(const DsBridge&) = delete;
+
+    bool connected() const { return m_ok; }
+    const std::string& socket_path() const { return m_path; }
+
+    // ─────────────────────── Read snapshots ────────────────────────
+    // Return whatever the listener thread last observed. nullopt for
+    // an unset key (where the schema has no default either).
+    std::optional<std::string>   remote_host()  const;
+    std::optional<std::uint32_t> remote_port()  const;
+    std::optional<std::string>   remote_proto() const;
+    std::optional<std::string>   cert_path()    const;
+    std::optional<std::string>   key_path()     const;
+    std::optional<std::string>   ca_path()      const;
+    std::optional<std::string>   cipher()       const;
+    std::optional<std::string>   dev()          const;
+    std::optional<std::uint32_t> mgmt_port()    const;
+
+    /// Returns nullopt when every required key is present
+    /// (vpn.remote.host, vpn.cert.path, vpn.key.path, vpn.ca.path).
+    /// Otherwise returns the list of missing key names so the caller
+    /// can refuse to start with a clear diagnostic. Schema defaults
+    /// satisfy the check for the optional keys (port/proto/cipher/dev/
+    /// mgmt.port) — those never appear in this list.
+    std::optional<std::vector<std::string>> missing_required() const;
+
+    // ─────────────────────── Write side ────────────────────────────
+    // Each setter issues a data_store::Client::set on the shared
+    // socket. Best-effort: a wire-level failure is logged but not
+    // surfaced — the caller's state machine has already advanced.
+
+    void set_state(const std::string& s);
+    void set_assigned_ip(const std::string& s);
+    void set_assigned_gateway(const std::string& s);
+    void set_assigned_netmask(const std::string& s);
+    void set_assigned_dns(const std::string& s);
+    void set_pid(std::uint32_t p);
+    void set_exit_code(std::int32_t c);
+
+    /// Register a per-key change listener. Fires on the
+    /// data_store::Client's listener thread — keep it short, don't
+    /// block on locks the main thread might hold.
+    void on_change(ChangeCallback cb);
+
+    /// Default ds-server socket path. Duplicated from
+    /// data_store::proto::kDefaultSocketPath so this header stays
+    /// free of data_store/ includes.
+    static const char* kDefaultSocketPath;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+    std::string           m_path;
+    bool                  m_ok = false;
+};
+
+} // namespace openvpn_client
+
+#endif /* __openvpn_client_ds_bridge_hpp__ */

--- a/modules/openvpn-client/src/main_impl.cpp
+++ b/modules/openvpn-client/src/main_impl.cpp
@@ -1,109 +1,86 @@
 #include "openvpn_client/client.hpp"
 
+#include "ds_bridge.hpp"
+
+#include <cstdint>
+#include <optional>
 #include <sstream>
 #include <string>
-#include <type_traits>
-#include <variant>
-#include <vector>
 
 #include <ace/Log_Msg.h>
-
-#include "data_store/client.hpp"
-#include "data_store/value.hpp"
 
 namespace openvpn_client {
 
 namespace {
 
-/// Stringify a Value for a single ACE_DEBUG log line. Keeps the
-/// dump human-readable without dragging in nlohmann::json.
-std::string value_to_display(const data_store::Value& v) {
-    return std::visit([](auto&& a) -> std::string {
-        using T = std::decay_t<decltype(a)>;
-        if constexpr (std::is_same_v<T, std::monostate>) return "(null)";
-        else if constexpr (std::is_same_v<T, bool>)
-            return a ? "true" : "false";
-        else if constexpr (std::is_same_v<T, std::string>) return a;
-        else if constexpr (std::is_same_v<T, double>) {
-            char buf[32];
-            std::snprintf(buf, sizeof(buf), "%g", a);
-            return buf;
-        } else {
-            return std::to_string(a);
-        }
-    }, v);
+/// Pretty-print an optional<string> for the snapshot dump.
+const char* show(const std::optional<std::string>& v) {
+    return v.has_value() ? v->c_str() : "(unset)";
 }
 
-/// All vpn.* keys the schema (L12/D1) declares. Order matches the
-/// schema file's read-then-write grouping so the dump reads naturally.
-const std::vector<std::string>& known_keys() {
-    static const std::vector<std::string> ks = {
-        "vpn.remote.host",
-        "vpn.remote.port",
-        "vpn.remote.proto",
-        "vpn.cert.path",
-        "vpn.key.path",
-        "vpn.ca.path",
-        "vpn.cipher",
-        "vpn.dev",
-        "vpn.mgmt.port",
-        "vpn.state",
-        "vpn.assigned.ip",
-        "vpn.assigned.gateway",
-        "vpn.assigned.netmask",
-        "vpn.assigned.dns",
-        "vpn.pid",
-        "vpn.exit_code",
-    };
-    return ks;
+/// Same idea for an optional<uint32_t> — into a thread-local buffer
+/// so the format spec stays %C (no %u juggling) and the caller can
+/// keep one dispatch path.
+const char* show(const std::optional<std::uint32_t>& v) {
+    static thread_local char buf[24];
+    if (!v.has_value()) return "(unset)";
+    std::snprintf(buf, sizeof(buf), "%u", static_cast<unsigned>(*v));
+    return buf;
 }
 
 } // namespace
 
 Status v0_dump_vpn_keys(const std::string& socketPath) {
-    data_store::Client cli;
-    auto cs = cli.connect(socketPath);
-    if (!cs.ok) {
-        ACE_ERROR((LM_ERROR,
-                   ACE_TEXT("%D [ovpn:%t] %M %N:%l data-store connect "
-                            "failed: %C\n"),
-                   cs.err.c_str()));
+    // D3 upgrade: replace the bare Client::get with a DsBridge, which
+    // primes the snapshot + registers a watch (so any concurrent
+    // ds-cli mutation surfaces while the dump is in flight — handy
+    // for live operator inspection).
+    DsBridge ds(socketPath);
+    if (!ds.connected()) {
+        // DsBridge already logged the connect-failure reason; just
+        // surface a Status the caller can return as a non-zero exit.
         Status s;
-        s.ok = false;
-        s.code = cs.code;
-        s.err = cs.err;
-        return s;
-    }
-
-    std::vector<data_store::Client::GetResult> got;
-    auto gs = cli.get(known_keys(), got);
-    if (!gs.ok) {
-        ACE_ERROR((LM_ERROR,
-                   ACE_TEXT("%D [ovpn:%t] %M %N:%l get(vpn.*) failed: %C\n"),
-                   gs.err.c_str()));
-        Status s;
-        s.ok = false;
-        s.code = gs.code;
-        s.err = gs.err;
+        s.ok   = false;
+        s.code = 1;
+        s.err  = "data-store connect failed";
         return s;
     }
 
     ACE_DEBUG((LM_INFO,
-               ACE_TEXT("%D [ovpn:%t] %M %N:%l vpn.* snapshot "
-                        "(%u keys) from %C:\n"),
-               static_cast<unsigned>(got.size()),
-               socketPath.empty() ? "(default socket)" : socketPath.c_str()));
-    for (const auto& r : got) {
-        if (!r.has_value) {
-            ACE_DEBUG((LM_INFO,
-                       ACE_TEXT("%D [ovpn:%t] %M %N:%l   %C = <unset>\n"),
-                       r.key.c_str()));
-        } else {
-            ACE_DEBUG((LM_INFO,
-                       ACE_TEXT("%D [ovpn:%t] %M %N:%l   %C = %C\n"),
-                       r.key.c_str(), value_to_display(r.value).c_str()));
+               ACE_TEXT("%D [ovpn:%t] %M %N:%l vpn.* snapshot from %C:\n"),
+               ds.socket_path().c_str()));
+
+    // Read keys — accessor-by-accessor so the variant unwrap (and
+    // schema-default application) happens in one place per key.
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.remote.host  = %C\n"), show(ds.remote_host())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.remote.port  = %C\n"), show(ds.remote_port())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.remote.proto = %C\n"), show(ds.remote_proto())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.cert.path    = %C\n"), show(ds.cert_path())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.key.path     = %C\n"), show(ds.key_path())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.ca.path      = %C\n"), show(ds.ca_path())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.cipher       = %C\n"), show(ds.cipher())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.dev          = %C\n"), show(ds.dev())));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ovpn:%t] %M %N:%l   vpn.mgmt.port    = %C\n"), show(ds.mgmt_port())));
+
+    // Required-key gate: D6's lifecycle will refuse to spawn openvpn
+    // here. For v0 we just log so operators can see which keys are
+    // still missing as they bring up a fresh deployment.
+    if (auto missing = ds.missing_required()) {
+        std::ostringstream joined;
+        for (std::size_t i = 0; i < missing->size(); ++i) {
+            if (i) joined << ", ";
+            joined << (*missing)[i];
         }
+        ACE_DEBUG((LM_WARNING,
+                   ACE_TEXT("%D [ovpn:%t] %M %N:%l required keys missing: "
+                            "%C — daemon mode (D6) will refuse to start\n"),
+                   joined.str().c_str()));
+    } else {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [ovpn:%t] %M %N:%l all required keys "
+                            "present; ready for D6 lifecycle\n")));
     }
+
     return {};
 }
 

--- a/modules/openvpn-client/test/ds_bridge_test.cpp
+++ b/modules/openvpn-client/test/ds_bridge_test.cpp
@@ -1,0 +1,75 @@
+/// Light-touch unit tests for DsBridge — only the bits that DON'T
+/// need a live ds-server. End-to-end behaviour (snapshot priming
+/// against real keys, watch callbacks firing) is exercised by the
+/// log/L12/*-smoke.sh harnesses against a real ds-server.
+
+#include <gtest/gtest.h>
+
+#include "ds_bridge.hpp"
+
+using openvpn_client::DsBridge;
+
+namespace {
+
+/// A socket path that almost certainly doesn't exist. mkdtemp is
+/// overkill — we only need the connect to fail with ECONNREFUSED /
+/// ENOENT, both of which DsBridge absorbs into `connected()==false`.
+constexpr const char* kBogusSocket = "/var/run/iot/this-path-cannot-exist.sock";
+
+} // namespace
+
+TEST(DsBridge, ConstructAgainstMissingSocketIsNotFatal) {
+    // The bridge MUST NOT throw or crash when the socket isn't
+    // there — the calling daemon is responsible for surfacing the
+    // failure via missing_required() + connected() checks.
+    DsBridge ds(kBogusSocket);
+    EXPECT_FALSE(ds.connected());
+    EXPECT_EQ(std::string(kBogusSocket), ds.socket_path());
+}
+
+TEST(DsBridge, AccessorsReturnNulloptWhenDisconnected) {
+    DsBridge ds(kBogusSocket);
+    ASSERT_FALSE(ds.connected());
+
+    // Spot-check one accessor per type; the rest follow the same
+    // mutex-then-snapshot pattern.
+    EXPECT_FALSE(ds.remote_host().has_value());
+    EXPECT_FALSE(ds.remote_port().has_value());
+    EXPECT_FALSE(ds.cert_path().has_value());
+}
+
+TEST(DsBridge, MissingRequiredListsAllRequiredKeysWhenDisconnected) {
+    // Disconnected → no way to know what's actually in the store →
+    // contract says "report every required key as missing" so the
+    // caller's missing-config path is uniform.
+    DsBridge ds(kBogusSocket);
+    auto missing = ds.missing_required();
+    ASSERT_TRUE(missing.has_value());
+    EXPECT_EQ(4u, missing->size());
+    // Order matches DsBridge.cpp's hardcoded ordering — keep these
+    // in sync if either side changes.
+    EXPECT_EQ("vpn.remote.host", (*missing)[0]);
+    EXPECT_EQ("vpn.cert.path",   (*missing)[1]);
+    EXPECT_EQ("vpn.key.path",    (*missing)[2]);
+    EXPECT_EQ("vpn.ca.path",     (*missing)[3]);
+}
+
+TEST(DsBridge, SettersAreNoopWhenDisconnected) {
+    // Daemon shouldn't crash if a setter fires after ds-server died.
+    // No assertion on side effects — just verify nothing throws.
+    DsBridge ds(kBogusSocket);
+    ds.set_state("connecting");
+    ds.set_assigned_ip("10.0.0.1");
+    ds.set_pid(42);
+    ds.set_exit_code(0);
+    SUCCEED();
+}
+
+TEST(DsBridge, OnChangeAcceptsNullCallbackForReset) {
+    DsBridge ds(kBogusSocket);
+    // Register, then null-out — proves the setter doesn't keep a
+    // stale handle that the listener thread could fire.
+    ds.on_change([](DsBridge::Key) {});
+    ds.on_change(nullptr);
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary
DsBridge mirrors \`apps/src/ds_config.cpp\`'s pattern for the \`vpn.*\` namespace.

- Owns a \`data_store::Client\` for the daemon lifetime; primes snapshot via one \`Get\`, registers callback-style \`Watch\` on the 9 readable keys
- Listener thread updates the snapshot + invokes the caller's on_change (first-cut R4 policy: log "needs restart"; live re-application is FUP-L12-1)
- Read accessors return \`std::optional<T>\` (string/uint32 per schema); setters issue \`Client::set\` for the 7 write keys
- \`missing_required()\` returns the unset required keys (host, cert.path, key.path, ca.path) so D6's lifecycle can refuse to spawn openvpn half-configured

\`v0_dump_vpn_keys\` refactored to use DsBridge — exercises the bridge end-to-end on every binary run.

## Test plan
- [x] 5/5 unit tests pass (build with \`-DBUILD_OPENVPN_CLIENT_TESTS=ON\`)
- [x] Integration smoke against live ds-server:
  - No required keys → \`required keys missing: vpn.remote.host, vpn.cert.path, vpn.key.path, vpn.ca.path — daemon mode (D6) will refuse to start\`
  - All required keys → \`all required keys present; ready for D6 lifecycle\`
  - Schema defaults still apply (port=1194, proto=udp, cipher=AES-256-GCM, dev=tun, mgmt.port=7505)

🤖 Generated with [Claude Code](https://claude.com/claude-code)