### PR TITLE
feat(wifi-client): L15/D2 — wifi.* schema + design.md

### DIFF
--- a/modules/wan/wifi/client/CMakeLists.txt
+++ b/modules/wan/wifi/client/CMakeLists.txt
@@ -51,7 +51,8 @@ if(BUILD_WIFI_CLIENT_TESTS)
     enable_testing()
 
     add_executable(wifi-client-tests
-        test/main_test.cpp)
+        test/main_test.cpp
+        test/schema_test.cpp)
 
     target_link_libraries(wifi-client-tests
         wifi_client_lib

--- a/modules/wan/wifi/client/docs/design.md
+++ b/modules/wan/wifi/client/docs/design.md
@@ -1,0 +1,271 @@
+# wifi-client — module design (L15)
+
+> Status: **L15/D1+D2 landed**, D3..D8 in flight per
+> [`log/L15/plan.md`](../../../../log/L15/plan.md) and the TDD
+> traceability at [`log/L15/tdd.md`](../../../../log/L15/tdd.md).
+
+## What this module is
+
+`wifi-client` is a single-host daemon that owns the
+`wpa_supplicant(8)` lifecycle for one wifi interface, drives scan
++ association via wpa_supplicant's local control protocol, and
+spawns a sibling DHCP child once associated. It publishes scan
+results, signal level, association state, and DHCP state into the
+data store under the `wifi.*` namespace.
+
+Slot in the WAN-gate chain: operator sets `wifi.networks` →
+wifi-client brings `wlan0` up → kernel writes OPER UP → net-router
+sees it → publishes `net.iface.active="wlan0"` → openvpn-client's
+WAN gate fires → tunnel comes up. wifi-client is one link in that
+chain; it does not know about openvpn or net-router.
+
+## Runtime requirements
+
+| Dep                | Why                                                              | Where installed                          |
+|--------------------|------------------------------------------------------------------|------------------------------------------|
+| `wpa_supplicant`   | Spawned to do the radio/auth/4-way-handshake work                | `/usr/sbin/wpa_supplicant` (apt: `wpasupplicant`) |
+| `udhcpc`           | Spawned to lease an IPv4 once associated (default DHCP client)   | `/usr/bin/udhcpc` (apt: `udhcpc` from busybox)    |
+| `dhclient`         | Fallback DHCP client when `wifi.dhcp.client="dhclient"`          | `/usr/sbin/dhclient` (apt: `isc-dhcp-client`)     |
+| `CAP_NET_ADMIN`    | wpa_supplicant configures iface state + manages keys             | systemd `AmbientCapabilities=`           |
+| `CAP_NET_RAW`      | Scan requires raw sockets                                        | systemd `AmbientCapabilities=`           |
+| `/run/wpa_supplicant` | Control socket parent dir (mkdir -p on startup)               | `RuntimeDirectory=` in the systemd unit  |
+| `/dev/rfkill`      | wpa_supplicant queries soft-block state                          | systemd `DeviceAllow=/dev/rfkill rw`     |
+
+D7 lands the systemd unit + the apt installs in
+`packaging/Containerfile` + `docker/Dockerfile`.
+
+## Architecture (D3..D6)
+
+```
+            ┌────────────────────────────────────────┐
+            │              wifi-client                │
+            │                                         │
+   ds-cli   │  ┌──────────┐    ┌──────────────────┐  │
+   set …  ──┼─▶│ DsBridge │───▶│   Supervisor     │  │
+            │  │  (D3)    │    │    (D6)          │  │
+            │  └──────────┘    │  Lifecycle FSM   │  │
+            │       ▲           │  pure (testable) │  │
+            │       │           └────────┬─────────┘  │
+            │ wifi.assoc.state            │            │
+            │ wifi.signal.rssi            │            │
+            │ wifi.scan.results          ▼            │
+            │       │           ┌──────────────────┐  │
+            │       └───────────│  ctrl::Client    │  │
+            │                   │    (D4)          │  │
+            │                   │  ACE LSOCK over  │  │
+            │                   │ /run/wpa_supp/<i>│  │
+            │                   └────────┬─────────┘  │
+            │                            │            │
+            │                   ┌────────▼─────────┐  │
+            │                   │  Process (D5)    │  │
+            │                   │  RAII ACE_Process│  │
+            │                   └────────┬─────────┘  │
+            └────────────────────────────┼────────────┘
+                                         │ fork/exec
+                                         ▼
+                          ┌─────────────────────────────┐
+                          │  wpa_supplicant(8) -i <if>  │
+                          │  udhcpc -i <if> -f -q       │
+                          └─────────────────────────────┘
+```
+
+`DsBridge` and `Supervisor` are the only pieces that touch the
+data store; `ctrl::Client` only knows the wpa_supplicant control
+protocol; `Process` only knows fork/exec/reap. This mirrors
+openvpn-client's split exactly so a reader who's seen one module
+recognises the layout.
+
+## Who does what on the kernel
+
+- **wifi-client (this daemon)**: owns the *policy* — which SSID to
+  associate to, when to scan, which DHCP client to spawn. It
+  configures wpa_supplicant via the control socket and observes
+  the kernel iface state by reading wpa_supplicant's CTRL-EVENT
+  stream. It does NOT directly `ioctl()` netlink or `ip link set`.
+- **wpa_supplicant**: owns the *mechanism* — does the scan, the
+  authentication exchange, the 4-way handshake, the iface keys.
+  Brings the iface to L2-ready. Writes its CTRL-EVENT stream over
+  the unix control socket.
+- **udhcpc/dhclient**: owns the L3 lease. wifi-client spawns it
+  on `CTRL-EVENT-CONNECTED`, reaps it on `CTRL-EVENT-DISCONNECTED`.
+- **kernel**: owns the actual netdev. On association + DHCP, the
+  iface goes OPER UP, which net-router observes independently via
+  its iface_monitor (`net.iface.active`).
+
+### What if we wanted to own the kernel state ourselves?
+
+Same trade openvpn-client made: re-implementing wpa_supplicant's
+scan/auth/4-way state machine in C++ is a multi-quarter project
+with security implications. We delegate to upstream; the daemon
+is a thin policy layer that publishes observable state.
+
+## NetworkManager conflict gate
+
+REQ-WIFI-022: on startup the daemon probes for a competing
+manager and refuses to spawn wpa_supplicant if it finds one. Two
+checks:
+
+1. `systemctl is-active NetworkManager` returns `active` → conflict.
+2. `<wifi.ctrl.dir>/<wifi.iface>` already exists as a socket →
+   somebody else is talking to wpa_supplicant.
+
+On either positive, the daemon writes `wifi.assoc.state="conflict"`
++ `wifi.last.error="…"` and stays parked. Operator fixes the
+collision (typically `systemctl mask NetworkManager`) and
+re-enables via a restart.
+
+Cooperative coexistence (handing iface management to NM via D-Bus
+on the fly) is FUP-L16e — out of L15 scope.
+
+## Plaintext PSK posture
+
+`wifi.networks[].psk` is stored in ds-server's `data_store.lua` in
+plaintext, same posture L12 took for `vpn.cert.path` / `vpn.ca.path`
+(they're plain paths, the cert content is on disk in cleartext).
+Operator with the ds-server socket can read every PSK; that's the
+threat model.
+
+A secrets-vault store (encrypt at rest in ds-server, decrypt on
+demand by the consuming daemon) is FUP-L15-1 → L16a. Documented
+non-goal here, not a defect.
+
+## Schema layout
+
+[`schemas/wifi.lua`](../schemas/wifi.lua) declares every read +
+write key with `(type, default, min?, max?)`. ds-server
+auto-loads it from `/etc/iot/ds-schemas/` so a set with a bad
+type lands as `SchemaRejected` on the wire.
+
+Read keys (operator → daemon): `wifi.iface`, `wifi.ctrl.dir`,
+`wifi.wpa.path`, `wifi.networks`, `wifi.scan.interval.sec`,
+`wifi.scan.max.results`, `wifi.scan.request`, `wifi.dhcp.client`,
+`wifi.dhcp.path`.
+
+Write keys (daemon → operator): `wifi.assoc.state`, `wifi.assoc.ssid`,
+`wifi.assoc.bssid`, `wifi.signal.rssi`, `wifi.scan.results`,
+`wifi.scan.last.unix`, `wifi.dhcp.state`, `wifi.dhcp.ip`,
+`wifi.pid.wpa`, `wifi.pid.dhcp`, `wifi.last.error`.
+
+### `wifi.networks` JSON shape
+
+```json
+[
+  {"ssid": "HomeAP", "psk": "correcthorse",  "priority": 10},
+  {"ssid": "Guest",  "psk": "battery",       "priority": 5},
+  {"ssid": "Lab",    "psk": "",              "priority": 1, "key_mgmt": "NONE"}
+]
+```
+
+Fields:
+- `ssid` (required, string)
+- `psk` (required unless `key_mgmt="NONE"`, string)
+- `priority` (optional, integer, default 0)
+- `key_mgmt` (optional, default `"WPA-PSK"`; `"NONE"` for open
+  networks)
+
+Validated in code via nlohmann::json (D5). Bad shape →
+`wifi.assoc.state="conflict"` + `wifi.last.error="bad_networks_json: …"`.
+
+### `wifi.scan.results` JSON shape
+
+```json
+[
+  {"ssid": "HomeAP", "bssid": "aa:bb:cc:dd:ee:ff", "signal": -52, "flags": "[WPA2-PSK-CCMP]"},
+  {"ssid": "Guest",  "bssid": "aa:bb:cc:dd:ee:00", "signal": -67, "flags": "[WPA2-PSK-CCMP]"}
+]
+```
+
+Ordered strongest-signal-first, truncated to
+`wifi.scan.max.results` (default 20). Rewritten on each
+`CTRL-EVENT-SCAN-RESULTS`; no rolling-window history (NFR-WIFI-003).
+
+## Module layout
+
+```
+modules/wan/wifi/client/
+├── CMakeLists.txt                  # wifi_client_lib + wifi-client + tests
+├── inc/
+│   └── client.hpp                  # v0 entry points + ParsedCli
+├── src/
+│   ├── main.cpp                    # CLI dispatch (thin)
+│   ├── main_impl.cpp               # parse_cli + v0_dump + run_daemon stub
+│   ├── ds_bridge.{hpp,cpp}         # D3 — wifi.* prime + watch + setters
+│   ├── ctrl.{hpp,cpp}              # D4 — ACE LSOCK + event parser
+│   ├── process.{hpp,cpp}           # D5 — RAII over ACE_Process
+│   ├── lifecycle.{hpp,cpp}         # D6 — pure FSM
+│   └── supervisor.{hpp,cpp}        # D6 — impure wiring
+├── schemas/
+│   └── wifi.lua                    # auto-loaded by ds-server
+├── test/                           # gtest, one combined binary
+│   ├── main_test.cpp               # D1 — parse_cli + v0_dump
+│   ├── ds_bridge_test.cpp          # D3
+│   ├── ctrl_test.cpp               # D4
+│   ├── process_test.cpp            # D5
+│   ├── lifecycle_test.cpp          # D6
+│   └── supervisor_test.cpp         # D6
+└── docs/
+    └── design.md                   # this file
+```
+
+## State machine (D6 preview)
+
+```
+   ┌──────────────┐
+   │ disconnected │◀────────────────┐
+   └──────┬───────┘                 │
+          │ wpa.start  + SCAN       │
+          ▼                         │
+   ┌──────────────┐                 │
+   │   scanning   │                 │
+   └──────┬───────┘                 │
+          │ CTRL-EVENT-SCAN-RESULTS │
+          │ → choose best SSID      │
+          │ → SELECT_NETWORK <id>   │
+          ▼                         │
+   ┌──────────────┐                 │
+   │ associating  │                 │
+   └──────┬───────┘                 │
+          │ associated (key mgmt)   │
+          ▼                         │
+   ┌──────────────┐                 │
+   │     4way     │                 │
+   └──────┬───────┘                 │
+          │ CTRL-EVENT-CONNECTED    │
+          │ → spawn DHCP child      │
+          ▼                         │
+   ┌──────────────┐                 │
+   │  connected   │                 │
+   └──────┬───────┘                 │
+          │ CTRL-EVENT-DISCONNECTED │
+          │ / -TERMINATING / -REJECT│
+          └─────────────────────────┘
+```
+
+`conflict` and `exited` are terminal-ish states reached from any
+of the above:
+- `conflict`: NM-conflict gate (REQ-WIFI-022); only restart escapes.
+- `exited`: wpa_supplicant subprocess exited unexpectedly; the
+  supervisor publishes the state and respawns on its retry
+  schedule (D6 design — mirrors openvpn's `vpn.state="exited"`
+  + retry path).
+
+## Module layout convention
+
+`modules/wan/` is the parent for *radio-link / WAN access-layer*
+daemons. Subdirs:
+
+- `wifi/client/` — this module (wpa_supplicant supplicant role)
+- `wifi/ap/` — reserved for hostapd-based AP mode (FUP-L16d)
+- `cellular/` — reserved for ModemManager / mmcli or raw AT-over-serial (FUP-L16c)
+
+Single-radio per daemon by convention. A second radio means a
+second daemon instance keyed by `--iface=` against a second
+control-dir, or schema generalisation (FUP).
+
+## Related docs
+
+- [`../../../../log/L15/plan.md`](../../../../log/L15/plan.md) — L15 forward plan
+- [`../../../../log/L15/tdd.md`](../../../../log/L15/tdd.md) — REQ/NFR traceability
+- [`../schemas/wifi.lua`](../schemas/wifi.lua) — authoritative schema
+- [`../../../openvpn/client/docs/design.md`](../../../openvpn/client/docs/design.md) — sibling module; this design mirrors its structure
+- [`../../../net/router/docs/design.md`](../../../net/router/docs/design.md) — downstream consumer (sees `wlan0` OPER UP)

--- a/modules/wan/wifi/client/schemas/wifi.lua
+++ b/modules/wan/wifi/client/schemas/wifi.lua
@@ -1,0 +1,91 @@
+-- wifi.* schema for wifi-client (L15).
+--
+-- Read keys (operator → daemon):
+--   wifi.iface              - kernel iface to manage (default "wlan0")
+--   wifi.ctrl.dir           - wpa_supplicant control-socket dir
+--                             (default "/run/wpa_supplicant")
+--   wifi.wpa.path           - path to wpa_supplicant(8)
+--                             (default "/usr/sbin/wpa_supplicant")
+--   wifi.networks           - JSON array of {ssid, psk, priority, key_mgmt}
+--                             entries (default "[]"; validated in code, not lua)
+--   wifi.scan.interval.sec  - periodic background scan cadence in seconds
+--                             (default 60; 0 disables periodic scans)
+--   wifi.scan.max.results   - cap on the length of wifi.scan.results
+--                             (default 20, range 1..200)
+--   wifi.scan.request       - bump (any change) to trigger an immediate scan
+--                             (default 0; mirrors net.iface.* "bump-counter"
+--                             convention)
+--   wifi.dhcp.client        - "udhcpc" / "dhclient" / "auto" (default "auto";
+--                             "auto" probes udhcpc first, dhclient second)
+--   wifi.dhcp.path          - override DHCP-client binary path; empty = use
+--                             the default for whichever client was chosen
+--
+-- Write keys (daemon → operator):
+--   wifi.assoc.state        - "disconnected" / "scanning" / "associating" /
+--                             "4way" / "connected" / "conflict" / "exited"
+--   wifi.assoc.ssid         - SSID of the AP we're associated to; empty when
+--                             not connected
+--   wifi.assoc.bssid        - BSSID (AP MAC) of the current association
+--   wifi.signal.rssi        - latest signal level in dBm (integer);
+--                             coalesced to one write per 5 s (NFR-WIFI-002)
+--   wifi.scan.results       - JSON array [{ssid, bssid, signal, flags}, ...]
+--                             ordered strongest-signal-first, truncated to
+--                             wifi.scan.max.results
+--   wifi.scan.last.unix     - unix timestamp of the most recent scan result
+--                             write
+--   wifi.dhcp.state         - "idle" / "requesting" / "bound" / "rebinding"
+--                             / "exited"
+--   wifi.dhcp.ip            - IPv4 leased on the iface (empty when not bound)
+--   wifi.pid.wpa            - live wpa_supplicant pid (0 when not running)
+--   wifi.pid.dhcp           - live DHCP-client pid (0 when not running)
+--   wifi.last.error         - last non-fatal error message (auth reject,
+--                             scan fail, bad_networks_json: ...)
+--
+-- Install at /etc/iot/ds-schemas/wifi.lua (ds-server auto-loads).
+--
+-- Convention: every key segment is dot-separated, no underscores in segment
+-- names. Same as vpn.lua + net.lua. C++-side identifiers (parsed_networks,
+-- scan_results_json, ...) keep underscores because dots are illegal there.
+--
+-- Note: wifi.networks is schema-typed as "string"; the JSON shape is
+-- validated in code (nlohmann::json). Bad shape surfaces as
+-- wifi.assoc.state="conflict" + wifi.last.error="bad_networks_json: ...".
+-- The schema can't json-parse, hence the in-code check at start-of-cycle.
+--
+-- Note: paths (wpa.path, dhcp.path) are STRING-validated here. Filesystem
+-- existence is checked by the daemon at spawn time, not at set time
+-- (the schema can't stat() the host filesystem).
+
+return {
+  namespace = "wifi",
+  keys = {
+    -- ───────── Read keys (operator → daemon) ─────────
+    ["wifi.iface"]              = { type = "string",  default = "wlan0" },
+    ["wifi.ctrl.dir"]           = { type = "string",
+                                    default = "/run/wpa_supplicant" },
+    ["wifi.wpa.path"]           = { type = "string",
+                                    default = "/usr/sbin/wpa_supplicant" },
+    ["wifi.networks"]           = { type = "string",  default = "[]" },
+    ["wifi.scan.interval.sec"]  = { type = "integer", default = 60,
+                                    min = 0, max = 86400 },
+    ["wifi.scan.max.results"]   = { type = "integer", default = 20,
+                                    min = 1, max = 200 },
+    ["wifi.scan.request"]       = { type = "integer", default = 0,
+                                    min = 0 },
+    ["wifi.dhcp.client"]        = { type = "string",  default = "auto" },
+    ["wifi.dhcp.path"]          = { type = "string",  default = "" },
+
+    -- ───────── Write keys (daemon → operator) ─────────
+    ["wifi.assoc.state"]        = { type = "string" },
+    ["wifi.assoc.ssid"]         = { type = "string" },
+    ["wifi.assoc.bssid"]        = { type = "string" },
+    ["wifi.signal.rssi"]        = { type = "integer" },
+    ["wifi.scan.results"]       = { type = "string" },
+    ["wifi.scan.last.unix"]     = { type = "integer", min = 0 },
+    ["wifi.dhcp.state"]         = { type = "string" },
+    ["wifi.dhcp.ip"]            = { type = "string" },
+    ["wifi.pid.wpa"]            = { type = "integer", min = 0 },
+    ["wifi.pid.dhcp"]           = { type = "integer", min = 0 },
+    ["wifi.last.error"]         = { type = "string" },
+  },
+}

--- a/modules/wan/wifi/client/test/schema_test.cpp
+++ b/modules/wan/wifi/client/test/schema_test.cpp
@@ -1,0 +1,219 @@
+/// D2 schema-file content tests for schemas/wifi.lua.
+///
+/// REQ-WIFI-004 — ds-server rejects bad-type sets. The hard
+/// enforcement happens via ds-server's SchemaRegistry (already
+/// covered by modules/data-store/test/schema_test.cpp). This file
+/// keeps the unit-test scope to "the wifi.lua we ship declares the
+/// surface our daemon uses, with the expected types + defaults."
+/// The wire-level "bad set is SchemaRejected" assertion runs in
+/// log/L15/smoke.sh against a real ds-server (D8).
+///
+/// REQ-WIFI-005 — every read key from main_impl.cpp's kReadKeys
+/// MUST appear in wifi.lua with the documented default.
+/// REQ-WIFI-006 — every write key from main_impl.cpp's kWriteKeys
+/// MUST appear in wifi.lua with the right type; integer keys MUST
+/// be typed integer; assoc.state is the documented string enum.
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <fstream>
+#include <regex>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <utility>
+
+#include "client.hpp"
+
+namespace wifi_client {
+const std::string_view* read_keys_data();
+std::size_t             read_keys_size();
+const std::string_view* write_keys_data();
+std::size_t             write_keys_size();
+} // namespace wifi_client
+
+namespace {
+
+/// Load the lua schema file. The relative path resolves from the
+/// CTest working directory (the build dir), which is one level
+/// below modules/wan/wifi/client/. CMake adds ".." as the test's
+/// reference frame.
+std::string load_schema() {
+    // Try the canonical install location first (in-tree dev test
+    // run via CTest from the build/ dir).
+    const char* candidates[] = {
+        "../schemas/wifi.lua",
+        "schemas/wifi.lua",
+        "modules/wan/wifi/client/schemas/wifi.lua",
+        "/src/modules/wan/wifi/client/schemas/wifi.lua",
+    };
+    for (auto p : candidates) {
+        std::ifstream in(p);
+        if (in.good()) {
+            std::ostringstream buf;
+            buf << in.rdbuf();
+            return buf.str();
+        }
+    }
+    return {};
+}
+
+/// Pull the `{ ... }` body of a key declaration. Returns empty if
+/// the key isn't declared at all. The match is intentionally
+/// permissive — Lua allows surprising whitespace + trailing
+/// commas; we only assert what we care about (type, default, range).
+std::string entry_body(const std::string& schema, const std::string& key) {
+    // ["wifi.foo.bar"] = { ... }  — capture the braced body.
+    std::string pattern = R"(\[\")" + key + R"(\"\]\s*=\s*\{([^}]*)\})";
+    std::regex re(pattern);
+    std::smatch m;
+    if (std::regex_search(schema, m, re)) return m[1].str();
+    return {};
+}
+
+bool has_type(const std::string& body, const std::string& type) {
+    std::regex re("type\\s*=\\s*\"" + type + "\"");
+    return std::regex_search(body, re);
+}
+
+bool has_default(const std::string& body, const std::string& expected) {
+    // Default values for strings appear quoted; integers bare.
+    std::regex quoted(R"(default\s*=\s*\")" + expected + R"(\")");
+    std::regex bare("default\\s*=\\s*" + expected + R"(\b)");
+    return std::regex_search(body, quoted) || std::regex_search(body, bare);
+}
+
+} // namespace
+
+// ─────────────────────────── REQ-WIFI-005 ───────────────────────────
+
+class WIFI_REQ_WIFI_005_read_keys_have_defaults : public ::testing::Test {
+protected:
+    std::string schema;
+    void SetUp() override {
+        schema = load_schema();
+        ASSERT_FALSE(schema.empty())
+            << "could not load schemas/wifi.lua from any candidate path; "
+            << "test working dir was probably wrong";
+    }
+};
+
+TEST_F(WIFI_REQ_WIFI_005_read_keys_have_defaults, every_read_key_is_declared) {
+    for (std::size_t i = 0; i < wifi_client::read_keys_size(); ++i) {
+        std::string k(wifi_client::read_keys_data()[i]);
+        EXPECT_FALSE(entry_body(schema, k).empty())
+            << "wifi.lua MUST declare " << k
+            << " — main_impl.cpp kReadKeys lists it";
+    }
+}
+
+TEST_F(WIFI_REQ_WIFI_005_read_keys_have_defaults, documented_defaults_match) {
+    // The L15 plan §D2 + design.md fix the defaults; these MUST
+    // not drift between the doc and the lua file.
+    struct Pair { std::string key; std::string deflt; };
+    const Pair pairs[] = {
+        {"wifi.iface",             "wlan0"},
+        {"wifi.ctrl.dir",          "/run/wpa_supplicant"},
+        {"wifi.wpa.path",          "/usr/sbin/wpa_supplicant"},
+        {"wifi.networks",          "\\[\\]"},   // escape brackets for regex
+        {"wifi.scan.interval.sec", "60"},
+        {"wifi.scan.max.results",  "20"},
+        {"wifi.scan.request",      "0"},
+        {"wifi.dhcp.client",       "auto"},
+    };
+    for (const auto& p : pairs) {
+        auto body = entry_body(schema, p.key);
+        ASSERT_FALSE(body.empty()) << "missing key: " << p.key;
+        EXPECT_TRUE(has_default(body, p.deflt))
+            << p.key << " default expected " << p.deflt << ", body was:\n  " << body;
+    }
+}
+
+// ─────────────────────────── REQ-WIFI-006 ───────────────────────────
+
+class WIFI_REQ_WIFI_006_write_keys_typed : public ::testing::Test {
+protected:
+    std::string schema;
+    void SetUp() override {
+        schema = load_schema();
+        ASSERT_FALSE(schema.empty());
+    }
+};
+
+TEST_F(WIFI_REQ_WIFI_006_write_keys_typed, every_write_key_is_declared) {
+    for (std::size_t i = 0; i < wifi_client::write_keys_size(); ++i) {
+        std::string k(wifi_client::write_keys_data()[i]);
+        EXPECT_FALSE(entry_body(schema, k).empty())
+            << "wifi.lua MUST declare " << k
+            << " — main_impl.cpp kWriteKeys lists it";
+    }
+}
+
+TEST_F(WIFI_REQ_WIFI_006_write_keys_typed, integer_keys_typed_integer) {
+    const std::string int_keys[] = {
+        "wifi.signal.rssi",
+        "wifi.scan.last.unix",
+        "wifi.pid.wpa",
+        "wifi.pid.dhcp",
+    };
+    for (const auto& k : int_keys) {
+        auto body = entry_body(schema, k);
+        ASSERT_FALSE(body.empty()) << "missing key: " << k;
+        EXPECT_TRUE(has_type(body, "integer"))
+            << k << " expected type=integer, body was:\n  " << body;
+    }
+}
+
+TEST_F(WIFI_REQ_WIFI_006_write_keys_typed, string_keys_typed_string) {
+    const std::string str_keys[] = {
+        "wifi.assoc.state",
+        "wifi.assoc.ssid",
+        "wifi.assoc.bssid",
+        "wifi.scan.results",
+        "wifi.dhcp.state",
+        "wifi.dhcp.ip",
+        "wifi.last.error",
+    };
+    for (const auto& k : str_keys) {
+        auto body = entry_body(schema, k);
+        ASSERT_FALSE(body.empty()) << "missing key: " << k;
+        EXPECT_TRUE(has_type(body, "string"))
+            << k << " expected type=string, body was:\n  " << body;
+    }
+}
+
+// ─────────────────────────── REQ-WIFI-004 ───────────────────────────
+// File-level sanity that the schema is loadable: namespace declared,
+// table closes cleanly. The actual "bad set rejected" wire test
+// lives in log/L15/smoke.sh against a real ds-server.
+
+TEST(WIFI_REQ_WIFI_004_schema_loadable, declares_wifi_namespace) {
+    auto schema = load_schema();
+    ASSERT_FALSE(schema.empty());
+    EXPECT_NE(std::string::npos, schema.find("namespace = \"wifi\""))
+        << "wifi.lua must declare its namespace as 'wifi' so ds-server's "
+        << "WARN-on-duplicate path treats this file as the wifi owner";
+}
+
+TEST(WIFI_REQ_WIFI_004_schema_loadable, return_statement_at_top_level) {
+    auto schema = load_schema();
+    ASSERT_FALSE(schema.empty());
+    // ds-server's SchemaRegistry runs the file via dofile() and
+    // expects the top-level chunk to RETURN the table.
+    EXPECT_NE(std::string::npos, schema.find("return {"))
+        << "wifi.lua must return a table at top level; without it "
+        << "SchemaRegistry::load_one() raises";
+}
+
+TEST(WIFI_REQ_WIFI_004_schema_loadable, scan_max_results_has_documented_range) {
+    auto schema = load_schema();
+    ASSERT_FALSE(schema.empty());
+    auto body = entry_body(schema, "wifi.scan.max.results");
+    ASSERT_FALSE(body.empty());
+    EXPECT_TRUE(has_type(body, "integer"));
+    EXPECT_NE(std::string::npos, body.find("min = 1"))
+        << "wifi.scan.max.results min=1 documented in design.md, body:\n  " << body;
+    EXPECT_NE(std::string::npos, body.find("max = 200"))
+        << "wifi.scan.max.results max=200 documented in design.md, body:\n  " << body;
+}


### PR DESCRIPTION
## Summary
Lands the `wifi.*` schema (20 keys) and the module design doc.

- `schemas/wifi.lua` — 9 read keys (iface/ctrl.dir/wpa.path/networks/scan.*/dhcp.*) + 11 write keys (assoc.*/signal.rssi/scan.results/scan.last.unix/dhcp.*/pid.*/last.error). Auto-loaded by ds-server from `/etc/iot/ds-schemas/` exactly like `vpn.lua` and `net.lua`. Every segment dot-separated.
- `docs/design.md` — mirrors openvpn-client's structure: What / Runtime requirements / Architecture / Who does what / NM-conflict gate / Plaintext PSK posture / Schema / Module layout / State machine / Related docs. ASCII architecture diagram of the D3..D6 split and the disconnected→scanning→associating→4way→connected state diagram.

## Tests
8 new cases in `schema_test.cpp`, total wifi-client-tests at 19/19 green:
- REQ-WIFI-004 (3): namespace declared, top-level return, scan.max.results range present
- REQ-WIFI-005 (2): every read key declared, documented defaults match
- REQ-WIFI-006 (3): every write key declared, integer-typed keys, string-typed keys

The unit tests are intentionally file-content based (parse the lua text via regex). The wire-level "ds-server actually rejects" enforcement runs against a real ds-server in `log/L15/smoke.sh` (D8); same trade-off net-router took.

## Manual wire smoke
Run inside `naushada/iot:latest` with `ds-server --ds-schema-dir=/tmp/schemas`:

```
loaded 20 schema key(s) from /tmp/schemas
set wifi.iface 7              -> schema(wifi.iface): expected string, got 7
set wifi.scan.max.results 0   -> schema(...): 0 below min 1
set wifi.scan.max.results 99  -> ok
get wifi.iface                -> wifi.iface=wlan0
get wifi.dhcp.client          -> wifi.dhcp.client=auto
get wifi.scan.max.results     -> wifi.scan.max.results=99
```

Schema enforcement end-to-end confirmed.

## Test plan
- [x] `make wifi-client-tests && ./wifi-client-tests` → 19/19 green
- [x] Wire smoke against a live ds-server: bad-type reject, range reject, in-range accept, defaults returned
- [x] design.md ASCII diagrams render in GitHub-flavored markdown

Closes REQ-WIFI-004, REQ-WIFI-005, REQ-WIFI-006.

🤖 Generated with [Claude Code](https://claude.com/claude-code)