### PR TITLE
L12: install openvpn(8) + wire openvpn-client into apps build

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -53,6 +53,28 @@ podman run -d --name iot-server -e IOT_ROLE=server \
     iot:l11
 ```
 
+For **openvpn-client** (L12) — needs `CAP_NET_ADMIN` and
+`/dev/net/tun` because the spawned `openvpn(8)` brings up the TUN
+device + writes routes:
+
+```sh
+# vpn.* keys must be set before openvpn-client starts; see modules/openvpn/client/docs/design.md
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock set vpn.remote.host '"vpn.example.com"'
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock set vpn.cert.path  '"/etc/iot/vpn/client.crt"'
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock set vpn.key.path   '"/etc/iot/vpn/client.key"'
+podman exec iot-ds ds-cli --socket=/run/iot/data_store.sock set vpn.ca.path    '"/etc/iot/vpn/ca.crt"'
+
+podman run -d --name iot-ovpn \
+    --cap-add=NET_ADMIN --device=/dev/net/tun \
+    --volumes-from iot-ds \
+    -v /etc/iot/vpn:/etc/iot/vpn:ro \
+    iot:l11 openvpn-client --ds-sock=/run/iot/data_store.sock
+```
+
+The image ships `openvpn(8)` from Ubuntu (`apt install openvpn` in
+the runtime stage). Default path `/usr/sbin/openvpn`; override with
+`--openvpn=PATH`.
+
 ### 3. Tune config via ds-cli
 
 ```sh

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -52,6 +52,13 @@ include_directories(inc)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store
                  ${CMAKE_BINARY_DIR}/data-store)
 
+# OpenVPN client daemon (L12). Sibling under ../modules/openvpn/client.
+# Adding it here means a top-level `cmake apps && make install` lands
+# the openvpn-client binary + its vpn.lua schema alongside everything
+# else. Standalone module build at modules/openvpn/client/ still works.
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/openvpn/client
+                 ${CMAKE_BINARY_DIR}/openvpn-client)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store/inc)
 
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,6 +1,10 @@
 FROM ubuntu:jammy
+# Build deps (gcc/g++/etc.) + dev-side runtime deps (openvpn(8) — the
+# openvpn-client daemon spawns it; netcat-openbsd for the L12 fake-
+# openvpn smoke harness). Neither is a link-time dep, just runtime.
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev python3-dev autoconf wget pkg-config
+    apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev python3-dev autoconf wget pkg-config \
+                       openvpn netcat-openbsd
 
 # ACE/TAO 7.0.0 — same install prefix as the xpmile project so the include
 # / link paths in apps/CMakeLists.txt resolve. `ssl=1` is load-bearing; without

--- a/log/L12/plan.md
+++ b/log/L12/plan.md
@@ -7,7 +7,8 @@
 >
 > **Status (2026-05-31):** All D-items done. PRs #29 (D1+D2), #30 (D3),
 > #31 (D4), #33 (D5), #35 (D6). Restructure in PR #32; inc/ flatten
-> in PR #34. Module sits at `modules/openvpn/client/`.
+> in PR #34; **openvpn(8) runtime install + cap docs in PR #36**.
+> Module sits at `modules/openvpn/client/`.
 
 ---
 

--- a/modules/openvpn/client/docs/design.md
+++ b/modules/openvpn/client/docs/design.md
@@ -1,8 +1,8 @@
 # openvpn-client — module design (L12)
 
-> **Status (2026-05-31):** D1 + D2 scaffold landed. D3 (DsBridge),
-> D4 (mgmt parser), D5 (ACE_Process wrapper), D6 (lifecycle glue +
-> e2e smoke) pending.
+> **Status (2026-05-31):** L12 closed. D1+D2 (scaffold), D3 (DsBridge),
+> D4 (mgmt parser), D5 (ACE_Process wrapper), D6 (lifecycle + e2e
+> smoke) all done; openvpn(8) install + cap docs in this PR.
 
 ## What this module is
 
@@ -11,6 +11,26 @@ mirrors its state into the data store. Operators configure via
 `ds-cli set vpn.*`; the daemon spawns openvpn with a generated
 config, watches its management interface, and publishes the assigned
 virtual IP + state back to the same store.
+
+## Runtime requirements
+
+| Dep                       | Why                                                                          | Where it's installed                                |
+|---------------------------|------------------------------------------------------------------------------|------------------------------------------------------|
+| `openvpn(8)`              | Spawned by `OpenVpnProcess`; default path `/usr/sbin/openvpn`                | `docker/Dockerfile` (dev) + `packaging/Containerfile` (OCI runtime) |
+| `CAP_NET_ADMIN` capability | openvpn writes routes + brings the TUN device up                              | Container: `--cap-add=NET_ADMIN`. Bare-metal systemd: needs `AmbientCapabilities=CAP_NET_ADMIN` (FUP for the systemd unit) |
+| `/dev/net/tun`            | The TUN device node openvpn opens                                            | Container: `--device=/dev/net/tun`. Bare-metal: already there |
+| `ds-server` reachable     | DsBridge connects to the unix socket on startup                              | Same `/run/iot/data_store.sock` the lwm2m binary uses |
+
+Container example:
+
+```sh
+podman run -d --name iot-ovpn \
+    --cap-add=NET_ADMIN \
+    --device=/dev/net/tun \
+    --volumes-from iot-ds \
+    -v /etc/iot/vpn:/etc/iot/vpn:ro \
+    iot:l11 openvpn-client --ds-sock=/run/iot/data_store.sock
+```
 
 ```
 ┌──────────────────────────────────────────────────────────────┐

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -55,14 +55,22 @@ RUN strip /staging/usr/bin/ds-server \
 # ──────────────────────────────────────────────────────────────────────
 FROM ubuntu:22.04 AS runtime
 
-# Runtime apt: only the libs the binaries actually link against per ldd.
-# --no-install-recommends keeps the layer small.
+# Runtime apt: libs the binaries link against per ldd, plus
+# openvpn(8) which `openvpn-client` spawns at /usr/sbin/openvpn.
+# --no-install-recommends keeps the layer small (openvpn alone pulls
+# ~6 MB; with recommends it'd drag in systemd, dnsmasq, etc.).
+#
+# Container-runtime caveat: openvpn(8) needs CAP_NET_ADMIN +
+# /dev/net/tun. Run with:
+#   podman run --cap-add=NET_ADMIN --device=/dev/net/tun ...
+# DEPLOY.md covers this in the operator walkthrough.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends -qq \
         libreadline8 \
         libssl3 \
         zlib1g \
-        ca-certificates && \
+        ca-certificates \
+        openvpn && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* /usr/share/doc/* /usr/share/man/*
 
@@ -81,10 +89,11 @@ RUN echo /usr/local/ACE_TAO-7.0.0/lib > /etc/ld.so.conf.d/ace-tao.conf && \
     ldconfig
 
 # Binaries + config + entrypoint.
-COPY --from=build /staging/usr/bin/ds-server   /usr/local/bin/
-COPY --from=build /staging/usr/bin/ds-cli      /usr/local/bin/
-COPY --from=build /staging/usr/bin/lwm2m       /usr/local/bin/
-COPY --from=build /staging/etc/iot             /etc/iot
+COPY --from=build /staging/usr/bin/ds-server       /usr/local/bin/
+COPY --from=build /staging/usr/bin/ds-cli          /usr/local/bin/
+COPY --from=build /staging/usr/bin/lwm2m           /usr/local/bin/
+COPY --from=build /staging/usr/bin/openvpn-client  /usr/local/bin/
+COPY --from=build /staging/etc/iot                 /etc/iot
 
 COPY packaging/iot-entrypoint.sh /usr/local/bin/iot-entrypoint
 RUN chmod +x /usr/local/bin/iot-entrypoint

--- a/packaging/iot-entrypoint.sh
+++ b/packaging/iot-entrypoint.sh
@@ -20,7 +20,7 @@ set -e
 # If the first arg is one of our binaries, forward verbatim — supports
 # `podman run iot:l11 ds-cli get foo`.
 case "${1:-}" in
-    ds-cli|ds-server|lwm2m)
+    ds-cli|ds-server|lwm2m|openvpn-client|openvpn)
         exec "$@"
         ;;
 esac


### PR DESCRIPTION
## Summary
Closes a real gap from L12: openvpn-client wasn't actually deployable.

**Problems**
- \`docker/Dockerfile\` (dev) didn't install openvpn(8) → no smoke without a fake
- \`packaging/Containerfile\` (OCI) didn't install openvpn either, and didn't even copy the openvpn-client binary
- \`apps/CMakeLists.txt\` didn't \`add_subdirectory\` the openvpn-client module, so \`make install\` skipped it entirely

**Fix**
- Both Dockerfiles: \`apt install openvpn\` (+ netcat-openbsd in dev for the fake-openvpn smoke)
- Containerfile: \`COPY --from=build /staging/usr/bin/openvpn-client\`
- iot-entrypoint.sh: add \`openvpn\` + \`openvpn-client\` to the direct-invoke whitelist
- apps/CMakeLists.txt: \`add_subdirectory(modules/openvpn/client)\`
- Docs: \`docs/design.md\` runtime-requirements table; \`DEPLOY.md\` container snippet with cap-add + device flags + ds-cli vpn.* seeding

## Test plan
- [x] \`podman run --rm iot:l12 openvpn --version\` → OpenVPN 2.5.11
- [x] \`podman run --rm iot:l12 openvpn-client --help\` → L12/D6 banner
- [x] Image size: 127.9 MB (was 118.6); +9.3 MB for openvpn+openvpn-client. Still over 100 MB target (FUP-L11-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)