### PR TITLE
L12/D4: openvpn mgmt-protocol parser (pure logic)

### DIFF
--- a/log/L12/plan.md
+++ b/log/L12/plan.md
@@ -5,8 +5,8 @@
 > binary via its management interface. Config in + state out flows
 > through the same `ds-server` that the lwm2m binary integrates with.
 >
-> **Status (2026-05-31):** D1 + D2 (PR #29), D3 (PR #30) done.
-> D4–D6 pending.
+> **Status (2026-05-31):** D1 + D2 (PR #29), D3 (PR #30), D4 (PR #31)
+> done. D5 + D6 pending.
 
 ---
 
@@ -184,7 +184,28 @@ as a clear error.
 
 ---
 
-### D4 — Mgmt-protocol parser
+### D4 — Mgmt-protocol parser ✅ (PR #31)
+
+Closed 2026-05-31. `src/mgmt_protocol.{hpp,cpp}` lands as pure
+logic — no sockets, no ACE. `Parser::feed(bytes)` accumulates a line
+buffer and emits one `Event` per newline; `next()` pops in FIFO.
+Event::Kind covers 15 prefix-classified flavours (Banner / State /
+PushReply / ByteCount / Log / Hold / Fatal / Echo / Password /
+NeedOk / Client / SuccessReply / ErrorReply / EndMarker / DataLine /
+Unknown). Comma-split fields populated for the three async events
+that use that shape. `split_push_option()` helper for the option-
+name-vs-value follow-on parse.
+
+16 table-driven tests in `test/mgmt_protocol_test.cpp` cover:
+banner, STATE field layout, ASSIGN_IP IP-in-field-3, PUSH_REPLY
+comma split, split_push_option (bare option + key value + multi-
+word value + leading-ws), BYTECOUNT, SUCCESS/ERROR, END marker,
+multi-event batch feed, partial-line buffering, CRLF tolerance,
+empty-line drop, unknown async event, non-prefixed data line, and
+a realistic boot-to-CONNECTED stream from a single feed.
+
+Total: 21 openvpn-client tests now (5 DsBridge + 16 parser);
+39/39 ds-tests still green.
 
 **Scope.** `mgmt_protocol.{hpp,cpp}` — pure logic, no I/O. Takes raw
 bytes, emits events:

--- a/modules/openvpn-client/CMakeLists.txt
+++ b/modules/openvpn-client/CMakeLists.txt
@@ -29,10 +29,12 @@ include_directories(
 link_directories(${ACE_ROOT}/lib)
 
 # Internal lib so test targets can link the same code that the
-# binary uses. D3 added ds_bridge.cpp; D4/D5/D6 will append.
+# binary uses. D3 added ds_bridge.cpp; D4 added mgmt_protocol.cpp;
+# D5/D6 will append process.cpp + client.cpp.
 add_library(openvpn_client_lib STATIC
     src/main_impl.cpp
-    src/ds_bridge.cpp)
+    src/ds_bridge.cpp
+    src/mgmt_protocol.cpp)
 
 target_include_directories(openvpn_client_lib PUBLIC src)
 
@@ -53,7 +55,8 @@ if(BUILD_OPENVPN_CLIENT_TESTS)
     enable_testing()
 
     add_executable(openvpn-client-tests
-        test/ds_bridge_test.cpp)
+        test/ds_bridge_test.cpp
+        test/mgmt_protocol_test.cpp)
 
     target_link_libraries(openvpn-client-tests
         openvpn_client_lib

--- a/modules/openvpn-client/src/mgmt_protocol.cpp
+++ b/modules/openvpn-client/src/mgmt_protocol.cpp
@@ -1,0 +1,155 @@
+#include "mgmt_protocol.hpp"
+
+#include <algorithm>
+#include <cstddef>
+#include <string>
+#include <string_view>
+#include <utility>
+
+namespace openvpn_client::mgmt {
+
+namespace {
+
+/// Split `s` on `,` into tokens. No empty-token suppression — OpenVPN's
+/// STATE messages legitimately have trailing empty fields
+/// (`...,1194,,`), so the caller can index them positionally.
+std::vector<std::string> comma_split(std::string_view s) {
+    std::vector<std::string> out;
+    std::size_t start = 0;
+    for (std::size_t i = 0; i <= s.size(); ++i) {
+        if (i == s.size() || s[i] == ',') {
+            out.emplace_back(s.substr(start, i - start));
+            start = i + 1;
+        }
+    }
+    return out;
+}
+
+/// True iff `s` starts with `prefix`. C++17-friendly (string_view's
+/// starts_with arrived in C++20).
+bool starts_with(std::string_view s, std::string_view prefix) {
+    return s.size() >= prefix.size() &&
+           s.compare(0, prefix.size(), prefix) == 0;
+}
+
+/// Strip trailing CR (some openvpn builds CRLF the mgmt socket on
+/// Windows; harmless to handle defensively everywhere).
+void rstrip_cr(std::string& s) {
+    if (!s.empty() && s.back() == '\r') s.pop_back();
+}
+
+} // namespace
+
+void Parser::feed(std::string_view bytes) {
+    m_buf.append(bytes.data(), bytes.size());
+    // Scan for newlines; emit one Event per complete line.
+    std::size_t start = 0;
+    for (std::size_t i = 0; i < m_buf.size(); ++i) {
+        if (m_buf[i] != '\n') continue;
+        std::string line = m_buf.substr(start, i - start);
+        rstrip_cr(line);
+        emit(std::move(line));
+        start = i + 1;
+    }
+    if (start > 0) {
+        m_buf.erase(0, start);
+    }
+}
+
+std::optional<Event> Parser::next() {
+    if (m_events.empty()) return std::nullopt;
+    Event e = std::move(m_events.front());
+    m_events.pop_front();
+    return e;
+}
+
+void Parser::emit(std::string line) {
+    Event ev;
+
+    // Async events have a `>EVENT:body` shape.
+    if (!line.empty() && line.front() == '>') {
+        // Find the colon that separates `>EVENT` from `body`. If
+        // there's no colon at all (`>SOMETHING-WITHOUT-COLON`), treat
+        // the whole thing past `>` as a tag with empty body.
+        const auto colon = line.find(':');
+        std::string tag = (colon == std::string::npos)
+                          ? line.substr(1)
+                          : line.substr(1, colon - 1);
+        std::string body = (colon == std::string::npos)
+                           ? std::string{}
+                           : line.substr(colon + 1);
+
+        if      (tag == "INFO")       ev.kind = Event::Kind::Banner;
+        else if (tag == "STATE")      ev.kind = Event::Kind::State;
+        else if (tag == "PUSH_REPLY") ev.kind = Event::Kind::PushReply;
+        else if (tag == "BYTECOUNT")  ev.kind = Event::Kind::ByteCount;
+        else if (tag == "LOG")        ev.kind = Event::Kind::Log;
+        else if (tag == "HOLD")       ev.kind = Event::Kind::Hold;
+        else if (tag == "FATAL")      ev.kind = Event::Kind::Fatal;
+        else if (tag == "ECHO")       ev.kind = Event::Kind::Echo;
+        else if (tag == "PASSWORD")   ev.kind = Event::Kind::Password;
+        else if (tag == "NEED-OK")    ev.kind = Event::Kind::NeedOk;
+        else if (tag == "CLIENT")     ev.kind = Event::Kind::Client;
+        else                          ev.kind = Event::Kind::Unknown;
+
+        ev.raw = std::move(body);
+
+        // Fields population: STATE / PUSH_REPLY / BYTECOUNT all
+        // comma-separate their payload. Other event kinds put their
+        // raw body in `raw` only.
+        if (ev.kind == Event::Kind::State     ||
+            ev.kind == Event::Kind::PushReply ||
+            ev.kind == Event::Kind::ByteCount) {
+            ev.fields = comma_split(ev.raw);
+        }
+    }
+    else if (starts_with(line, "SUCCESS:")) {
+        ev.kind = Event::Kind::SuccessReply;
+        // body starts after "SUCCESS:" — and openvpn typically adds
+        // a leading space ("SUCCESS: pid=1234"), which we keep
+        // verbatim so consumers can parse the form they expect.
+        ev.raw = line.substr(8);
+    }
+    else if (starts_with(line, "ERROR:")) {
+        ev.kind = Event::Kind::ErrorReply;
+        ev.raw = line.substr(6);
+    }
+    else if (line == "END") {
+        ev.kind = Event::Kind::EndMarker;
+        // raw stays empty
+    }
+    else if (!line.empty()) {
+        ev.kind = Event::Kind::DataLine;
+        ev.raw = std::move(line);
+    }
+    else {
+        // Empty line — drop, don't enqueue.
+        return;
+    }
+
+    m_events.push_back(std::move(ev));
+}
+
+std::pair<std::string, std::string>
+split_push_option(std::string_view option) {
+    // Trim leading whitespace (PUSH_REPLY can be `dhcp-option DNS …`
+    // or rarely `,dhcp-option DNS …` after a trailing comma; the
+    // caller's comma_split handles the latter but a stray leading
+    // space is still possible).
+    std::size_t start = 0;
+    while (start < option.size() &&
+           (option[start] == ' ' || option[start] == '\t')) {
+        ++start;
+    }
+    option.remove_prefix(start);
+
+    auto space = option.find(' ');
+    if (space == std::string_view::npos) {
+        // Bare option like "redirect-gateway" — name only, no value.
+        return { std::string(option), std::string{} };
+    }
+    return { std::string(option.substr(0, space)),
+             std::string(option.substr(space + 1)) };
+}
+
+} // namespace openvpn_client::mgmt

--- a/modules/openvpn-client/src/mgmt_protocol.hpp
+++ b/modules/openvpn-client/src/mgmt_protocol.hpp
@@ -1,0 +1,109 @@
+#ifndef __openvpn_client_mgmt_protocol_hpp__
+#define __openvpn_client_mgmt_protocol_hpp__
+
+/// OpenVPN management-interface protocol parser.
+///
+/// Pure logic — no sockets, no ACE, no I/O. The reactor-thread
+/// wrapper (D6) feeds raw bytes from the mgmt socket; this parser
+/// accumulates them into newline-delimited lines, classifies each
+/// by the `>EVENT:` / `SUCCESS:` / `ERROR:` / `END` prefixes, and
+/// emits one `Event` per fully-parsed line.
+///
+/// Reference: openvpn(8) man page §"Management interface", plus the
+/// protocol notes in OpenVPN's `doc/management-notes.txt`.
+///
+/// Wire shape (asynchronous events have a `>` prefix; command
+/// responses don't):
+///
+///   >INFO:OpenVPN Management Interface Version 1 -- type 'help' …
+///   >STATE:1701420000,CONNECTED,SUCCESS,10.8.0.6,vpn.example.com,1194,,
+///   >PUSH_REPLY:dhcp-option DNS 1.1.1.1,route-gateway 10.8.0.1,ifconfig 10.8.0.6 255.255.255.0
+///   >BYTECOUNT:12345,67890
+///   >LOG:1701420000,N,Tunnel rebuilt
+///   >HOLD:Waiting for hold release.
+///   SUCCESS: hold release succeeded
+///   ERROR: unknown command
+///   END
+///
+/// The parser does NOT interpret semantics — STATE field 1 is just
+/// `fields[1]`, PushReply options are just comma-split tokens. The
+/// D6 lifecycle FSM is responsible for mapping `fields[1]=="CONNECTED"`
+/// → vpn.state, etc. Keeping the parser semantic-free makes it
+/// table-driven testable + immune to OpenVPN spec drift.
+
+#include <cstddef>
+#include <deque>
+#include <optional>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace openvpn_client::mgmt {
+
+struct Event {
+    enum class Kind {
+        Banner,        ///< `>INFO:` — first line after connect
+        State,         ///< `>STATE:` — periodic state notification
+        PushReply,     ///< `>PUSH_REPLY:` — server pushed options
+        ByteCount,     ///< `>BYTECOUNT:` — periodic tunnel stats
+        Log,           ///< `>LOG:` — log line forwarded from openvpn
+        Hold,          ///< `>HOLD:` — daemon paused; needs `hold release`
+        Fatal,         ///< `>FATAL:` — terminal error from openvpn
+        Echo,          ///< `>ECHO:` — push echo
+        Password,      ///< `>PASSWORD:` — request for credentials
+        NeedOk,        ///< `>NEED-OK:` — request to confirm something
+        Client,        ///< `>CLIENT:` — server-mode client lifecycle
+        SuccessReply,  ///< `SUCCESS:` — response to a command
+        ErrorReply,    ///< `ERROR:` — response to a command
+        EndMarker,     ///< bare `END` line — terminator of a multi-line response
+        DataLine,      ///< any other non-prefixed line (response payload)
+        Unknown,       ///< didn't match any of the above (caller decides what to do)
+    };
+
+    Kind kind = Kind::Unknown;
+
+    /// Everything after the prefix (or the whole line for DataLine /
+    /// EndMarker / Unknown). Trailing CR stripped.
+    std::string raw;
+
+    /// For State / PushReply / ByteCount: comma-split tokens.
+    /// PushReply's tokens still need a second whitespace split to
+    /// extract the option name + value — keep that in the consumer
+    /// so this struct stays generic.
+    std::vector<std::string> fields;
+};
+
+class Parser {
+public:
+    /// Append `bytes` to the internal line buffer. Any complete
+    /// newline-delimited lines are immediately classified and
+    /// enqueued for `next()`.
+    void feed(std::string_view bytes);
+
+    /// Pop the next ready event in FIFO order. Returns nullopt
+    /// when nothing is queued (caller waits for more bytes).
+    std::optional<Event> next();
+
+    /// Diagnostic: how many bytes are still sitting in the line
+    /// buffer waiting for a newline. Mostly useful for tests that
+    /// want to assert a partial-feed didn't leak.
+    std::size_t buffer_size() const { return m_buf.size(); }
+
+private:
+    std::string       m_buf;
+    std::deque<Event> m_events;
+
+    /// Classify a single, newline-stripped line and enqueue.
+    void emit(std::string line);
+};
+
+/// Helper: split a `>PUSH_REPLY:` field (e.g. "ifconfig 10.8.0.6
+/// 255.255.255.0") into option name + remaining whitespace-joined
+/// value. Returns {name, value} pair; value is empty for bare
+/// options like "redirect-gateway".
+std::pair<std::string, std::string>
+split_push_option(std::string_view option);
+
+} // namespace openvpn_client::mgmt
+
+#endif /* __openvpn_client_mgmt_protocol_hpp__ */

--- a/modules/openvpn-client/test/mgmt_protocol_test.cpp
+++ b/modules/openvpn-client/test/mgmt_protocol_test.cpp
@@ -1,0 +1,253 @@
+/// Table-driven tests for the openvpn(8) management-interface parser.
+///
+/// Fixtures are byte-for-byte captures (or close approximations) of
+/// what `openvpn --management 127.0.0.1 7505` writes on the mgmt
+/// socket. The parser is pure logic so we drive it with raw strings
+/// and assert on the emitted Event stream.
+
+#include <gtest/gtest.h>
+
+#include "mgmt_protocol.hpp"
+
+using openvpn_client::mgmt::Event;
+using openvpn_client::mgmt::Parser;
+
+namespace {
+
+/// Drain every available event from a parser into a vector — keeps
+/// the tests linear instead of a while-loop boilerplate per case.
+std::vector<Event> drain(Parser& p) {
+    std::vector<Event> out;
+    while (auto ev = p.next()) out.push_back(*std::move(ev));
+    return out;
+}
+
+} // namespace
+
+/* ─────────────────────────── Banner ──────────────────────────────── */
+
+TEST(MgmtParser, BannerLineProducesOneBannerEvent) {
+    Parser p;
+    p.feed(">INFO:OpenVPN Management Interface Version 1 -- "
+           "type 'help' for more info\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::Banner, evs[0].kind);
+    EXPECT_EQ("OpenVPN Management Interface Version 1 -- "
+              "type 'help' for more info", evs[0].raw);
+    EXPECT_EQ(0u, p.buffer_size());
+}
+
+/* ─────────────────────────── STATE ───────────────────────────────── */
+
+TEST(MgmtParser, StateConnectedFieldsAreCommaSplit) {
+    Parser p;
+    p.feed(">STATE:1701420000,CONNECTED,SUCCESS,10.8.0.6,"
+           "vpn.example.com,1194,,\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::State, evs[0].kind);
+    ASSERT_EQ(8u, evs[0].fields.size());
+    EXPECT_EQ("1701420000",      evs[0].fields[0]);
+    EXPECT_EQ("CONNECTED",       evs[0].fields[1]);
+    EXPECT_EQ("SUCCESS",         evs[0].fields[2]);
+    EXPECT_EQ("10.8.0.6",        evs[0].fields[3]);
+    EXPECT_EQ("vpn.example.com", evs[0].fields[4]);
+    EXPECT_EQ("1194",            evs[0].fields[5]);
+    EXPECT_EQ("",                evs[0].fields[6]);
+    EXPECT_EQ("",                evs[0].fields[7]);
+}
+
+TEST(MgmtParser, StateAssignIpCarriesAssignedIpInFieldThree) {
+    Parser p;
+    p.feed(">STATE:1701420001,ASSIGN_IP,,10.8.0.6,,,,,\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::State, evs[0].kind);
+    ASSERT_GE(evs[0].fields.size(), 4u);
+    EXPECT_EQ("ASSIGN_IP", evs[0].fields[1]);
+    EXPECT_EQ("10.8.0.6",  evs[0].fields[3]);
+}
+
+/* ─────────────────────────── PUSH_REPLY ──────────────────────────── */
+
+TEST(MgmtParser, PushReplyCommaSplitsOptions) {
+    Parser p;
+    p.feed(">PUSH_REPLY:dhcp-option DNS 1.1.1.1,route-gateway 10.8.0.1,"
+           "topology subnet,ifconfig 10.8.0.6 255.255.255.0,"
+           "cipher AES-256-GCM,peer-id 0\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::PushReply, evs[0].kind);
+    ASSERT_EQ(6u, evs[0].fields.size());
+    EXPECT_EQ("dhcp-option DNS 1.1.1.1",          evs[0].fields[0]);
+    EXPECT_EQ("route-gateway 10.8.0.1",           evs[0].fields[1]);
+    EXPECT_EQ("topology subnet",                  evs[0].fields[2]);
+    EXPECT_EQ("ifconfig 10.8.0.6 255.255.255.0",  evs[0].fields[3]);
+    EXPECT_EQ("cipher AES-256-GCM",               evs[0].fields[4]);
+    EXPECT_EQ("peer-id 0",                        evs[0].fields[5]);
+}
+
+TEST(MgmtParser, SplitPushOptionSeparatesNameAndValue) {
+    using openvpn_client::mgmt::split_push_option;
+
+    auto [n1, v1] = split_push_option("dhcp-option DNS 1.1.1.1");
+    EXPECT_EQ("dhcp-option",     n1);
+    EXPECT_EQ("DNS 1.1.1.1",     v1);
+
+    auto [n2, v2] = split_push_option("ifconfig 10.8.0.6 255.255.255.0");
+    EXPECT_EQ("ifconfig",                 n2);
+    EXPECT_EQ("10.8.0.6 255.255.255.0",   v2);
+
+    auto [n3, v3] = split_push_option("redirect-gateway");
+    EXPECT_EQ("redirect-gateway", n3);
+    EXPECT_EQ("",                 v3);
+
+    // Leading whitespace from a stray "," tolerated.
+    auto [n4, v4] = split_push_option("  cipher AES-256-GCM");
+    EXPECT_EQ("cipher",          n4);
+    EXPECT_EQ("AES-256-GCM",     v4);
+}
+
+/* ─────────────────────────── ByteCount ───────────────────────────── */
+
+TEST(MgmtParser, ByteCountFieldsAreIntegersAsStrings) {
+    Parser p;
+    p.feed(">BYTECOUNT:12345,67890\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::ByteCount, evs[0].kind);
+    ASSERT_EQ(2u, evs[0].fields.size());
+    EXPECT_EQ("12345", evs[0].fields[0]);
+    EXPECT_EQ("67890", evs[0].fields[1]);
+}
+
+/* ─────────────────────────── Command replies ─────────────────────── */
+
+TEST(MgmtParser, SuccessReplyKeepsBodyVerbatim) {
+    Parser p;
+    p.feed("SUCCESS: pid=12345\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::SuccessReply, evs[0].kind);
+    EXPECT_EQ(" pid=12345", evs[0].raw);   // includes the leading space
+}
+
+TEST(MgmtParser, ErrorReplyClassifiesUnknownCommand) {
+    Parser p;
+    p.feed("ERROR: unknown command, enter 'help' for more options\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::ErrorReply, evs[0].kind);
+}
+
+TEST(MgmtParser, EndMarkerIsItsOwnEvent) {
+    Parser p;
+    p.feed("END\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::EndMarker, evs[0].kind);
+}
+
+/* ─────────────────────────── Edge cases ──────────────────────────── */
+
+TEST(MgmtParser, MultipleEventsDeliveredInOneFeed) {
+    Parser p;
+    p.feed(">INFO:Hello\n>STATE:0,CONNECTING,,,,,\n>HOLD:Waiting for hold release.\n");
+    auto evs = drain(p);
+    ASSERT_EQ(3u, evs.size());
+    EXPECT_EQ(Event::Kind::Banner, evs[0].kind);
+    EXPECT_EQ(Event::Kind::State,  evs[1].kind);
+    EXPECT_EQ(Event::Kind::Hold,   evs[2].kind);
+}
+
+TEST(MgmtParser, PartialLineHeldUntilNewline) {
+    Parser p;
+    p.feed(">STATE:0,CONNECT");   // partial
+    EXPECT_EQ(0u, drain(p).size());
+    EXPECT_GT(p.buffer_size(), 0u);
+
+    p.feed("ING,,,,,\n");          // completes the line
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::State, evs[0].kind);
+    EXPECT_EQ("CONNECTING", evs[0].fields[1]);
+    EXPECT_EQ(0u, p.buffer_size());
+}
+
+TEST(MgmtParser, CrlfLineEndingsTolerated) {
+    Parser p;
+    p.feed(">STATE:0,WAIT,,,,,\r\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::State, evs[0].kind);
+    // Trailing CR stripped — fields[5] is "" not "\r".
+    EXPECT_EQ("WAIT", evs[0].fields[1]);
+    EXPECT_EQ("",     evs[0].fields[5]);
+}
+
+TEST(MgmtParser, EmptyLineDropped) {
+    Parser p;
+    p.feed("\n");
+    EXPECT_EQ(0u, drain(p).size());
+}
+
+TEST(MgmtParser, UnknownAsyncEventClassifiedAsUnknown) {
+    Parser p;
+    p.feed(">FANCY-NEW-EVENT:something\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::Unknown, evs[0].kind);
+    EXPECT_EQ("something", evs[0].raw);
+}
+
+TEST(MgmtParser, NonPrefixedLineIsDataLine) {
+    // e.g. response to `status` command: the rows between SUCCESS:
+    // and END are bare data lines.
+    Parser p;
+    p.feed("OpenVPN STATISTICS\n");
+    auto evs = drain(p);
+    ASSERT_EQ(1u, evs.size());
+    EXPECT_EQ(Event::Kind::DataLine, evs[0].kind);
+    EXPECT_EQ("OpenVPN STATISTICS", evs[0].raw);
+}
+
+TEST(MgmtParser, RealisticOpenvpnConnectStreamProducesExpectedSequence) {
+    // Real-ish capture of the early frames an openvpn client emits
+    // on the mgmt socket between connect + first ASSIGN_IP. Caller's
+    // FSM (D6) would walk this stream and write back state/IP keys.
+    Parser p;
+    p.feed(
+        ">INFO:OpenVPN Management Interface Version 1 -- type 'help' for more info\n"
+        ">HOLD:Waiting for hold release.\n"
+        ">STATE:1701420000,CONNECTING,,,,,\n"
+        ">STATE:1701420001,WAIT,,,,,\n"
+        ">STATE:1701420002,AUTH,,,,,\n"
+        ">STATE:1701420003,GET_CONFIG,,,,,\n"
+        ">PUSH_REPLY:dhcp-option DNS 1.1.1.1,route-gateway 10.8.0.1,"
+        "ifconfig 10.8.0.6 255.255.255.0,cipher AES-256-GCM\n"
+        ">STATE:1701420004,ASSIGN_IP,,10.8.0.6,,,,,\n"
+        ">STATE:1701420005,CONNECTED,SUCCESS,10.8.0.6,"
+        "vpn.example.com,1194,,\n");
+
+    auto evs = drain(p);
+    ASSERT_EQ(9u, evs.size());
+    EXPECT_EQ(Event::Kind::Banner,    evs[0].kind);
+    EXPECT_EQ(Event::Kind::Hold,      evs[1].kind);
+    EXPECT_EQ(Event::Kind::State,     evs[2].kind);
+    EXPECT_EQ("CONNECTING",           evs[2].fields[1]);
+    EXPECT_EQ(Event::Kind::State,     evs[3].kind);
+    EXPECT_EQ("WAIT",                 evs[3].fields[1]);
+    EXPECT_EQ(Event::Kind::State,     evs[4].kind);
+    EXPECT_EQ("AUTH",                 evs[4].fields[1]);
+    EXPECT_EQ(Event::Kind::State,     evs[5].kind);
+    EXPECT_EQ("GET_CONFIG",           evs[5].fields[1]);
+    EXPECT_EQ(Event::Kind::PushReply, evs[6].kind);
+    ASSERT_EQ(4u, evs[6].fields.size());
+    EXPECT_EQ("ifconfig 10.8.0.6 255.255.255.0", evs[6].fields[2]);
+    EXPECT_EQ(Event::Kind::State,     evs[7].kind);
+    EXPECT_EQ("ASSIGN_IP",            evs[7].fields[1]);
+    EXPECT_EQ("10.8.0.6",             evs[7].fields[3]);
+    EXPECT_EQ(Event::Kind::State,     evs[8].kind);
+    EXPECT_EQ("CONNECTED",            evs[8].fields[1]);
+}


### PR DESCRIPTION
## Summary
Pure-logic OpenVPN management-interface parser. No sockets, no ACE.

\`Parser::feed(bytes)\` accumulates a line buffer; \`next()\` pops one classified \`Event\` per newline in FIFO. 15 \`Kind\` flavours covering every prefix the parser sees from a real openvpn(8) management socket; comma-split fields populated for the three event kinds whose payload is comma-separated (State / PushReply / ByteCount).

\`split_push_option()\` helper for the consumer's option-name-vs-value split (e.g. \`"ifconfig 10.8.0.6 255.255.255.0"\` → \`{"ifconfig", "10.8.0.6 255.255.255.0"}\`).

CRLF tolerated; empty lines dropped; partial-line feeds buffer until the newline arrives.

## Test plan
- [x] 16 new table-driven tests in \`test/mgmt_protocol_test.cpp\` covering banner, STATE field layout, ASSIGN_IP, PUSH_REPLY, split_push_option (4 sub-cases), BYTECOUNT, SUCCESS/ERROR replies, END marker, batch feed, partial line, CRLF, empty line, unknown event, data line, realistic boot-to-CONNECTED stream
- [x] 21/21 openvpn-client tests pass (5 DsBridge + 16 parser)
- [x] 39/39 ds-tests still green

## Next
D5 — \`ACE_Process\` wrapper around openvpn(8)

🤖 Generated with [Claude Code](https://claude.com/claude-code)