### PR TITLE
feat(wifi-client): L15/D7 — packaging + systemd + DEPLOY.md

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -237,6 +237,41 @@ DNAT'd to `net.lwm2m.target.ip`. Override via `net.forward.ports`
 and add operator drops/forwards via the JSON `net.custom.rules`
 schema key (see `/etc/iot/ds-schemas/net.lua`).
 
+For the **wifi-client** unit (L15: wpa_supplicant + DHCP-client
+supervisor; publishes `wifi.*`), seed the network list and enable.
+NetworkManager MUST be masked on hosts running wifi-client — the
+daemon's startup probe writes `wifi.assoc.state="conflict"` and
+refuses to spawn wpa_supplicant if NM is active.
+
+```sh
+sudo systemctl mask NetworkManager   # avoid the conflict gate
+
+ds-cli --socket=/run/iot/data_store.sock set wifi.networks \
+    '[{"ssid":"HomeAP","psk":"correcthorse","priority":10}]'
+
+# Optional: pick a different iface or DHCP client.
+ds-cli --socket=/run/iot/data_store.sock set wifi.iface       '"wlan0"'
+ds-cli --socket=/run/iot/data_store.sock set wifi.dhcp.client '"udhcpc"'
+
+sudo systemctl enable --now iot-wifi-client.service
+journalctl -u iot-wifi-client.service -f | grep "ctrl attached\|assoc\|connected\|dhcp"
+
+# Observe the published wifi.* keys.
+ds-cli --socket=/run/iot/data_store.sock get \
+    wifi.assoc.state wifi.assoc.ssid wifi.assoc.bssid \
+    wifi.dhcp.state wifi.dhcp.ip wifi.signal.rssi
+```
+
+The unit ships with `AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW`
++ `DeviceAllow=/dev/rfkill rw`; scan needs raw sockets, key mgmt
+needs NET_ADMIN, soft-block check needs /dev/rfkill. Plaintext PSK
+posture: `wifi.networks[].psk` lives in `/var/lib/iot/data_store.lua`
+in plaintext, same as `vpn.cert.path`. Secrets-vault is FUP-L15-1.
+
+The chain closes here: wifi-client brings `wlan0` up → kernel
+flags it OPER UP → net-router writes `net.iface.active="wlan0"`
+→ openvpn-client's WAN gate fires → tunnel comes up.
+
 ### 4. Same ds-cli tuning as the container path
 
 ```sh

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -119,6 +119,7 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-lwm2m-server.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-openvpn-client.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-net-router.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-wifi-client.service
             DESTINATION lib/systemd/system)
 
     # tmpfiles.d fallback for hosts where RuntimeDirectory= doesn't
@@ -140,6 +141,7 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/lwm2m-server.env
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/openvpn-client.env
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/net-router.env
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/etc-iot/wifi-client.env
             DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot)
 
     # Object-resource config templates. Land each .lua as .lua.example

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,15 @@ FROM ubuntu:jammy
 #   openvpn(8) — the openvpn-client daemon spawns it
 #   netcat-openbsd — L12 fake-openvpn smoke harness
 #   nftables + iproute2 — the net-router daemon shells out to nft + ip
+#   wpasupplicant + udhcpc + wireless-tools — wifi-client daemon
+#                                              spawns wpa_supplicant +
+#                                              udhcpc, smoke harness
+#                                              uses wpa_cli for verify
 # None of them are link-time deps, just runtime.
 RUN apt-get update && apt-get -y upgrade && \
     apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev python3-dev autoconf wget pkg-config \
-                       openvpn netcat-openbsd nftables iproute2
+                       openvpn netcat-openbsd nftables iproute2 \
+                       wpasupplicant udhcpc wireless-tools
 
 # ACE/TAO 7.0.0 — same install prefix as the xpmile project so the include
 # / link paths in apps/CMakeLists.txt resolve. `ssl=1` is load-bearing; without

--- a/packaging/Containerfile
+++ b/packaging/Containerfile
@@ -48,7 +48,10 @@ RUN find /staging/etc/iot/config -name '*.lua.example' \
 # Strip the binaries — saves ~20 MB across the three.
 RUN strip /staging/usr/bin/ds-server \
           /staging/usr/bin/ds-cli \
-          /staging/usr/bin/lwm2m
+          /staging/usr/bin/lwm2m \
+          /staging/usr/bin/openvpn-client \
+          /staging/usr/bin/net-router \
+          /staging/usr/bin/wifi-client
 
 # ──────────────────────────────────────────────────────────────────────
 # Stage 2: runtime
@@ -75,7 +78,10 @@ RUN apt-get update -qq && \
         ca-certificates \
         openvpn \
         nftables \
-        iproute2 && \
+        iproute2 \
+        wpasupplicant \
+        udhcpc \
+        wireless-tools && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /var/cache/apt/* /usr/share/doc/* /usr/share/man/*
 
@@ -99,6 +105,7 @@ COPY --from=build /staging/usr/bin/ds-cli          /usr/local/bin/
 COPY --from=build /staging/usr/bin/lwm2m           /usr/local/bin/
 COPY --from=build /staging/usr/bin/openvpn-client  /usr/local/bin/
 COPY --from=build /staging/usr/bin/net-router      /usr/local/bin/
+COPY --from=build /staging/usr/bin/wifi-client     /usr/local/bin/
 COPY --from=build /staging/etc/iot                 /etc/iot
 
 COPY packaging/iot-entrypoint.sh /usr/local/bin/iot-entrypoint

--- a/packaging/etc-iot/wifi-client.env
+++ b/packaging/etc-iot/wifi-client.env
@@ -1,0 +1,28 @@
+# EnvironmentFile for iot-wifi-client.service.
+#
+# WIFI_CLIENT_ARGS is the literal argv tail passed to
+# /usr/local/bin/wifi-client. The wifi.* config keys (networks,
+# iface, ctrl.dir, scan.*, dhcp.*) come from ds-server via ds-cli —
+# see /etc/iot/ds-schemas/wifi.lua for the schema. The .env file
+# only carries process-level wiring (socket path, binary paths).
+#
+# Hot-reloadable via ds-cli (preferred over editing this file):
+#   wifi.networks       (JSON array of {ssid, psk, priority, key_mgmt})
+#   wifi.iface          (default "wlan0")
+#   wifi.ctrl.dir       (default "/run/wpa_supplicant")
+#   wifi.scan.interval.sec / wifi.scan.max.results / wifi.scan.request
+#   wifi.dhcp.client    ("udhcpc" / "dhclient" / "auto")
+#   wifi.dhcp.path      (override DHCP binary path)
+#
+# Operator workflow (bare metal):
+#   sudo systemctl mask NetworkManager           # avoid conflict
+#   sudo systemctl daemon-reload
+#   sudo systemctl enable --now iot-wifi-client.service
+#   ds-cli set wifi.networks '[{"ssid":"HomeAP","psk":"correcthorse","priority":10}]'
+#   journalctl -u iot-wifi-client.service -f
+#
+# Plaintext PSK posture: wifi.networks values are stored in
+# /var/lib/iot/data_store.lua in plaintext (same posture L12 took
+# for vpn.cert.path). A secrets-vault store is FUP-L15-1.
+
+WIFI_CLIENT_ARGS="--ds-sock=/run/iot/data_store.sock --wpa=/usr/sbin/wpa_supplicant --iface=wlan0 --ctrl-dir=/run/wpa_supplicant"

--- a/packaging/iot-entrypoint.sh
+++ b/packaging/iot-entrypoint.sh
@@ -8,6 +8,11 @@
 #                       --device=/dev/net/tun on the podman run)
 #   IOT_ROLE=net     → run net-router (needs --cap-add=NET_ADMIN +
 #                       host's /proc/net visible; usually --network=host)
+#   IOT_ROLE=wifi    → run wifi-client (needs --cap-add=NET_ADMIN
+#                       --cap-add=NET_RAW + --network=host + host
+#                       /dev/rfkill + a real wifi NIC. Container
+#                       runs are dev-only; production is bare-metal
+#                       systemd.)
 #
 # Per-role default args live in /etc/iot/lwm2m-*.env (sourced via
 # . , so they end up as shell vars). Operators override by:
@@ -24,7 +29,7 @@ set -e
 # If the first arg is one of our binaries, forward verbatim — supports
 # `podman run iot:l11 ds-cli get foo`.
 case "${1:-}" in
-    ds-cli|ds-server|lwm2m|openvpn-client|openvpn|net-router|nft|ip)
+    ds-cli|ds-server|lwm2m|openvpn-client|openvpn|net-router|nft|ip|wifi-client|wpa_supplicant|wpa_cli|udhcpc|dhclient)
         exec "$@"
         ;;
 esac
@@ -65,13 +70,20 @@ case "${IOT_ROLE:-}" in
         # shellcheck disable=SC2086
         exec /usr/local/bin/net-router $NET_ROUTER_ARGS "$@"
         ;;
+    wifi)
+        # shellcheck disable=SC1091
+        [ -f /etc/iot/wifi-client.env ] && . /etc/iot/wifi-client.env
+        : "${WIFI_CLIENT_ARGS:?wifi-client.env missing WIFI_CLIENT_ARGS}"
+        # shellcheck disable=SC2086
+        exec /usr/local/bin/wifi-client $WIFI_CLIENT_ARGS "$@"
+        ;;
     "")
-        echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server | ovpn | net" >&2
-        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m / openvpn-client / openvpn / net-router / nft / ip" >&2
+        echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server | ovpn | net | wifi" >&2
+        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m / openvpn-client / openvpn / net-router / wifi-client / wpa_supplicant / wpa_cli / udhcpc / dhclient / nft / ip" >&2
         exit 64
         ;;
     *)
-        echo "iot-entrypoint: unknown IOT_ROLE='$IOT_ROLE' (expected ds|client|server|ovpn|net)" >&2
+        echo "iot-entrypoint: unknown IOT_ROLE='$IOT_ROLE' (expected ds|client|server|ovpn|net|wifi)" >&2
         exit 64
         ;;
 esac

--- a/packaging/systemd/iot-wifi-client.service
+++ b/packaging/systemd/iot-wifi-client.service
@@ -1,0 +1,59 @@
+[Unit]
+Description=IoT wifi-client (spawns wpa_supplicant + udhcpc, publishes wifi.* to ds-server)
+Documentation=file:///etc/iot/wifi-client.env
+Documentation=file:///usr/local/share/doc/iot/wifi-client-design.md
+# DsBridge connects to ds-server's unix socket; wait for it.
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+# Refuse coexistence with NetworkManager — wifi-client probes at
+# startup and writes wifi.assoc.state="conflict" if it finds NM
+# running (REQ-WIFI-022). Operators expected to mask NM on hosts
+# running wifi-client. systemd-level Conflicts= would also work
+# but couples us tighter than necessary — the runtime probe is
+# the canonical source of truth.
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/wifi-client.env
+ExecStart=/usr/local/bin/wifi-client $WIFI_CLIENT_ARGS
+
+# wpa_supplicant(8) configures iface state, manages keys, and the
+# child udhcpc binds DHCP sockets — all need CAP_NET_ADMIN. Scan
+# uses raw sockets so CAP_NET_RAW too. DynamicUser=yes works with
+# AmbientCapabilities on systemd 244+; we drop every other cap so
+# a compromised wifi-client can only manage its iface, nothing else.
+DynamicUser=yes
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
+
+# wpa_supplicant queries soft-block via /dev/rfkill on startup.
+# Without it the soft-block check returns ENOENT and wpa silently
+# treats the iface as un-blocked, but the access is logged either
+# way — making it explicit avoids the noise.
+DeviceAllow=/dev/rfkill rw
+
+# Same RuntimeDirectory=iot as iot-ds.service so the daemon sees
+# the same /run/iot/data_store.sock socket file.
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+# PrivateTmp=yes is incompatible with wpa_supplicant putting its
+# control socket under /run/wpa_supplicant/ when systemd remaps
+# /run. Default to NO so the control-dir is shared with udhcpc
+# and any operator wpa_cli session.
+PrivateTmp=no
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
Packaging glue: systemd unit, env file, container entrypoint dispatch, runtime + dev image apt installs, install rules, operator docs.

## Files
- **`packaging/systemd/iot-wifi-client.service`** — Type=simple unit, After=iot-ds.service, `AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW`, `DeviceAllow=/dev/rfkill rw`, `DynamicUser=yes`, `PrivateTmp=no` (must share `/run/wpa_supplicant` with udhcpc), `Restart=on-failure RestartSec=5s`.
- **`packaging/etc-iot/wifi-client.env`** — `WIFI_CLIENT_ARGS` defaults pointing at `/run/iot/data_store.sock` + `/usr/sbin/wpa_supplicant` + `wlan0` + `/run/wpa_supplicant`. Header documents the hot-reloadable wifi.* keys, the NM-mask workflow, plaintext-PSK posture.
- **`packaging/iot-entrypoint.sh`** — `IOT_ROLE=wifi` branch; direct-invocation allowlist gains wifi-client/wpa_supplicant/wpa_cli/udhcpc/dhclient.
- **`packaging/Containerfile`** — runtime apt installs `wpasupplicant udhcpc wireless-tools`; copies + strips wifi-client into /usr/local/bin.
- **`docker/Dockerfile`** — dev-image apt installs the same trio.
- **`apps/CMakeLists.txt`** — iot-wifi-client.service joins systemd install list; wifi-client.env joins /etc/iot install list.
- **`DEPLOY.md`** — new wifi-client operator section between net-router and the iot.* tuning step. Covers: systemctl mask NetworkManager, ds-cli seed of wifi.networks/iface/dhcp.client, enable+start the unit, journalctl follow, ds-cli get of wifi.assoc.* + wifi.dhcp.* + wifi.signal.rssi.

## Container vs bare-metal
Bare-metal systemd is the production path (same as openvpn-client / net-router). Container target works for dev with `--cap-add=NET_ADMIN --cap-add=NET_RAW --network=host` + a real wifi NIC.

## Test plan
- [x] `podman run` inside dev image: `wifi-client` builds and installs to /staging/usr/bin
- [x] `cmake --install` stages `wifi.lua` to /etc/iot/ds-schemas/
- [x] systemd unit + env file install rules added to apps/CMakeLists.txt
- [x] Containerfile apt list includes wpasupplicant + udhcpc + wireless-tools
- [x] DEPLOY.md operator section follows the same shape as net-router's

Closes REQ-WIFI-023, REQ-WIFI-024.

🤖 Generated with [Claude Code](https://claude.com/claude-code)