### PR TITLE
L13/D7: net-router daemon mode + packaging integration (closes L13)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -41,6 +41,11 @@ client can connect to ds-server's unix socket:
 podman volume create iot-run
 podman run -d --name iot-ds     -e IOT_ROLE=ds     -v iot-run:/run/iot iot:l11
 podman run -d --name iot-client -e IOT_ROLE=client -v iot-run:/run/iot iot:l11
+# Optional: net-router for nftables DNAT into the local lwm2m client.
+# --network=host so the daemon sees the host's ifaces + applies nft
+# rules in the host's network namespace.
+podman run -d --name iot-net --cap-add=NET_ADMIN --network=host \
+    -e IOT_ROLE=net -v iot-run:/run/iot iot:l11
 ```
 
 For the server role (Bootstrap + DM), substitute `IOT_ROLE=server` and
@@ -179,6 +184,27 @@ journalctl -u iot-openvpn-client.service -f | grep "PUSH_REPLY\|state"
 The unit ships with `AmbientCapabilities=CAP_NET_ADMIN` +
 `DeviceAllow=/dev/net/tun rw` so openvpn(8) can create the TUN
 device + write routes under DynamicUser — no `root` required.
+
+For the **net-router** unit (L13: nftables DNAT + iface priority),
+seed the only required key and enable:
+
+```sh
+ds-cli --socket=/run/iot/data_store.sock set net.lwm2m.target_ip '"192.168.10.5"'
+# Optional: rename per-class iface keys to match your host
+ds-cli --socket=/run/iot/data_store.sock set net.iface.eth.name      '"eth0"'
+ds-cli --socket=/run/iot/data_store.sock set net.iface.wifi.name     '"wlan0"'
+ds-cli --socket=/run/iot/data_store.sock set net.iface.cellular.name '"wwan0"'
+
+sudo systemctl enable --now iot-net-router.service
+journalctl -u iot-net-router.service -f | grep "ruleset applied\|metric\|active"
+```
+
+The unit ships with `AmbientCapabilities=CAP_NET_ADMIN`; that's
+enough for `nft -f` and `ip route replace` under DynamicUser. Default
+forwarded ports are `80,443,5684` (HTTP/HTTPS + LwM2M/CoAP-over-DTLS)
+DNAT'd to `net.lwm2m.target_ip`. Override via `net.forward.ports`
+and add operator drops/forwards via the JSON `net.custom_rules`
+schema key (see `/etc/iot/ds-schemas/net.lua`).
 
 ### 4. Same ds-cli tuning as the container path
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -59,6 +59,12 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/openvpn/client
                  ${CMAKE_BINARY_DIR}/openvpn-client)
 
+# net-router daemon (L13). Sibling under ../modules/net/router.
+# Brings the net-router binary + net.lua schema into the same install
+# tree as everything else.
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/net/router
+                 ${CMAKE_BINARY_DIR}/net-router)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store/inc)
 
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)
@@ -105,6 +111,7 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-lwm2m-client.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-lwm2m-server.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-openvpn-client.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-net-router.service
             DESTINATION lib/systemd/system)
 
     # tmpfiles.d fallback for hosts where RuntimeDirectory= doesn't
@@ -125,6 +132,7 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/lwm2m-client.env
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/lwm2m-server.env
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/openvpn-client.env
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/net-router.env
             DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot)
 
     # Object-resource config templates. Land each .lua as .lua.example

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,12 @@
 FROM ubuntu:jammy
-# Build deps (gcc/g++/etc.) + dev-side runtime deps (openvpn(8) — the
-# openvpn-client daemon spawns it; netcat-openbsd for the L12 fake-
-# openvpn smoke harness). Neither is a link-time dep, just runtime.
+# Build deps (gcc/g++/etc.) + dev-side runtime deps:
+#   openvpn(8) — the openvpn-client daemon spawns it
+#   netcat-openbsd — L12 fake-openvpn smoke harness
+#   nftables + iproute2 — the net-router daemon shells out to nft + ip
+# None of them are link-time deps, just runtime.
 RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev python3-dev autoconf wget pkg-config \
-                       openvpn netcat-openbsd
+                       openvpn netcat-openbsd nftables iproute2
 
 # ACE/TAO 7.0.0 — same install prefix as the xpmile project so the include
 # / link paths in apps/CMakeLists.txt resolve. `ssl=1` is load-bearing; without

--- a/modules/net/router/CMakeLists.txt
+++ b/modules/net/router/CMakeLists.txt
@@ -33,6 +33,7 @@ link_directories(${ACE_ROOT}/lib)
 # ip_route/iface_monitor/apply.
 add_library(net_router_lib STATIC
     src/main_impl.cpp
+    src/daemon.cpp
     src/ds_bridge.cpp
     src/nft_rules.cpp
     src/shell.cpp

--- a/modules/net/router/docs/design.md
+++ b/modules/net/router/docs/design.md
@@ -1,10 +1,10 @@
 # net-router — module design (L13)
 
-> **Status (2026-05-31):** D1–D6 landed (schema, scaffold, DsBridge,
-> nft_rules generator, ip_route + iface_monitor, lifecycle FSM +
-> `nft -f` apply wrapper). D7 (packaging: systemd unit, IOT_ROLE=net,
-> apt-install nftables in both images, apps/CMakeLists.txt
-> add_subdirectory) remains.
+> **Status (2026-05-31):** L13 complete (D1–D7). The daemon wires
+> DsBridge + iface_monitor + ip_route + apply + Lifecycle behind a
+> simple poll loop, ships as `iot-net-router.service` (systemd) and
+> `IOT_ROLE=net` (container). nftables + iproute2 are now in both
+> the dev image and the runtime image.
 
 ## What this module is
 
@@ -84,7 +84,8 @@ modules/net/router/
 │   ├── ip_route.{hpp,cpp}      `ip route replace` metric writer — D5
 │   ├── iface_monitor.{hpp,cpp} `ip -j link/route show` parser — D5
 │   ├── apply.{hpp,cpp}         tempfile + `nft -f` apply wrapper — D6
-│   └── lifecycle.{hpp,cpp}     pure FSM: Sinks + Inputs → step() — D6
+│   ├── lifecycle.{hpp,cpp}     pure FSM: Sinks + Inputs → step() — D6
+│   └── daemon.cpp              run_daemon() — poll loop, signals — D7
 ├── schemas/net.lua
 ├── test/
 │   ├── ds_bridge_test.cpp      D3

--- a/modules/net/router/inc/router.hpp
+++ b/modules/net/router/inc/router.hpp
@@ -26,6 +26,15 @@ struct Status {
 /// privileged.
 Status v0_dump_net_keys(const std::string& socketPath);
 
+/// Daemon mode: connect to ds-server, build a Lifecycle wiring
+/// nft apply + ip route + DsBridge writers, then tick every
+/// `poll_interval_sec_override` seconds (0 = use net.poll.interval_sec
+/// from ds, falls back to 5s). Returns when SIGTERM/SIGINT fires
+/// (g_run flag flipped by signal handler) or a fatal error happens.
+Status run_daemon(const std::string& socketPath,
+                  const std::string& nft_path,
+                  unsigned           poll_interval_sec_override = 0);
+
 } // namespace net_router
 
 #endif /* __net_router_router_hpp__ */

--- a/modules/net/router/src/daemon.cpp
+++ b/modules/net/router/src/daemon.cpp
@@ -1,0 +1,209 @@
+/// run_daemon() — wires DsBridge + iface_monitor + ip_route + apply
+/// + Lifecycle into a simple poll loop. Mirrors openvpn-client's
+/// run_daemon (blocking loop, no ACE_Reactor) for the same reason:
+/// the tick is slow (seconds), the side effects are atomic shell-outs,
+/// no need for event-driven plumbing.
+
+#include "router.hpp"
+
+#include "apply.hpp"
+#include "ds_bridge.hpp"
+#include "iface_monitor.hpp"
+#include "ip_route.hpp"
+#include "lifecycle.hpp"
+#include "nft_rules.hpp"
+#include "shell.hpp"
+
+#include <atomic>
+#include <chrono>
+#include <csignal>
+#include <ctime>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+
+namespace net_router {
+
+namespace {
+
+std::atomic_bool g_run{true};
+
+void signal_handler(int) { g_run.store(false); }
+
+void install_signals() {
+    struct sigaction sa{};
+    sa.sa_handler = signal_handler;
+    sigemptyset(&sa.sa_mask);
+    sa.sa_flags = 0;
+    ::sigaction(SIGTERM, &sa, nullptr);
+    ::sigaction(SIGINT,  &sa, nullptr);
+    // SIGPIPE: ignore — popen()/shell-outs can fire it under stress.
+    struct sigaction ig{};
+    ig.sa_handler = SIG_IGN;
+    ::sigaction(SIGPIPE, &ig, nullptr);
+}
+
+/// Walk net.iface.priority ("eth,wifi,cellular") + the per-slot
+/// name keys to produce the ordered iface name list. Slots whose
+/// name key is unset or whose tag isn't in {eth,wifi,cellular} are
+/// silently dropped — Lifecycle handles an empty list as "nothing
+/// up".
+std::vector<std::string>
+ordered_iface_names(const DsBridge& ds) {
+    const std::string prio = ds.iface_priority().value_or("eth,wifi,cellular");
+    auto eth  = ds.iface_eth_name();
+    auto wifi = ds.iface_wifi_name();
+    auto cell = ds.iface_cellular_name();
+
+    std::vector<std::string> out;
+    std::stringstream ss(prio);
+    std::string tag;
+    while (std::getline(ss, tag, ',')) {
+        // Strip surrounding whitespace.
+        while (!tag.empty() && std::isspace(static_cast<unsigned char>(tag.front()))) tag.erase(tag.begin());
+        while (!tag.empty() && std::isspace(static_cast<unsigned char>(tag.back())))  tag.pop_back();
+        if      (tag == "eth"      && eth  && !eth->empty())  out.push_back(*eth);
+        else if (tag == "wifi"     && wifi && !wifi->empty()) out.push_back(*wifi);
+        else if (tag == "cellular" && cell && !cell->empty()) out.push_back(*cell);
+    }
+    return out;
+}
+
+Lifecycle::Inputs snapshot_inputs(const DsBridge&                         ds,
+                                  const std::vector<iface::State>&        ifaces) {
+    Lifecycle::Inputs in;
+    in.tun_dev             = ds.tun_dev().value_or("");
+    in.lwm2m_target_ip     = ds.lwm2m_target_ip().value_or("");
+    in.lwm2m_target_port   = ds.lwm2m_target_port().value_or(0);
+    in.forward_ports       = nft::parse_forward_ports(
+                                  ds.forward_ports().value_or("80,443,5684"));
+    {
+        std::string err;
+        in.custom_rules = nft::parse_custom_rules(
+                              ds.custom_rules().value_or(""), &err);
+        if (!err.empty()) {
+            ACE_DEBUG((LM_WARNING,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l net.custom_rules parse "
+                                "error (keeping previous): %C\n"),
+                       err.c_str()));
+        }
+    }
+    in.ifaces_in_priority_order = ifaces;
+    in.now_unix = static_cast<std::uint32_t>(std::time(nullptr));
+    return in;
+}
+
+} // namespace
+
+Status run_daemon(const std::string& socketPath,
+                  const std::string& nft_path,
+                  unsigned           poll_interval_sec_override) {
+    DsBridge ds(socketPath);
+    if (!ds.connected()) {
+        Status s; s.ok = false; s.code = 1;
+        s.err = "data-store connect failed"; return s;
+    }
+    if (auto missing = ds.missing_required()) {
+        std::ostringstream joined;
+        for (std::size_t i = 0; i < missing->size(); ++i) {
+            if (i) joined << ", ";
+            joined << (*missing)[i];
+        }
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D [netr:%t] %M %N:%l refuse to start; "
+                            "required keys missing: %C\n"),
+                   joined.str().c_str()));
+        Status s; s.ok = false; s.code = 2;
+        s.err = "missing required net.* keys"; return s;
+    }
+
+    install_signals();
+
+    // Build sinks. Shell + apply runners use the popen()-backed
+    // defaults from D5/D6. The Lifecycle never sees a syscall directly.
+    auto shell_runner = shell::default_runner();
+    auto nft_apply    = apply::default_nft_apply(nft_path);
+
+    Lifecycle::Sinks sinks;
+    sinks.apply_nft = [&nft_apply](const std::string& rs, std::string* err) {
+        bool ok = nft_apply(rs, err);
+        if (!ok) {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l nft apply FAILED: %C\n"),
+                       err && !err->empty() ? err->c_str() : "(no diag)"));
+        } else {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [netr:%t] %M %N:%l nft ruleset applied "
+                                "(%u bytes)\n"),
+                       static_cast<unsigned>(rs.size())));
+        }
+        return ok;
+    };
+    sinks.apply_routes = [&shell_runner](const std::vector<iface::State>& v) {
+        auto rr = route::apply_priorities(v, shell_runner);
+        for (const auto& step : rr.steps) {
+            if (step.applied) {
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D [netr:%t] %M %N:%l route: %C metric %u "
+                                    "applied\n"),
+                           step.iface.c_str(), step.metric));
+            } else if (!step.error.empty() && step.error != "iface not up") {
+                ACE_DEBUG((LM_WARNING,
+                           ACE_TEXT("%D [netr:%t] %M %N:%l route: %C metric %u "
+                                    "skipped: %C\n"),
+                           step.iface.c_str(), step.metric, step.error.c_str()));
+            }
+        }
+        return rr.all_ok;
+    };
+    sinks.set_state               = [&ds](const std::string& s) { ds.set_state(s); };
+    sinks.set_iface_active        = [&ds](const std::string& s) { ds.set_iface_active(s); };
+    sinks.set_rules_applied_count = [&ds](std::uint32_t n)      { ds.set_rules_applied_count(n); };
+    sinks.set_last_apply_unix     = [&ds](std::uint32_t t)      { ds.set_last_apply_unix(t); };
+
+    Lifecycle lc(std::move(sinks));
+
+    // DsBridge::on_change is a hint — we don't act inside the callback
+    // (it fires on the watch-thread). We just flip a flag so the next
+    // tick happens immediately instead of after the full poll interval.
+    std::atomic_bool wake{false};
+    ds.on_change([&wake](DsBridge::Key) { wake.store(true); });
+
+    const auto names = ordered_iface_names(ds);
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [netr:%t] %M %N:%l daemon up; priority ifaces: "
+                        "%C (%u entries)\n"),
+               names.empty() ? "(none)" : names.front().c_str(),
+               static_cast<unsigned>(names.size())));
+
+    while (g_run.load()) {
+        const auto ifaces = iface::probe_all(names, shell_runner);
+        auto in = snapshot_inputs(ds, ifaces);
+        lc.step(in);
+
+        // Sleep interval: override (CLI) > ds key > 5s. Re-read every
+        // tick so an operator's `ds-cli set net.poll.interval_sec` lands
+        // without a restart.
+        unsigned interval = poll_interval_sec_override
+                          ? poll_interval_sec_override
+                          : ds.poll_interval_sec().value_or(5);
+        if (interval < 1) interval = 1;
+
+        // Short-sleep loop so SIGTERM + on_change wake reasonably fast.
+        for (unsigned slept = 0; slept < interval && g_run.load(); ++slept) {
+            if (wake.exchange(false)) break;
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+        }
+    }
+
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [netr:%t] %M %N:%l SIGTERM/SIGINT received; "
+                        "exiting cleanly\n")));
+    ds.set_state("stopped");
+    return {};
+}
+
+} // namespace net_router

--- a/modules/net/router/src/main.cpp
+++ b/modules/net/router/src/main.cpp
@@ -1,13 +1,10 @@
-/// net-router — daemon entry (L13/D2 scaffold).
+/// net-router — daemon entry.
 ///
-/// Usage:
-///   net-router [--ds-sock=PATH] [--dump] [--help]
+/// Modes:
+///   --dump            snapshot net.* and exit (default with no other mode)
+///   --daemon          run the FSM loop forever (systemd unit uses this)
 ///
-/// Today (D2 scaffold): connects to ds-server, dumps every known
-/// net.* key (whether set or unset), warns if net.lwm2m.target_ip
-/// is missing, exits. D3..D7 add the DsBridge, nftables rule
-/// generator, ip route metrics, iface monitor, and the
-/// IOT_ROLE=net systemd integration.
+/// All other args are wiring (socket path, nft binary, poll override).
 
 #include <cstdlib>
 #include <iostream>
@@ -19,25 +16,37 @@ namespace {
 
 void usage() {
     std::cout <<
-        "net-router (L13/D2 scaffold)\n"
+        "net-router\n"
         "\n"
-        "Usage: net-router [--ds-sock=PATH] [--dump] [--help]\n"
+        "Usage: net-router [--ds-sock=PATH] [--nft=PATH] [--poll=SECS]\n"
+        "                  [--dump | --daemon] [--help]\n"
         "\n"
-        "  --ds-sock=PATH   ds-server unix socket; defaults to ds-server's\n"
-        "                   built-in default (/var/run/iot/data_store.sock).\n"
-        "  --dump           snapshot net.* and exit (current default).\n"
-        "  --help           show this and exit.\n";
+        "  --ds-sock=PATH  ds-server unix socket; defaults to ds-server's\n"
+        "                  built-in default (/var/run/iot/data_store.sock).\n"
+        "  --nft=PATH      nft(8) binary path (default: \"nft\" via $PATH).\n"
+        "  --poll=SECS     override net.poll.interval_sec (default: use ds key).\n"
+        "  --dump          snapshot net.* and exit (default if no mode).\n"
+        "  --daemon        run the lifecycle FSM forever.\n"
+        "  --help          show this and exit.\n";
 }
+
+enum class Mode { Dump, Daemon };
 
 } // namespace
 
 int main(int argc, char** argv) {
     std::string sock;
+    std::string nft_path = "nft";
+    unsigned    poll     = 0;
+    Mode        mode     = Mode::Dump;
 
     for (int i = 1; i < argc; ++i) {
         std::string a = argv[i];
         if      (a.rfind("--ds-sock=", 0) == 0) sock = a.substr(10);
-        else if (a == "--dump")                 { /* default mode */ }
+        else if (a.rfind("--nft=", 0)     == 0) nft_path = a.substr(6);
+        else if (a.rfind("--poll=", 0)    == 0) poll = static_cast<unsigned>(std::stoul(a.substr(7)));
+        else if (a == "--dump")                 mode = Mode::Dump;
+        else if (a == "--daemon")               mode = Mode::Daemon;
         else if (a == "--help" || a == "-h")    { usage(); return 0; }
         else {
             std::cerr << "net-router: unknown argument '" << a << "'\n";
@@ -46,6 +55,8 @@ int main(int argc, char** argv) {
         }
     }
 
-    auto rs = net_router::v0_dump_net_keys(sock);
+    auto rs = (mode == Mode::Daemon)
+            ? net_router::run_daemon(sock, nft_path, poll)
+            : net_router::v0_dump_net_keys(sock);
     return rs.ok ? 0 : 1;
 }

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -56,21 +56,26 @@ RUN strip /staging/usr/bin/ds-server \
 FROM ubuntu:22.04 AS runtime
 
 # Runtime apt: libs the binaries link against per ldd, plus
-# openvpn(8) which `openvpn-client` spawns at /usr/sbin/openvpn.
+# openvpn(8) which `openvpn-client` spawns at /usr/sbin/openvpn,
+# plus nftables + iproute2 which `net-router` shells out to for
+# atomic ruleset apply (`nft -f -`) and metric writes
+# (`ip route replace …`).
 # --no-install-recommends keeps the layer small (openvpn alone pulls
 # ~6 MB; with recommends it'd drag in systemd, dnsmasq, etc.).
 #
-# Container-runtime caveat: openvpn(8) needs CAP_NET_ADMIN +
-# /dev/net/tun. Run with:
-#   podman run --cap-add=NET_ADMIN --device=/dev/net/tun ...
-# DEPLOY.md covers this in the operator walkthrough.
+# Container-runtime caveats:
+#   openvpn(8): CAP_NET_ADMIN + /dev/net/tun → --cap-add=NET_ADMIN --device=/dev/net/tun
+#   net-router: CAP_NET_ADMIN + host network namespace → --cap-add=NET_ADMIN --network=host
+# DEPLOY.md covers both in the operator walkthrough.
 RUN apt-get update -qq && \
     apt-get install -y --no-install-recommends -qq \
         libreadline8 \
         libssl3 \
         zlib1g \
         ca-certificates \
-        openvpn && \
+        openvpn \
+        nftables \
+        iproute2 && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* /usr/share/doc/* /usr/share/man/*
 
@@ -93,6 +98,7 @@ COPY --from=build /staging/usr/bin/ds-server       /usr/local/bin/
 COPY --from=build /staging/usr/bin/ds-cli          /usr/local/bin/
 COPY --from=build /staging/usr/bin/lwm2m           /usr/local/bin/
 COPY --from=build /staging/usr/bin/openvpn-client  /usr/local/bin/
+COPY --from=build /staging/usr/bin/net-router      /usr/local/bin/
 COPY --from=build /staging/etc/iot                 /etc/iot
 
 COPY packaging/iot-entrypoint.sh /usr/local/bin/iot-entrypoint

--- a/packaging/etc-iot/net-router.env
+++ b/packaging/etc-iot/net-router.env
@@ -1,0 +1,28 @@
+# EnvironmentFile for iot-net-router.service.
+#
+# NET_ROUTER_ARGS is the literal argv tail passed to
+# /usr/local/bin/net-router. The net.* policy keys
+# (net.lwm2m.target_ip, net.forward.ports, net.iface.{eth,wifi,cellular}.name,
+# net.iface.priority, net.custom_rules, …) come from ds-server via
+# ds-cli — see /etc/iot/ds-schemas/net.lua for the schema. This file
+# only carries process-level wiring (socket path, nft binary, poll
+# override).
+#
+# Hot-reloadable via ds-cli (preferred over editing this file):
+#   net.lwm2m.target_ip / net.forward.ports / net.custom_rules
+#   net.iface.priority / net.iface.{eth,wifi,cellular}.name
+#   net.poll.interval_sec
+#
+# Operator workflow (bare metal):
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now iot-net-router.service
+#   ds-cli set net.lwm2m.target_ip '"192.168.10.5"'
+#   ds-cli set net.iface.eth.name '"eth0"'
+#   ds-cli set net.iface.wifi.name '"wlan0"'
+#   journalctl -u iot-net-router.service -f
+#
+# Required runtime deps in the host image: nftables (for `nft`),
+# iproute2 (for `ip`). The Containerfile + docker/Dockerfile both
+# apt-install them.
+
+NET_ROUTER_ARGS="--daemon --ds-sock=/run/iot/data_store.sock --nft=/usr/sbin/nft"

--- a/packaging/iot-entrypoint.sh
+++ b/packaging/iot-entrypoint.sh
@@ -6,6 +6,8 @@
 #   IOT_ROLE=server  → run lwm2m role=server
 #   IOT_ROLE=ovpn    → run openvpn-client (needs --cap-add=NET_ADMIN
 #                       --device=/dev/net/tun on the podman run)
+#   IOT_ROLE=net     → run net-router (needs --cap-add=NET_ADMIN +
+#                       host's /proc/net visible; usually --network=host)
 #
 # Per-role default args live in /etc/iot/lwm2m-*.env (sourced via
 # . , so they end up as shell vars). Operators override by:
@@ -22,7 +24,7 @@ set -e
 # If the first arg is one of our binaries, forward verbatim — supports
 # `podman run iot:l11 ds-cli get foo`.
 case "${1:-}" in
-    ds-cli|ds-server|lwm2m|openvpn-client|openvpn)
+    ds-cli|ds-server|lwm2m|openvpn-client|openvpn|net-router|nft|ip)
         exec "$@"
         ;;
 esac
@@ -56,13 +58,20 @@ case "${IOT_ROLE:-}" in
         # shellcheck disable=SC2086
         exec /usr/local/bin/openvpn-client $OPENVPN_CLIENT_ARGS "$@"
         ;;
+    net)
+        # shellcheck disable=SC1091
+        [ -f /etc/iot/net-router.env ] && . /etc/iot/net-router.env
+        : "${NET_ROUTER_ARGS:?net-router.env missing NET_ROUTER_ARGS}"
+        # shellcheck disable=SC2086
+        exec /usr/local/bin/net-router $NET_ROUTER_ARGS "$@"
+        ;;
     "")
-        echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server | ovpn" >&2
-        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m / openvpn-client / openvpn" >&2
+        echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server | ovpn | net" >&2
+        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m / openvpn-client / openvpn / net-router / nft / ip" >&2
         exit 64
         ;;
     *)
-        echo "iot-entrypoint: unknown IOT_ROLE='$IOT_ROLE' (expected ds|client|server|ovpn)" >&2
+        echo "iot-entrypoint: unknown IOT_ROLE='$IOT_ROLE' (expected ds|client|server|ovpn|net)" >&2
         exit 64
         ;;
 esac

--- a/packaging/systemd/iot-net-router.service
+++ b/packaging/systemd/iot-net-router.service
@@ -1,0 +1,48 @@
+[Unit]
+Description=IoT net-router (nftables DNAT + iface priority manager, watches ds-server net.*)
+Documentation=file:///etc/iot/net-router.env
+Documentation=file:///usr/local/share/doc/iot/net-router-design.md
+# Needs ds-server up (DsBridge connects on startup). We also order
+# After iot-openvpn-client.service so the tun device exists by the
+# time we generate ruleset(s) that DNAT into it — openvpn(8) creates
+# tun0 from inside the openvpn-client unit, see L12 docs.
+After=network-online.target iot-ds.service iot-openvpn-client.service
+Wants=network-online.target iot-ds.service
+# Note: not `Requires=iot-openvpn-client.service` — net-router still
+# usefully runs on hosts without VPN (DNAT into the local lwm2m
+# client over a direct iface). Hard-requires would lock that out.
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/net-router.env
+ExecStart=/usr/local/bin/net-router $NET_ROUTER_ARGS
+
+# nftables apply + `ip route replace` both require CAP_NET_ADMIN.
+# DynamicUser=yes works with AmbientCapabilities on systemd 244+.
+# We drop everything else: even a compromised net-router can only
+# nat/route, not load modules, mount, ptrace, etc.
+DynamicUser=yes
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
+
+# Same RuntimeDirectory=iot as iot-ds.service so the daemon sees
+# the same /run/iot/data_store.sock socket file.
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- `run_daemon()` wires `DsBridge` + `iface_monitor` + `ip_route` + `apply` + `Lifecycle` into a simple blocking poll loop (same shape as openvpn-client). Re-uses every D3–D6 piece without further refactor.
- Signal handling: SIGTERM/SIGINT → graceful exit; SIGPIPE ignored. DsBridge `on_change` flips a wake flag so ds-cli edits land on the next tick.
- main.cpp gains `--daemon` / `--nft=` / `--poll=`; `--dump` stays the default for bring-up.
- Packaging:
  - `iot-net-router.service` — DynamicUser + `CAP_NET_ADMIN` (no /dev/net/tun needed). `After=iot-openvpn-client.service` so tun0 exists by the time we DNAT into it; `Wants=` ds only (router still useful without a VPN).
  - `net-router.env` carries process-level wiring; all policy keys come from ds-server.
  - Entrypoint adds `IOT_ROLE=net` + `net-router`/`nft`/`ip` to the whitelist.
  - Both `packaging/Containerfile` (runtime) and `docker/Dockerfile` (dev) apt-install `nftables` + `iproute2`.
  - `apps/CMakeLists.txt` `add_subdirectory(modules/net/router)` + install rules for the new service file + env file.
- `DEPLOY.md` operator walkthrough for container and bare-metal both.

## Test plan
- [x] `podman run … cmake … && make net-router && make net-router-tests && ./net-router-tests` → 50/50 passing
- [x] `./net-router --help` renders the new flag set
- [x] `./net-router --daemon --ds-sock=/nope/missing.sock` exits 1 with the missing-socket diagnostic
- [ ] Manual smoke on a Linux host with real ds-server + real nft: `systemctl start iot-net-router.service && ds-cli set net.lwm2m.target_ip '"…"' && journalctl -u iot-net-router.service -f | grep applied`
- [ ] Full apps-tree build verification (cmake apps && make install) — this PR's apps/CMakeLists.txt change mirrors L12's openvpn-client integration line-for-line, low risk but worth one CI pass

## Notes
- Closes L13 (D1–D7 complete).
- L13 plan's "outgoing iface priority via metric writes" lands without ip rule / fwmark complexity — just the metric on each iface's default route. Sufficient for the eth → wifi → cellular preference order; if a user later needs source-routing or per-app routing we can layer it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)