### PR TITLE
L13/D1+D2: net.* schema + modules/net/router/ scaffold

### DIFF
--- a/log/L13/plan.md
+++ b/log/L13/plan.md
@@ -7,7 +7,7 @@
 > via `ip route` metrics, and exposes a per-rule custom-rules
 > escape hatch via a single JSON-encoded ds-server key.
 >
-> **Status (drafted 2026-05-31):** all D-items pending.
+> **Status (2026-05-31):** D1 + D2 done (PR #41). D3–D7 pending.
 
 ---
 

--- a/modules/net/router/CMakeLists.txt
+++ b/modules/net/router/CMakeLists.txt
@@ -1,0 +1,68 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(net_router CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+if(NOT DEFINED ACE_ROOT)
+    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
+endif()
+
+set(NET_ROUTER_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Pull in the data-store client lib (and its public headers) the same
+# way the openvpn/client module does. Skip the re-add when a parent
+# project already added it (apps/CMakeLists.txt does in the integrated
+# build).
+if(NOT TARGET datastore_client)
+    add_subdirectory(${NET_ROUTER_MODULE_DIR}/../../data-store
+                     ${CMAKE_BINARY_DIR}/data-store)
+endif()
+
+include_directories(
+    ${NET_ROUTER_MODULE_DIR}/inc
+    ${NET_ROUTER_MODULE_DIR}/../../data-store/inc
+    ${ACE_ROOT}/include
+)
+
+link_directories(${ACE_ROOT}/lib)
+
+# Internal lib so test targets link the same code the binary uses.
+# D2 ships only main_impl.cpp; D3..D6 append ds_bridge/nft_rules/
+# ip_route/iface_monitor/apply.
+add_library(net_router_lib STATIC
+    src/main_impl.cpp)
+
+target_include_directories(net_router_lib PUBLIC src)
+target_link_libraries(net_router_lib
+    PUBLIC datastore_client ACE pthread)
+
+add_executable(net-router src/main.cpp)
+target_link_libraries(net-router PRIVATE net_router_lib)
+
+# ───────────────────────── Install ─────────────────────────
+include(GNUInstallDirs)
+if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+    install(TARGETS net-router
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    install(FILES schemas/net.lua
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+endif()
+
+# ───────────────────────── Tests ───────────────────────────
+option(BUILD_NET_ROUTER_TESTS "Build net-router gtest suite" OFF)
+if(BUILD_NET_ROUTER_TESTS)
+    find_package(GTest REQUIRED)
+    enable_testing()
+
+    # D3+ will append additional test files.
+    add_executable(net-router-tests
+        test/placeholder_test.cpp)
+
+    target_link_libraries(net-router-tests
+        net_router_lib
+        GTest::gtest_main
+        GTest::gtest)
+
+    add_test(NAME net-router-tests COMMAND net-router-tests)
+endif()

--- a/modules/net/router/docs/design.md
+++ b/modules/net/router/docs/design.md
@@ -1,0 +1,96 @@
+# net-router — module design (L13)
+
+> **Status (2026-05-31):** D1 + D2 scaffold landed. D3 (DsBridge),
+> D4 (nft_rules), D5 (ip_route + iface_monitor), D6 (lifecycle +
+> e2e smoke), D7 (packaging) pending.
+
+## What this module is
+
+A daemon that watches `vpn.assigned.*` + `iot.*` via ds-server,
+generates an **nftables** ruleset that DNATs inbound tunnel traffic
+to the lwm2m client, and manages outgoing-traffic interface
+priority (eth → wifi → cellular) via `ip route` metric writes.
+Operator-set custom forward/drop/accept rules flow through a single
+`net.custom_rules` ds-server key as a JSON-encoded string.
+
+```
+              ┌──────────────────────────────────────┐
+              │  Operator / Other apps               │
+              │  ds-cli set net.lwm2m.target_ip ...  │
+              │  ds-cli set net.custom_rules ...     │
+              └─────────────────┬────────────────────┘
+                                │ EMP over /run/iot/data_store.sock
+                          ┌─────▼─────┐
+                          │ ds-server │  (schemas: iot.lua, vpn.lua, net.lua)
+                          └─────┬─────┘
+                                │ libdatastore_client (watch + get + set)
+                        ┌───────▼──────────┐
+                        │ net-router       │  this module
+                        │ (ACE_Reactor)    │
+                        └───┬───────┬──────┘
+              shell-out     │       │  shell-out
+                   ┌────────▼──┐  ┌─▼──────────┐
+                   │ nft -f -  │  │ ip route   │
+                   │ (kernel)  │  │ replace ...│
+                   └───────────┘  └────────────┘
+```
+
+## Runtime requirements
+
+| Dep                       | Why                                                                  | Where it's installed                                  |
+|---------------------------|----------------------------------------------------------------------|--------------------------------------------------------|
+| `nft` (nftables userspace) | Pipes the generated ruleset to `nft -f -` for atomic apply           | docker/Dockerfile (dev) + packaging/Containerfile (D7) |
+| `ip` (iproute2)            | `ip link show -j` for iface monitoring; `ip route replace` for prio  | already in base ubuntu                                 |
+| `nft_*` kernel modules     | `nft_nat`, `nft_chain_nat`, `nft_chain_route`                        | host kernel — distro defaults are fine                 |
+| `CAP_NET_ADMIN`            | Required for nftables apply AND `ip route` table writes              | systemd unit (D7) ships `AmbientCapabilities=CAP_NET_ADMIN` |
+| ds-server reachable        | DsBridge connects on startup                                         | same `/run/iot/data_store.sock` as the other daemons   |
+
+## Why nftables (not iptables)
+
+User explicitly picked the modern path. Wins:
+- Atomic ruleset apply via `nft -f -` (single transaction)
+- Cleaner data model: tables/chains/rules with explicit hooks + priorities
+- Single binary handles both v4 + v6 via `inet` family
+
+Trade-off: minimal hosts may not ship `nft`. D7 apt-installs it.
+An iptables fallback is FUP only if a target without nftables surfaces.
+
+## Schema layout
+
+`schemas/net.lua` (installed to `/etc/iot/ds-schemas/net.lua` by D7's
+install rule). 9 read keys + 6 write keys; the only required read
+key is `net.lwm2m.target_ip`. Custom rules ship as a JSON-encoded
+string in `net.custom_rules`; shape is validated at the JSON-parse
+step in the daemon (the schema can't json-parse).
+
+See [L13 plan §2.D1](../../../../log/L13/plan.md) for the full
+key list; the schema file itself is the canonical reference.
+
+## Module layout
+
+```
+modules/net/router/
+├── CMakeLists.txt
+├── inc/
+│   └── router.hpp              v0 public API (run_daemon, dump)
+├── src/
+│   ├── main.cpp                CLI parse + entry
+│   ├── main_impl.cpp           v0 dump-net-keys (D2)
+│   ├── ds_bridge.{hpp,cpp}     net.* DsBridge — D3, pending
+│   ├── nft_rules.{hpp,cpp}     pure ruleset generator — D4, pending
+│   ├── ip_route.{hpp,cpp}      metric write wrapper — D5, pending
+│   ├── iface_monitor.{hpp,cpp} `ip link show -j` parser — D5, pending
+│   └── apply.{hpp,cpp}         `nft -f -` invoker — D5, pending
+├── schemas/net.lua
+├── test/
+│   └── placeholder_test.cpp    keeps net-router-tests linkable
+│                               until D3 lands ds_bridge_test.cpp
+└── docs/design.md              this file
+```
+
+## Related docs
+
+- [L13 plan](../../../../log/L13/plan.md)
+- [data-store protocol](../../../data-store/docs/protocol.md)
+- [data-store client API](../../../data-store/docs/client_api.md)
+- [openvpn-client design](../../../openvpn/client/docs/design.md) — same DsBridge pattern + kernel-ownership story

--- a/modules/net/router/inc/router.hpp
+++ b/modules/net/router/inc/router.hpp
@@ -1,0 +1,31 @@
+#ifndef __net_router_router_hpp__
+#define __net_router_router_hpp__
+
+/// Public-ish header for the net-router module. Same shape as
+/// `modules/openvpn/client/inc/client.hpp` — only "public" because
+/// the test binary links the same lib the daemon uses.
+///
+/// L13/D2 scaffold: holds the bare interface needed by main.cpp.
+/// D3..D7 add DsBridge, nft_rules, ip_route, iface_monitor, apply,
+/// + packaging integration.
+
+#include <string>
+
+namespace net_router {
+
+/// Mirrors the data_store::Status / openvpn_client::Status shape.
+struct Status {
+    bool        ok = true;
+    int         code = 0;
+    std::string err;
+};
+
+/// Diagnostic mode: connect to ds-server, dump the net.* snapshot,
+/// exit. Useful for bring-up to confirm the schema landed + the
+/// daemon would see the right values without spawning anything
+/// privileged.
+Status v0_dump_net_keys(const std::string& socketPath);
+
+} // namespace net_router
+
+#endif /* __net_router_router_hpp__ */

--- a/modules/net/router/schemas/net.lua
+++ b/modules/net/router/schemas/net.lua
@@ -1,0 +1,52 @@
+-- net.* schema for net-router (L13).
+--
+-- Read keys (operator → daemon):
+--   net.tun.dev               - tun interface to monitor (default "tun0")
+--   net.lwm2m.target_ip       - DNAT target (required; lwm2m client IP)
+--   net.lwm2m.target_port     - DNAT target port (default 5684)
+--   net.iface.priority        - comma-joined outgoing priority list
+--                               (default "eth,wifi,cellular")
+--   net.iface.eth.name        - kernel name for the eth slot (default "eth0")
+--   net.iface.wifi.name       - kernel name for the wifi slot (default "wlan0")
+--   net.iface.cellular.name   - kernel name for the cellular slot (default "wwan0")
+--   net.custom_rules          - JSON array of {action, proto, dport, ...} (default "[]")
+--   net.poll.interval_sec     - iface-state poll cadence (default 5)
+--
+-- Write keys (daemon → operator):
+--   net.state                 - "monitoring"/"installing"/"bad_custom_rules"/"error"/"exited"
+--   net.tun.ip                - current IP on net.tun.dev (mirrors vpn.assigned.ip)
+--   net.tun.gateway           - current gateway on the tun
+--   net.iface.active          - highest-priority interface currently OPER UP
+--   net.rules.applied_count   - count of nft rules installed by this daemon
+--   net.last_apply_unix       - unix timestamp of last successful `nft -f -`
+--
+-- Install at /etc/iot/ds-schemas/net.lua (ds-server auto-loads).
+--
+-- Note: net.custom_rules is schema-typed as "string"; JSON shape is
+-- validated in code (the schema can't json-parse).
+
+return {
+  namespace = "net",
+  keys = {
+    -- ───────── Read keys (operator → daemon) ─────────
+    ["net.tun.dev"]               = { type = "string",  default = "tun0" },
+    ["net.lwm2m.target_ip"]       = { type = "string"  },
+    ["net.lwm2m.target_port"]     = { type = "integer", default = 5684,
+                                      min = 1, max = 65535 },
+    ["net.iface.priority"]        = { type = "string",  default = "eth,wifi,cellular" },
+    ["net.iface.eth.name"]        = { type = "string",  default = "eth0" },
+    ["net.iface.wifi.name"]       = { type = "string",  default = "wlan0" },
+    ["net.iface.cellular.name"]   = { type = "string",  default = "wwan0" },
+    ["net.custom_rules"]          = { type = "string",  default = "[]" },
+    ["net.poll.interval_sec"]     = { type = "integer", default = 5,
+                                      min = 1, max = 600 },
+
+    -- ───────── Write keys (daemon → operator) ─────────
+    ["net.state"]                 = { type = "string" },
+    ["net.tun.ip"]                = { type = "string" },
+    ["net.tun.gateway"]           = { type = "string" },
+    ["net.iface.active"]          = { type = "string" },
+    ["net.rules.applied_count"]   = { type = "integer", min = 0 },
+    ["net.last_apply_unix"]       = { type = "integer", min = 0 },
+  },
+}

--- a/modules/net/router/src/main.cpp
+++ b/modules/net/router/src/main.cpp
@@ -1,0 +1,51 @@
+/// net-router — daemon entry (L13/D2 scaffold).
+///
+/// Usage:
+///   net-router [--ds-sock=PATH] [--dump] [--help]
+///
+/// Today (D2 scaffold): connects to ds-server, dumps every known
+/// net.* key (whether set or unset), warns if net.lwm2m.target_ip
+/// is missing, exits. D3..D7 add the DsBridge, nftables rule
+/// generator, ip route metrics, iface monitor, and the
+/// IOT_ROLE=net systemd integration.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "router.hpp"
+
+namespace {
+
+void usage() {
+    std::cout <<
+        "net-router (L13/D2 scaffold)\n"
+        "\n"
+        "Usage: net-router [--ds-sock=PATH] [--dump] [--help]\n"
+        "\n"
+        "  --ds-sock=PATH   ds-server unix socket; defaults to ds-server's\n"
+        "                   built-in default (/var/run/iot/data_store.sock).\n"
+        "  --dump           snapshot net.* and exit (current default).\n"
+        "  --help           show this and exit.\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    std::string sock;
+
+    for (int i = 1; i < argc; ++i) {
+        std::string a = argv[i];
+        if      (a.rfind("--ds-sock=", 0) == 0) sock = a.substr(10);
+        else if (a == "--dump")                 { /* default mode */ }
+        else if (a == "--help" || a == "-h")    { usage(); return 0; }
+        else {
+            std::cerr << "net-router: unknown argument '" << a << "'\n";
+            usage();
+            return 2;
+        }
+    }
+
+    auto rs = net_router::v0_dump_net_keys(sock);
+    return rs.ok ? 0 : 1;
+}

--- a/modules/net/router/src/main_impl.cpp
+++ b/modules/net/router/src/main_impl.cpp
@@ -1,0 +1,119 @@
+#include "router.hpp"
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+
+#include "data_store/client.hpp"
+#include "data_store/value.hpp"
+
+namespace net_router {
+
+namespace {
+
+/// All net.* keys the schema (L13/D1) declares — read keys first,
+/// then write keys, matching the schema file ordering for an
+/// easily-eyeballed dump.
+const std::vector<std::string>& known_keys() {
+    static const std::vector<std::string> ks = {
+        // Reads
+        "net.tun.dev",
+        "net.lwm2m.target_ip",
+        "net.lwm2m.target_port",
+        "net.iface.priority",
+        "net.iface.eth.name",
+        "net.iface.wifi.name",
+        "net.iface.cellular.name",
+        "net.custom_rules",
+        "net.poll.interval_sec",
+        // Writes (will be unset on first boot)
+        "net.state",
+        "net.tun.ip",
+        "net.tun.gateway",
+        "net.iface.active",
+        "net.rules.applied_count",
+        "net.last_apply_unix",
+    };
+    return ks;
+}
+
+} // namespace
+
+Status v0_dump_net_keys(const std::string& socketPath) {
+    data_store::Client cli;
+    auto cs = cli.connect(socketPath);
+    if (!cs.ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l data-store connect "
+                            "failed: %C\n"),
+                   cs.err.c_str()));
+        Status s; s.ok = false; s.code = cs.code; s.err = cs.err;
+        return s;
+    }
+
+    std::vector<data_store::Client::GetResult> got;
+    auto gs = cli.get(known_keys(), got);
+    if (!gs.ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l get(net.*) failed: %C\n"),
+                   gs.err.c_str()));
+        Status s; s.ok = false; s.code = gs.code; s.err = gs.err;
+        return s;
+    }
+
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [netr:%t] %M %N:%l net.* snapshot (%u keys) "
+                        "from %C:\n"),
+               static_cast<unsigned>(got.size()),
+               socketPath.empty() ? "(default socket)" : socketPath.c_str()));
+    for (const auto& r : got) {
+        if (!r.has_value) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l   %C = (unset)\n"),
+                       r.key.c_str()));
+            continue;
+        }
+        // Render via the typed accessors lifted into value.hpp in
+        // PR #37 — same pattern openvpn-client's dump uses.
+        if (auto v = data_store::to_string(r.value)) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l   %C = %C\n"),
+                       r.key.c_str(), v->c_str()));
+        } else if (auto v = data_store::to_uint32(r.value)) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l   %C = %u\n"),
+                       r.key.c_str(), static_cast<unsigned>(*v)));
+        } else {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l   %C = (unrecognised type)\n"),
+                       r.key.c_str()));
+        }
+    }
+
+    // Bring-up gate: net.lwm2m.target_ip is the only required read
+    // key (the rest have schema defaults). Mirror the openvpn-client
+    // missing-required diagnostic so the operator sees what to fix.
+    bool target_ip_set = false;
+    for (const auto& r : got) {
+        if (r.key == "net.lwm2m.target_ip" && r.has_value) {
+            target_ip_set = true;
+            break;
+        }
+    }
+    if (!target_ip_set) {
+        ACE_DEBUG((LM_WARNING,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l required key missing: "
+                            "net.lwm2m.target_ip — daemon mode (D6) will "
+                            "refuse to start\n")));
+    } else {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l required keys present; "
+                            "ready for D3..D6 lifecycle\n")));
+    }
+    return {};
+}
+
+} // namespace net_router

--- a/modules/net/router/test/placeholder_test.cpp
+++ b/modules/net/router/test/placeholder_test.cpp
@@ -1,0 +1,8 @@
+/// L13/D2 placeholder — keeps net-router-tests linkable until D3
+/// adds the first real test file. Replace when ds_bridge_test.cpp
+/// lands.
+#include <gtest/gtest.h>
+
+TEST(NetRouterScaffold, BuildLinksAgainstNetRouterLib) {
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary
First slice of L13 (net-router daemon, nftables backend).

**D1 — \`net.*\` schema**
9 read keys + 6 write keys. Read covers tun device, lwm2m DNAT target IP+port, interface priority list + per-slot kernel names (eth/wifi/cellular), JSON-encoded \`net.custom_rules\`, poll cadence. Write covers daemon state, observed tun IP+gateway, active interface, nft rule count, last-apply timestamp. Defaults for all optionals; only \`net.lwm2m.target_ip\` required.

**D2 — module scaffold**
\`modules/net/router/\` mirrors \`modules/openvpn/client/\` — standalone CMake module, \`net_router_lib\` internal STATIC lib, \`net-router\` binary. v0 binary connects to ds-server, dumps the 15 net.* keys via the typed accessors lifted in PR #37, warns if \`net.lwm2m.target_ip\` is unset.

## Test plan
- [x] 1/1 placeholder test (full suite lands in D3)
- [x] Build clean under podman
- [x] Dump against live ds-server: 15 keys render with defaults; required-key gate fires when \`net.lwm2m.target_ip\` unset; once set → "ready for D3..D6 lifecycle"
- [x] \`ds-cli set net.lwm2m.target_port 99999\` → \`schema(net.lwm2m.target_port): 99999 above max 65535\`

## Next
- D3 — DsBridge for net.* (snapshot + watch + write-back)
- D4 — \`nft_rules\` pure ruleset generator
- D5 — \`ip route\` metric manager + iface monitor
- D6 — Lifecycle glue + e2e smoke against fake nft
- D7 — Packaging integration (systemd, IOT_ROLE=net, nftables apt deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)