### PR TITLE
L13/D3 + partial D4: net-router DsBridge + nft rules (80/443/lwm2m)

### DIFF
--- a/log/L13/plan.md
+++ b/log/L13/plan.md
@@ -7,7 +7,7 @@
 > via `ip route` metrics, and exposes a per-rule custom-rules
 > escape hatch via a single JSON-encoded ds-server key.
 >
-> **Status (2026-05-31):** D1 + D2 done (PR #41). D3–D7 pending.
+> **Status (2026-05-31):** D1+D2 (PR #41), D3 + partial D4 (PR #42) done. D5–D7 pending.
 
 ---
 

--- a/modules/net/router/CMakeLists.txt
+++ b/modules/net/router/CMakeLists.txt
@@ -22,6 +22,7 @@ endif()
 include_directories(
     ${NET_ROUTER_MODULE_DIR}/inc
     ${NET_ROUTER_MODULE_DIR}/../../data-store/inc
+    ${NET_ROUTER_MODULE_DIR}/../../../apps/3rdparty/json/single_include
     ${ACE_ROOT}/include
 )
 
@@ -31,7 +32,9 @@ link_directories(${ACE_ROOT}/lib)
 # D2 ships only main_impl.cpp; D3..D6 append ds_bridge/nft_rules/
 # ip_route/iface_monitor/apply.
 add_library(net_router_lib STATIC
-    src/main_impl.cpp)
+    src/main_impl.cpp
+    src/ds_bridge.cpp
+    src/nft_rules.cpp)
 
 target_include_directories(net_router_lib PUBLIC src)
 target_link_libraries(net_router_lib
@@ -55,9 +58,9 @@ if(BUILD_NET_ROUTER_TESTS)
     find_package(GTest REQUIRED)
     enable_testing()
 
-    # D3+ will append additional test files.
     add_executable(net-router-tests
-        test/placeholder_test.cpp)
+        test/ds_bridge_test.cpp
+        test/nft_rules_test.cpp)
 
     target_link_libraries(net-router-tests
         net_router_lib

--- a/modules/net/router/schemas/net.lua
+++ b/modules/net/router/schemas/net.lua
@@ -9,6 +9,8 @@
 --   net.iface.eth.name        - kernel name for the eth slot (default "eth0")
 --   net.iface.wifi.name       - kernel name for the wifi slot (default "wlan0")
 --   net.iface.cellular.name   - kernel name for the cellular slot (default "wwan0")
+--   net.forward.ports         - comma-joined ports to DNAT to net.lwm2m.target_ip
+--                               (default "80,443,5684" — http, https, lwm2m/CoAP)
 --   net.custom_rules          - JSON array of {action, proto, dport, ...} (default "[]")
 --   net.poll.interval_sec     - iface-state poll cadence (default 5)
 --
@@ -37,6 +39,7 @@ return {
     ["net.iface.eth.name"]        = { type = "string",  default = "eth0" },
     ["net.iface.wifi.name"]       = { type = "string",  default = "wlan0" },
     ["net.iface.cellular.name"]   = { type = "string",  default = "wwan0" },
+    ["net.forward.ports"]         = { type = "string",  default = "80,443,5684" },
     ["net.custom_rules"]          = { type = "string",  default = "[]" },
     ["net.poll.interval_sec"]     = { type = "integer", default = 5,
                                       min = 1, max = 600 },

--- a/modules/net/router/src/ds_bridge.cpp
+++ b/modules/net/router/src/ds_bridge.cpp
@@ -1,0 +1,252 @@
+#include "ds_bridge.hpp"
+
+#include <mutex>
+#include <utility>
+
+#include <ace/Log_Msg.h>
+
+#include "data_store/client.hpp"
+#include "data_store/proto.hpp"
+#include "data_store/value.hpp"
+
+namespace net_router {
+
+const char* DsBridge::kDefaultSocketPath = data_store::proto::kDefaultSocketPath;
+
+namespace {
+
+// Single source of truth for wire-level key strings.
+constexpr const char* kTunDev          = "net.tun.dev";
+constexpr const char* kLwM2MTargetIp   = "net.lwm2m.target_ip";
+constexpr const char* kLwM2MTargetPort = "net.lwm2m.target_port";
+constexpr const char* kIfacePriority   = "net.iface.priority";
+constexpr const char* kIfaceEthName    = "net.iface.eth.name";
+constexpr const char* kIfaceWifiName   = "net.iface.wifi.name";
+constexpr const char* kIfaceCellName   = "net.iface.cellular.name";
+constexpr const char* kForwardPorts    = "net.forward.ports";
+constexpr const char* kCustomRules     = "net.custom_rules";
+constexpr const char* kPollIntervalSec = "net.poll.interval_sec";
+
+constexpr const char* kState               = "net.state";
+constexpr const char* kTunIp               = "net.tun.ip";
+constexpr const char* kTunGateway          = "net.tun.gateway";
+constexpr const char* kIfaceActive         = "net.iface.active";
+constexpr const char* kRulesAppliedCount   = "net.rules.applied_count";
+constexpr const char* kLastApplyUnix       = "net.last_apply_unix";
+
+} // namespace
+
+// ─────────────────────────── Impl ──────────────────────────────────
+
+struct DsBridge::Impl {
+    data_store::Client              client;
+    data_store::Client::WatchHandle watch_handle =
+        data_store::Client::kInvalidHandle;
+
+    mutable std::mutex            mtx;
+    // Snapshot — listener thread writes, accessors read.
+    std::optional<std::string>    tun_dev;
+    std::optional<std::string>    lwm2m_target_ip;
+    std::optional<std::uint32_t>  lwm2m_target_port;
+    std::optional<std::string>    iface_priority;
+    std::optional<std::string>    iface_eth_name;
+    std::optional<std::string>    iface_wifi_name;
+    std::optional<std::string>    iface_cellular_name;
+    std::optional<std::string>    forward_ports;
+    std::optional<std::string>    custom_rules;
+    std::optional<std::uint32_t>  poll_interval_sec;
+    ChangeCallback                cb;
+};
+
+DsBridge::DsBridge(std::string socketPath)
+  : m_impl(std::make_unique<Impl>()),
+    m_path(socketPath.empty() ? std::string(kDefaultSocketPath)
+                              : std::move(socketPath)) {
+    auto cs = m_impl->client.connect(m_path);
+    if (!cs.ok) {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l data-store not "
+                            "available at %C (%C); net-router cannot "
+                            "start\n"),
+                   m_path.c_str(), cs.err.c_str()));
+        return;
+    }
+    m_ok = true;
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [netr:%t] %M %N:%l data-store ready at %C\n"),
+               m_path.c_str()));
+
+    const std::vector<std::string> read_keys = {
+        kTunDev, kLwM2MTargetIp, kLwM2MTargetPort,
+        kIfacePriority, kIfaceEthName, kIfaceWifiName, kIfaceCellName,
+        kForwardPorts, kCustomRules, kPollIntervalSec,
+    };
+
+    std::vector<data_store::Client::GetResult> got;
+    auto gs = m_impl->client.get(read_keys, got);
+    if (gs.ok) {
+        std::lock_guard<std::mutex> g(m_impl->mtx);
+        for (auto& r : got) {
+            if (!r.has_value) continue;
+            if      (r.key == kTunDev)          m_impl->tun_dev             = data_store::to_string(r.value);
+            else if (r.key == kLwM2MTargetIp)   m_impl->lwm2m_target_ip     = data_store::to_string(r.value);
+            else if (r.key == kLwM2MTargetPort) m_impl->lwm2m_target_port   = data_store::to_uint32(r.value);
+            else if (r.key == kIfacePriority)   m_impl->iface_priority      = data_store::to_string(r.value);
+            else if (r.key == kIfaceEthName)    m_impl->iface_eth_name      = data_store::to_string(r.value);
+            else if (r.key == kIfaceWifiName)   m_impl->iface_wifi_name     = data_store::to_string(r.value);
+            else if (r.key == kIfaceCellName)   m_impl->iface_cellular_name = data_store::to_string(r.value);
+            else if (r.key == kForwardPorts)    m_impl->forward_ports       = data_store::to_string(r.value);
+            else if (r.key == kCustomRules)     m_impl->custom_rules        = data_store::to_string(r.value);
+            else if (r.key == kPollIntervalSec) m_impl->poll_interval_sec   = data_store::to_uint32(r.value);
+        }
+    }
+
+    auto ws = m_impl->client.watch(
+        read_keys,
+        [this](const data_store::Client::Event& ev) {
+            std::optional<Key> changed;
+            {
+                std::lock_guard<std::mutex> g(m_impl->mtx);
+                if      (ev.key == kTunDev)          { m_impl->tun_dev             = data_store::to_string(ev.value);   changed = Key::TunDev;            }
+                else if (ev.key == kLwM2MTargetIp)   { m_impl->lwm2m_target_ip     = data_store::to_string(ev.value);   changed = Key::LwM2MTargetIp;     }
+                else if (ev.key == kLwM2MTargetPort) { m_impl->lwm2m_target_port   = data_store::to_uint32(ev.value);   changed = Key::LwM2MTargetPort;   }
+                else if (ev.key == kIfacePriority)   { m_impl->iface_priority      = data_store::to_string(ev.value);   changed = Key::IfacePriority;     }
+                else if (ev.key == kIfaceEthName)    { m_impl->iface_eth_name      = data_store::to_string(ev.value);   changed = Key::IfaceEthName;      }
+                else if (ev.key == kIfaceWifiName)   { m_impl->iface_wifi_name     = data_store::to_string(ev.value);   changed = Key::IfaceWifiName;     }
+                else if (ev.key == kIfaceCellName)   { m_impl->iface_cellular_name = data_store::to_string(ev.value);   changed = Key::IfaceCellularName; }
+                else if (ev.key == kForwardPorts)    { m_impl->forward_ports       = data_store::to_string(ev.value);   changed = Key::ForwardPorts;      }
+                else if (ev.key == kCustomRules)     { m_impl->custom_rules        = data_store::to_string(ev.value);   changed = Key::CustomRules;       }
+                else if (ev.key == kPollIntervalSec) { m_impl->poll_interval_sec   = data_store::to_uint32(ev.value);   changed = Key::PollIntervalSec;   }
+            }
+            if (!changed) return;
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l net config key '%C' "
+                                "changed — nft ruleset regen required on "
+                                "next tick\n"),
+                       ev.key.c_str()));
+            ChangeCallback cbcopy;
+            {
+                std::lock_guard<std::mutex> g(m_impl->mtx);
+                cbcopy = m_impl->cb;
+            }
+            if (cbcopy) cbcopy(*changed);
+        },
+        &m_impl->watch_handle);
+    if (!ws.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l watch register failed: "
+                            "%C — cache primed but hot-reload disabled\n"),
+                   ws.err.c_str()));
+    }
+}
+
+DsBridge::~DsBridge() {
+    if (!m_impl) return;
+    if (m_impl->watch_handle != data_store::Client::kInvalidHandle) {
+        m_impl->client.unwatch(m_impl->watch_handle, /*timeout_ms=*/200);
+    }
+    m_impl->client.close();
+}
+
+// ─────────────────────── Read accessors ────────────────────────────
+
+std::optional<std::string> DsBridge::tun_dev() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->tun_dev;
+}
+std::optional<std::string> DsBridge::lwm2m_target_ip() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->lwm2m_target_ip;
+}
+std::optional<std::uint32_t> DsBridge::lwm2m_target_port() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->lwm2m_target_port;
+}
+std::optional<std::string> DsBridge::iface_priority() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->iface_priority;
+}
+std::optional<std::string> DsBridge::iface_eth_name() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->iface_eth_name;
+}
+std::optional<std::string> DsBridge::iface_wifi_name() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->iface_wifi_name;
+}
+std::optional<std::string> DsBridge::iface_cellular_name() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->iface_cellular_name;
+}
+std::optional<std::string> DsBridge::forward_ports() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->forward_ports;
+}
+std::optional<std::string> DsBridge::custom_rules() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->custom_rules;
+}
+std::optional<std::uint32_t> DsBridge::poll_interval_sec() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->poll_interval_sec;
+}
+
+std::optional<std::vector<std::string>>
+DsBridge::missing_required() const {
+    if (!m_ok) {
+        return std::vector<std::string>{kLwM2MTargetIp};
+    }
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    if (m_impl->lwm2m_target_ip.has_value()) return std::nullopt;
+    return std::vector<std::string>{kLwM2MTargetIp};
+}
+
+// ───────────────────────── Write side ──────────────────────────────
+
+void DsBridge::set_state(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kState, s);
+    if (!rs.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l set %C='%C' failed: %C\n"),
+                   kState, s.c_str(), rs.err.c_str()));
+    }
+}
+void DsBridge::set_tun_ip(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kTunIp, s);
+}
+void DsBridge::set_tun_gateway(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kTunGateway, s);
+}
+void DsBridge::set_iface_active(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kIfaceActive, s);
+}
+void DsBridge::set_rules_applied_count(std::uint32_t n) {
+    if (!m_ok) return;
+    m_impl->client.set(kRulesAppliedCount, n);
+}
+void DsBridge::set_last_apply_unix(std::uint32_t t) {
+    if (!m_ok) return;
+    m_impl->client.set(kLastApplyUnix, t);
+}
+
+void DsBridge::on_change(ChangeCallback cb) {
+    if (!m_impl) return;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    m_impl->cb = std::move(cb);
+}
+
+} // namespace net_router

--- a/modules/net/router/src/ds_bridge.hpp
+++ b/modules/net/router/src/ds_bridge.hpp
@@ -1,0 +1,93 @@
+#ifndef __net_router_ds_bridge_hpp__
+#define __net_router_ds_bridge_hpp__
+
+/// Bridge between net-router and ds-server.
+///
+/// Same pattern as modules/openvpn/client/src/ds_bridge.hpp (L12/D3):
+/// owns the data_store::Client for the daemon lifetime, primes a
+/// thread-safe snapshot of the readable net.* keys on startup,
+/// registers a callback-style watch so subsequent ds-cli mutations
+/// land in the cache and fire on_change.
+///
+/// First-cut hot-reload policy (matches L12 R4): log "rule regen
+/// required" on any read-key change. Live regenerate + nft -f -
+/// apply lands in D6 once the lifecycle FSM exists.
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace net_router {
+
+class DsBridge {
+public:
+    enum class Key {
+        TunDev,
+        LwM2MTargetIp,
+        LwM2MTargetPort,
+        IfacePriority,
+        IfaceEthName,
+        IfaceWifiName,
+        IfaceCellularName,
+        ForwardPorts,
+        CustomRules,
+        PollIntervalSec,
+    };
+
+    using ChangeCallback = std::function<void(Key)>;
+
+    explicit DsBridge(std::string socketPath = {});
+    ~DsBridge();
+
+    DsBridge(const DsBridge&)            = delete;
+    DsBridge& operator=(const DsBridge&) = delete;
+
+    bool connected() const { return m_ok; }
+    const std::string& socket_path() const { return m_path; }
+
+    // ─────────── Read snapshots ───────────
+    std::optional<std::string>   tun_dev()              const;
+    std::optional<std::string>   lwm2m_target_ip()      const;
+    std::optional<std::uint32_t> lwm2m_target_port()    const;
+    std::optional<std::string>   iface_priority()       const;
+    std::optional<std::string>   iface_eth_name()       const;
+    std::optional<std::string>   iface_wifi_name()      const;
+    std::optional<std::string>   iface_cellular_name()  const;
+    std::optional<std::string>   forward_ports()        const;
+    std::optional<std::string>   custom_rules()         const;
+    std::optional<std::uint32_t> poll_interval_sec()    const;
+
+    /// Returns nullopt if net.lwm2m.target_ip is present; otherwise
+    /// returns the one-element list {"net.lwm2m.target_ip"} so the
+    /// caller's missing-required diagnostic is uniform with the
+    /// other DsBridges.
+    std::optional<std::vector<std::string>> missing_required() const;
+
+    // ─────────── Write side ───────────
+    void set_state(const std::string& s);
+    void set_tun_ip(const std::string& s);
+    void set_tun_gateway(const std::string& s);
+    void set_iface_active(const std::string& s);
+    void set_rules_applied_count(std::uint32_t n);
+    void set_last_apply_unix(std::uint32_t t);
+
+    void on_change(ChangeCallback cb);
+
+    /// Default ds-server socket path. Duplicated from
+    /// data_store::proto::kDefaultSocketPath so this header stays
+    /// free of data_store/ includes.
+    static const char* kDefaultSocketPath;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+    std::string           m_path;
+    bool                  m_ok = false;
+};
+
+} // namespace net_router
+
+#endif /* __net_router_ds_bridge_hpp__ */

--- a/modules/net/router/src/nft_rules.cpp
+++ b/modules/net/router/src/nft_rules.cpp
@@ -1,0 +1,143 @@
+#include "nft_rules.hpp"
+
+#include <cstdint>
+#include <sstream>
+#include <string>
+#include <vector>
+
+#include "nlohmann/json.hpp"
+
+namespace net_router::nft {
+
+namespace {
+
+/// Whitespace-trim both ends.
+std::string trim(std::string s) {
+    auto issp = [](unsigned char c) { return std::isspace(c) != 0; };
+    while (!s.empty() && issp(s.back())) s.pop_back();
+    std::size_t i = 0;
+    while (i < s.size() && issp(s[i])) ++i;
+    return s.substr(i);
+}
+
+} // namespace
+
+std::vector<std::uint16_t> parse_forward_ports(const std::string& csv) {
+    std::vector<std::uint16_t> out;
+    std::string cur;
+    auto flush = [&]() {
+        std::string t = trim(cur);
+        cur.clear();
+        if (t.empty()) return;
+        try {
+            std::size_t pos = 0;
+            unsigned long v = std::stoul(t, &pos);
+            if (pos != t.size()) return;          // junk after digits
+            if (v == 0 || v > 65535) return;       // out of u16 range
+            out.push_back(static_cast<std::uint16_t>(v));
+        } catch (...) {
+            // Bad token — skip silently. Caller can log if needed.
+        }
+    };
+    for (char c : csv) {
+        if (c == ',') flush();
+        else          cur.push_back(c);
+    }
+    flush();
+    return out;
+}
+
+std::vector<CustomRule>
+parse_custom_rules(const std::string& json, std::string* parse_error) {
+    std::vector<CustomRule> out;
+    if (json.empty()) return out;
+    try {
+        auto j = nlohmann::json::parse(json);
+        if (!j.is_array()) {
+            if (parse_error) *parse_error = "net.custom_rules: top-level must be a JSON array";
+            return {};
+        }
+        for (const auto& e : j) {
+            if (!e.is_object()) continue;
+            CustomRule r;
+            if (e.contains("action") && e["action"].is_string())  r.action = e["action"].get<std::string>();
+            if (e.contains("proto")  && e["proto"].is_string())   r.proto  = e["proto"].get<std::string>();
+            if (e.contains("dport")  && e["dport"].is_number_unsigned())  r.dport  = e["dport"].get<std::uint32_t>();
+            if (e.contains("sport")  && e["sport"].is_number_unsigned())  r.sport  = e["sport"].get<std::uint32_t>();
+            if (e.contains("to_ip")  && e["to_ip"].is_string())   r.to_ip  = e["to_ip"].get<std::string>();
+            if (e.contains("to_port") && e["to_port"].is_number_unsigned()) r.to_port = e["to_port"].get<std::uint32_t>();
+            // Minimal validation — action + proto required.
+            if (r.action.empty() || r.proto.empty()) continue;
+            out.push_back(std::move(r));
+        }
+    } catch (const std::exception& e) {
+        if (parse_error) *parse_error = std::string("net.custom_rules: ") + e.what();
+        return {};
+    }
+    return out;
+}
+
+std::string build_nft_ruleset(const State& s) {
+    std::ostringstream ss;
+    // Flush our scoped table first so re-apply is idempotent. We never
+    // touch other writers' tables (NetworkManager, docker, fail2ban) —
+    // each scopes by its own table name.
+    ss << "flush table inet iot_router\n";
+    ss << "table inet iot_router {\n";
+
+    // ──────────── prerouting (NAT) ────────────
+    // Inbound traffic from the tun interface gets DNAT'd to the
+    // lwm2m client's target IP, one rule per forwarded port. If
+    // no target IP is set OR no ports, emit an empty chain so
+    // `nft -f -` still parses cleanly.
+    ss << "    chain prerouting {\n";
+    ss << "        type nat hook prerouting priority -100; policy accept;\n";
+    if (!s.lwm2m_target_ip.empty() && !s.forward_ports.empty()) {
+        for (auto p : s.forward_ports) {
+            // Forward both TCP and UDP — covers HTTP/HTTPS (TCP) and
+            // CoAP/DTLS (UDP) without the operator having to specify.
+            ss << "        iifname \"" << s.tun_dev
+               << "\" tcp dport " << p
+               << " dnat to " << s.lwm2m_target_ip << ":" << p << "\n";
+            ss << "        iifname \"" << s.tun_dev
+               << "\" udp dport " << p
+               << " dnat to " << s.lwm2m_target_ip << ":" << p << "\n";
+        }
+    }
+    ss << "    }\n";
+
+    // ──────────── forward (filter) ────────────
+    // Default-accept + return early on tun→tun traffic. Custom rules
+    // appended below.
+    ss << "    chain forward {\n";
+    ss << "        type filter hook forward priority 0; policy accept;\n";
+    if (!s.tun_dev.empty()) {
+        ss << "        iifname \"" << s.tun_dev
+           << "\" oifname \"" << s.tun_dev << "\" return\n";
+    }
+    for (const auto& r : s.custom) {
+        ss << "        ";
+        // protocol clause
+        ss << r.proto;
+        if (r.dport) ss << " dport " << r.dport;
+        if (r.sport) ss << " sport " << r.sport;
+        // action clause
+        if (r.action == "drop")        ss << " drop";
+        else if (r.action == "accept") ss << " accept";
+        else if (r.action == "forward" && !r.to_ip.empty()) {
+            ss << " dnat to " << r.to_ip;
+            if (r.to_port) ss << ":" << r.to_port;
+        } else {
+            // Unrecognised action — leave as a comment so operators
+            // see it landed somewhere (rather than silently dropped).
+            ss << " # unknown action '" << r.action << "'";
+        }
+        ss << "\n";
+    }
+    ss << "    }\n";
+
+    ss << "}\n";
+    return ss.str();
+}
+
+} // namespace net_router::nft

--- a/modules/net/router/src/nft_rules.hpp
+++ b/modules/net/router/src/nft_rules.hpp
@@ -1,0 +1,60 @@
+#ifndef __net_router_nft_rules_hpp__
+#define __net_router_nft_rules_hpp__
+
+/// Pure nftables ruleset generator.
+///
+/// No syscalls, no `nft` invocation, no logging — takes a State POD,
+/// returns the script text that gets piped to `nft -f -` in D6.
+/// Keeps unit tests table-driven; the apply step (privileged) is
+/// orthogonal.
+///
+/// Generated ruleset uses table `inet iot_router` so it never
+/// collides with NetworkManager / docker / fail2ban rules (each
+/// nftables writer scopes by table name).
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace net_router::nft {
+
+/// Operator-supplied rule (parsed from `net.custom_rules` JSON).
+struct CustomRule {
+    std::string action;  ///< "forward" | "drop" | "accept"
+    std::string proto;   ///< "tcp" | "udp"  (lowercase)
+    std::uint32_t dport = 0;  ///< 0 = unspecified
+    std::uint32_t sport = 0;
+    std::string to_ip;        ///< only meaningful when action=="forward"
+    std::uint32_t to_port = 0;
+};
+
+/// Inputs to the rule generator. Mirrors the read-key surface of
+/// DsBridge plus the live tun IP observed at runtime. Plain POD so
+/// the tests stay pure.
+struct State {
+    std::string tun_dev;                 ///< e.g. "tun0"
+    std::string lwm2m_target_ip;         ///< required for any DNAT rule
+    std::uint32_t lwm2m_target_port = 0; ///< informational; net.forward.ports is authoritative
+    std::vector<std::uint16_t> forward_ports;
+    std::vector<CustomRule>    custom;
+};
+
+/// Parse the comma-joined forward_ports string ("80,443,5684") into
+/// a vector. Empty input → empty vector. Tokens that don't parse as
+/// a u16 in [1,65535] are skipped (logged by the caller if it cares).
+std::vector<std::uint16_t> parse_forward_ports(const std::string& csv);
+
+/// Parse the operator-supplied `net.custom_rules` JSON-string into
+/// a vector of CustomRule. Returns empty vector on parse error +
+/// sets `*parse_error` (non-null) to the diagnostic. The daemon
+/// keeps the previous ruleset live on parse failure.
+std::vector<CustomRule>
+parse_custom_rules(const std::string& json, std::string* parse_error = nullptr);
+
+/// Render the full nft script text. Idempotent: always starts with
+/// `flush table inet iot_router` so re-applying never doubles.
+std::string build_nft_ruleset(const State& s);
+
+} // namespace net_router::nft
+
+#endif /* __net_router_nft_rules_hpp__ */

--- a/modules/net/router/test/ds_bridge_test.cpp
+++ b/modules/net/router/test/ds_bridge_test.cpp
@@ -1,0 +1,52 @@
+/// Light-touch DsBridge unit tests — only the don't-need-a-live-
+/// ds-server paths. End-to-end watch + writeback is exercised by
+/// the integration smoke (`log/L13/net-router-smoke.sh`, D6).
+
+#include <gtest/gtest.h>
+
+#include "ds_bridge.hpp"
+
+using net_router::DsBridge;
+
+namespace {
+constexpr const char* kBogus = "/var/run/iot/net-router-no-such-socket.sock";
+}
+
+TEST(DsBridge, ConstructAgainstMissingSocketIsNotFatal) {
+    DsBridge ds(kBogus);
+    EXPECT_FALSE(ds.connected());
+    EXPECT_EQ(std::string(kBogus), ds.socket_path());
+}
+
+TEST(DsBridge, AccessorsReturnNulloptWhenDisconnected) {
+    DsBridge ds(kBogus);
+    EXPECT_FALSE(ds.tun_dev().has_value());
+    EXPECT_FALSE(ds.lwm2m_target_ip().has_value());
+    EXPECT_FALSE(ds.lwm2m_target_port().has_value());
+    EXPECT_FALSE(ds.forward_ports().has_value());
+    EXPECT_FALSE(ds.custom_rules().has_value());
+}
+
+TEST(DsBridge, MissingRequiredReportsTargetIpWhenDisconnected) {
+    DsBridge ds(kBogus);
+    auto missing = ds.missing_required();
+    ASSERT_TRUE(missing.has_value());
+    ASSERT_EQ(1u, missing->size());
+    EXPECT_EQ("net.lwm2m.target_ip", (*missing)[0]);
+}
+
+TEST(DsBridge, SettersAreNoopWhenDisconnected) {
+    DsBridge ds(kBogus);
+    ds.set_state("monitoring");
+    ds.set_tun_ip("10.8.0.6");
+    ds.set_rules_applied_count(7);
+    ds.set_last_apply_unix(1701420000);
+    SUCCEED();
+}
+
+TEST(DsBridge, OnChangeAcceptsNullCallbackForReset) {
+    DsBridge ds(kBogus);
+    ds.on_change([](DsBridge::Key) {});
+    ds.on_change(nullptr);
+    SUCCEED();
+}

--- a/modules/net/router/test/nft_rules_test.cpp
+++ b/modules/net/router/test/nft_rules_test.cpp
@@ -1,0 +1,147 @@
+/// Table-driven tests for the pure nft ruleset generator.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "nft_rules.hpp"
+
+using net_router::nft::build_nft_ruleset;
+using net_router::nft::CustomRule;
+using net_router::nft::parse_custom_rules;
+using net_router::nft::parse_forward_ports;
+using net_router::nft::State;
+
+/* ─────────────────────── parse_forward_ports ─────────────────────── */
+
+TEST(ParseForwardPorts, DefaultListYields3Ports) {
+    auto ps = parse_forward_ports("80,443,5684");
+    ASSERT_EQ(3u, ps.size());
+    EXPECT_EQ(80,   ps[0]);
+    EXPECT_EQ(443,  ps[1]);
+    EXPECT_EQ(5684, ps[2]);
+}
+
+TEST(ParseForwardPorts, ToleratesWhitespaceAndEmptyTokens) {
+    auto ps = parse_forward_ports(" 80 , , 443,5684 ,");
+    ASSERT_EQ(3u, ps.size());
+}
+
+TEST(ParseForwardPorts, SkipsOutOfRangeAndJunk) {
+    auto ps = parse_forward_ports("80,99999,abc,443,0");
+    ASSERT_EQ(2u, ps.size());   // 99999, abc, 0 dropped
+    EXPECT_EQ(80,  ps[0]);
+    EXPECT_EQ(443, ps[1]);
+}
+
+/* ─────────────────────── parse_custom_rules ──────────────────────── */
+
+TEST(ParseCustomRules, EmptyArrayProducesEmptyVector) {
+    std::string err;
+    auto rs = parse_custom_rules("[]", &err);
+    EXPECT_TRUE(rs.empty());
+    EXPECT_TRUE(err.empty());
+}
+
+TEST(ParseCustomRules, ValidObjectsRoundTrip) {
+    std::string json =
+        "[{\"action\":\"drop\",\"proto\":\"tcp\",\"dport\":23},"
+        " {\"action\":\"forward\",\"proto\":\"udp\",\"dport\":5683,"
+        "  \"to_ip\":\"10.8.0.6\",\"to_port\":5683}]";
+    auto rs = parse_custom_rules(json);
+    ASSERT_EQ(2u, rs.size());
+    EXPECT_EQ("drop",     rs[0].action);
+    EXPECT_EQ("tcp",      rs[0].proto);
+    EXPECT_EQ(23u,        rs[0].dport);
+    EXPECT_EQ("forward",  rs[1].action);
+    EXPECT_EQ("10.8.0.6", rs[1].to_ip);
+    EXPECT_EQ(5683u,      rs[1].to_port);
+}
+
+TEST(ParseCustomRules, MalformedJsonReportsError) {
+    std::string err;
+    auto rs = parse_custom_rules("[{not valid}]", &err);
+    EXPECT_TRUE(rs.empty());
+    EXPECT_FALSE(err.empty());
+}
+
+TEST(ParseCustomRules, NonArrayTopLevelReportsError) {
+    std::string err;
+    auto rs = parse_custom_rules("{\"action\":\"drop\"}", &err);
+    EXPECT_TRUE(rs.empty());
+    EXPECT_NE(std::string::npos, err.find("must be a JSON array"));
+}
+
+/* ─────────────────────── build_nft_ruleset ───────────────────────── */
+
+TEST(BuildNft, AlwaysStartsWithFlush) {
+    State s;
+    s.tun_dev = "tun0";
+    auto r = build_nft_ruleset(s);
+    EXPECT_EQ(0u, r.find("flush table inet iot_router"));
+}
+
+TEST(BuildNft, EmitsDnatPerForwardPortForBothTcpAndUdp) {
+    State s;
+    s.tun_dev          = "tun0";
+    s.lwm2m_target_ip  = "10.8.0.6";
+    s.forward_ports    = {80, 443, 5684};
+    auto r = build_nft_ruleset(s);
+
+    // Each port → one TCP rule + one UDP rule, all DNAT'd to the
+    // target IP keeping the original dport.
+    for (auto p : {80, 443, 5684}) {
+        std::string tcp = "iifname \"tun0\" tcp dport " + std::to_string(p)
+                          + " dnat to 10.8.0.6:" + std::to_string(p);
+        std::string udp = "iifname \"tun0\" udp dport " + std::to_string(p)
+                          + " dnat to 10.8.0.6:" + std::to_string(p);
+        EXPECT_NE(std::string::npos, r.find(tcp)) << "missing TCP for port " << p;
+        EXPECT_NE(std::string::npos, r.find(udp)) << "missing UDP for port " << p;
+    }
+}
+
+TEST(BuildNft, SkipsDnatWhenTargetIpMissing) {
+    State s;
+    s.tun_dev       = "tun0";
+    s.forward_ports = {80, 443};
+    auto r = build_nft_ruleset(s);
+    EXPECT_EQ(std::string::npos, r.find("dnat to"));
+    // Still has the empty prerouting chain — proves the script parses.
+    EXPECT_NE(std::string::npos, r.find("chain prerouting"));
+}
+
+TEST(BuildNft, CustomDropRuleAppears) {
+    State s;
+    s.tun_dev = "tun0";
+    CustomRule cr;
+    cr.action = "drop";
+    cr.proto  = "tcp";
+    cr.dport  = 23;
+    s.custom.push_back(cr);
+    auto r = build_nft_ruleset(s);
+    EXPECT_NE(std::string::npos, r.find("tcp dport 23 drop"));
+}
+
+TEST(BuildNft, CustomForwardRuleEmitsDnat) {
+    State s;
+    s.tun_dev = "tun0";
+    CustomRule cr;
+    cr.action  = "forward";
+    cr.proto   = "udp";
+    cr.dport   = 5683;
+    cr.to_ip   = "192.168.1.10";
+    cr.to_port = 5683;
+    s.custom.push_back(cr);
+    auto r = build_nft_ruleset(s);
+    EXPECT_NE(std::string::npos,
+              r.find("udp dport 5683 dnat to 192.168.1.10:5683"));
+}
+
+TEST(BuildNft, TunToTunReturnRuleEmittedWhenTunDevPresent) {
+    State s;
+    s.tun_dev = "tun0";
+    auto r = build_nft_ruleset(s);
+    EXPECT_NE(std::string::npos,
+              r.find("iifname \"tun0\" oifname \"tun0\" return"));
+}

--- a/modules/net/router/test/placeholder_test.cpp
+++ b/modules/net/router/test/placeholder_test.cpp
@@ -1,8 +1,0 @@
-/// L13/D2 placeholder — keeps net-router-tests linkable until D3
-/// adds the first real test file. Replace when ds_bridge_test.cpp
-/// lands.
-#include <gtest/gtest.h>
-
-TEST(NetRouterScaffold, BuildLinksAgainstNetRouterLib) {
-    SUCCEED();
-}


### PR DESCRIPTION
## Summary
Per user ask: bundle D3 (DsBridge) with the partial-D4 rule generator that DNATs incoming traffic on **80, 443, and the lwm2m port (5684)** to the lwm2m client.

**Schema extension**
\`net.forward.ports\` — string default \`"80,443,5684"\` — comma-joined list of inbound ports the daemon DNATs to \`net.lwm2m.target_ip\`. Operator overridable.

**D3 — DsBridge** (\`src/ds_bridge.{hpp,cpp}\`)
Same shape as L12 openvpn-client DsBridge. Owns Client for daemon lifetime, primes snapshot of all 10 read keys, watches them, emits change callbacks. Setters for the 6 write keys. \`missing_required()\` returns \`net.lwm2m.target_ip\` when absent.

**D4 (partial) — nft_rules** (\`src/nft_rules.{hpp,cpp}\`, pure)
- \`parse_forward_ports("80,443,5684")\` → \`vector<uint16>\`
- \`parse_custom_rules(json[, *err])\` → \`vector<CustomRule>\`
- \`build_nft_ruleset(State)\` → nft script text

Table \`inet iot_router\` (scoped — never collides with NetworkManager / docker / fail2ban). Always starts with \`flush table inet iot_router\` for idempotent re-apply. **Per forwarded port: one TCP DNAT rule + one UDP DNAT rule** (covers HTTP/HTTPS on TCP and CoAP/DTLS on UDP without extra knobs). Custom rules appended after baseline; tun→tun loopback guard prevents reflection.

No actual \`nft\` apply yet — that's D6 (privileged + needs the lifecycle FSM).

## Test plan
- [x] 18/18 net-router tests (13 new): \`ParseForwardPorts.*\`, \`ParseCustomRules.*\`, \`BuildNft.*\`, \`DsBridge.*\`
- [x] Dump-mode smoke: missing-required gate fires; once set → "ready for D3..D6 lifecycle"

## Next
- D5 — \`ip_route\` metric manager + iface monitor
- D6 — Lifecycle glue + actual \`nft -f -\` apply + e2e smoke
- D7 — Packaging integration (systemd + IOT_ROLE=net + nftables apt deps)

🤖 Generated with [Claude Code](https://claude.com/claude-code)