### PR TITLE
L13/D6: net-router Lifecycle FSM + nft -f apply wrapper

### DIFF
--- a/modules/net/router/CMakeLists.txt
+++ b/modules/net/router/CMakeLists.txt
@@ -37,7 +37,9 @@ add_library(net_router_lib STATIC
     src/nft_rules.cpp
     src/shell.cpp
     src/iface_monitor.cpp
-    src/ip_route.cpp)
+    src/ip_route.cpp
+    src/apply.cpp
+    src/lifecycle.cpp)
 
 target_include_directories(net_router_lib PUBLIC src)
 target_link_libraries(net_router_lib
@@ -65,7 +67,9 @@ if(BUILD_NET_ROUTER_TESTS)
         test/ds_bridge_test.cpp
         test/nft_rules_test.cpp
         test/iface_monitor_test.cpp
-        test/ip_route_test.cpp)
+        test/ip_route_test.cpp
+        test/apply_test.cpp
+        test/lifecycle_test.cpp)
 
     target_link_libraries(net-router-tests
         net_router_lib

--- a/modules/net/router/docs/design.md
+++ b/modules/net/router/docs/design.md
@@ -1,9 +1,10 @@
 # net-router — module design (L13)
 
-> **Status (2026-05-31):** D1, D2, D3 (DsBridge), partial D4
-> (nft_rules generator), D5 (ip_route + iface_monitor) landed.
-> D6 (lifecycle + `nft -f -` apply + e2e smoke) and D7 (packaging)
-> pending.
+> **Status (2026-05-31):** D1–D6 landed (schema, scaffold, DsBridge,
+> nft_rules generator, ip_route + iface_monitor, lifecycle FSM +
+> `nft -f` apply wrapper). D7 (packaging: systemd unit, IOT_ROLE=net,
+> apt-install nftables in both images, apps/CMakeLists.txt
+> add_subdirectory) remains.
 
 ## What this module is
 
@@ -82,13 +83,16 @@ modules/net/router/
 │   ├── shell.{hpp,cpp}         popen()-backed Runner abstraction — D5
 │   ├── ip_route.{hpp,cpp}      `ip route replace` metric writer — D5
 │   ├── iface_monitor.{hpp,cpp} `ip -j link/route show` parser — D5
-│   └── apply.{hpp,cpp}         `nft -f -` invoker — D6, pending
+│   ├── apply.{hpp,cpp}         tempfile + `nft -f` apply wrapper — D6
+│   └── lifecycle.{hpp,cpp}     pure FSM: Sinks + Inputs → step() — D6
 ├── schemas/net.lua
 ├── test/
 │   ├── ds_bridge_test.cpp      D3
 │   ├── nft_rules_test.cpp      D4
 │   ├── iface_monitor_test.cpp  D5
-│   └── ip_route_test.cpp       D5
+│   ├── ip_route_test.cpp       D5
+│   ├── apply_test.cpp          D6 (uses a real fake-nft shell script)
+│   └── lifecycle_test.cpp      D6 (FSM transitions + recovery)
 └── docs/design.md              this file
 ```
 

--- a/modules/net/router/src/apply.cpp
+++ b/modules/net/router/src/apply.cpp
@@ -1,0 +1,110 @@
+#include "apply.hpp"
+
+#include <array>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+namespace net_router::apply {
+
+namespace {
+
+/// Locate a writable directory for the tempfile. Mirrors the L12/D5
+/// $TMPDIR → /tmp → cwd fallback chain we use for ovpn keys.
+std::string pick_tmpdir() {
+    if (const char* env = std::getenv("TMPDIR")) {
+        struct stat st{};
+        if (stat(env, &st) == 0 && S_ISDIR(st.st_mode)) return env;
+    }
+    {
+        struct stat st{};
+        if (stat("/tmp", &st) == 0 && S_ISDIR(st.st_mode)) return "/tmp";
+        if (mkdir("/tmp", 0777) == 0) return "/tmp";
+    }
+    return ".";
+}
+
+/// Shell-quote for /bin/sh -c — single-quote wrap, escape inner '.
+std::string shquote(const std::string& s) {
+    std::string out;
+    out.reserve(s.size() + 2);
+    out.push_back('\'');
+    for (char c : s) {
+        if (c == '\'') out += "'\\''";
+        else           out.push_back(c);
+    }
+    out.push_back('\'');
+    return out;
+}
+
+bool write_all(int fd, const std::string& s) {
+    const char* p = s.data();
+    std::size_t left = s.size();
+    while (left) {
+        ssize_t n = ::write(fd, p, left);
+        if (n < 0) {
+            if (errno == EINTR) continue;
+            return false;
+        }
+        p    += n;
+        left -= static_cast<std::size_t>(n);
+    }
+    return true;
+}
+
+} // namespace
+
+NftApply default_nft_apply(const std::string& nft_path) {
+    return [nft_path](const std::string& ruleset, std::string* err) -> bool {
+        auto dir = pick_tmpdir();
+        std::string templ = dir + "/iot-nft.XXXXXX";
+        std::vector<char> buf(templ.begin(), templ.end());
+        buf.push_back('\0');
+
+        int fd = ::mkstemp(buf.data());
+        if (fd < 0) {
+            if (err) *err = std::string("mkstemp failed: ") + std::strerror(errno);
+            return false;
+        }
+        const std::string path(buf.data());
+        bool wrote = write_all(fd, ruleset);
+        ::close(fd);
+        if (!wrote) {
+            if (err) *err = "short write to " + path;
+            ::unlink(path.c_str());
+            return false;
+        }
+
+        // Combined output capture: `nft -f <path> 2>&1` through popen.
+        const std::string cmd = shquote(nft_path) + " -f " + shquote(path) + " 2>&1";
+        std::FILE* fp = ::popen(cmd.c_str(), "r");
+        if (!fp) {
+            if (err) *err = "popen(nft) failed";
+            ::unlink(path.c_str());
+            return false;
+        }
+        std::string captured;
+        std::array<char, 4096> chunk{};
+        std::size_t n = 0;
+        while ((n = std::fread(chunk.data(), 1, chunk.size(), fp)) > 0) {
+            captured.append(chunk.data(), n);
+        }
+        int status = ::pclose(fp);
+        ::unlink(path.c_str());
+
+        const int rc = WIFEXITED(status) ? WEXITSTATUS(status) : 127;
+        if (rc != 0) {
+            if (err) *err = captured.empty()
+                ? ("nft exited " + std::to_string(rc))
+                : captured;
+            return false;
+        }
+        return true;
+    };
+}
+
+} // namespace net_router::apply

--- a/modules/net/router/src/apply.hpp
+++ b/modules/net/router/src/apply.hpp
@@ -1,0 +1,30 @@
+#ifndef __net_router_apply_hpp__
+#define __net_router_apply_hpp__
+
+/// Wrapper around `nft -f <file>` for atomic ruleset apply.
+///
+/// Pure-ish: the NftApply callable type is injectable so tests can
+/// stub it. The default impl writes the ruleset to a tempfile in
+/// $TMPDIR (or /tmp) and invokes `nft` via popen() with combined
+/// stdout+stderr captured so error messages survive into the daemon
+/// log on rejection.
+
+#include <functional>
+#include <string>
+
+namespace net_router::apply {
+
+/// Returns true if nft exited 0. On non-zero exit (or spawn failure)
+/// `*err` (when non-null) receives the captured combined output of
+/// nft so the daemon can ACE_ERROR the parser diagnostic verbatim.
+using NftApply = std::function<bool(const std::string& ruleset,
+                                    std::string*       err)>;
+
+/// Default impl: writes ruleset to a tempfile, runs
+/// `<nft_path> -f <tempfile> 2>&1`, captures combined output,
+/// unlinks the tempfile (best-effort). Returns true on exit code 0.
+NftApply default_nft_apply(const std::string& nft_path = "nft");
+
+} // namespace net_router::apply
+
+#endif /* __net_router_apply_hpp__ */

--- a/modules/net/router/src/lifecycle.cpp
+++ b/modules/net/router/src/lifecycle.cpp
@@ -1,0 +1,77 @@
+#include "lifecycle.hpp"
+
+namespace net_router {
+
+const char* Lifecycle::state_name(State s) {
+    switch (s) {
+        case State::Init:       return "init";
+        case State::NeedConfig: return "need-config";
+        case State::Steady:     return "steady";
+        case State::Failed:     return "failed";
+    }
+    return "?";
+}
+
+void Lifecycle::transition(State next) {
+    if (next == m_state) return;
+    m_state = next;
+    if (m_sinks.set_state) m_sinks.set_state(state_name(next));
+}
+
+Lifecycle::State Lifecycle::step(const Inputs& in) {
+    // 1) Required-config gate.
+    if (in.lwm2m_target_ip.empty()) {
+        transition(State::NeedConfig);
+        return m_state;
+    }
+
+    // 2) Build the ruleset. Re-apply only when text actually changed —
+    //    nft -f is idempotent but a no-op apply still incurs the
+    //    parser + transaction cost.
+    nft::State ns;
+    ns.tun_dev          = in.tun_dev;
+    ns.lwm2m_target_ip  = in.lwm2m_target_ip;
+    ns.lwm2m_target_port = in.lwm2m_target_port;
+    ns.forward_ports    = in.forward_ports;
+    ns.custom           = in.custom_rules;
+    const std::string ruleset = nft::build_nft_ruleset(ns);
+
+    bool nft_ok = true;
+    if (ruleset != m_last_ruleset) {
+        std::string err;
+        nft_ok = m_sinks.apply_nft
+                 ? m_sinks.apply_nft(ruleset, &err)
+                 : false;
+        if (nft_ok) {
+            m_last_ruleset = ruleset;
+            ++m_apply_count;
+            if (m_sinks.set_rules_applied_count)
+                m_sinks.set_rules_applied_count(m_apply_count);
+            if (m_sinks.set_last_apply_unix && in.now_unix)
+                m_sinks.set_last_apply_unix(in.now_unix);
+        }
+    }
+
+    // 3) Route metrics. Always run — apply_priorities is idempotent
+    //    per-iface (ip route replace is a no-op when target == current).
+    bool route_ok = true;
+    if (m_sinks.apply_routes) {
+        route_ok = m_sinks.apply_routes(in.ifaces_in_priority_order);
+    }
+
+    // 4) Emit net.iface.active if the pick changed (empty string when
+    //    nothing is up — operator-visible signal that we're offline).
+    std::string new_active;
+    if (auto idx = iface::pick_active(in.ifaces_in_priority_order)) {
+        new_active = in.ifaces_in_priority_order[*idx].name;
+    }
+    if (new_active != m_last_iface) {
+        m_last_iface = new_active;
+        if (m_sinks.set_iface_active) m_sinks.set_iface_active(new_active);
+    }
+
+    transition((nft_ok && route_ok) ? State::Steady : State::Failed);
+    return m_state;
+}
+
+} // namespace net_router

--- a/modules/net/router/src/lifecycle.hpp
+++ b/modules/net/router/src/lifecycle.hpp
@@ -1,0 +1,91 @@
+#ifndef __net_router_lifecycle_hpp__
+#define __net_router_lifecycle_hpp__
+
+/// Lifecycle FSM that drives net-router's reactor tick.
+///
+/// Pure logic: takes a Sinks struct (apply-nft, apply-routes, ds
+/// writers) and an Inputs snapshot (ds-server reads + iface probe
+/// results + current unix time) and computes the next action set.
+/// Mirrors modules/openvpn/client/src/lifecycle.hpp's pattern so
+/// tests can substitute lambdas without standing up a real DsBridge,
+/// iface_monitor, nft, or ds-server.
+
+#include <cstdint>
+#include <functional>
+#include <string>
+#include <vector>
+
+#include "iface_monitor.hpp"
+#include "nft_rules.hpp"
+
+namespace net_router {
+
+class Lifecycle {
+public:
+    enum class State {
+        Init,         ///< Constructed; nothing applied yet
+        NeedConfig,   ///< Required keys (net.lwm2m.target_ip) absent
+        Steady,       ///< Last apply succeeded
+        Failed,       ///< Last apply (nft or routes) returned false
+    };
+
+    /// Per-action writers. Production wires apply_nft to
+    /// apply::default_nft_apply(), apply_routes to a closure over
+    /// route::apply_priorities(), and the set_* writers to the
+    /// DsBridge setters. Tests substitute lambdas that capture.
+    struct Sinks {
+        std::function<bool(const std::string& ruleset,
+                           std::string*       err)>            apply_nft;
+        std::function<bool(const std::vector<iface::State>&)>  apply_routes;
+        std::function<void(const std::string&)>                set_state;
+        std::function<void(const std::string&)>                set_iface_active;
+        std::function<void(std::uint32_t)>                     set_rules_applied_count;
+        std::function<void(std::uint32_t)>                     set_last_apply_unix;
+    };
+
+    /// Snapshot the Lifecycle uses to compute its next step.
+    struct Inputs {
+        // From DsBridge — net.* read keys
+        std::string                tun_dev;
+        std::string                lwm2m_target_ip;
+        std::uint32_t              lwm2m_target_port = 0;
+        std::vector<std::uint16_t> forward_ports;
+        std::vector<nft::CustomRule> custom_rules;
+        // From iface_monitor::probe_all() in priority order
+        std::vector<iface::State>  ifaces_in_priority_order;
+        // Wall-clock (passed in for determinism in tests)
+        std::uint32_t              now_unix = 0;
+    };
+
+    explicit Lifecycle(Sinks sinks) : m_sinks(std::move(sinks)) {}
+
+    /// One reactor tick. Returns the new State.
+    /// - If lwm2m_target_ip empty → NeedConfig, no side effects
+    /// - Else build ruleset; if differs from last → apply_nft
+    /// - Pick active iface; apply_routes; if changed → set_iface_active
+    /// - On any nft/route failure → Failed (kept until next clean tick)
+    /// - On all-ok → Steady (and emit set_state("steady") if changed)
+    State step(const Inputs& in);
+
+    State state()                       const { return m_state;          }
+    std::uint32_t apply_count()         const { return m_apply_count;    }
+    const std::string& last_ruleset()   const { return m_last_ruleset;   }
+    const std::string& last_iface()     const { return m_last_iface;     }
+
+    /// State → schema-friendly string for set_state ("init",
+    /// "need-config", "steady", "failed").
+    static const char* state_name(State s);
+
+private:
+    Sinks         m_sinks;
+    State         m_state        = State::Init;
+    std::uint32_t m_apply_count  = 0;
+    std::string   m_last_ruleset;
+    std::string   m_last_iface;
+
+    void transition(State next);
+};
+
+} // namespace net_router
+
+#endif /* __net_router_lifecycle_hpp__ */

--- a/modules/net/router/test/apply_test.cpp
+++ b/modules/net/router/test/apply_test.cpp
@@ -1,0 +1,136 @@
+/// Tests for the nft apply wrapper. Uses a real fake-nft shell
+/// script written to a tempdir so we exercise the popen() +
+/// tempfile + capture path without touching real nft.
+
+#include <gtest/gtest.h>
+
+#include <cstdio>
+#include <cstdlib>
+#include <fstream>
+#include <string>
+#include <sys/stat.h>
+#include <unistd.h>
+
+#include "apply.hpp"
+
+using net_router::apply::default_nft_apply;
+
+namespace {
+
+/// Owns a tempdir + fake-nft script for the duration of a TEST.
+class FakeNft {
+public:
+    FakeNft() {
+        char templ[] = "/tmp/iot-apply-test.XXXXXX";
+        if (!::mkdtemp(templ)) std::abort();
+        m_dir = templ;
+        m_path = m_dir + "/nft";
+    }
+
+    ~FakeNft() {
+        ::unlink(m_path.c_str());
+        ::unlink((m_dir + "/last_input").c_str());
+        ::rmdir(m_dir.c_str());
+    }
+
+    /// Writes a `#!/bin/sh` script that copies its `-f <file>` arg
+    /// to <dir>/last_input and exits `rc`. If `stderr_msg` non-empty,
+    /// echoes it to stderr first.
+    void install(int rc, const std::string& stderr_msg = {}) {
+        std::ofstream f(m_path);
+        f << "#!/bin/sh\n";
+        if (!stderr_msg.empty()) {
+            // Escape single quotes for shell.
+            std::string esc;
+            for (char c : stderr_msg) {
+                if (c == '\'') esc += "'\\''"; else esc.push_back(c);
+            }
+            f << "printf '%s\\n' '" << esc << "' 1>&2\n";
+        }
+        // $1 = "-f", $2 = "<tempfile>"
+        f << "if [ \"$1\" = \"-f\" ] && [ -n \"$2\" ]; then\n";
+        f << "  cp \"$2\" '" << m_dir << "/last_input'\n";
+        f << "fi\n";
+        f << "exit " << rc << "\n";
+        f.close();
+        ::chmod(m_path.c_str(), 0755);
+    }
+
+    std::string read_last_input() const {
+        std::ifstream f(m_dir + "/last_input");
+        if (!f) return {};
+        std::string out((std::istreambuf_iterator<char>(f)),
+                         std::istreambuf_iterator<char>());
+        return out;
+    }
+
+    const std::string& path() const { return m_path; }
+
+private:
+    std::string m_dir;
+    std::string m_path;
+};
+
+} // namespace
+
+TEST(NftApply, SuccessfulApplyReturnsTrueAndDeliversRulesetIntact) {
+    FakeNft fn;
+    fn.install(/*rc=*/0);
+
+    auto fn_apply = default_nft_apply(fn.path());
+    const std::string ruleset =
+        "table inet iot_router {\n"
+        "  chain prerouting { type nat hook prerouting priority -100; }\n"
+        "}\n";
+
+    std::string err;
+    EXPECT_TRUE(fn_apply(ruleset, &err));
+    EXPECT_TRUE(err.empty());
+    // The fake nft saved its `-f` input — must be byte-identical.
+    EXPECT_EQ(ruleset, fn.read_last_input());
+}
+
+TEST(NftApply, NonZeroExitYieldsFalseAndCapturesStderr) {
+    FakeNft fn;
+    fn.install(/*rc=*/2, "iot-router:5: syntax error");
+
+    auto fn_apply = default_nft_apply(fn.path());
+    std::string err;
+    EXPECT_FALSE(fn_apply("garbage ruleset", &err));
+    // The wrapper combines stdout+stderr; the fake wrote only to stderr.
+    EXPECT_NE(std::string::npos, err.find("syntax error"));
+}
+
+TEST(NftApply, MissingBinaryReturnsFalseWithDiagnostic) {
+    auto fn_apply = default_nft_apply("/usr/bin/definitely-not-a-tool");
+    std::string err;
+    EXPECT_FALSE(fn_apply("any ruleset", &err));
+    EXPECT_FALSE(err.empty());  // popen succeeds; shell reports not-found
+}
+
+TEST(NftApply, NullErrPointerIsTolerated) {
+    FakeNft fn;
+    fn.install(/*rc=*/3);
+    auto fn_apply = default_nft_apply(fn.path());
+    EXPECT_FALSE(fn_apply("x", nullptr));  // must not crash
+}
+
+TEST(NftApply, TempfileIsCleanedUpAfterApply) {
+    FakeNft fn;
+    fn.install(/*rc=*/0);
+    auto fn_apply = default_nft_apply(fn.path());
+    fn_apply("some ruleset", nullptr);
+
+    // Walk the tmpdir(s) we'd use — the iot-nft.XXXXXX pattern from
+    // pick_tmpdir() should leave nothing behind.
+    const std::string dirs[] = {"/tmp", "."};
+    for (const auto& d : dirs) {
+        std::string cmd = "ls " + d + "/iot-nft.* 2>/dev/null | wc -l";
+        std::FILE* p = ::popen(cmd.c_str(), "r");
+        ASSERT_TRUE(p);
+        char buf[16] = {0};
+        std::fread(buf, 1, sizeof(buf) - 1, p);
+        ::pclose(p);
+        EXPECT_EQ('0', buf[0]) << "leftover iot-nft.* in " << d;
+    }
+}

--- a/modules/net/router/test/lifecycle_test.cpp
+++ b/modules/net/router/test/lifecycle_test.cpp
@@ -1,0 +1,232 @@
+/// Tests for the Lifecycle FSM. Pure: lambda fakes capture all the
+/// would-be side effects, so we assert on what step() emits.
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+#include "iface_monitor.hpp"
+#include "lifecycle.hpp"
+#include "nft_rules.hpp"
+
+using net_router::iface::State;
+using net_router::Lifecycle;
+
+namespace {
+
+/// Captures every side effect the Lifecycle attempts. Defaults to
+/// "all successes"; tests flip nft_ok / routes_ok to exercise the
+/// error branches.
+struct Capture {
+    std::vector<std::string>            nft_rulesets;
+    std::vector<std::vector<State>>     route_calls;
+    std::vector<std::string>            state_writes;
+    std::vector<std::string>            iface_writes;
+    std::vector<std::uint32_t>          rules_applied_count_writes;
+    std::vector<std::uint32_t>          last_apply_unix_writes;
+    bool nft_ok    = true;
+    bool routes_ok = true;
+    std::string nft_err;
+
+    Lifecycle::Sinks make_sinks() {
+        Lifecycle::Sinks s;
+        s.apply_nft = [this](const std::string& rs, std::string* err) {
+            nft_rulesets.push_back(rs);
+            if (!nft_ok && err) *err = nft_err.empty() ? "fake-fail" : nft_err;
+            return nft_ok;
+        };
+        s.apply_routes = [this](const std::vector<State>& v) {
+            route_calls.push_back(v);
+            return routes_ok;
+        };
+        s.set_state              = [this](const std::string& v){ state_writes.push_back(v); };
+        s.set_iface_active       = [this](const std::string& v){ iface_writes.push_back(v); };
+        s.set_rules_applied_count= [this](std::uint32_t v){ rules_applied_count_writes.push_back(v); };
+        s.set_last_apply_unix    = [this](std::uint32_t v){ last_apply_unix_writes.push_back(v); };
+        return s;
+    }
+};
+
+State up(const std::string& n, const std::string& gw = "10.0.0.1") {
+    State s; s.name = n; s.present = true; s.up = true; s.gateway = gw;
+    return s;
+}
+State down(const std::string& n) {
+    State s; s.name = n; s.present = true; s.up = false; return s;
+}
+
+Lifecycle::Inputs configured(std::vector<State> ifaces = {up("eth0")}) {
+    Lifecycle::Inputs in;
+    in.tun_dev                  = "tun0";
+    in.lwm2m_target_ip          = "192.168.1.10";
+    in.lwm2m_target_port        = 5684;
+    in.forward_ports            = {80, 443, 5684};
+    in.ifaces_in_priority_order = std::move(ifaces);
+    in.now_unix                 = 1748707200;  // 2026-05-31 00:00 UTC
+    return in;
+}
+
+} // namespace
+
+/* ─────────────── Init / NeedConfig ─────────────── */
+
+TEST(Lifecycle, EmptyTargetIpYieldsNeedConfigAndNoApplyAttempt) {
+    Capture cap;
+    Lifecycle lc(cap.make_sinks());
+
+    Lifecycle::Inputs in;
+    in.tun_dev = "tun0";   // target_ip deliberately empty
+    in.ifaces_in_priority_order = {up("eth0")};
+
+    EXPECT_EQ(Lifecycle::State::NeedConfig, lc.step(in));
+    EXPECT_TRUE(cap.nft_rulesets.empty());
+    EXPECT_TRUE(cap.route_calls.empty());
+    // Init → NeedConfig emits a state write.
+    ASSERT_EQ(1u, cap.state_writes.size());
+    EXPECT_EQ("need-config", cap.state_writes[0]);
+}
+
+/* ─────────────── First successful apply ─────────────── */
+
+TEST(Lifecycle, FirstStepAppliesNftAndRoutesAndReachesSteady) {
+    Capture cap;
+    Lifecycle lc(cap.make_sinks());
+
+    auto rc = lc.step(configured());
+
+    EXPECT_EQ(Lifecycle::State::Steady, rc);
+    EXPECT_EQ(1u, cap.nft_rulesets.size());
+    EXPECT_EQ(1u, cap.route_calls.size());
+    EXPECT_EQ(1u, lc.apply_count());
+
+    // Ruleset must come from nft::build_nft_ruleset — sanity check
+    // a couple of substrings the generator always emits.
+    const auto& rs = cap.nft_rulesets[0];
+    EXPECT_NE(std::string::npos, rs.find("flush table inet iot_router"));
+    EXPECT_NE(std::string::npos, rs.find("dnat to 192.168.1.10:80"));
+
+    ASSERT_EQ(1u, cap.rules_applied_count_writes.size());
+    EXPECT_EQ(1u, cap.rules_applied_count_writes[0]);
+    ASSERT_EQ(1u, cap.last_apply_unix_writes.size());
+    EXPECT_EQ(1748707200u, cap.last_apply_unix_writes[0]);
+
+    ASSERT_EQ(1u, cap.iface_writes.size());
+    EXPECT_EQ("eth0", cap.iface_writes[0]);
+    ASSERT_EQ(1u, cap.state_writes.size());
+    EXPECT_EQ("steady", cap.state_writes[0]);
+}
+
+TEST(Lifecycle, IdenticalSecondStepDoesNotReApplyNft) {
+    Capture cap;
+    Lifecycle lc(cap.make_sinks());
+
+    lc.step(configured());
+    lc.step(configured());          // no change
+
+    EXPECT_EQ(1u, cap.nft_rulesets.size());          // still 1
+    EXPECT_EQ(1u, cap.rules_applied_count_writes.size());
+    EXPECT_EQ(2u, cap.route_calls.size());           // routes always run
+    EXPECT_EQ(1u, lc.apply_count());
+    // Steady → Steady: no extra state write.
+    EXPECT_EQ(1u, cap.state_writes.size());
+}
+
+TEST(Lifecycle, ForwardPortsChangeTriggersReapply) {
+    Capture cap;
+    Lifecycle lc(cap.make_sinks());
+
+    lc.step(configured());
+    auto in2 = configured();
+    in2.forward_ports = {80, 443, 5684, 8883};   // added 8883
+    lc.step(in2);
+
+    EXPECT_EQ(2u, cap.nft_rulesets.size());
+    EXPECT_NE(std::string::npos,
+              cap.nft_rulesets[1].find("dnat to 192.168.1.10:8883"));
+    EXPECT_EQ(2u, lc.apply_count());
+}
+
+/* ─────────────── pick_active interface tracking ─────────────── */
+
+TEST(Lifecycle, IfaceFlipFromEthToWlanWritesNewActive) {
+    Capture cap;
+    Lifecycle lc(cap.make_sinks());
+
+    // eth up, wlan up — priority picks eth0
+    lc.step(configured({up("eth0"), up("wlan0")}));
+    EXPECT_EQ("eth0", lc.last_iface());
+
+    // eth goes down — should flip to wlan
+    lc.step(configured({down("eth0"), up("wlan0")}));
+    EXPECT_EQ("wlan0", lc.last_iface());
+
+    ASSERT_EQ(2u, cap.iface_writes.size());
+    EXPECT_EQ("eth0",  cap.iface_writes[0]);
+    EXPECT_EQ("wlan0", cap.iface_writes[1]);
+}
+
+TEST(Lifecycle, AllIfacesDownEmitsEmptyActive) {
+    Capture cap;
+    Lifecycle lc(cap.make_sinks());
+
+    lc.step(configured({up("eth0")}));
+    lc.step(configured({down("eth0")}));
+
+    ASSERT_EQ(2u, cap.iface_writes.size());
+    EXPECT_EQ("eth0", cap.iface_writes[0]);
+    EXPECT_EQ("",     cap.iface_writes[1]);   // operator signal: offline
+}
+
+/* ─────────────── Failure + recovery ─────────────── */
+
+TEST(Lifecycle, NftFailureTransitionsToFailedWithoutBumpingCount) {
+    Capture cap;
+    cap.nft_ok  = false;
+    cap.nft_err = "iot-router:7: invalid type";
+    Lifecycle lc(cap.make_sinks());
+
+    auto rc = lc.step(configured());
+    EXPECT_EQ(Lifecycle::State::Failed, rc);
+    EXPECT_EQ(0u, lc.apply_count());            // no count bump
+    EXPECT_TRUE(cap.rules_applied_count_writes.empty());
+    // last_ruleset stays empty so the next clean tick will re-apply.
+    EXPECT_TRUE(lc.last_ruleset().empty());
+    ASSERT_EQ(1u, cap.state_writes.size());
+    EXPECT_EQ("failed", cap.state_writes[0]);
+}
+
+TEST(Lifecycle, RouteFailureAloneTransitionsToFailed) {
+    Capture cap;
+    cap.routes_ok = false;
+    Lifecycle lc(cap.make_sinks());
+    auto rc = lc.step(configured());
+    EXPECT_EQ(Lifecycle::State::Failed, rc);
+    // nft side still succeeded → ruleset is recorded so we don't
+    // re-apply it on the next tick.
+    EXPECT_EQ(1u, lc.apply_count());
+}
+
+TEST(Lifecycle, FailedToSteadyEmitsSteadyStateWrite) {
+    Capture cap;
+    cap.nft_ok = false;
+    Lifecycle lc(cap.make_sinks());
+
+    lc.step(configured());     // → Failed
+    cap.nft_ok = true;
+    lc.step(configured());     // → Steady (re-applies)
+
+    ASSERT_GE(cap.state_writes.size(), 2u);
+    EXPECT_EQ("failed", cap.state_writes[0]);
+    EXPECT_EQ("steady", cap.state_writes[1]);
+    EXPECT_EQ(1u, lc.apply_count());
+}
+
+/* ─────────────── state_name helper ─────────────── */
+
+TEST(Lifecycle, StateNameRoundTrip) {
+    EXPECT_STREQ("init",        Lifecycle::state_name(Lifecycle::State::Init));
+    EXPECT_STREQ("need-config", Lifecycle::state_name(Lifecycle::State::NeedConfig));
+    EXPECT_STREQ("steady",      Lifecycle::state_name(Lifecycle::State::Steady));
+    EXPECT_STREQ("failed",      Lifecycle::state_name(Lifecycle::State::Failed));
+}


### PR DESCRIPTION
## Summary
- `apply.hpp/cpp` — `NftApply = function<bool(ruleset, *err)>` callable type. `default_nft_apply(path)` writes the ruleset to a tempfile in `\$TMPDIR`/`/tmp` (same fallback chain as L12/D5), invokes `<path> -f <tempfile> 2>&1` through popen, captures combined output for parser-error diagnostics, unlinks the tempfile.
- `lifecycle.hpp/cpp` — pure FSM mirroring openvpn-client's Sinks pattern. States `Init → NeedConfig → Steady → Failed` with recovery. `step(Inputs)` only re-applies the nft ruleset when the rendered text changes; routes apply every tick (kernel makes `ip route replace` a no-op when target == current). pick_active drives `net.iface.active` writes (empty string = offline).
- Sinks-based design means the daemon (D7) wires `apply_nft` → `default_nft_apply`, `apply_routes` → closure over `route::apply_priorities`, and the `set_*` writers → DsBridge setters — no further refactor needed.

## Test plan
- [x] 50/50 tests passing under podman dev image (15 new on top of 35).
- [x] `apply_test` exercises the real popen+tempfile path with a per-test fake-nft shell script — covers success, non-zero exit + stderr capture, missing-binary, null-err tolerance, tempfile cleanup.
- [x] `lifecycle_test` covers 10 scenarios: NeedConfig gate, first apply, no-op repeat, forward_ports change, eth→wlan flip, all-down, nft failure (no count bump), route failure alone, Failed → Steady recovery, state_name round-trip.
- [ ] Manual smoke on a Linux host once D7 wires the daemon to an ACE_Reactor tick + ds-server connection.

## Notes
- D7 (systemd unit + IOT_ROLE=net + nftables apt-install in both images + apps/CMakeLists.txt add_subdirectory) is all that remains for L13.
- Kept the FSM stateless w.r.t. ds-server connectivity — DsBridge connection liveness is the daemon's concern, the Lifecycle just consumes a snapshot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)