### PR TITLE
L14/D1: compose harness + fake openvpn + fake nft

### DIFF
--- a/log/L14/compose.sh
+++ b/log/L14/compose.sh
@@ -1,0 +1,154 @@
+#!/bin/sh
+# L14 — compose helpers for the full-stack smoke.
+#
+# Sourced by log/L14/smoke.sh. Exports image tags, pod/container
+# names, and host-side directory paths; provides compose_up and
+# compose_down functions that wrap stock `podman` calls so the
+# smoke doesn't need podman-compose / k8s tooling.
+#
+# Why hand-rolled instead of podman-compose.yml or `podman play kube`?
+# - One file, one tool dependency (stock podman), no Python wrapper.
+# - L12 prior art (log/L12/openvpn-smoke.sh) is also a flat shell
+#   script — same debugging surface.
+# - The fakes get bind-mounted in, so there's no Containerfile.l14
+#   layer to maintain.
+#
+# Bring-up plumbing:
+#   * One pod (POD_NAME) shares network + an emptyDir-style named
+#     volume (VOL_RUN) mounted at /run/iot across the four iot
+#     containers, so each daemon's DsBridge finds the ds-server
+#     socket at /run/iot/data_store.sock.
+#   * Fakes are bind-mounted read-only from FAKES_DIR; recorder dirs
+#     are bind-mounted read-write from RECORDER_DIR so the smoke
+#     can assert on what each daemon attempted.
+#   * Leshan ports (5683/5684 UDP web + 8080 TCP API) are exposed
+#     on the host via the pod's published ports.
+
+set -eu
+
+# ─────────────────────── config knobs ─────────────────────────
+IOT_IMAGE="${IOT_IMAGE:-localhost/iot:l14}"
+LESHAN_IMAGE="${LESHAN_IMAGE:-docker.io/dre/leshan-server-demo:latest}"
+POD_NAME="${POD_NAME:-iot-l14}"
+VOL_RUN="${VOL_RUN:-iot-l14-run}"
+
+# Host-side dirs. The smoke uses a per-run mktemp -d so reruns don't
+# stomp on each other; compose.sh just consumes whatever the caller
+# (smoke.sh) exports.
+: "${RUNDIR:?compose.sh expects RUNDIR exported by the caller}"
+FAKES_DIR="${FAKES_DIR:-$(cd "$(dirname "$0")/fakes" && pwd)}"
+RECORDER_DIR="${RECORDER_DIR:-$RUNDIR/recorder}"
+
+# Container names — short slugs so `podman logs iot-ds` reads nice.
+C_DS="iot-ds"
+C_LWM2M="iot-lwm2m"
+C_OVPN="iot-ovpn"
+C_NETR="iot-netr"
+C_LESHAN="iot-leshan"
+
+# ─────────────────────── helpers ──────────────────────────────
+
+# Build the iot image from the repo's Containerfile if absent. The
+# build is cached, so reruns are fast; the explicit pull/build keeps
+# the smoke self-contained.
+ensure_iot_image() {
+    if ! podman image exists "$IOT_IMAGE"; then
+        echo "compose: building $IOT_IMAGE (one-time)..."
+        podman build -f packaging/Containerfile -t "$IOT_IMAGE" .
+    fi
+}
+
+# Pre-pull leshan so the pod creation doesn't stall on a slow
+# registry round-trip mid-`podman run`.
+ensure_leshan_image() {
+    if ! podman image exists "$LESHAN_IMAGE"; then
+        echo "compose: pulling $LESHAN_IMAGE (one-time)..."
+        podman pull "$LESHAN_IMAGE"
+    fi
+}
+
+# Idempotent: removes a pre-existing pod with the same name + a
+# pre-existing named volume so re-runs start from a clean slate.
+_reset_pod() {
+    podman pod exists "$POD_NAME" && podman pod rm -f "$POD_NAME" >/dev/null
+    podman volume exists "$VOL_RUN" && podman volume rm "$VOL_RUN" >/dev/null
+    return 0
+}
+
+compose_up() {
+    ensure_iot_image
+    ensure_leshan_image
+    _reset_pod
+    mkdir -p "$RECORDER_DIR/ovpn" "$RECORDER_DIR/netr"
+
+    podman volume create "$VOL_RUN" >/dev/null
+
+    # Pod publishes leshan's UDP CoAP ports + its 8080 web API so the
+    # smoke can curl /api/clients from the host.
+    podman pod create \
+        --name "$POD_NAME" \
+        --publish 8080:8080/tcp \
+        --publish 5683:5683/udp \
+        --publish 5684:5684/udp \
+        >/dev/null
+
+    # ── ds-server ─────────────────────────────────────────────
+    podman run -d --pod "$POD_NAME" --name "$C_DS" \
+        -e IOT_ROLE=ds \
+        -v "$VOL_RUN:/run/iot" \
+        "$IOT_IMAGE" >/dev/null
+
+    # ── leshan (CoAP/LwM2M demo server) ───────────────────────
+    podman run -d --pod "$POD_NAME" --name "$C_LESHAN" \
+        "$LESHAN_IMAGE" >/dev/null
+
+    # ── lwm2m client ──────────────────────────────────────────
+    # IOT_ROLE=client → entrypoint reads /etc/iot/lwm2m-client.env
+    # for LWM2M_ARGS. Default endpoint comes from there; the smoke
+    # can override via ds-cli set iot.endpoint after boot.
+    podman run -d --pod "$POD_NAME" --name "$C_LWM2M" \
+        -e IOT_ROLE=client \
+        -v "$VOL_RUN:/run/iot" \
+        "$IOT_IMAGE" >/dev/null
+
+    # ── openvpn-client + fake openvpn ─────────────────────────
+    # Override OPENVPN_CLIENT_ARGS so the daemon spawns the bind-
+    # mounted fake instead of /usr/sbin/openvpn (which the runtime
+    # image has but which would need cert material + a real peer).
+    podman run -d --pod "$POD_NAME" --name "$C_OVPN" \
+        -e IOT_ROLE=ovpn \
+        -e OPENVPN_CLIENT_ARGS="--ds-sock=/run/iot/data_store.sock --openvpn=/fakes/fake-openvpn.sh" \
+        -e FAKE_RECORDER_DIR=/recorder \
+        -v "$VOL_RUN:/run/iot" \
+        -v "$FAKES_DIR:/fakes:ro" \
+        -v "$RECORDER_DIR/ovpn:/recorder:rw" \
+        "$IOT_IMAGE" >/dev/null
+
+    # ── net-router + fake nft ─────────────────────────────────
+    # Same override pattern: --nft= points at the recorder script.
+    # NET_ADMIN isn't strictly needed here because the fake never
+    # touches the kernel, but we add it so this command line stays
+    # identical to the production --nft=/usr/sbin/nft variant.
+    podman run -d --pod "$POD_NAME" --name "$C_NETR" \
+        --cap-add=NET_ADMIN \
+        -e IOT_ROLE=net \
+        -e NET_ROUTER_ARGS="--daemon --ds-sock=/run/iot/data_store.sock --nft=/fakes/fake-nft.sh --poll=2" \
+        -e FAKE_RECORDER_DIR=/recorder \
+        -v "$VOL_RUN:/run/iot" \
+        -v "$FAKES_DIR:/fakes:ro" \
+        -v "$RECORDER_DIR/netr:/recorder:rw" \
+        "$IOT_IMAGE" >/dev/null
+}
+
+compose_down() {
+    podman pod exists "$POD_NAME" && podman pod rm -f "$POD_NAME" >/dev/null
+    podman volume exists "$VOL_RUN" && podman volume rm "$VOL_RUN" >/dev/null
+    return 0
+}
+
+# Convenience: tail a container's logs through the pod boundary.
+# Used by smoke.sh's failure path.
+compose_logs() {
+    name="$1"
+    podman logs --tail 50 "$name" 2>&1 || true
+}

--- a/log/L14/fakes/fake-nft.sh
+++ b/log/L14/fakes/fake-nft.sh
@@ -1,0 +1,34 @@
+#!/bin/sh
+# Fake nft(8) for the L14 end-to-end smoke.
+#
+# net-router invokes `nft -f <tempfile>` via apply::default_nft_apply.
+# This script copies the tempfile to a host-visible recorder dir + exits
+# 0 so the daemon thinks the apply succeeded. The smoke later asserts
+# that the recorded ruleset contains the expected substrings (target IP,
+# DNAT for ports 80/443/5684, etc.).
+#
+# Same shape as the FakeNft used in modules/net/router/test/apply_test.cpp,
+# minus the per-test rc/stderr knobs — the smoke only exercises the
+# happy path.
+
+set -eu
+
+RECORDER_DIR="${FAKE_RECORDER_DIR:-/recorder}"
+mkdir -p "$RECORDER_DIR"
+
+# argv pattern: `nft -f <path>`. Anything else (e.g. `nft list table`)
+# is logged but otherwise ignored so a future smoke that lists tables
+# doesn't trip.
+if [ "${1:-}" = "-f" ] && [ -n "${2:-}" ]; then
+    cp "$2" "$RECORDER_DIR/last_ruleset.nft"
+    # Append-only history so a regression can scan every applied ruleset.
+    cat "$2" >> "$RECORDER_DIR/ruleset_history.nft"
+    printf '\n# --- apply %s ---\n' "$(date -u +%FT%TZ)" \
+        >> "$RECORDER_DIR/ruleset_history.nft"
+else
+    printf 'fake-nft: ignored argv:' >> "$RECORDER_DIR/fake-nft.log"
+    for a in "$@"; do printf ' %s' "$a"; done >> "$RECORDER_DIR/fake-nft.log"
+    printf '\n' >> "$RECORDER_DIR/fake-nft.log"
+fi
+
+exit 0

--- a/log/L14/fakes/fake-openvpn.sh
+++ b/log/L14/fakes/fake-openvpn.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# Fake openvpn(8) for the L14 end-to-end smoke.
+#
+# Adapted from log/L12/openvpn-smoke.sh's inline fake, with one
+# behaviour change: instead of replaying the canned mgmt stream
+# once and exiting, this fake stays alive until killed so the
+# openvpn-client daemon (running WITHOUT --once) sees a persistent
+# tunnel. The compose-up path runs openvpn-client as a service,
+# not a one-shot.
+#
+# argv we get from openvpn-client: --config /path/to/conf
+#                                   --management 127.0.0.1 <port>
+#                                   --daemon -- and friends
+# We only care about --management <addr> <port>.
+
+set -eu
+
+PORT=""
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --management) PORT="$3"; shift 3 ;;
+        *)            shift ;;
+    esac
+done
+
+if [ -z "$PORT" ]; then
+    echo "fake-openvpn: no --management <addr> <port> in argv" >&2
+    exit 64
+fi
+
+# Recorder: write our argv to a host-visible file so the smoke can
+# assert "openvpn-client really spawned us with the expected port".
+RECORDER_DIR="${FAKE_RECORDER_DIR:-/recorder}"
+mkdir -p "$RECORDER_DIR"
+printf 'invoked port=%s pid=%s at=%s\n' "$PORT" "$$" "$(date -u +%FT%TZ)" \
+    >> "$RECORDER_DIR/fake-openvpn.log"
+
+# Spool a canned mgmt stream into the mgmt-socket peer (openvpn-client).
+# nc -lN means "listen, exit when peer closes" — but we want this fake
+# to hang forever so the daemon's lifecycle stays in `running`. Use a
+# FIFO + tail -f to keep the listener pipe open after the canned
+# payload is drained.
+SPOOL=$(mktemp -u "${TMPDIR:-/tmp}/fake-ovpn-spool.XXXXXX")
+mkfifo "$SPOOL"
+trap 'rm -f "$SPOOL"' EXIT
+
+(
+    printf '>INFO:OpenVPN Management Interface Version 1 -- type help for more info\r\n'
+    sleep 0.1
+    printf '>STATE:1,CONNECTING,,,,,\r\n'
+    sleep 0.1
+    printf '>STATE:2,WAIT,,,,,\r\n'
+    sleep 0.1
+    printf '>STATE:3,AUTH,,,,,\r\n'
+    sleep 0.1
+    printf '>STATE:4,GET_CONFIG,,,,,\r\n'
+    sleep 0.1
+    printf '>PUSH_REPLY:dhcp-option DNS 1.1.1.1,route-gateway 10.8.0.1,ifconfig 10.8.0.99 255.255.255.0\r\n'
+    sleep 0.1
+    printf '>STATE:5,ASSIGN_IP,,10.8.0.99,,,,,\r\n'
+    sleep 0.1
+    printf '>STATE:6,CONNECTED,SUCCESS,10.8.0.99,vpn.example.com,1194,,\r\n'
+    # Stay open: tail -f /dev/null keeps the pipe alive so the listener
+    # nc doesn't EOF us out.
+    tail -f /dev/null
+) > "$SPOOL" &
+SPOOLER_PID=$!
+
+# Use nc-openbsd (which is what the dev/runtime image ships via
+# `netcat-openbsd`). -k = keep listening across peer disconnects.
+nc -lk 127.0.0.1 "$PORT" < "$SPOOL" &
+NC_PID=$!
+
+# Reap children on signal.
+trap 'kill $SPOOLER_PID $NC_PID 2>/dev/null || true; rm -f "$SPOOL"; exit 0' \
+    TERM INT HUP
+
+wait $NC_PID


### PR DESCRIPTION
## Summary
- **Tooling decision** (deferred from plan): hand-rolled \`podman\` orchestration, not podman-compose or \`podman play kube\`. Same shape as the L12 smoke (flat shell), one-tool dependency, no extra YAML to learn.
- \`log/L14/fakes/fake-openvpn.sh\` — adapted from the L12 inline fake; canned mgmt stream + stays alive (\`tail -f /dev/null\` feeding \`nc -lk\`) so openvpn-client running without \`--once\` sees a persistent tunnel. Records argv to a host-visible recorder file.
- \`log/L14/fakes/fake-nft.sh\` — mirrors the FakeNft from \`apply_test.cpp\`: copies the \`-f <tempfile>\` argument to \`last_ruleset.nft\` + appends to \`ruleset_history.nft\`, exits 0.
- \`log/L14/compose.sh\` — bring-up/teardown helpers plus image-ensure hooks. One pod, 5 containers (ds, lwm2m, ovpn, netr, leshan), shared \`/run/iot\` named volume so every DsBridge finds the socket. Leshan publishes 8080/tcp + 5683/5684 udp for the smoke to curl.

## Test plan
- [x] \`sh -n\` parse-check on all three scripts
- [ ] D2 (next PR) will exercise compose_up + compose_down end-to-end and assert on the recorder dirs + leshan registration

## Notes
- Skipping a derivative \`Containerfile.l14\` — fakes bind-mount in, avoiding a new image to maintain.
- \`NET_ADMIN\` cap on \`iot-netr\` isn't strictly needed (fake nft doesn't touch the kernel) but kept so the command line stays identical to production \`--nft=/usr/sbin/nft\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)