### PR TITLE
feat(wifi-client): L15/D3 — DsBridge for wifi.*

### DIFF
--- a/modules/wan/wifi/client/CMakeLists.txt
+++ b/modules/wan/wifi/client/CMakeLists.txt
@@ -31,7 +31,8 @@ link_directories(${ACE_ROOT}/lib)
 # D1 ships only main_impl; D3..D6 add ds_bridge, ctrl, process, lifecycle,
 # supervisor as their phases land.
 add_library(wifi_client_lib STATIC
-    src/main_impl.cpp)
+    src/main_impl.cpp
+    src/ds_bridge.cpp)
 
 target_include_directories(wifi_client_lib PUBLIC src)
 
@@ -52,7 +53,8 @@ if(BUILD_WIFI_CLIENT_TESTS)
 
     add_executable(wifi-client-tests
         test/main_test.cpp
-        test/schema_test.cpp)
+        test/schema_test.cpp
+        test/ds_bridge_test.cpp)
 
     target_link_libraries(wifi-client-tests
         wifi_client_lib

--- a/modules/wan/wifi/client/src/ds_bridge.cpp
+++ b/modules/wan/wifi/client/src/ds_bridge.cpp
@@ -1,0 +1,300 @@
+#include "ds_bridge.hpp"
+
+#include <mutex>
+#include <type_traits>
+#include <utility>
+#include <variant>
+
+#include <ace/Log_Msg.h>
+
+#include "data_store/client.hpp"
+#include "data_store/proto.hpp"
+#include "data_store/value.hpp"
+
+namespace wifi_client {
+
+const char* DsBridge::kDefaultSocketPath = data_store::proto::kDefaultSocketPath;
+
+namespace {
+
+// ─────────────────────── Key constants ──────────────────────────────
+// Single source of truth for the wire-level key strings. Same names
+// as main_impl.cpp's kReadKeys / kWriteKeys and schemas/wifi.lua so
+// the daemon, the schema, and the test suite can't drift apart.
+constexpr const char* kIface             = "wifi.iface";
+constexpr const char* kCtrlDir           = "wifi.ctrl.dir";
+constexpr const char* kWpaPath           = "wifi.wpa.path";
+constexpr const char* kNetworks          = "wifi.networks";
+constexpr const char* kScanIntervalSec   = "wifi.scan.interval.sec";
+constexpr const char* kScanMaxResults    = "wifi.scan.max.results";
+constexpr const char* kScanRequest       = "wifi.scan.request";
+constexpr const char* kDhcpClient        = "wifi.dhcp.client";
+constexpr const char* kDhcpPath          = "wifi.dhcp.path";
+
+constexpr const char* kAssocState        = "wifi.assoc.state";
+constexpr const char* kAssocSsid         = "wifi.assoc.ssid";
+constexpr const char* kAssocBssid        = "wifi.assoc.bssid";
+constexpr const char* kSignalRssi        = "wifi.signal.rssi";
+constexpr const char* kScanResults       = "wifi.scan.results";
+constexpr const char* kScanLastUnix      = "wifi.scan.last.unix";
+constexpr const char* kDhcpState         = "wifi.dhcp.state";
+constexpr const char* kDhcpIp            = "wifi.dhcp.ip";
+constexpr const char* kPidWpa            = "wifi.pid.wpa";
+constexpr const char* kPidDhcp           = "wifi.pid.dhcp";
+constexpr const char* kLastError         = "wifi.last.error";
+
+} // namespace
+
+// ───────────────────────────── Impl ─────────────────────────────────
+
+struct DsBridge::Impl {
+    data_store::Client              client;
+    data_store::Client::WatchHandle watch_handle =
+        data_store::Client::kInvalidHandle;
+
+    mutable std::mutex            mtx;
+    // Snapshots updated by the listener thread + initial prime.
+    std::optional<std::string>    iface;
+    std::optional<std::string>    ctrl_dir;
+    std::optional<std::string>    wpa_path;
+    std::optional<std::string>    networks;
+    std::optional<std::uint32_t>  scan_interval_sec;
+    std::optional<std::uint32_t>  scan_max_results;
+    std::optional<std::uint32_t>  scan_request;
+    std::optional<std::string>    dhcp_client;
+    std::optional<std::string>    dhcp_path;
+    ChangeCallback                cb;
+};
+
+// ─────────────────────── ctor / dtor ────────────────────────────────
+
+DsBridge::DsBridge(std::string socketPath)
+  : m_impl(std::make_unique<Impl>()),
+    m_path(socketPath.empty() ? std::string(kDefaultSocketPath)
+                              : std::move(socketPath)) {
+    auto cs = m_impl->client.connect(m_path);
+    if (!cs.ok) {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [wifi:%t] %M %N:%l data-store not available "
+                            "at %C (%C); wifi-client cannot start\n"),
+                   m_path.c_str(), cs.err.c_str()));
+        return;
+    }
+    m_ok = true;
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D [wifi:%t] %M %N:%l data-store ready at %C\n"),
+               m_path.c_str()));
+
+    // Prime the snapshot with one initial get. Every read key has a
+    // schema default (per schemas/wifi.lua) so the cache is fully
+    // populated as soon as ds-server returns. wifi.networks defaults
+    // to "[]" — empty JSON array — which the Supervisor treats as
+    // "no networks configured" (parks in disconnected).
+    const std::vector<std::string> read_keys = {
+        kIface, kCtrlDir, kWpaPath, kNetworks,
+        kScanIntervalSec, kScanMaxResults, kScanRequest,
+        kDhcpClient, kDhcpPath,
+    };
+    std::vector<data_store::Client::GetResult> got;
+    auto gs = m_impl->client.get(read_keys, got);
+    if (gs.ok) {
+        std::lock_guard<std::mutex> g(m_impl->mtx);
+        for (auto& r : got) {
+            if (!r.has_value) continue;
+            if      (r.key == kIface)            m_impl->iface             = data_store::to_string(r.value);
+            else if (r.key == kCtrlDir)          m_impl->ctrl_dir          = data_store::to_string(r.value);
+            else if (r.key == kWpaPath)          m_impl->wpa_path          = data_store::to_string(r.value);
+            else if (r.key == kNetworks)         m_impl->networks          = data_store::to_string(r.value);
+            else if (r.key == kScanIntervalSec)  m_impl->scan_interval_sec = data_store::to_uint32(r.value);
+            else if (r.key == kScanMaxResults)   m_impl->scan_max_results  = data_store::to_uint32(r.value);
+            else if (r.key == kScanRequest)      m_impl->scan_request      = data_store::to_uint32(r.value);
+            else if (r.key == kDhcpClient)       m_impl->dhcp_client       = data_store::to_string(r.value);
+            else if (r.key == kDhcpPath)         m_impl->dhcp_path         = data_store::to_string(r.value);
+        }
+    }
+
+    // Register the watch. Same 9 keys; the listener thread routes by
+    // string match into the snapshot + the per-key Key enum the
+    // caller's on_change handler sees.
+    auto ws = m_impl->client.watch(
+        read_keys,
+        [this](const data_store::Client::Event& ev) {
+            std::optional<Key> changed;
+            {
+                std::lock_guard<std::mutex> g(m_impl->mtx);
+                if      (ev.key == kIface)           { m_impl->iface             = data_store::to_string(ev.value);   changed = Key::Iface;           }
+                else if (ev.key == kCtrlDir)         { m_impl->ctrl_dir          = data_store::to_string(ev.value);   changed = Key::CtrlDir;         }
+                else if (ev.key == kWpaPath)         { m_impl->wpa_path          = data_store::to_string(ev.value);   changed = Key::WpaPath;         }
+                else if (ev.key == kNetworks)        { m_impl->networks          = data_store::to_string(ev.value);   changed = Key::Networks;        }
+                else if (ev.key == kScanIntervalSec) { m_impl->scan_interval_sec = data_store::to_uint32(ev.value); changed = Key::ScanIntervalSec; }
+                else if (ev.key == kScanMaxResults)  { m_impl->scan_max_results  = data_store::to_uint32(ev.value); changed = Key::ScanMaxResults;  }
+                else if (ev.key == kScanRequest)     { m_impl->scan_request      = data_store::to_uint32(ev.value); changed = Key::ScanRequest;     }
+                else if (ev.key == kDhcpClient)      { m_impl->dhcp_client       = data_store::to_string(ev.value);   changed = Key::DhcpClient;      }
+                else if (ev.key == kDhcpPath)        { m_impl->dhcp_path         = data_store::to_string(ev.value);   changed = Key::DhcpPath;        }
+            }
+            if (!changed) return;
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [wifi:%t] %M %N:%l config key "
+                                "'%C' changed\n"),
+                       ev.key.c_str()));
+            ChangeCallback cbcopy;
+            {
+                std::lock_guard<std::mutex> g(m_impl->mtx);
+                cbcopy = m_impl->cb;
+            }
+            if (cbcopy) cbcopy(*changed);
+        },
+        &m_impl->watch_handle);
+    if (!ws.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [wifi:%t] %M %N:%l watch register failed: "
+                            "%C — cache primed but change notifications "
+                            "disabled\n"),
+                   ws.err.c_str()));
+    }
+}
+
+DsBridge::~DsBridge() {
+    if (!m_impl) return;
+    if (m_impl->watch_handle != data_store::Client::kInvalidHandle) {
+        m_impl->client.unwatch(m_impl->watch_handle, /*timeout_ms=*/200);
+    }
+    m_impl->client.close();
+}
+
+// ─────────────────────── Read accessors ─────────────────────────────
+
+std::optional<std::string> DsBridge::iface() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->iface;
+}
+std::optional<std::string> DsBridge::ctrl_dir() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->ctrl_dir;
+}
+std::optional<std::string> DsBridge::wpa_path() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->wpa_path;
+}
+std::optional<std::string> DsBridge::networks() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->networks;
+}
+std::optional<std::uint32_t> DsBridge::scan_interval_sec() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->scan_interval_sec;
+}
+std::optional<std::uint32_t> DsBridge::scan_max_results() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->scan_max_results;
+}
+std::optional<std::uint32_t> DsBridge::scan_request() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->scan_request;
+}
+std::optional<std::string> DsBridge::dhcp_client() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->dhcp_client;
+}
+std::optional<std::string> DsBridge::dhcp_path() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->dhcp_path;
+}
+
+std::optional<std::vector<std::string>>
+DsBridge::missing_required() const {
+    if (!m_ok) {
+        // Not connected → surface placeholder list so the caller's
+        // "missing config" diagnostic path is uniform with
+        // openvpn-client's shape.
+        return std::vector<std::string>{kIface};
+    }
+    // Schema defaults make every read key satisfied at this layer.
+    // wifi.networks shape validation lives in the Supervisor.
+    return std::nullopt;
+}
+
+// ─────────────────────── Write side ─────────────────────────────────
+
+namespace {
+void log_set_failure(const char* key, const data_store::Status& rs) {
+    ACE_ERROR((LM_WARNING,
+               ACE_TEXT("%D [wifi:%t] %M %N:%l set %C failed: %C\n"),
+               key, rs.err.c_str()));
+}
+} // namespace
+
+void DsBridge::set_assoc_state(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kAssocState, s);
+    if (!rs.ok) log_set_failure(kAssocState, rs);
+}
+void DsBridge::set_assoc_ssid(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kAssocSsid, s);
+    if (!rs.ok) log_set_failure(kAssocSsid, rs);
+}
+void DsBridge::set_assoc_bssid(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kAssocBssid, s);
+    if (!rs.ok) log_set_failure(kAssocBssid, rs);
+}
+void DsBridge::set_signal_rssi(std::int32_t dbm) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kSignalRssi, dbm);
+    if (!rs.ok) log_set_failure(kSignalRssi, rs);
+}
+void DsBridge::set_scan_results(const std::string& json) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kScanResults, json);
+    if (!rs.ok) log_set_failure(kScanResults, rs);
+}
+void DsBridge::set_scan_last_unix(std::uint32_t unix_ts) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kScanLastUnix, unix_ts);
+    if (!rs.ok) log_set_failure(kScanLastUnix, rs);
+}
+void DsBridge::set_dhcp_state(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kDhcpState, s);
+    if (!rs.ok) log_set_failure(kDhcpState, rs);
+}
+void DsBridge::set_dhcp_ip(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kDhcpIp, s);
+    if (!rs.ok) log_set_failure(kDhcpIp, rs);
+}
+void DsBridge::set_pid_wpa(std::uint32_t p) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kPidWpa, p);
+    if (!rs.ok) log_set_failure(kPidWpa, rs);
+}
+void DsBridge::set_pid_dhcp(std::uint32_t p) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kPidDhcp, p);
+    if (!rs.ok) log_set_failure(kPidDhcp, rs);
+}
+void DsBridge::set_last_error(const std::string& s) {
+    if (!m_ok) return;
+    auto rs = m_impl->client.set(kLastError, s);
+    if (!rs.ok) log_set_failure(kLastError, rs);
+}
+
+// ─────────────────────── on_change registration ─────────────────────
+
+void DsBridge::on_change(ChangeCallback cb) {
+    if (!m_impl) return;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    m_impl->cb = std::move(cb);
+}
+
+} // namespace wifi_client

--- a/modules/wan/wifi/client/src/ds_bridge.hpp
+++ b/modules/wan/wifi/client/src/ds_bridge.hpp
@@ -1,0 +1,125 @@
+#ifndef __wifi_client_ds_bridge_hpp__
+#define __wifi_client_ds_bridge_hpp__
+
+/// Bridge between wifi-client and ds-server.
+///
+/// Mirrors modules/openvpn/client/src/ds_bridge.hpp for the wifi.*
+/// namespace. Holds a data_store::Client for the daemon lifetime;
+/// primes a thread-safe snapshot of the readable keys on startup;
+/// registers a callback-style watch so subsequent `ds-cli set wifi.*`
+/// mutations land in the cache and fire the caller's on_change handler.
+///
+/// L15/D3 — first-cut hot-reload policy: the watch logs the change
+/// and fires the caller's on_change handler with a typed Key enum.
+/// Live re-application (regenerating wpa_supplicant.conf, RECONFIGURE
+/// vs full restart) is the Supervisor's responsibility (D6).
+///
+/// Threading: all read accessors and missing_required() are
+/// thread-safe (internal mutex). The data_store::Client's listener
+/// thread is the source of cache updates; main-thread callers take
+/// the same mutex for read.
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace wifi_client {
+
+class DsBridge {
+public:
+    /// Which key did the on_change() callback fire for? Exposing
+    /// the raw string would work too, but an enum makes
+    /// switch-statements in the consumer exhaustive-warnings-friendly.
+    enum class Key {
+        Iface,
+        CtrlDir,
+        WpaPath,
+        Networks,
+        ScanIntervalSec,
+        ScanMaxResults,
+        ScanRequest,
+        DhcpClient,
+        DhcpPath,
+    };
+
+    using ChangeCallback = std::function<void(Key)>;
+
+    /// Connect to `socketPath` (empty → default
+    /// /var/run/iot/data_store.sock), prime the snapshot, register
+    /// the watch. Connection failures are silently absorbed — call
+    /// connected() to check before exercising the accessors.
+    explicit DsBridge(std::string socketPath = {});
+    ~DsBridge();
+
+    DsBridge(const DsBridge&)            = delete;
+    DsBridge& operator=(const DsBridge&) = delete;
+
+    bool connected() const { return m_ok; }
+    const std::string& socket_path() const { return m_path; }
+
+    // ─────────────────────── Read snapshots ────────────────────────
+    // Return whatever the listener thread last observed. nullopt
+    // for keys that were never set AND have no schema default (the
+    // wifi.* schema gives every read key a default, so accessors
+    // mostly return a value as soon as connected() is true).
+    std::optional<std::string>   iface()              const;
+    std::optional<std::string>   ctrl_dir()           const;
+    std::optional<std::string>   wpa_path()           const;
+    std::optional<std::string>   networks()           const;  // raw JSON
+    std::optional<std::uint32_t> scan_interval_sec()  const;
+    std::optional<std::uint32_t> scan_max_results()   const;
+    std::optional<std::uint32_t> scan_request()       const;
+    std::optional<std::string>   dhcp_client()        const;
+    std::optional<std::string>   dhcp_path()          const;
+
+    /// Returns nullopt when the connection is healthy (every read
+    /// key has a schema default, so there are no genuinely-missing
+    /// keys at this layer — JSON validation of wifi.networks is
+    /// the Supervisor's job, not the bridge's). When `connected()`
+    /// is false the function returns a placeholder list so the
+    /// caller's "ds unreachable" diagnostic path can be uniform
+    /// with openvpn-client's missing_required() shape.
+    std::optional<std::vector<std::string>> missing_required() const;
+
+    // ─────────────────────── Write side ────────────────────────────
+    // Each setter issues a data_store::Client::set on the shared
+    // socket. Best-effort: a wire-level failure is logged via
+    // ACE_ERROR but not surfaced — the caller's state machine has
+    // already advanced.
+
+    void set_assoc_state(const std::string& s);
+    void set_assoc_ssid(const std::string& s);
+    void set_assoc_bssid(const std::string& s);
+    void set_signal_rssi(std::int32_t dbm);
+    void set_scan_results(const std::string& json);
+    void set_scan_last_unix(std::uint32_t unix_ts);
+    void set_dhcp_state(const std::string& s);
+    void set_dhcp_ip(const std::string& s);
+    void set_pid_wpa(std::uint32_t p);
+    void set_pid_dhcp(std::uint32_t p);
+    void set_last_error(const std::string& s);
+
+    /// Register a per-key change listener. Fires on the
+    /// data_store::Client's listener thread — keep it short, don't
+    /// block on locks the main thread might hold. Pass nullptr to
+    /// clear a previous registration (REQ-WIFI-009).
+    void on_change(ChangeCallback cb);
+
+    /// Default ds-server socket path. Duplicated from
+    /// data_store::proto::kDefaultSocketPath so this header stays
+    /// free of data_store/ includes.
+    static const char* kDefaultSocketPath;
+
+private:
+    struct Impl;
+    std::unique_ptr<Impl> m_impl;
+    std::string           m_path;
+    bool                  m_ok = false;
+};
+
+} // namespace wifi_client
+
+#endif /* __wifi_client_ds_bridge_hpp__ */

--- a/modules/wan/wifi/client/test/ds_bridge_test.cpp
+++ b/modules/wan/wifi/client/test/ds_bridge_test.cpp
@@ -1,0 +1,121 @@
+/// Light-touch unit tests for wifi-client's DsBridge — only the bits
+/// that DON'T need a live ds-server. End-to-end prime + watch
+/// behaviour against real keys lives in log/L15/smoke.sh against a
+/// real ds-server (D8). Same trade-off openvpn-client took.
+
+#include <gtest/gtest.h>
+
+#include "ds_bridge.hpp"
+
+using wifi_client::DsBridge;
+
+namespace {
+
+/// A socket path that almost certainly doesn't exist. The bridge
+/// must absorb the failure as `connected()==false` without crashing.
+constexpr const char* kBogusSocket =
+    "/var/run/iot/this-wifi-path-cannot-exist.sock";
+
+} // namespace
+
+// ─────────────────────────── REQ-WIFI-007 ───────────────────────────
+// "DsBridge MUST prime by get-ing every read key, then register for
+// change events." The prime+watch path requires a live ds-server;
+// the smoke covers it. Here we verify the disconnected branch is
+// non-crashing so the supervisor's "ds down" diagnostic is uniform.
+
+TEST(WIFI_REQ_WIFI_007_start_primes_then_registers,
+     construct_against_missing_socket_is_not_fatal) {
+    DsBridge ds(kBogusSocket);
+    EXPECT_FALSE(ds.connected());
+    EXPECT_EQ(std::string(kBogusSocket), ds.socket_path());
+}
+
+TEST(WIFI_REQ_WIFI_007_start_primes_then_registers,
+     accessors_return_nullopt_when_disconnected) {
+    DsBridge ds(kBogusSocket);
+    ASSERT_FALSE(ds.connected());
+    // Spot-check one accessor per type; the rest follow the same
+    // mutex-then-snapshot pattern.
+    EXPECT_FALSE(ds.iface().has_value());
+    EXPECT_FALSE(ds.scan_max_results().has_value());
+    EXPECT_FALSE(ds.networks().has_value());
+}
+
+TEST(WIFI_REQ_WIFI_007_start_primes_then_registers,
+     missing_required_lists_placeholder_when_disconnected) {
+    // Disconnected → surface a placeholder list so the caller's
+    // "ds unreachable" branch is uniform with openvpn-client's
+    // missing_required() shape. Schema defaults make connected()==true
+    // → nullopt the normal case (no genuinely missing keys at this
+    // layer; JSON validation of wifi.networks is the Supervisor's job).
+    DsBridge ds(kBogusSocket);
+    auto missing = ds.missing_required();
+    ASSERT_TRUE(missing.has_value());
+    EXPECT_FALSE(missing->empty());
+    // Order matches DsBridge.cpp; keep in sync if either side changes.
+    EXPECT_EQ("wifi.iface", (*missing)[0]);
+}
+
+// ─────────────────────────── REQ-WIFI-008 ───────────────────────────
+// Setters must log + return without throwing on wire failure. We
+// can't directly inspect log output here; the assertion is "no
+// throw, no crash" when fired against a disconnected bridge.
+
+TEST(WIFI_REQ_WIFI_008_setter_logs_on_failure_no_throw,
+     all_setters_noop_when_disconnected) {
+    DsBridge ds(kBogusSocket);
+    ASSERT_FALSE(ds.connected());
+
+    // Every published write key. If a future setter throws on a
+    // disconnected bridge, this test catches it.
+    ds.set_assoc_state("scanning");
+    ds.set_assoc_ssid("HomeAP");
+    ds.set_assoc_bssid("aa:bb:cc:dd:ee:ff");
+    ds.set_signal_rssi(-52);
+    ds.set_scan_results("[]");
+    ds.set_scan_last_unix(1717293600u);
+    ds.set_dhcp_state("idle");
+    ds.set_dhcp_ip("10.0.0.42");
+    ds.set_pid_wpa(0u);
+    ds.set_pid_dhcp(0u);
+    ds.set_last_error("");
+    SUCCEED();
+}
+
+TEST(WIFI_REQ_WIFI_008_setter_logs_on_failure_no_throw,
+     negative_rssi_does_not_underflow_or_throw) {
+    // wifi.signal.rssi is a signed int — operator values are dBm,
+    // typically -30 to -90. Make sure the setter accepts the range.
+    DsBridge ds(kBogusSocket);
+    ds.set_signal_rssi(-90);
+    ds.set_signal_rssi(0);
+    ds.set_signal_rssi(-30);
+    SUCCEED();
+}
+
+// ─────────────────────────── REQ-WIFI-009 ───────────────────────────
+// on_change(nullptr) MUST clear a previously-registered callback so
+// the Supervisor can swap handlers between phases without leaking
+// the old one onto the listener thread.
+
+TEST(WIFI_REQ_WIFI_009_on_change_null_callback_resets,
+     on_change_accepts_null_after_real_callback) {
+    DsBridge ds(kBogusSocket);
+    bool fired = false;
+    ds.on_change([&](DsBridge::Key) { fired = true; });
+    ds.on_change(nullptr);
+    // We can't drive the listener thread from a disconnected bridge,
+    // but the SetUp/TearDown alone proves the registration setter
+    // doesn't crash when called with nullptr after a real callback.
+    EXPECT_FALSE(fired);
+}
+
+TEST(WIFI_REQ_WIFI_009_on_change_null_callback_resets,
+     on_change_idempotent_under_repeated_null) {
+    DsBridge ds(kBogusSocket);
+    ds.on_change(nullptr);
+    ds.on_change(nullptr);
+    ds.on_change(nullptr);
+    SUCCEED();
+}


### PR DESCRIPTION
## Summary
Bridge between wifi-client and ds-server. Mirrors `modules/openvpn/client/src/ds_bridge.{hpp,cpp}` for the `wifi.*` namespace: prime the 9 read keys on startup via `Client::get`, register a `Client::watch` for change events, route updates into a mutex-guarded snapshot, fire the caller's `ChangeCallback` with a typed `Key` enum.

## API surface
**Read accessors** (mutex-guarded; `nullopt` when disconnected):
`iface()`, `ctrl_dir()`, `wpa_path()`, `networks()`, `scan_interval_sec()`, `scan_max_results()`, `scan_request()`, `dhcp_client()`, `dhcp_path()`.

**Setters** (best-effort; log via `ACE_ERROR` on wire failure, no throw):
`set_assoc_state/ssid/bssid`, `set_signal_rssi` (signed int, dBm), `set_scan_results` (JSON string), `set_scan_last_unix`, `set_dhcp_state/ip`, `set_pid_wpa/dhcp`, `set_last_error`.

**`missing_required()`**: returns `nullopt` when connected (schema defaults populate every read key — `wifi.networks` defaults to `"[]"`). Returns a placeholder list when disconnected so the caller's "ds unreachable" branch matches openvpn-client's shape.

**`on_change(nullptr)`**: clears a previously-registered callback (REQ-WIFI-009). Listener thread fires the callback off-lock so a recursive `set` inside the callback can't deadlock.

## Tests
7 new cases in `ds_bridge_test.cpp`; total wifi-client-tests at 26/26 green.

- REQ-WIFI-007 (3): construct-against-bogus-socket non-fatal, accessors-`nullopt` when disconnected, `missing_required` placeholder shape
- REQ-WIFI-008 (2): all 11 setters no-op when disconnected, signed-int rssi range
- REQ-WIFI-009 (2): `on_change(nullptr)` after real callback, idempotent repeated nulls

Same trade-off openvpn-client took: real prime+watch against actual `ds-server` keys is exercised by `log/L15/smoke.sh` (D8). Unit tests cover the disconnected/no-throw contract.

## Test plan
- [x] `make wifi-client-tests && ./wifi-client-tests` → 26/26 green
- [x] CMake adds `src/ds_bridge.cpp` to `wifi_client_lib` and `test/ds_bridge_test.cpp` to the test binary
- [ ] Wire-level prime+watch validation deferred to D8 smoke

Closes REQ-WIFI-007, REQ-WIFI-008, REQ-WIFI-009.

🤖 Generated with [Claude Code](https://claude.com/claude-code)