### PR TITLE
fix(wifi-client): FUP-L15-D8-1 — publish wifi.scan.results end-to-end

### DIFF
--- a/log/L15/smoke.sh
+++ b/log/L15/smoke.sh
@@ -116,6 +116,19 @@ else
     echo "WARN wifi.assoc.ssid empty (fake-wpa id_str path is informational)" >&2
 fi
 
+# REQ-WIFI-025: wifi.scan.results MUST be non-empty JSON.
+RESULTS=$("$DS_CLI" --socket="$DS_SOCK" get wifi.scan.results 2>/dev/null \
+            | sed -n 's/^wifi\.scan\.results=//p')
+case "$RESULTS" in
+    ""|"(null)"|"[]")
+        echo "FAIL wifi.scan.results = '$RESULTS' (expected non-empty JSON)" >&2
+        PASS=0
+        ;;
+    *)
+        echo "OK wifi.scan.results = $RESULTS"
+        ;;
+esac
+
 # Write the transcript before exiting (transcript wanted regardless
 # of pass/fail so a CI failure carries the evidence).
 {

--- a/log/L15/wifi-smoke.txt
+++ b/log/L15/wifi-smoke.txt
@@ -1,26 +1,26 @@
-L15/D8 smoke transcript 2026-06-01 17:45:56Z
+L15/D8 smoke transcript 2026-06-01 17:54:39Z
 ===========================================
 ds.log:
-  2026-06-01 17:45:55.761106 [DS:192] LM_INFO /work/modules/data-store/src/server/main.cpp:63 socket=/tmp/wifi-smoke/ds.sock store=/tmp/wifi-smoke/store.lua schemas=/tmp/wifi-smoke/schemas
-  2026-06-01 17:45:55.761682 [DS:192] LM_INFO /work/modules/data-store/src/server/main.cpp:76 loaded 26 schema key(s) from /tmp/wifi-smoke/schemas
-  2026-06-01 17:45:55.761750 [DS:192] LM_INFO /work/modules/data-store/src/server/main.cpp:97 loaded 0 key(s) from /tmp/wifi-smoke/store.lua
-  2026-06-01 17:45:55.761874 [Worker:194] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 0 started
-  2026-06-01 17:45:55.761948 [Worker:198] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 4 started
-  2026-06-01 17:45:55.762007 [Worker:197] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 3 started
-  2026-06-01 17:45:55.762068 [Worker:196] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 2 started
-  2026-06-01 17:45:55.761951 [Worker:195] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 1 started
-  2026-06-01 17:45:55.762268 [DS:192] LM_DEBUG /work/modules/data-store/src/server/server.cpp:74 listening on /tmp/wifi-smoke/ds.sock (mode 0660)
+  2026-06-01 17:54:38.213626 [DS:197] LM_INFO /work/modules/data-store/src/server/main.cpp:63 socket=/tmp/wifi-smoke/ds.sock store=/tmp/wifi-smoke/store.lua schemas=/tmp/wifi-smoke/schemas
+  2026-06-01 17:54:38.214141 [DS:197] LM_INFO /work/modules/data-store/src/server/main.cpp:76 loaded 26 schema key(s) from /tmp/wifi-smoke/schemas
+  2026-06-01 17:54:38.214205 [DS:197] LM_INFO /work/modules/data-store/src/server/main.cpp:97 loaded 0 key(s) from /tmp/wifi-smoke/store.lua
+  2026-06-01 17:54:38.214324 [Worker:199] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 0 started
+  2026-06-01 17:54:38.214396 [Worker:200] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 1 started
+  2026-06-01 17:54:38.214464 [Worker:203] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 4 started
+  2026-06-01 17:54:38.214572 [Worker:201] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 2 started
+  2026-06-01 17:54:38.214630 [Worker:202] LM_DEBUG /work/modules/data-store/src/server/worker.cpp:117 worker 3 started
+  2026-06-01 17:54:38.214671 [DS:197] LM_DEBUG /work/modules/data-store/src/server/server.cpp:74 listening on /tmp/wifi-smoke/ds.sock (mode 0660)
 
 wifi-client.log:
-  2026-06-01 17:45:56.290619 [wifi:205] LM_INFO /src/modules/wan/wifi/client/src/ds_bridge.cpp:84 data-store ready at /tmp/wifi-smoke/ds.sock
-  2026-06-01 17:45:56.292038 [wifi:205] LM_INFO /src/modules/wan/wifi/client/src/main_impl.cpp:141 starting on iface=wlan-smoke wpa=/src/log/L15/fake-wpa.py ctrl_dir=/tmp/wifi-smoke/wpa-ctrl
+  2026-06-01 17:54:38.743336 [wifi:210] LM_INFO /src/modules/wan/wifi/client/src/ds_bridge.cpp:84 data-store ready at /tmp/wifi-smoke/ds.sock
+  2026-06-01 17:54:38.744435 [wifi:210] LM_INFO /src/modules/wan/wifi/client/src/main_impl.cpp:141 starting on iface=wlan-smoke wpa=/src/log/L15/fake-wpa.py ctrl_dir=/tmp/wifi-smoke/wpa-ctrl
   [fake-wpa] listening at /tmp/wifi-smoke/wpa-ctrl/wlan-smoke
-  [fake-wpa] ATTACH from /tmp/wpa_ctrl_iot_205_WiGp6x
-  2026-06-01 17:45:56.349549 [wifi:205] LM_INFO /src/modules/wan/wifi/client/src/ctrl.cpp:182 ctrl attached to /tmp/wifi-smoke/wpa-ctrl/wlan-smoke
+  [fake-wpa] ATTACH from /tmp/wpa_ctrl_iot_210_qGE6JD
+  2026-06-01 17:54:38.802679 [wifi:210] LM_INFO /src/modules/wan/wifi/client/src/ctrl.cpp:190 ctrl attached to /tmp/wifi-smoke/wpa-ctrl/wlan-smoke
 
 final state:
   wifi.assoc.state=connected
   wifi.assoc.ssid=HomeAP
   wifi.assoc.bssid=aa:bb:cc:dd:ee:ff
-  wifi.scan.results=(null)
+  wifi.scan.results=[{"bssid":"aa:bb:cc:dd:ee:ff","flags":"[WPA2-PSK-CCMP][ESS]","signal":-42,"ssid":"HomeAP"},{"bssid":"11:22:33:44:55:66","flags":"[WPA2-PSK-CCMP][ESS]","signal":-67,"ssid":"GuestNet"}]
   wifi.last.error=(null)

--- a/modules/wan/wifi/client/src/ctrl.cpp
+++ b/modules/wan/wifi/client/src/ctrl.cpp
@@ -1,9 +1,11 @@
 #include "ctrl.hpp"
 
 #include <cerrno>
+#include <chrono>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <deque>
 #include <unistd.h>
 
 #include <ace/INET_Addr.h>      // for time-based send/recv (ACE_Time_Value)
@@ -122,6 +124,12 @@ struct Client::Impl {
     ACE_UNIX_Addr   peer;
     std::string     local_path;
     bool            open = false;
+    /// Datagrams received during a request() that were unsolicited
+    /// events (priority-prefixed). Drained by recv_event() before
+    /// any fresh socket recv. Real wpa_ctrl does the same — events
+    /// and replies share one socket, the client distinguishes by the
+    /// leading "<N>" prefix on events.
+    std::deque<std::string> deferred_events;
 };
 
 Client::Client() : m_impl(new Impl{}) {}
@@ -200,26 +208,65 @@ bool Client::request(const std::string& cmd, std::string& reply) {
         return false;
     }
 
-    char buf[4096];
-    ACE_UNIX_Addr src;
-    ACE_Time_Value timeout(2, 0);
-    ssize_t got = m_impl->sock.recv(buf, sizeof(buf) - 1, src, 0, &timeout);
-    if (got <= 0) {
-        ACE_ERROR((LM_WARNING,
-                   ACE_TEXT("%D [wifi:%t] %M %N:%l recv('%C') n=%d errno=%d\n"),
-                   cmd.c_str(), static_cast<int>(got), errno));
-        return false;
+    // Recv-loop with a global deadline. Datagrams starting with "<"
+    // are unsolicited events — defer them so a concurrent CTRL-EVENT
+    // burst (which is common right after SCAN_RESULTS) doesn't get
+    // mistaken for our reply. Real wpa_ctrl_request() in
+    // wpa_supplicant's own client lib does the same dance.
+    const auto deadline = std::chrono::steady_clock::now()
+                        + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        auto now      = std::chrono::steady_clock::now();
+        auto leftover = std::chrono::duration_cast<std::chrono::milliseconds>(
+                            deadline - now).count();
+        if (leftover <= 0) break;
+        ACE_Time_Value tv(static_cast<time_t>(leftover / 1000),
+                          static_cast<suseconds_t>((leftover % 1000) * 1000));
+        char buf[4096];
+        ACE_UNIX_Addr src;
+        ssize_t got = m_impl->sock.recv(buf, sizeof(buf) - 1, src, 0, &tv);
+        if (got <= 0) {
+            ACE_ERROR((LM_WARNING,
+                       ACE_TEXT("%D [wifi:%t] %M %N:%l recv('%C') n=%d "
+                                "errno=%d\n"),
+                       cmd.c_str(), static_cast<int>(got), errno));
+            return false;
+        }
+        buf[got] = '\0';
+        std::string datagram(buf, got);
+        if (!datagram.empty() && datagram.front() == '<') {
+            // Unsolicited event — defer + keep waiting for our reply.
+            m_impl->deferred_events.push_back(std::move(datagram));
+            continue;
+        }
+        reply = std::move(datagram);
+        while (!reply.empty()
+               && (reply.back() == '\n' || reply.back() == '\r')) {
+            reply.pop_back();
+        }
+        return reply.compare(0, 4, "FAIL") != 0;
     }
-    buf[got] = '\0';
-    reply.assign(buf, got);
-    while (!reply.empty() && (reply.back() == '\n' || reply.back() == '\r')) {
-        reply.pop_back();
-    }
-    return reply.compare(0, 4, "FAIL") != 0;
+    ACE_ERROR((LM_WARNING,
+               ACE_TEXT("%D [wifi:%t] %M %N:%l recv('%C') timed out waiting "
+                        "for reply (events deferred=%d)\n"),
+               cmd.c_str(),
+               static_cast<int>(m_impl->deferred_events.size())));
+    return false;
 }
 
 std::optional<CtrlEvent> Client::recv_event(int timeout_ms) {
     if (!connected()) return std::nullopt;
+    // Drain any events deferred during a previous request() call
+    // before doing a fresh socket recv. This is what keeps the
+    // Supervisor's "issue SCAN_RESULTS, parse, publish" path
+    // compatible with the concurrent CTRL-EVENT burst that follows
+    // SCAN: events arriving during request() get queued here and
+    // the FSM sees them on the next event-loop tick.
+    if (!m_impl->deferred_events.empty()) {
+        auto s = std::move(m_impl->deferred_events.front());
+        m_impl->deferred_events.pop_front();
+        return Parser::classify(s);
+    }
     char buf[4096];
     ACE_UNIX_Addr src;
     ACE_Time_Value timeout(timeout_ms / 1000, (timeout_ms % 1000) * 1000);

--- a/modules/wan/wifi/client/src/supervisor.cpp
+++ b/modules/wan/wifi/client/src/supervisor.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <ctime>
 #include <sstream>
 #include <string>
 #include <sys/stat.h>
@@ -299,16 +300,24 @@ int Supervisor::run() {
             continue;
         }
         m_fsm.step(*ev);
-        // FUP-L15-D8-1: on ScanResults the Supervisor should issue
-        // SCAN_RESULTS + publish wifi.scan.results JSON. Naive
-        // request() mid-loop collides with concurrent unsolicited
-        // CTRL-EVENT datagrams (real wpa_ctrl skips events between
-        // request/reply; our minimal parser doesn't). Plumbed as a
-        // follow-up — the unit tests already verify the
-        // cap_and_serialize_scan_results + parse_scan_results
-        // helpers (D6 supervisor_test.cpp), and the smoke proves
-        // the connect path end-to-end.
-        if (ev->kind == ctrl::CtrlEvent::Kind::Connected) {
+        if (ev->kind == ctrl::CtrlEvent::Kind::ScanResults) {
+            // Issue SCAN_RESULTS, parse, cap+serialize, publish.
+            // ctrl::Client::request() defers concurrent CTRL-EVENT
+            // datagrams so the CONNECTED event that often follows
+            // close on the heels of SCAN_RESULTS isn't swallowed —
+            // it lands in the listener's deferred queue and we see
+            // it on the next recv_event tick.
+            std::string reply;
+            if (m_ctrl.request("SCAN_RESULTS", reply)) {
+                auto rows = parse_scan_results(reply);
+                auto cap  = m_ds.scan_max_results().value_or(20u);
+                m_ds.set_scan_results(
+                    cap_and_serialize_scan_results(std::move(rows),
+                                                   static_cast<std::size_t>(cap)));
+                m_ds.set_scan_last_unix(static_cast<std::uint32_t>(
+                    std::time(nullptr)));
+            }
+        } else if (ev->kind == ctrl::CtrlEvent::Kind::Connected) {
             m_ds.set_assoc_ssid(ev->ssid);
             m_ds.set_assoc_bssid(ev->bssid);
             auto dhcp_path = pick_dhcp_client(


### PR DESCRIPTION
## Summary
Closes the follow-up flagged at D8 (`FUP-L15-D8-1`): the Supervisor's `SCAN_RESULTS` round-trip used to swallow the CONNECTED event that arrives 50ms behind SCAN-RESULTS on the same DGRAM socket. Fix by teaching `ctrl::Client::request()` to defer unsolicited events into a per-Client queue (same dance real `wpa_ctrl_request()` does in wpa_supplicant's own client lib).

## Mechanics
- `Client::Impl` gains `std::deque<std::string> deferred_events`.
- `request()` loop:
  - send command
  - recv with a **global 2s deadline** (rebuilt per-iteration so it doesn't drift when an event arrives mid-wait)
  - datagram starts with `<` → `deferred_events.push_back` + keep waiting for our reply
  - otherwise → reply; strip CR/LF; FAIL detection
- `recv_event()` drains `deferred_events` before doing a fresh socket recv. The FSM gets the queued events on subsequent ticks.

## Supervisor change
Re-enables the SCAN_RESULTS handler that D8 backed out:

```cpp
if (ev->kind == ctrl::CtrlEvent::Kind::ScanResults) {
    std::string reply;
    if (m_ctrl.request("SCAN_RESULTS", reply)) {
        auto rows = parse_scan_results(reply);
        auto cap  = m_ds.scan_max_results().value_or(20u);
        m_ds.set_scan_results(
            cap_and_serialize_scan_results(std::move(rows), cap));
        m_ds.set_scan_last_unix(std::time(nullptr));
    }
}
```

## Test plan
- [x] 90/90 unit tests green (no test changes — the deferred-queue mechanics are exercised by the smoke since they're inherently I/O-bound)
- [x] `log/L15/smoke.sh` exits 0 with the new `wifi.scan.results` non-empty assertion
- [x] Smoke transcript shows the sorted, capped JSON array:
  ```
  wifi.scan.results=[
    {"bssid":"aa:bb:cc:dd:ee:ff","flags":"[WPA2-PSK-CCMP][ESS]","signal":-42,"ssid":"HomeAP"},
    {"bssid":"11:22:33:44:55:66","flags":"[WPA2-PSK-CCMP][ESS]","signal":-67,"ssid":"GuestNet"}
  ]
  ```
  Strongest-first per NFR-WIFI-003.
- [x] `wifi.assoc.state=connected` still reaches its terminal value (CONNECTED event no longer swallowed)

Closes FUP-L15-D8-1. REQ-WIFI-025's "non-empty JSON" assertion in the smoke now passes by design, not by coincidence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)