### PR TITLE
feat(wifi-client): L15/D1 — module scaffold + CLI + --dump keylist

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,6 +36,7 @@
 apps/build/
 modules/*/build/
 modules/*/*/build/
+modules/*/*/*/build/
 
 # tinydtls autoconf output (regenerated on every build)
 apps/3rdparty/tinydtls/Makefile

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -65,6 +65,13 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/openvpn/client
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/net/router
                  ${CMAKE_BINARY_DIR}/net-router)
 
+# wifi-client daemon (L15). Sibling under ../modules/wan/wifi/client.
+# Owns the wpa_supplicant(8) + DHCP client lifecycle for one wifi
+# iface; publishes wifi.* state into ds-server. Standalone module
+# build at modules/wan/wifi/client/ still works.
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/wan/wifi/client
+                 ${CMAKE_BINARY_DIR}/wifi-client)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store/inc)
 
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)

--- a/modules/wan/wifi/client/CMakeLists.txt
+++ b/modules/wan/wifi/client/CMakeLists.txt
@@ -1,0 +1,77 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(wifi_client CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# ACE_TAO install prefix — same idiom as data-store + openvpn-client cmake.
+if(NOT DEFINED ACE_ROOT)
+    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
+endif()
+
+set(WIFI_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+# Pull in the sibling data-store module so we get libdatastore_client +
+# its public headers. Same pattern openvpn-client uses. Skip the re-add
+# if a parent project has already added data-store.
+if(NOT TARGET datastore_client)
+    add_subdirectory(${WIFI_MODULE_DIR}/../../../data-store
+                     ${CMAKE_BINARY_DIR}/data-store)
+endif()
+
+include_directories(
+    ${WIFI_MODULE_DIR}/inc
+    ${WIFI_MODULE_DIR}/../../../data-store/inc
+    ${ACE_ROOT}/include
+)
+
+link_directories(${ACE_ROOT}/lib)
+
+# Internal lib so test targets can link the same code the binary uses.
+# D1 ships only main_impl; D3..D6 add ds_bridge, ctrl, process, lifecycle,
+# supervisor as their phases land.
+add_library(wifi_client_lib STATIC
+    src/main_impl.cpp)
+
+target_include_directories(wifi_client_lib PUBLIC src)
+
+target_link_libraries(wifi_client_lib
+    PUBLIC datastore_client ACE pthread)
+
+add_executable(wifi-client src/main.cpp)
+target_link_libraries(wifi-client PRIVATE wifi_client_lib)
+
+# ─────────────────────────── Tests ─────────────────────────────
+# Light unit tests for the bits of wifi_client that don't need a live
+# ds-server or a real wpa_supplicant. Smoke against fake-wpa.sh +
+# real ds-server lives at log/L15/smoke.sh.
+option(BUILD_WIFI_CLIENT_TESTS "Build wifi-client gtest suite" OFF)
+if(BUILD_WIFI_CLIENT_TESTS)
+    find_package(GTest REQUIRED)
+    enable_testing()
+
+    add_executable(wifi-client-tests
+        test/main_test.cpp)
+
+    target_link_libraries(wifi-client-tests
+        wifi_client_lib
+        GTest::gtest_main
+        GTest::gtest)
+
+    add_test(NAME wifi-client-tests COMMAND wifi-client-tests)
+endif()
+
+# Install rule. Skip if IOT_PACKAGING_INSTALL is OFF (set by parent
+# apps/CMakeLists.txt for dev builds that shouldn't touch /etc/iot).
+include(GNUInstallDirs)
+if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+    install(TARGETS wifi-client
+            RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    # Ship the canonical wifi.* schema alongside iot.lua/vpn.lua/net.lua
+    # so ds-server auto-loads it from /etc/iot/ds-schemas/. D2 lands the
+    # actual schema file; the install rule is here for symmetry from D1.
+    if(EXISTS ${WIFI_MODULE_DIR}/schemas/wifi.lua)
+        install(FILES schemas/wifi.lua
+                DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+    endif()
+endif()

--- a/modules/wan/wifi/client/inc/client.hpp
+++ b/modules/wan/wifi/client/inc/client.hpp
@@ -1,0 +1,77 @@
+#ifndef __wifi_client_client_hpp__
+#define __wifi_client_client_hpp__
+
+/// Public-ish header for the wifi-client module. Only really "public"
+/// in the sense that the in-tree test target links against the same
+/// lib (wifi_client_lib) the binary uses — there is no API stability
+/// contract for external consumers.
+///
+/// L15/D1 scaffold: CLI parse + `--dump` keylist diagnostic.
+/// D3..D6 add DsBridge, ctrl protocol parser, process wrapper, and
+/// the lifecycle FSM as their phases land.
+
+#include <iosfwd>
+#include <string>
+
+namespace wifi_client {
+
+/// Status surfaced by the v0 main. Mirrors openvpn_client::Status +
+/// data_store::Status shape so callers can switch on `.ok` + read `.err`.
+struct Status {
+    bool        ok = true;
+    int         code = 0;
+    std::string err;
+};
+
+/// Result of parsing argv. Pure data — `main` dispatches; `parse_cli`
+/// stays unit-testable without spawning the binary.
+struct ParsedCli {
+    std::string sock;
+    std::string wpa_path  = "/usr/sbin/wpa_supplicant";
+    std::string iface     = "wlan0";
+    std::string ctrl_dir  = "/run/wpa_supplicant";
+    bool        dump      = false;
+    bool        once      = false;
+    bool        help      = false;
+    /// Non-zero when argv was malformed. `err` carries the diagnostic
+    /// main.cpp prints to stderr before exiting with this code.
+    /// 0 = ok; 2 = unknown / malformed argument.
+    int         exit_code = 0;
+    std::string err;
+};
+
+/// Parse argv into a ParsedCli. Recognises:
+///   --ds-sock=PATH  --wpa=PATH  --iface=NAME  --ctrl-dir=DIR
+///   --dump  --once  --help / -h
+/// Unknown flags MUST land as `exit_code=2` with a descriptive `err`.
+ParsedCli parse_cli(int argc, char** argv);
+
+/// Help text. Streamed to `out` so tests don't need to capture cout.
+void print_usage(std::ostream& out);
+
+/// Diagnostic mode: list every wifi.* key this daemon reads and
+/// writes, exit 0 without contacting ds-server. REQ-WIFI-003.
+///
+/// The `socketPath` argument is accepted-but-ignored so the dispatch
+/// in main.cpp can pass it uniformly; once ds-server contact is on
+/// the table for a v1 of this op, the signature won't change.
+Status v0_dump_wifi_keys(const std::string& socketPath,
+                         std::ostream&      out);
+
+/// Full lifecycle: connect to ds-server, refuse on missing_required()
+/// (today: nothing required — wifi.iface defaults to "wlan0"), spawn
+/// wpa_supplicant(8), connect to its control socket, route CTRL-EVENT
+/// lines through Lifecycle::step into DsBridge writes. Spawns a DHCP
+/// client child once CTRL-EVENT-CONNECTED arrives. Quiesces on
+/// subprocess exit (or after the first CTRL-EVENT-CONNECTED if `once`).
+///
+/// D1 stub: returns `ok=false code=75` until D3..D6 land.
+Status run_daemon(const std::string& socketPath,
+                  const std::string& wpa_path = "/usr/sbin/wpa_supplicant",
+                  const std::string& iface    = "wlan0",
+                  const std::string& ctrl_dir = "/run/wpa_supplicant",
+                  bool               once     = false);
+
+} // namespace wifi_client
+
+#endif /* __wifi_client_client_hpp__ */

--- a/modules/wan/wifi/client/src/main.cpp
+++ b/modules/wan/wifi/client/src/main.cpp
@@ -1,0 +1,39 @@
+/// wifi-client — daemon entry (L15/D1).
+///
+/// Usage:
+///   wifi-client [--ds-sock=PATH] [--wpa=PATH] [--iface=NAME]
+///               [--ctrl-dir=DIR] [--dump] [--once] [--help]
+///
+/// Default (no --dump): full lifecycle — spawn wpa_supplicant(8),
+/// connect to its control socket, route CTRL-EVENT-* lines into
+/// wifi.* writes; spawn DHCP client on CTRL-EVENT-CONNECTED.
+/// --once exits after the first CTRL-EVENT-CONNECTED (smoke tests).
+/// --dump lists every wifi.* key the daemon touches and exits 0
+/// without contacting ds-server.
+
+#include <cstdlib>
+#include <iostream>
+
+#include "client.hpp"
+
+int main(int argc, char** argv) {
+    auto pc = wifi_client::parse_cli(argc, argv);
+    if (pc.exit_code != 0) {
+        std::cerr << pc.err << "\n";
+        wifi_client::print_usage(std::cerr);
+        return pc.exit_code;
+    }
+    if (pc.help) {
+        wifi_client::print_usage(std::cout);
+        return 0;
+    }
+
+    auto rs = pc.dump
+            ? wifi_client::v0_dump_wifi_keys(pc.sock, std::cout)
+            : wifi_client::run_daemon(pc.sock, pc.wpa_path, pc.iface,
+                                      pc.ctrl_dir, pc.once);
+    if (!rs.ok && !rs.err.empty()) {
+        std::cerr << "wifi-client: " << rs.err << "\n";
+    }
+    return rs.ok ? 0 : 1;
+}

--- a/modules/wan/wifi/client/src/main_impl.cpp
+++ b/modules/wan/wifi/client/src/main_impl.cpp
@@ -1,0 +1,147 @@
+/// wifi-client v0 main implementation (L15/D1 scaffold).
+///
+/// D1 ships:
+///   - parse_cli: argv → ParsedCli (testable without spawning).
+///   - v0_dump_wifi_keys: REQ-WIFI-003 — list every wifi.* key the
+///     daemon will read/write, exit 0 without contacting ds-server.
+///   - run_daemon: D1 stub returning a typed "not yet implemented"
+///     Status so operators can't be confused into thinking nothing
+///     is happening. D3..D6 land the real lifecycle.
+
+#include "client.hpp"
+
+#include <array>
+#include <cstddef>
+#include <ostream>
+#include <string_view>
+
+namespace wifi_client {
+
+namespace {
+
+/// Every wifi.* key the daemon will touch, broken out by direction
+/// so `--dump` can print one section per role. The lists are the
+/// authoritative source for the D2 schema (schemas/wifi.lua); when
+/// D2 lands it MUST agree with these entries.
+constexpr std::array<std::string_view, 9> kReadKeys = {
+    "wifi.iface",
+    "wifi.ctrl.dir",
+    "wifi.wpa.path",
+    "wifi.networks",
+    "wifi.scan.interval.sec",
+    "wifi.scan.max.results",
+    "wifi.scan.request",
+    "wifi.dhcp.client",
+    "wifi.dhcp.path",
+};
+
+constexpr std::array<std::string_view, 11> kWriteKeys = {
+    "wifi.assoc.state",
+    "wifi.assoc.ssid",
+    "wifi.assoc.bssid",
+    "wifi.signal.rssi",
+    "wifi.scan.results",
+    "wifi.scan.last.unix",
+    "wifi.dhcp.state",
+    "wifi.dhcp.ip",
+    "wifi.pid.wpa",
+    "wifi.pid.dhcp",
+    "wifi.last.error",
+};
+
+bool starts_with(std::string_view s, std::string_view prefix) {
+    return s.size() >= prefix.size()
+        && s.compare(0, prefix.size(), prefix) == 0;
+}
+
+} // namespace
+
+void print_usage(std::ostream& out) {
+    out <<
+        "wifi-client (L15/D1)\n"
+        "\n"
+        "Usage: wifi-client [--ds-sock=PATH] [--wpa=PATH] [--iface=NAME]\n"
+        "                   [--ctrl-dir=DIR] [--dump] [--once] [--help]\n"
+        "\n"
+        "  --ds-sock=PATH   ds-server unix socket; defaults to ds-server's\n"
+        "                   built-in default (/var/run/iot/data_store.sock).\n"
+        "  --wpa=PATH       path to wpa_supplicant(8); defaults to\n"
+        "                   /usr/sbin/wpa_supplicant.\n"
+        "  --iface=NAME     wifi iface to manage; defaults to wlan0.\n"
+        "  --ctrl-dir=DIR   wpa_supplicant control-socket dir; defaults to\n"
+        "                   /run/wpa_supplicant.\n"
+        "  --dump           snapshot wifi.* keys and exit (diagnostic).\n"
+        "  --once           exit after the first CTRL-EVENT-CONNECTED (smoke).\n"
+        "  --help           show this and exit.\n";
+}
+
+ParsedCli parse_cli(int argc, char** argv) {
+    ParsedCli pc;
+    for (int i = 1; i < argc; ++i) {
+        std::string_view a = argv[i];
+        if (starts_with(a, "--ds-sock=")) {
+            pc.sock = std::string(a.substr(10));
+        } else if (starts_with(a, "--wpa=")) {
+            pc.wpa_path = std::string(a.substr(6));
+        } else if (starts_with(a, "--iface=")) {
+            pc.iface = std::string(a.substr(8));
+        } else if (starts_with(a, "--ctrl-dir=")) {
+            pc.ctrl_dir = std::string(a.substr(11));
+        } else if (a == "--dump") {
+            pc.dump = true;
+        } else if (a == "--once") {
+            pc.once = true;
+        } else if (a == "--help" || a == "-h") {
+            pc.help = true;
+        } else {
+            pc.exit_code = 2;
+            pc.err = "wifi-client: unknown argument '" + std::string(a) + "'";
+            return pc;
+        }
+    }
+    return pc;
+}
+
+Status v0_dump_wifi_keys(const std::string& /*socketPath*/,
+                         std::ostream&      out) {
+    // REQ-WIFI-003: --dump MUST exit 0 without contacting ds-server.
+    // Operator-facing output streams to `out` (cout from main, a
+    // stringstream from gtest). That's the documented carve-out from
+    // feedback_ace_logging.md — CLI output stays on stdout, only
+    // runtime diagnostics route through ACE_DEBUG/ACE_ERROR.
+    out << "wifi-client wifi.* keys (L15)\n";
+    out << "\n";
+    out << "Read keys (operator -> daemon):\n";
+    for (const auto& k : kReadKeys) {
+        out << "  " << k << "\n";
+    }
+    out << "\n";
+    out << "Write keys (daemon -> operator):\n";
+    for (const auto& k : kWriteKeys) {
+        out << "  " << k << "\n";
+    }
+    return {};
+}
+
+Status run_daemon(const std::string& /*socketPath*/,
+                  const std::string& /*wpa_path*/,
+                  const std::string& /*iface*/,
+                  const std::string& /*ctrl_dir*/,
+                  bool               /*once*/) {
+    Status s;
+    s.ok   = false;
+    s.code = 75;   // EX_TEMPFAIL — feature not yet built.
+    s.err  = "wifi-client run_daemon not yet implemented (L15/D1 scaffold; "
+             "D3..D6 land DsBridge, ctrl, and the Supervisor)";
+    return s;
+}
+
+// Test-only accessors so main_test.cpp can assert the keylist
+// without re-declaring it (which would defeat the test). Returning
+// pointer+size keeps the header free of <array>.
+const std::string_view* read_keys_data()    { return kReadKeys.data(); }
+std::size_t             read_keys_size()    { return kReadKeys.size(); }
+const std::string_view* write_keys_data()   { return kWriteKeys.data(); }
+std::size_t             write_keys_size()   { return kWriteKeys.size(); }
+
+} // namespace wifi_client

--- a/modules/wan/wifi/client/test/main_test.cpp
+++ b/modules/wan/wifi/client/test/main_test.cpp
@@ -1,0 +1,186 @@
+/// Unit tests for wifi-client D1 surface: CLI parse + --dump keylist.
+///
+/// REQ-WIFI-002 — parse_cli recognises every documented flag and
+/// rejects unknown args with exit_code=2.
+/// REQ-WIFI-003 — v0_dump_wifi_keys streams every wifi.* key
+/// (read + write) into the provided ostream, returns ok, and does
+/// not perform any I/O against ds-server (the socket argument is
+/// accepted but unused in this op).
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#include "client.hpp"
+
+// Test-only accessors defined in main_impl.cpp.
+namespace wifi_client {
+const std::string_view* read_keys_data();
+std::size_t             read_keys_size();
+const std::string_view* write_keys_data();
+std::size_t             write_keys_size();
+} // namespace wifi_client
+
+namespace {
+
+/// Build a fake argv from a vector of strings so each test can
+/// craft its own command line without strdup-and-leak hackery.
+/// The returned vector OWNS the char* storage via the underlying
+/// std::string lifetimes — pass it by reference, don't move it.
+class FakeArgv {
+public:
+    FakeArgv(std::initializer_list<std::string> args) : m_storage(args) {
+        for (auto& s : m_storage) m_argv.push_back(s.data());
+        m_argv.push_back(nullptr);
+    }
+    int    argc() const { return static_cast<int>(m_storage.size()); }
+    char** argv()       { return m_argv.data(); }
+private:
+    std::vector<std::string> m_storage;
+    std::vector<char*>       m_argv;
+};
+
+} // namespace
+
+// ─────────────────────────── REQ-WIFI-002 ───────────────────────────
+
+TEST(WIFI_REQ_WIFI_002_cli_parses_known_and_rejects_unknown, defaults_when_no_args) {
+    FakeArgv a{"wifi-client"};
+    auto pc = wifi_client::parse_cli(a.argc(), a.argv());
+    EXPECT_EQ(0, pc.exit_code);
+    EXPECT_TRUE(pc.err.empty());
+    EXPECT_EQ("",                       pc.sock);
+    EXPECT_EQ("/usr/sbin/wpa_supplicant", pc.wpa_path);
+    EXPECT_EQ("wlan0",                   pc.iface);
+    EXPECT_EQ("/run/wpa_supplicant",     pc.ctrl_dir);
+    EXPECT_FALSE(pc.dump);
+    EXPECT_FALSE(pc.once);
+    EXPECT_FALSE(pc.help);
+}
+
+TEST(WIFI_REQ_WIFI_002_cli_parses_known_and_rejects_unknown, every_known_flag) {
+    FakeArgv a{"wifi-client",
+               "--ds-sock=/tmp/ds.sock",
+               "--wpa=/usr/local/sbin/wpa_supplicant",
+               "--iface=wlan1",
+               "--ctrl-dir=/var/run/wpa",
+               "--dump",
+               "--once"};
+    auto pc = wifi_client::parse_cli(a.argc(), a.argv());
+    ASSERT_EQ(0, pc.exit_code) << pc.err;
+    EXPECT_EQ("/tmp/ds.sock",                  pc.sock);
+    EXPECT_EQ("/usr/local/sbin/wpa_supplicant", pc.wpa_path);
+    EXPECT_EQ("wlan1",                          pc.iface);
+    EXPECT_EQ("/var/run/wpa",                   pc.ctrl_dir);
+    EXPECT_TRUE(pc.dump);
+    EXPECT_TRUE(pc.once);
+}
+
+TEST(WIFI_REQ_WIFI_002_cli_parses_known_and_rejects_unknown, help_flag_short_and_long) {
+    {
+        FakeArgv a{"wifi-client", "--help"};
+        auto pc = wifi_client::parse_cli(a.argc(), a.argv());
+        EXPECT_EQ(0, pc.exit_code);
+        EXPECT_TRUE(pc.help);
+    }
+    {
+        FakeArgv a{"wifi-client", "-h"};
+        auto pc = wifi_client::parse_cli(a.argc(), a.argv());
+        EXPECT_EQ(0, pc.exit_code);
+        EXPECT_TRUE(pc.help);
+    }
+}
+
+TEST(WIFI_REQ_WIFI_002_cli_parses_known_and_rejects_unknown, unknown_flag_rejected_with_exit_2) {
+    FakeArgv a{"wifi-client", "--bogus"};
+    auto pc = wifi_client::parse_cli(a.argc(), a.argv());
+    EXPECT_EQ(2, pc.exit_code);
+    EXPECT_NE(std::string::npos, pc.err.find("--bogus"))
+        << "expected the error to name the offending arg, got: " << pc.err;
+}
+
+TEST(WIFI_REQ_WIFI_002_cli_parses_known_and_rejects_unknown, bare_positional_rejected) {
+    // Bare positional args have never been a thing in iot daemon CLIs.
+    // Treating them as unknown matches openvpn-client's behaviour.
+    FakeArgv a{"wifi-client", "wlan0"};
+    auto pc = wifi_client::parse_cli(a.argc(), a.argv());
+    EXPECT_EQ(2, pc.exit_code);
+}
+
+TEST(WIFI_REQ_WIFI_002_cli_parses_known_and_rejects_unknown, malformed_kv_unknown_rejected) {
+    // --iface (no '=') isn't recognised as the iface flag; it's a
+    // bare flag, so parse_cli should reject it.
+    FakeArgv a{"wifi-client", "--iface"};
+    auto pc = wifi_client::parse_cli(a.argc(), a.argv());
+    EXPECT_EQ(2, pc.exit_code);
+}
+
+// ─────────────────────────── REQ-WIFI-003 ───────────────────────────
+
+TEST(WIFI_REQ_WIFI_003_dump_lists_keys_without_ds, dump_returns_ok_with_empty_socket) {
+    std::ostringstream sink;
+    // Empty socket path; the function MUST NOT attempt to connect.
+    auto rs = wifi_client::v0_dump_wifi_keys("", sink);
+    EXPECT_TRUE(rs.ok) << rs.err;
+    EXPECT_EQ(0, rs.code);
+}
+
+TEST(WIFI_REQ_WIFI_003_dump_lists_keys_without_ds, dump_lists_every_read_key) {
+    std::ostringstream sink;
+    wifi_client::v0_dump_wifi_keys("ignored", sink);
+    auto out = sink.str();
+    for (std::size_t i = 0; i < wifi_client::read_keys_size(); ++i) {
+        auto k = std::string(wifi_client::read_keys_data()[i]);
+        EXPECT_NE(std::string::npos, out.find(k))
+            << "expected " << k << " in --dump output, got:\n" << out;
+    }
+}
+
+TEST(WIFI_REQ_WIFI_003_dump_lists_keys_without_ds, dump_lists_every_write_key) {
+    std::ostringstream sink;
+    wifi_client::v0_dump_wifi_keys("ignored", sink);
+    auto out = sink.str();
+    for (std::size_t i = 0; i < wifi_client::write_keys_size(); ++i) {
+        auto k = std::string(wifi_client::write_keys_data()[i]);
+        EXPECT_NE(std::string::npos, out.find(k))
+            << "expected " << k << " in --dump output, got:\n" << out;
+    }
+}
+
+TEST(WIFI_REQ_WIFI_003_dump_lists_keys_without_ds, dump_separates_read_and_write_sections) {
+    std::ostringstream sink;
+    wifi_client::v0_dump_wifi_keys("", sink);
+    auto out = sink.str();
+    auto reads  = out.find("Read keys");
+    auto writes = out.find("Write keys");
+    ASSERT_NE(std::string::npos, reads);
+    ASSERT_NE(std::string::npos, writes);
+    EXPECT_LT(reads, writes) << "Read section should precede Write section";
+}
+
+// ─────────────────────────── REQ-WIFI-026 ───────────────────────────
+// (Sanity check that the D1 source files don't emit any std::cout
+// from places other than the operator-facing CLI surface. Not an
+// invariant we can fully assert here — REQ-WIFI-026 is enforced by
+// the manual grep in the traceability matrix. This test just guards
+// the easy regression: v0_dump_wifi_keys must write to its ostream,
+// not to global cout.)
+
+TEST(WIFI_REQ_WIFI_026_diag_logs_via_ACE, dump_does_not_write_to_global_cout) {
+    // Capture global cout; if any of the D1 functions accidentally
+    // write to it, the captured string will be non-empty.
+    auto* prev = std::cout.rdbuf();
+    std::ostringstream cout_sink;
+    std::cout.rdbuf(cout_sink.rdbuf());
+    std::ostringstream explicit_sink;
+    wifi_client::v0_dump_wifi_keys("", explicit_sink);
+    std::cout.rdbuf(prev);
+    EXPECT_TRUE(cout_sink.str().empty())
+        << "v0_dump_wifi_keys wrote to global cout instead of its ostream arg: "
+        << cout_sink.str();
+    EXPECT_FALSE(explicit_sink.str().empty());
+}


### PR DESCRIPTION
## Summary
Greenfield `modules/wan/wifi/client/`. First D-phase of L15 — the scaffold, the CLI, and the `--dump` keylist diagnostic. Real lifecycle (DsBridge prime+watch, ctrl::Client over wpa_supplicant's control protocol, process supervision, FSM) lands across D3..D6.

Mirrors openvpn-client's layout exactly: one STATIC lib (`wifi_client_lib`) + one binary (`wifi-client`) + one combined gtest binary (`wifi-client-tests`) guarded by `BUILD_WIFI_CLIENT_TESTS=OFF` default. Namespace `wifi_client::`, include guards `__wifi_client_<file>__`, `m_` member prefix — every convention verified against openvpn-client + net-router and held identical.

## D1 deliverables
- `parse_cli(argc, argv) -> ParsedCli` — pure function, unit-testable without spawning. Recognises `--ds-sock=PATH --wpa=PATH --iface=NAME --ctrl-dir=DIR --dump --once --help/-h`. Unknown args land as `exit_code=2` with a descriptive `err`.
- `print_usage(ostream&)` — help text streamed to caller's `ostream` so tests sink into a `stringstream`.
- `v0_dump_wifi_keys(sock, ostream&)` — REQ-WIFI-003: list every wifi.* key (read + write) without contacting ds-server, exit 0.
- `run_daemon(...)` — D1 stub returning `EX_TEMPFAIL` with a typed `Status.err` pointing to "D3..D6 land DsBridge, ctrl, and the Supervisor." main.cpp surfaces it as non-zero exit + a clear stderr line.

The 20 `wifi.*` keys are declared as two `constexpr std::array<string_view>` aggregates in `main_impl.cpp`. D2 will read these same names into `schemas/wifi.lua` — single source of truth for the key surface.

## Tests
11/11 green, all named `WIFI_REQ_WIFI_<NNN>_<predicate>`:
- REQ-WIFI-002 (6): `defaults_when_no_args`, `every_known_flag`, `help_flag_short_and_long`, `unknown_flag_rejected_with_exit_2`, `bare_positional_rejected`, `malformed_kv_unknown_rejected`
- REQ-WIFI-003 (4): `dump_returns_ok_with_empty_socket`, `dump_lists_every_read_key`, `dump_lists_every_write_key`, `dump_separates_read_and_write_sections`
- REQ-WIFI-026 (1): `dump_does_not_write_to_global_cout`

## Wiring
- `apps/CMakeLists.txt`: `add_subdirectory(... wifi/client ...)` after net-router so a top-level `make install` from `apps/build` lands the wifi-client binary alongside the others.
- `.gitignore`: extend `modules/*/*/build/` to also match `modules/*/*/*/build/` so the deeper `modules/wan/wifi/client/build/` is ignored like its shallower siblings.

## Test plan
- [x] `podman run naushada/iot:latest` → `cmake -DBUILD_WIFI_CLIENT_TESTS=ON .. && make && ./wifi-client-tests` → 11/11 green
- [x] `./wifi-client --help` exits 0, usage to stdout
- [x] `./wifi-client --dump` exits 0, all 20 keys listed
- [x] `./wifi-client --bogus` exits 2, error to stderr
- [x] `./wifi-client` (no args) exits 1, stub message to stderr

Closes REQ-WIFI-001, REQ-WIFI-002, REQ-WIFI-003.

🤖 Generated with [Claude Code](https://claude.com/claude-code)