### PR TITLE
L13/D5: net-router iface_monitor + ip_route metric manager

### DIFF
--- a/modules/net/router/CMakeLists.txt
+++ b/modules/net/router/CMakeLists.txt
@@ -34,7 +34,10 @@ link_directories(${ACE_ROOT}/lib)
 add_library(net_router_lib STATIC
     src/main_impl.cpp
     src/ds_bridge.cpp
-    src/nft_rules.cpp)
+    src/nft_rules.cpp
+    src/shell.cpp
+    src/iface_monitor.cpp
+    src/ip_route.cpp)
 
 target_include_directories(net_router_lib PUBLIC src)
 target_link_libraries(net_router_lib
@@ -60,7 +63,9 @@ if(BUILD_NET_ROUTER_TESTS)
 
     add_executable(net-router-tests
         test/ds_bridge_test.cpp
-        test/nft_rules_test.cpp)
+        test/nft_rules_test.cpp
+        test/iface_monitor_test.cpp
+        test/ip_route_test.cpp)
 
     target_link_libraries(net-router-tests
         net_router_lib

--- a/modules/net/router/docs/design.md
+++ b/modules/net/router/docs/design.md
@@ -1,8 +1,9 @@
 # net-router — module design (L13)
 
-> **Status (2026-05-31):** D1 + D2 scaffold landed. D3 (DsBridge),
-> D4 (nft_rules), D5 (ip_route + iface_monitor), D6 (lifecycle +
-> e2e smoke), D7 (packaging) pending.
+> **Status (2026-05-31):** D1, D2, D3 (DsBridge), partial D4
+> (nft_rules generator), D5 (ip_route + iface_monitor) landed.
+> D6 (lifecycle + `nft -f -` apply + e2e smoke) and D7 (packaging)
+> pending.
 
 ## What this module is
 
@@ -77,14 +78,17 @@ modules/net/router/
 │   ├── main.cpp                CLI parse + entry
 │   ├── main_impl.cpp           v0 dump-net-keys (D2)
 │   ├── ds_bridge.{hpp,cpp}     net.* DsBridge — D3, pending
-│   ├── nft_rules.{hpp,cpp}     pure ruleset generator — D4, pending
-│   ├── ip_route.{hpp,cpp}      metric write wrapper — D5, pending
-│   ├── iface_monitor.{hpp,cpp} `ip link show -j` parser — D5, pending
-│   └── apply.{hpp,cpp}         `nft -f -` invoker — D5, pending
+│   ├── nft_rules.{hpp,cpp}     pure ruleset generator — D4 (partial)
+│   ├── shell.{hpp,cpp}         popen()-backed Runner abstraction — D5
+│   ├── ip_route.{hpp,cpp}      `ip route replace` metric writer — D5
+│   ├── iface_monitor.{hpp,cpp} `ip -j link/route show` parser — D5
+│   └── apply.{hpp,cpp}         `nft -f -` invoker — D6, pending
 ├── schemas/net.lua
 ├── test/
-│   └── placeholder_test.cpp    keeps net-router-tests linkable
-│                               until D3 lands ds_bridge_test.cpp
+│   ├── ds_bridge_test.cpp      D3
+│   ├── nft_rules_test.cpp      D4
+│   ├── iface_monitor_test.cpp  D5
+│   └── ip_route_test.cpp       D5
 └── docs/design.md              this file
 ```
 

--- a/modules/net/router/src/iface_monitor.cpp
+++ b/modules/net/router/src/iface_monitor.cpp
@@ -1,0 +1,87 @@
+#include "iface_monitor.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace net_router::iface {
+
+namespace {
+
+using json = nlohmann::json;
+
+void parse_link_show(const std::string& body, State& out) {
+    if (body.empty()) return;
+    try {
+        auto j = json::parse(body);
+        // `ip -j link show <name>` returns a one-element array.
+        if (!j.is_array() || j.empty()) return;
+        const auto& e = j[0];
+        out.present = true;
+        if (e.contains("operstate") && e["operstate"].is_string()) {
+            out.up = (e["operstate"].get<std::string>() == "UP");
+        }
+        // Belt-and-braces: some kernels report operstate=UNKNOWN even
+        // for working ifaces (typical for tun*); fall back to the
+        // flags array containing both "UP" and "LOWER_UP".
+        if (!out.up && e.contains("flags") && e["flags"].is_array()) {
+            bool has_up = false, has_lower = false;
+            for (const auto& f : e["flags"]) {
+                if (!f.is_string()) continue;
+                const auto s = f.get<std::string>();
+                if (s == "UP")       has_up = true;
+                if (s == "LOWER_UP") has_lower = true;
+            }
+            out.up = has_up && has_lower;
+        }
+    } catch (const std::exception&) {
+        // Leave defaults; caller treats as not-usable.
+    }
+}
+
+void parse_route_default(const std::string& body, State& out) {
+    if (body.empty()) return;
+    try {
+        auto j = json::parse(body);
+        if (!j.is_array() || j.empty()) return;
+        const auto& e = j[0];
+        if (e.contains("gateway") && e["gateway"].is_string()) {
+            out.gateway = e["gateway"].get<std::string>();
+        }
+    } catch (const std::exception&) {
+        // No default route via this iface — fine, gateway stays empty.
+    }
+}
+
+} // namespace
+
+State probe(const std::string& name, shell::Runner runner) {
+    State s;
+    s.name = name;
+    if (name.empty() || !runner) return s;
+
+    int rc = 0;
+    auto link = runner({"ip", "-j", "link", "show", name}, &rc);
+    if (rc != 0) return s;          // iface absent
+    parse_link_show(link, s);
+
+    auto route = runner({"ip", "-j", "route", "show", "default", "dev", name},
+                        nullptr);
+    parse_route_default(route, s);
+    return s;
+}
+
+std::vector<State> probe_all(const std::vector<std::string>& names,
+                             shell::Runner runner) {
+    std::vector<State> out;
+    out.reserve(names.size());
+    for (const auto& n : names) out.push_back(probe(n, runner));
+    return out;
+}
+
+std::optional<std::size_t> pick_active(const std::vector<State>& states) {
+    for (std::size_t i = 0; i < states.size(); ++i) {
+        if (states[i].present && states[i].up) return i;
+    }
+    return std::nullopt;
+}
+
+} // namespace net_router::iface

--- a/modules/net/router/src/iface_monitor.hpp
+++ b/modules/net/router/src/iface_monitor.hpp
@@ -1,0 +1,41 @@
+#ifndef __net_router_iface_monitor_hpp__
+#define __net_router_iface_monitor_hpp__
+
+/// Stateless prober for a Linux network interface — shells out to
+/// `ip -j link show <name>` (oper state) and `ip -j route show
+/// default dev <name>` (gateway). All shell calls go through a
+/// `shell::Runner` so tests can inject canned JSON without touching
+/// the host.
+
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "shell.hpp"
+
+namespace net_router::iface {
+
+struct State {
+    std::string name;       ///< e.g. "eth0"
+    bool        present = false;  ///< iface exists in the kernel
+    bool        up      = false;  ///< OPER state == "UP"
+    std::string gateway;    ///< default route's `via`, empty if none
+};
+
+/// Probe a single interface. Empty `name` → returns a zero-init State
+/// (present=false). Parse failures are silent — the resulting State
+/// just keeps the defaults so the caller treats it as "not usable".
+State probe(const std::string& name,
+            shell::Runner       runner = shell::default_runner());
+
+/// Probe a list of interfaces in order.
+std::vector<State> probe_all(const std::vector<std::string>& names,
+                             shell::Runner runner = shell::default_runner());
+
+/// Pick the highest-priority interface that is BOTH present and up.
+/// Returns the index into `states` or std::nullopt if none qualify.
+std::optional<std::size_t> pick_active(const std::vector<State>& states);
+
+} // namespace net_router::iface
+
+#endif /* __net_router_iface_monitor_hpp__ */

--- a/modules/net/router/src/ip_route.cpp
+++ b/modules/net/router/src/ip_route.cpp
@@ -1,0 +1,56 @@
+#include "ip_route.hpp"
+
+namespace net_router::route {
+
+ApplyResult apply_priorities(const std::vector<iface::State>& priority_ordered,
+                             shell::Runner runner) {
+    ApplyResult out;
+    for (std::size_t i = 0; i < priority_ordered.size(); ++i) {
+        const auto& s = priority_ordered[i];
+        Step step;
+        step.iface  = s.name;
+        step.metric = static_cast<std::uint32_t>((i + 1) * 100);
+
+        if (s.name.empty()) {
+            step.error = "iface name empty";
+            out.all_ok = false;
+            out.steps.push_back(std::move(step));
+            continue;
+        }
+        if (!s.up) {
+            step.error = "iface not up";
+            out.steps.push_back(std::move(step));
+            continue;                          // not an error, just skipped
+        }
+        if (s.gateway.empty()) {
+            step.error = "no default gateway known";
+            out.steps.push_back(std::move(step));
+            continue;
+        }
+
+        step.cmd = {
+            "ip", "route", "replace", "default",
+            "via", s.gateway,
+            "dev", s.name,
+            "metric", std::to_string(step.metric),
+        };
+        if (!runner) {
+            step.error = "no shell runner";
+            out.all_ok = false;
+            out.steps.push_back(std::move(step));
+            continue;
+        }
+        int rc = 0;
+        runner(step.cmd, &rc);
+        step.rc      = rc;
+        step.applied = (rc == 0);
+        if (rc != 0) {
+            step.error = "ip route replace returned non-zero";
+            out.all_ok = false;
+        }
+        out.steps.push_back(std::move(step));
+    }
+    return out;
+}
+
+} // namespace net_router::route

--- a/modules/net/router/src/ip_route.hpp
+++ b/modules/net/router/src/ip_route.hpp
@@ -1,0 +1,47 @@
+#ifndef __net_router_ip_route_hpp__
+#define __net_router_ip_route_hpp__
+
+/// Wraps `ip route replace default …` so the daemon can express
+/// outgoing-traffic preference as: eth=100, wifi=200, cellular=300
+/// (lower metric wins in the Linux FIB). Pure-ish: every shell call
+/// goes through the injected `shell::Runner`.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "iface_monitor.hpp"
+#include "shell.hpp"
+
+namespace net_router::route {
+
+/// One step the apply produced. `cmd` is the argv that was (or would
+/// have been) handed to the runner. `applied=false` means the step
+/// was deliberately skipped (iface not up, no gateway, etc.); `error`
+/// holds the reason in that case.
+struct Step {
+    std::string              iface;
+    std::uint32_t            metric  = 0;
+    std::vector<std::string> cmd;
+    bool                     applied = false;
+    int                      rc      = 0;
+    std::string              error;
+};
+
+struct ApplyResult {
+    std::vector<Step> steps;
+    bool              all_ok = true;
+};
+
+/// Write default-route metrics for the priority-ordered iface list.
+/// `metric = (index + 1) * 100` → first iface gets 100, second 200, …
+/// Skips ifaces that aren't up or have no gateway. A runner that
+/// returns non-zero `exit_code` marks the step failed and flips
+/// `ApplyResult::all_ok` to false but does NOT abort — every iface
+/// is attempted independently so a busted wifi doesn't block eth.
+ApplyResult apply_priorities(const std::vector<iface::State>& priority_ordered,
+                             shell::Runner runner = shell::default_runner());
+
+} // namespace net_router::route
+
+#endif /* __net_router_ip_route_hpp__ */

--- a/modules/net/router/src/shell.cpp
+++ b/modules/net/router/src/shell.cpp
@@ -1,0 +1,60 @@
+#include "shell.hpp"
+
+#include <array>
+#include <cstdio>
+#include <sstream>
+#include <sys/wait.h>
+
+namespace net_router::shell {
+
+namespace {
+
+std::string shell_quote(const std::string& s) {
+    // Wrap in single quotes; any embedded `'` becomes `'\''`. Safe
+    // for /bin/sh -c.
+    std::string out;
+    out.reserve(s.size() + 2);
+    out.push_back('\'');
+    for (char c : s) {
+        if (c == '\'') out += "'\\''";
+        else           out.push_back(c);
+    }
+    out.push_back('\'');
+    return out;
+}
+
+} // namespace
+
+Runner default_runner() {
+    return [](const std::vector<std::string>& argv, int* exit_code) -> std::string {
+        if (argv.empty()) {
+            if (exit_code) *exit_code = 127;
+            return {};
+        }
+        std::ostringstream cmd;
+        for (std::size_t i = 0; i < argv.size(); ++i) {
+            if (i) cmd << ' ';
+            cmd << shell_quote(argv[i]);
+        }
+        cmd << " 2>/dev/null";
+
+        std::FILE* fp = ::popen(cmd.str().c_str(), "r");
+        if (!fp) {
+            if (exit_code) *exit_code = 127;
+            return {};
+        }
+        std::string out;
+        std::array<char, 4096> buf{};
+        std::size_t n = 0;
+        while ((n = std::fread(buf.data(), 1, buf.size(), fp)) > 0) {
+            out.append(buf.data(), n);
+        }
+        int status = ::pclose(fp);
+        if (exit_code) {
+            *exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : 127;
+        }
+        return out;
+    };
+}
+
+} // namespace net_router::shell

--- a/modules/net/router/src/shell.hpp
+++ b/modules/net/router/src/shell.hpp
@@ -1,0 +1,29 @@
+#ifndef __net_router_shell_hpp__
+#define __net_router_shell_hpp__
+
+/// Tiny shell-runner abstraction used by iface_monitor and ip_route.
+/// The "real" runner shells out via popen(); tests inject a fake
+/// runner so they never touch the host's network stack.
+
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace net_router::shell {
+
+/// Args are passed positionally — argv[0] is the binary. Caller does
+/// NOT shell-escape; the default runner builds a safely-quoted command
+/// line internally.
+///
+/// Returns stdout of the child. Non-zero exit + stderr go through the
+/// `exit_code` outparam if provided (nullptr → ignored).
+using Runner = std::function<std::string(const std::vector<std::string>& argv,
+                                         int* exit_code)>;
+
+/// popen()-backed runner. Builds `"<arg0>" "<arg1>" ... 2>/dev/null`,
+/// pipes stdout back, writes `WEXITSTATUS` to `*exit_code`.
+Runner default_runner();
+
+} // namespace net_router::shell
+
+#endif /* __net_router_shell_hpp__ */

--- a/modules/net/router/test/iface_monitor_test.cpp
+++ b/modules/net/router/test/iface_monitor_test.cpp
@@ -1,0 +1,182 @@
+/// Tests for iface_monitor — fake shell runner returns canned
+/// `ip -j …` output so nothing touches the host's network stack.
+
+#include <gtest/gtest.h>
+
+#include <map>
+#include <string>
+#include <vector>
+
+#include "iface_monitor.hpp"
+#include "shell.hpp"
+
+using net_router::iface::pick_active;
+using net_router::iface::probe;
+using net_router::iface::probe_all;
+using net_router::iface::State;
+using net_router::shell::Runner;
+
+namespace {
+
+/// Fake runner: programmable per-command response, records every
+/// argv it sees.
+class FakeRunner {
+public:
+    struct Resp { std::string stdout_; int rc = 0; };
+
+    void on(const std::vector<std::string>& argv, std::string body, int rc = 0) {
+        table_[signature(argv)] = Resp{std::move(body), rc};
+    }
+
+    Runner make() {
+        return [this](const std::vector<std::string>& argv, int* exit_code) {
+            calls.push_back(argv);
+            const auto key = signature(argv);
+            auto it = table_.find(key);
+            if (it == table_.end()) {
+                if (exit_code) *exit_code = 1;
+                return std::string{};
+            }
+            if (exit_code) *exit_code = it->second.rc;
+            return it->second.stdout_;
+        };
+    }
+
+    std::vector<std::vector<std::string>> calls;
+
+private:
+public:
+    static std::string signature(const std::vector<std::string>& argv) {
+        std::string s;
+        for (const auto& a : argv) { s += a; s += '\0'; }
+        return s;
+    }
+
+private:
+    std::map<std::string, Resp> table_;
+};
+
+const char* kEth0Up = R"([{
+  "ifindex": 2, "ifname": "eth0",
+  "flags": ["BROADCAST","MULTICAST","UP","LOWER_UP"],
+  "operstate": "UP"
+}])";
+
+const char* kEth0Down = R"([{
+  "ifindex": 2, "ifname": "eth0",
+  "flags": ["BROADCAST","MULTICAST"],
+  "operstate": "DOWN"
+}])";
+
+const char* kTun0Unknown = R"([{
+  "ifindex": 5, "ifname": "tun0",
+  "flags": ["POINTOPOINT","MULTICAST","NOARP","UP","LOWER_UP"],
+  "operstate": "UNKNOWN"
+}])";
+
+const char* kDefRouteEth0 = R"([{
+  "dst": "default", "gateway": "192.168.1.1",
+  "dev": "eth0", "protocol": "dhcp"
+}])";
+
+} // namespace
+
+/* ─────────────────────── probe() ─────────────────────────────── */
+
+TEST(IfaceProbe, ReturnsZeroInitForEmptyName) {
+    FakeRunner fr;
+    auto s = probe("", fr.make());
+    EXPECT_FALSE(s.present);
+    EXPECT_FALSE(s.up);
+    EXPECT_TRUE(s.gateway.empty());
+    EXPECT_TRUE(fr.calls.empty());      // never shells out
+}
+
+TEST(IfaceProbe, UpInterfaceWithGatewayPopulated) {
+    FakeRunner fr;
+    fr.on({"ip","-j","link","show","eth0"}, kEth0Up);
+    fr.on({"ip","-j","route","show","default","dev","eth0"}, kDefRouteEth0);
+    auto s = probe("eth0", fr.make());
+    EXPECT_TRUE(s.present);
+    EXPECT_TRUE(s.up);
+    EXPECT_EQ("192.168.1.1", s.gateway);
+    EXPECT_EQ("eth0", s.name);
+    ASSERT_EQ(2u, fr.calls.size());     // link + route
+}
+
+TEST(IfaceProbe, DownInterfaceMarkedNotUp) {
+    FakeRunner fr;
+    fr.on({"ip","-j","link","show","eth0"}, kEth0Down);
+    fr.on({"ip","-j","route","show","default","dev","eth0"}, "[]");
+    auto s = probe("eth0", fr.make());
+    EXPECT_TRUE(s.present);
+    EXPECT_FALSE(s.up);
+    EXPECT_TRUE(s.gateway.empty());
+}
+
+TEST(IfaceProbe, OperstateUnknownStillUpWhenFlagsHaveUpAndLowerUp) {
+    // tun devices typically report operstate=UNKNOWN even when
+    // running — the UP+LOWER_UP flag fallback should catch them.
+    FakeRunner fr;
+    fr.on({"ip","-j","link","show","tun0"}, kTun0Unknown);
+    fr.on({"ip","-j","route","show","default","dev","tun0"}, "[]");
+    auto s = probe("tun0", fr.make());
+    EXPECT_TRUE(s.present);
+    EXPECT_TRUE(s.up);
+}
+
+TEST(IfaceProbe, MissingInterfaceNonZeroExitYieldsNotPresent) {
+    FakeRunner fr;     // no `on()` calls → runner returns rc=1
+    auto s = probe("does-not-exist", fr.make());
+    EXPECT_FALSE(s.present);
+    EXPECT_FALSE(s.up);
+    // Confirms we bail out after the link probe — no route call.
+    EXPECT_EQ(1u, fr.calls.size());
+}
+
+TEST(IfaceProbe, GarbageJsonLeavesStateUntouched) {
+    FakeRunner fr;
+    fr.on({"ip","-j","link","show","eth0"}, "not-json");
+    fr.on({"ip","-j","route","show","default","dev","eth0"}, "{}");
+    auto s = probe("eth0", fr.make());
+    // rc=0 but JSON parse fails → present stays false.
+    EXPECT_FALSE(s.up);
+    EXPECT_TRUE(s.gateway.empty());
+}
+
+/* ─────────────────────── probe_all + pick_active ─────────────── */
+
+TEST(PickActive, FirstUpInterfaceWins) {
+    std::vector<State> ss(3);
+    ss[0].name = "eth0";     ss[0].present = true; ss[0].up = false;
+    ss[1].name = "wlan0";    ss[1].present = true; ss[1].up = true;
+    ss[2].name = "wwan0";    ss[2].present = true; ss[2].up = true;
+    auto idx = pick_active(ss);
+    ASSERT_TRUE(idx.has_value());
+    EXPECT_EQ(1u, *idx);
+}
+
+TEST(PickActive, NoneUpReturnsNullopt) {
+    std::vector<State> ss(2);
+    ss[0].present = true; ss[0].up = false;
+    ss[1].present = true; ss[1].up = false;
+    EXPECT_FALSE(pick_active(ss).has_value());
+}
+
+TEST(PickActive, AbsentInterfaceIgnoredEvenIfUpFieldSet) {
+    std::vector<State> ss(2);
+    ss[0].present = false; ss[0].up = true;   // can't happen in practice
+    ss[1].present = true;  ss[1].up = true;
+    EXPECT_EQ(1u, *pick_active(ss));
+}
+
+TEST(ProbeAll, OneCallPerName) {
+    FakeRunner fr;
+    fr.on({"ip","-j","link","show","eth0"}, kEth0Up);
+    fr.on({"ip","-j","route","show","default","dev","eth0"}, kDefRouteEth0);
+    // wlan0 absent → link probe rc=1.
+    auto v = probe_all({"eth0", "wlan0"}, fr.make());
+    ASSERT_EQ(2u, v.size());
+    EXPECT_TRUE(v[0].up);
+    EXPECT_FALSE(v[1].present);
+}

--- a/modules/net/router/test/ip_route_test.cpp
+++ b/modules/net/router/test/ip_route_test.cpp
@@ -1,0 +1,135 @@
+/// Tests for ip_route — fake runner records `ip route replace ...`
+/// invocations so we can assert command shape + skip behaviour.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "iface_monitor.hpp"
+#include "ip_route.hpp"
+#include "shell.hpp"
+
+using net_router::iface::State;
+using net_router::route::apply_priorities;
+using net_router::shell::Runner;
+
+namespace {
+
+struct Recorder {
+    std::vector<std::vector<std::string>> calls;
+    int rc_to_return = 0;
+
+    Runner make() {
+        return [this](const std::vector<std::string>& argv, int* ec) {
+            calls.push_back(argv);
+            if (ec) *ec = rc_to_return;
+            return std::string{};
+        };
+    }
+};
+
+State up(const std::string& n, const std::string& gw) {
+    State s; s.name = n; s.present = true; s.up = true; s.gateway = gw;
+    return s;
+}
+State down(const std::string& n) {
+    State s; s.name = n; s.present = true; s.up = false; return s;
+}
+State no_gw(const std::string& n) {
+    State s; s.name = n; s.present = true; s.up = true; return s;
+}
+
+} // namespace
+
+TEST(IpRoute, MetricIsIndexPlusOneTimesHundred) {
+    Recorder rec;
+    auto r = apply_priorities({
+        up("eth0",   "192.168.1.1"),
+        up("wlan0",  "10.0.0.1"),
+        up("wwan0",  "172.16.0.1"),
+    }, rec.make());
+
+    ASSERT_EQ(3u, r.steps.size());
+    EXPECT_EQ(100u, r.steps[0].metric);
+    EXPECT_EQ(200u, r.steps[1].metric);
+    EXPECT_EQ(300u, r.steps[2].metric);
+    EXPECT_TRUE(r.all_ok);
+    for (const auto& s : r.steps) EXPECT_TRUE(s.applied);
+}
+
+TEST(IpRoute, IssuesIpRouteReplaceWithViaAndDevAndMetric) {
+    Recorder rec;
+    apply_priorities({ up("eth0", "192.168.1.1") }, rec.make());
+    ASSERT_EQ(1u, rec.calls.size());
+    const auto& c = rec.calls[0];
+    // Expect exactly: ip route replace default via 192.168.1.1
+    //                 dev eth0 metric 100
+    ASSERT_EQ(10u, c.size());
+    EXPECT_EQ("ip",            c[0]);
+    EXPECT_EQ("route",         c[1]);
+    EXPECT_EQ("replace",       c[2]);
+    EXPECT_EQ("default",       c[3]);
+    EXPECT_EQ("via",           c[4]);
+    EXPECT_EQ("192.168.1.1",   c[5]);
+    EXPECT_EQ("dev",           c[6]);
+    EXPECT_EQ("eth0",          c[7]);
+    EXPECT_EQ("metric",        c[8]);
+    EXPECT_EQ("100",           c[9]);
+}
+
+TEST(IpRoute, SkipsDownInterfacesButContinuesWithOthers) {
+    Recorder rec;
+    auto r = apply_priorities({
+        down("eth0"),
+        up("wlan0", "10.0.0.1"),
+    }, rec.make());
+
+    ASSERT_EQ(2u, r.steps.size());
+    EXPECT_FALSE(r.steps[0].applied);
+    EXPECT_EQ("iface not up", r.steps[0].error);
+    EXPECT_TRUE(r.steps[1].applied);
+    // Down iface metric is still recorded for diagnostic completeness.
+    EXPECT_EQ(100u, r.steps[0].metric);
+    EXPECT_EQ(200u, r.steps[1].metric);
+    EXPECT_TRUE(r.all_ok);          // skip ≠ failure
+
+    // Only the wlan0 call actually went to the runner.
+    ASSERT_EQ(1u, rec.calls.size());
+    EXPECT_EQ("wlan0", rec.calls[0][7]);
+}
+
+TEST(IpRoute, NoGatewaySkipsApply) {
+    Recorder rec;
+    auto r = apply_priorities({ no_gw("eth0") }, rec.make());
+    ASSERT_EQ(1u, r.steps.size());
+    EXPECT_FALSE(r.steps[0].applied);
+    EXPECT_EQ("no default gateway known", r.steps[0].error);
+    EXPECT_TRUE(rec.calls.empty());
+    EXPECT_TRUE(r.all_ok);
+}
+
+TEST(IpRoute, EmptyNameFlagsAllOkFalse) {
+    Recorder rec;
+    State s; s.present = true; s.up = true; s.gateway = "1.2.3.4";
+    auto r = apply_priorities({ s }, rec.make());
+    EXPECT_FALSE(r.all_ok);
+    EXPECT_EQ("iface name empty", r.steps[0].error);
+    EXPECT_TRUE(rec.calls.empty());
+}
+
+TEST(IpRoute, NonZeroExitMarksStepFailedAndAllOkFalse) {
+    Recorder rec;
+    rec.rc_to_return = 2;
+    auto r = apply_priorities({ up("eth0", "192.168.1.1") }, rec.make());
+    ASSERT_EQ(1u, r.steps.size());
+    EXPECT_FALSE(r.steps[0].applied);
+    EXPECT_EQ(2, r.steps[0].rc);
+    EXPECT_FALSE(r.all_ok);
+}
+
+TEST(IpRoute, NullRunnerIsAnError) {
+    auto r = apply_priorities({ up("eth0", "192.168.1.1") }, Runner{});
+    EXPECT_FALSE(r.all_ok);
+    EXPECT_EQ("no shell runner", r.steps[0].error);
+}


### PR DESCRIPTION
## Summary
- `iface_monitor` shells out to `ip -j link show <iface>` + `ip -j route show default dev <iface>`, parses the JSON, returns `{name, present, up, gateway}`. `pick_active()` returns the index of the first iface that's up — drives the eth → wifi → cellular preference order.
- `ip_route::apply_priorities()` writes default-route metrics (eth=100, wifi=200, cellular=300) via `ip route replace default via <gw> dev <iface> metric <N>` for each up iface. Down/no-gateway entries are recorded but skipped without failing the whole apply.
- New `shell::Runner` abstraction (popen-backed default, easily fakeable) decouples both modules from the host. The fake recorder used in tests captures every argv so we assert command shape, not just output.

## Test plan
- [x] `podman run … apt-install lua/gtest/json && cmake … && make net-router-tests && ./net-router-tests` — 35/35 tests pass (18 pre-existing + 17 new D5)
- [ ] Manual smoke on a Linux host with real `ip` once D6 lands and wires the runner into the daemon

## Notes
- D6 (lifecycle FSM + `nft -f -` apply + e2e smoke against a fake nft) and D7 (packaging integration: systemd unit, IOT_ROLE=net, apt-install nftables in both images) remain — design.md updated to reflect status.
- The shell runner intentionally lives in `modules/net/router/src/shell.hpp` (not promoted to a shared header) because openvpn-client already has its own ACE_Process-based runner with different semantics. Once a third caller needs it we can lift it; YAGNI for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)