### PR TITLE
L16 — schema keys use '.' separator throughout

### DIFF
--- a/log/L16/plan.md
+++ b/log/L16/plan.md
@@ -25,17 +25,17 @@ existing gates. End state:
 ```
 operator                                                  ds-server
    │                                                          │
-   │  ds-cli svc disable openvpn-client                       │
+   │  ds-cli svc disable openvpn.client                       │
    ├─────────────────────────────────────────────────────────▶│
    │                                                          │
    │                                          changed event   │
    │   openvpn-client Supervisor◀─────────────────────────────┤
    │   - Gate flips closed                                    │
    │   - Active session: SIGTERM + reap openvpn(8)            │
-   │   - publish services.openvpn-client.state="disabled"     │
+   │   - publish services.openvpn.client.state="disabled"     │
    │   - WAN gate ignored while disabled                      │
    │                                                          │
-   │  ds-cli svc enable openvpn-client                        │
+   │  ds-cli svc enable openvpn.client                        │
    ├─────────────────────────────────────────────────────────▶│
    │                                                          │
    │   Supervisor◀────────────────────────────────────────────┤
@@ -76,9 +76,9 @@ Concretely, this phase delivers:
 - **RBAC.** Filesystem DAC on the ds-server socket is the only
   access control, identical to the existing get/set surface.
   Per-key ACL is FUP.
-- **Worker-internal granularity.** `services.wifi-client.enable`
+- **Worker-internal granularity.** `services.wifi.client.enable`
   toggles the whole wifi worker chain (wpa_supplicant + udhcpc);
-  there is no `services.wifi-client.dhcp.enable` sub-key in v1.
+  there is no `services.wifi.client.dhcp.enable` sub-key in v1.
 - **ds-server self-disable.** ds-server publishes
   `services.ds.state="running"` for uniformity but rejects
   `set services.ds.enable` — disabling the substrate via the
@@ -122,22 +122,22 @@ return {
     ["services.ds.uptime.sec"]             = { type = "integer", min = 0, default = 0 },
 
     -- net-router
-    ["services.net-router.enable"]         = { type = "boolean", default = true },
-    ["services.net-router.state"]          = { type = "string",  default = "running" },
+    ["services.net.router.enable"]         = { type = "boolean", default = true },
+    ["services.net.router.state"]          = { type = "string",  default = "running" },
 
     -- openvpn-client
-    ["services.openvpn-client.enable"]     = { type = "boolean", default = true },
-    ["services.openvpn-client.state"]      = { type = "string",  default = "running" },
+    ["services.openvpn.client.enable"]     = { type = "boolean", default = true },
+    ["services.openvpn.client.state"]      = { type = "string",  default = "running" },
 
     -- lwm2m-client / lwm2m-server
-    ["services.lwm2m-client.enable"]       = { type = "boolean", default = true },
-    ["services.lwm2m-client.state"]        = { type = "string",  default = "running" },
-    ["services.lwm2m-server.enable"]       = { type = "boolean", default = true },
-    ["services.lwm2m-server.state"]        = { type = "string",  default = "running" },
+    ["services.lwm2m.client.enable"]       = { type = "boolean", default = true },
+    ["services.lwm2m.client.state"]        = { type = "string",  default = "running" },
+    ["services.lwm2m.server.enable"]       = { type = "boolean", default = true },
+    ["services.lwm2m.server.state"]        = { type = "string",  default = "running" },
 
     -- wifi-client (lands when L15/D6 ships)
-    ["services.wifi-client.enable"]        = { type = "boolean", default = true },
-    ["services.wifi-client.state"]         = { type = "string",  default = "running" },
+    ["services.wifi.client.enable"]        = { type = "boolean", default = true },
+    ["services.wifi.client.state"]         = { type = "string",  default = "running" },
   },
 }
 ```
@@ -179,7 +179,7 @@ namespace data_store {
 /// other gates the Supervisor has: closed if ANY gate is closed.
 class ServiceGate {
 public:
-    explicit ServiceGate(Client& ds, std::string key); // "services.openvpn-client.enable"
+    explicit ServiceGate(Client& ds, std::string key); // "services.openvpn.client.enable"
 
     /// Snapshot the latest value (true on absent / default).
     bool enabled() const;
@@ -245,12 +245,12 @@ On `enable=false`:
 - Pause iface_monitor.
 - Run the full teardown: `nft delete table iot-fwd` (or whatever
   net-router owns), clear `net.iface.active=""`, publish
-  `services.net-router.state="disabled"`.
+  `services.net.router.state="disabled"`.
 - Stay parked in a `cv.wait` on the ServiceGate.
 
 On `enable=true`:
 - Re-prime the iface scan, re-create nft state, publish
-  `services.net-router.state="running"`.
+  `services.net.router.state="running"`.
 
 **Tests.** `net-router/test/supervisor_test.cpp::Services_disable_clears_active_iface`,
 `Services_reenable_restores_publishing`.
@@ -312,7 +312,7 @@ and D5b (server).
 
 ### D6 — wifi-client enable gate
 
-**Scope.** Wires `services.wifi-client.enable` into the
+**Scope.** Wires `services.wifi.client.enable` into the
 wifi-client Supervisor designed in L15/D6. Composes with the
 NetworkManager-conflict gate from L15/REQ-WIFI-022.
 
@@ -332,18 +332,18 @@ can enumerate the services row set without hardcoding it.
 $ ds-cli svc list
 NAME             ENABLE  STATE      UPTIME
 ds               n/a     running    1h12m
-net-router       true    running    1h12m
-openvpn-client   true    running    47m
-lwm2m-client     true    running    1h11m
-lwm2m-server     true    running    1h11m
-wifi-client      false   disabled   1h12m
+net.router       true    running    1h12m
+openvpn.client   true    running    47m
+lwm2m.client     true    running    1h11m
+lwm2m.server     true    running    1h11m
+wifi.client      false   disabled   1h12m
 
-$ ds-cli svc disable openvpn-client
+$ ds-cli svc disable openvpn.client
 ok
 
-$ ds-cli svc status openvpn-client
-services.openvpn-client.enable = true
-services.openvpn-client.state  = stopping
+$ ds-cli svc status openvpn.client
+services.openvpn.client.enable = true
+services.openvpn.client.state  = stopping
 ```
 
 `enable` `disable` `status` are thin wrappers over the existing
@@ -395,7 +395,7 @@ Candidate next phases (not committed):
 
 - **L17a — services dependency graph.** `services.<a>.depends_on`
   schema entries so disabling net-router auto-publishes a
-  `services.openvpn-client.gate.reason="dep_down"` instead of
+  `services.openvpn.client.gate.reason="dep_down"` instead of
   silently relying on the WAN gate to do the same thing.
 - **L17b — ephemeral disable.** `ds-cli svc disable --until-boot`
   → set into an in-memory overlay that doesn't persist to

--- a/log/L16/tdd.md
+++ b/log/L16/tdd.md
@@ -36,7 +36,7 @@ Out of scope for L16:
 - Cross-service dependency graph (FUP-L17a).
 - Boot-time vs ephemeral disable distinction (FUP-L17b).
 - Per-key ACL beyond filesystem DAC (FUP-L17c).
-- Sub-worker granularity (`services.wifi-client.dhcp.enable`).
+- Sub-worker granularity (`services.wifi.client.dhcp.enable`).
 
 ---
 
@@ -52,14 +52,14 @@ Out of scope for L16:
 | REQ-SVC-006   | `ServiceGate::publish_state(s)` MUST issue `Client::set("services.<name>.state", s)`; failures MUST be logged via `ACE_ERROR` and MUST NOT throw.                                                | M  | D1    |
 | REQ-SVC-007   | ds-server MUST publish `services.ds.state="running"` once its acceptor is up; MUST update `services.ds.uptime.sec` every 60 s via the same `ACE_Reactor` timer mechanism it uses today.         | M  | D2    |
 | REQ-SVC-008   | ds-server MUST reject `set services.ds.enable <any>` with `SchemaRejected`. The schema rejection path MUST be one of: (a) key omitted from `services.lua`, OR (b) explicit `readonly=true`.    | M  | D2    |
-| REQ-SVC-009   | net-router MUST honour `services.net-router.enable`. On `false`: stop iface_monitor, clear `net.iface.active=""`, run nft-teardown, publish `services.net-router.state="disabled"`.            | M  | D3    |
-| REQ-SVC-010   | net-router MUST restore full operation on `true`: re-spawn iface_monitor, re-install nft state, publish `services.net-router.state="running"`. Net effect MUST equal "fresh daemon start".      | M  | D3    |
-| REQ-SVC-011   | openvpn-client Supervisor MUST add a ServiceGate alongside the existing WAN gate. On `enable=false`: SIGTERM+reap the openvpn child within 5 s, publish `services.openvpn-client.state="disabled"`, set `vpn.gate.reason="disabled"`. | M | D4 |
+| REQ-SVC-009   | net-router MUST honour `services.net.router.enable`. On `false`: stop iface_monitor, clear `net.iface.active=""`, run nft-teardown, publish `services.net.router.state="disabled"`.            | M  | D3    |
+| REQ-SVC-010   | net-router MUST restore full operation on `true`: re-spawn iface_monitor, re-install nft state, publish `services.net.router.state="running"`. Net effect MUST equal "fresh daemon start".      | M  | D3    |
+| REQ-SVC-011   | openvpn-client Supervisor MUST add a ServiceGate alongside the existing WAN gate. On `enable=false`: SIGTERM+reap the openvpn child within 5 s, publish `services.openvpn.client.state="disabled"`, set `vpn.gate.reason="disabled"`. | M | D4 |
 | REQ-SVC-012   | openvpn-client gate composition MUST follow: `enable=false` dominates `wan_down`. `gate.reason="disabled"` when both are closed; never "wan_down" while disabled.                                | M  | D4    |
-| REQ-SVC-013   | openvpn-client `enable=true` while WAN-down MUST publish `services.openvpn-client.state="running"` (the daemon's idle-waiting-for-WAN state) and `vpn.gate.reason="wan_down"`. No openvpn child spawned. | M | D4 |
-| REQ-SVC-014   | lwm2m-client MUST honour `services.lwm2m-client.enable`. On `false` while registered: send Deregister, drop active observations, keep CoAP socket listening. On `true`: re-Register from scratch.    | M  | D5    |
-| REQ-SVC-015   | lwm2m-server MUST honour `services.lwm2m-server.enable`. On `false`: stop accepting new Register requests, drop active-registrations map, keep listening socket. On `true`: accept new Registers.    | M  | D5    |
-| REQ-SVC-016   | wifi-client Supervisor MUST add a ServiceGate. On `enable=false`: SIGTERM+reap wpa_supplicant + udhcpc, publish `wifi.assoc.state="disconnected"` + `services.wifi-client.state="disabled"`. Depends on L15/D6. | M | D6 |
+| REQ-SVC-013   | openvpn-client `enable=true` while WAN-down MUST publish `services.openvpn.client.state="running"` (the daemon's idle-waiting-for-WAN state) and `vpn.gate.reason="wan_down"`. No openvpn child spawned. | M | D4 |
+| REQ-SVC-014   | lwm2m-client MUST honour `services.lwm2m.client.enable`. On `false` while registered: send Deregister, drop active observations, keep CoAP socket listening. On `true`: re-Register from scratch.    | M  | D5    |
+| REQ-SVC-015   | lwm2m-server MUST honour `services.lwm2m.server.enable`. On `false`: stop accepting new Register requests, drop active-registrations map, keep listening socket. On `true`: accept new Registers.    | M  | D5    |
+| REQ-SVC-016   | wifi-client Supervisor MUST add a ServiceGate. On `enable=false`: SIGTERM+reap wpa_supplicant + udhcpc, publish `wifi.assoc.state="disconnected"` + `services.wifi.client.state="disabled"`. Depends on L15/D6. | M | D6 |
 | REQ-SVC-017   | wifi-client gate composition MUST follow: `enable=false` dominates the NM-conflict gate. `state="disabled"` takes precedence over `state="conflict"`.                                            | M  | D6    |
 | REQ-SVC-018   | ds-cli MUST gain `svc <verb>` subcommands: `list`, `enable <name>`, `disable <name>`, `status <name>`. Unknown verb MUST exit non-zero with usage on stderr.                                     | M  | D7    |
 | REQ-SVC-019   | `ds-cli svc list` MUST enumerate every `services.*.enable` row + matching `.state` + uptime if present. Order MUST be deterministic (alphabetical by name).                                       | M  | D7    |


### PR DESCRIPTION
## Summary
Aligns the L16 plan + TDD with the existing iot schema convention: keys use `.` separators only, no `_` or `-` (matches `vpn.remote.host`, `net.iface.active`, `wifi.assoc.state`, `iot.server.uri`).

Schema key renames:
- `services.openvpn-client.*` → `services.openvpn.client.*`
- `services.wifi-client.*` → `services.wifi.client.*`
- `services.net-router.*` → `services.net.router.*`
- `services.lwm2m-client.*` → `services.lwm2m.client.*`
- `services.lwm2m-server.*` → `services.lwm2m.server.*`

The `ds-cli svc enable/disable/status <name>` argument and the `svc list` NAME column move with the schema (they're derived from the key middle segment). Module names ("openvpn-client Supervisor"), systemd unit filenames, and binary paths keep `-` — those aren't schema.

## Test plan
- [x] `grep 'services\.\(openvpn-client\|wifi-client\|net-router\|lwm2m-client\|lwm2m-server\)'` returns zero hits across both files
- [x] All 28 dotted occurrences land in the new form (20 in plan.md, 8 in tdd.md)
- [x] No incidental changes to module / unit / binary names

🤖 Generated with [Claude Code](https://claude.com/claude-code)