### PR TITLE
L12 packaging: iot-openvpn-client systemd unit + IOT_ROLE=ovpn

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -163,6 +163,23 @@ sudo systemctl status iot-ds iot-lwm2m-client
 The lwm2m-client unit `After=iot-ds.service Wants=iot-ds.service` so
 DsConfig connects on the first try without falling back to defaults.
 
+For the **openvpn-client** unit, seed the required vpn.* keys first
+(or it will refuse to start) and then enable:
+
+```sh
+ds-cli --socket=/run/iot/data_store.sock set vpn.remote.host '"vpn.example.com"'
+ds-cli --socket=/run/iot/data_store.sock set vpn.cert.path  '"/etc/iot/vpn/client.crt"'
+ds-cli --socket=/run/iot/data_store.sock set vpn.key.path   '"/etc/iot/vpn/client.key"'
+ds-cli --socket=/run/iot/data_store.sock set vpn.ca.path    '"/etc/iot/vpn/ca.crt"'
+
+sudo systemctl enable --now iot-openvpn-client.service
+journalctl -u iot-openvpn-client.service -f | grep "PUSH_REPLY\|state"
+```
+
+The unit ships with `AmbientCapabilities=CAP_NET_ADMIN` +
+`DeviceAllow=/dev/net/tun rw` so openvpn(8) can create the TUN
+device + write routes under DynamicUser — no `root` required.
+
 ### 4. Same ds-cli tuning as the container path
 
 ```sh

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -104,6 +104,7 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-ds.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-lwm2m-client.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-lwm2m-server.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-openvpn-client.service
             DESTINATION lib/systemd/system)
 
     # tmpfiles.d fallback for hosts where RuntimeDirectory= doesn't
@@ -123,6 +124,7 @@ if(IOT_PACKAGING_INSTALL)
     install(FILES
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/lwm2m-client.env
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/lwm2m-server.env
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/openvpn-client.env
             DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot)
 
     # Object-resource config templates. Land each .lua as .lua.example

--- a/packaging/etc-iot/openvpn-client.env
+++ b/packaging/etc-iot/openvpn-client.env
@@ -1,0 +1,22 @@
+# EnvironmentFile for iot-openvpn-client.service.
+#
+# OPENVPN_CLIENT_ARGS is the literal argv tail passed to
+# /usr/local/bin/openvpn-client. The vpn.* config keys (remote.host,
+# cert.path, key.path, ca.path, etc.) come from ds-server via ds-cli —
+# see /etc/iot/ds-schemas/vpn.lua for the schema. The .env file only
+# carries process-level wiring (socket path, openvpn binary path).
+#
+# Hot-reloadable via ds-cli (preferred over editing this file):
+#   vpn.remote.host / vpn.remote.port / vpn.remote.proto
+#   vpn.cert.path / vpn.key.path / vpn.ca.path
+#   vpn.cipher / vpn.dev / vpn.mgmt.port
+#
+# Operator workflow (bare metal):
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now iot-openvpn-client.service
+#   ds-cli set vpn.remote.host '"vpn.example.com"'
+#   ds-cli set vpn.cert.path '"/etc/iot/vpn/client.crt"'
+#   …
+#   journalctl -u iot-openvpn-client.service -f
+
+OPENVPN_CLIENT_ARGS="--ds-sock=/run/iot/data_store.sock --openvpn=/usr/sbin/openvpn"

--- a/packaging/iot-entrypoint.sh
+++ b/packaging/iot-entrypoint.sh
@@ -4,6 +4,8 @@
 #   IOT_ROLE=ds      → run ds-server
 #   IOT_ROLE=client  → run lwm2m role=client
 #   IOT_ROLE=server  → run lwm2m role=server
+#   IOT_ROLE=ovpn    → run openvpn-client (needs --cap-add=NET_ADMIN
+#                       --device=/dev/net/tun on the podman run)
 #
 # Per-role default args live in /etc/iot/lwm2m-*.env (sourced via
 # . , so they end up as shell vars). Operators override by:
@@ -47,13 +49,20 @@ case "${IOT_ROLE:-}" in
         # shellcheck disable=SC2086
         exec /usr/local/bin/lwm2m $LWM2M_ARGS "$@"
         ;;
+    ovpn)
+        # shellcheck disable=SC1091
+        [ -f /etc/iot/openvpn-client.env ] && . /etc/iot/openvpn-client.env
+        : "${OPENVPN_CLIENT_ARGS:?openvpn-client.env missing OPENVPN_CLIENT_ARGS}"
+        # shellcheck disable=SC2086
+        exec /usr/local/bin/openvpn-client $OPENVPN_CLIENT_ARGS "$@"
+        ;;
     "")
-        echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server" >&2
-        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m" >&2
+        echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server | ovpn" >&2
+        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m / openvpn-client / openvpn" >&2
         exit 64
         ;;
     *)
-        echo "iot-entrypoint: unknown IOT_ROLE='$IOT_ROLE' (expected ds|client|server)" >&2
+        echo "iot-entrypoint: unknown IOT_ROLE='$IOT_ROLE' (expected ds|client|server|ovpn)" >&2
         exit 64
         ;;
 esac

--- a/packaging/systemd/iot-openvpn-client.service
+++ b/packaging/systemd/iot-openvpn-client.service
@@ -1,0 +1,44 @@
+[Unit]
+Description=IoT OpenVPN client (spawns openvpn(8), publishes tunnel state to ds-server)
+Documentation=file:///etc/iot/openvpn-client.env
+Documentation=file:///usr/local/share/doc/iot/openvpn-client-design.md
+# DsBridge connects to ds-server's unix socket; wait for it.
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/openvpn-client.env
+ExecStart=/usr/local/bin/openvpn-client $OPENVPN_CLIENT_ARGS
+
+# openvpn(8) needs to create the TUN device + write routes — both
+# require CAP_NET_ADMIN. DynamicUser=yes works fine with
+# AmbientCapabilities on systemd 244+; we drop everything else so
+# even if openvpn-client itself is compromised the blast radius is
+# scoped to the tunnel.
+DynamicUser=yes
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
+DeviceAllow=/dev/net/tun rw
+
+# Same RuntimeDirectory=iot as iot-ds.service so the daemon sees
+# the same /run/iot/data_store.sock socket file.
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Closes the L12 packaging gap PR #36 left: openvpn-client had a binary install + cap docs but no systemd unit, no env file, no IOT_ROLE entrypoint case.

**Adds**
- \`packaging/systemd/iot-openvpn-client.service\` — DynamicUser + \`AmbientCapabilities=CAP_NET_ADMIN\` + \`DeviceAllow=/dev/net/tun rw\` so openvpn(8) can run unprivileged. After/Wants \`iot-ds.service\`.
- \`packaging/etc-iot/openvpn-client.env\` — \`OPENVPN_CLIENT_ARGS\` only; substantive vpn.* config still flows via ds-cli.
- \`packaging/iot-entrypoint.sh\` — \`IOT_ROLE=ovpn\` case.
- \`apps/CMakeLists.txt\` — install rules extended.
- \`DEPLOY.md\` — bare-metal snippet (seed vpn.* + \`systemctl enable\`).

## Test plan
- [x] \`systemd-analyze verify\` clean on \`iot-openvpn-client.service\`
- [x] \`podman run -e IOT_ROLE=ovpn iot:l12b\` dispatches correctly (openvpn-client starts, fails on missing ds-server as expected)
- [x] cmake DESTDIR install includes new unit + env

🤖 Generated with [Claude Code](https://claude.com/claude-code)