### PR TITLE
feat(data-store): L16/D1 — services.lua + ServiceGate helper

### DIFF
--- a/modules/data-store/CMakeLists.txt
+++ b/modules/data-store/CMakeLists.txt
@@ -49,6 +49,7 @@ link_directories(${ACE_ROOT}/lib)
 # --------------------------------------------------------------------
 add_library(datastore_client STATIC
     src/client/client.cpp
+    src/client/service_gate.cpp
     src/proto/proto.cpp)
 
 target_include_directories(datastore_client
@@ -101,6 +102,7 @@ if(BUILD_DATA_STORE_TESTS)
         test/lua_persistor_test.cpp
         test/callback_test.cpp
         test/schema_test.cpp
+        test/service_gate_test.cpp
         src/server/server.cpp
         src/server/session.cpp
         src/server/data_store.cpp
@@ -109,7 +111,8 @@ if(BUILD_DATA_STORE_TESTS)
         src/server/worker.cpp
         src/server/worker_pool.cpp
         src/proto/proto.cpp
-        src/client/client.cpp)
+        src/client/client.cpp
+        src/client/service_gate.cpp)
 
     target_link_libraries(ds-tests
         GTest::gtest_main
@@ -140,4 +143,11 @@ install(DIRECTORY inc/data_store
 # the relative SYSCONFDIR would land at /usr/etc which ds-server won't
 # scan.
 install(FILES schemas/iot.lua
+        DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+
+# services.* schema (L16/D1) — central control plane for every iot
+# daemon's enable/state pair. Lives in data-store (not per-daemon)
+# because the set of services is small + the shape is uniform; one
+# enumerable source is what `ds-cli svc list` wants.
+install(FILES schemas/services.lua
         DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)

--- a/modules/data-store/inc/data_store/service_gate.hpp
+++ b/modules/data-store/inc/data_store/service_gate.hpp
@@ -1,0 +1,101 @@
+#ifndef __data_store_service_gate_hpp__
+#define __data_store_service_gate_hpp__
+
+/// Service-enable gate, shared across all iot daemons (L16/D1).
+///
+/// Wraps the (DsBridge -> on_change -> Supervisor) pattern that
+/// openvpn-client's WAN gate already uses, but for the
+/// services.<name>.enable key + the matching services.<name>.state
+/// publish.
+///
+/// One ServiceGate per daemon. Composes with other gates (WAN gate
+/// in openvpn-client, NM-conflict gate in wifi-client) — the
+/// composition rule from log/L16/plan.md is: `enabled()==false`
+/// dominates every other gate (the daemon's Supervisor evaluates
+/// `if (!gate.enabled()) park`; other gates only get consulted
+/// when enable is true).
+///
+/// Threading
+/// ---------
+/// - The data_store::Client's internal listener thread is the sole
+///   writer of the snapshot value.
+/// - `enabled()` is lock-protected; safe from any thread.
+/// - `wait()` blocks the calling thread on a condition variable;
+///   the listener wakes it on a value change OR `shutdown()`.
+/// - `publish_state()` is a thin set() that logs failures via
+///   ACE_ERROR and never throws — same posture as DsBridge's
+///   setters in modules/openvpn/client/src/ds_bridge.cpp.
+///
+/// The header keeps data_store::Client out of the include surface
+/// by forward-declaring it; the cpp pulls in the full type.
+
+#include <condition_variable>
+#include <cstdint>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace data_store {
+
+class Client;   // forward — defined in data_store/client.hpp
+
+class ServiceGate {
+public:
+    /// `client` MUST be a connected data_store::Client (the caller
+    /// keeps ownership). `name` is the bare daemon identifier
+    /// (e.g. "openvpn.client"); the gate constructs the full key
+    /// names from it as:
+    ///   services.<name>.enable    (read + watch)
+    ///   services.<name>.state     (write)
+    ServiceGate(Client& client, std::string name);
+    ~ServiceGate();
+
+    ServiceGate(const ServiceGate&)            = delete;
+    ServiceGate& operator=(const ServiceGate&) = delete;
+
+    /// Last observed value. True when the key is absent or unset
+    /// (the schema default is `true`). Lock-protected.
+    bool enabled() const;
+
+    /// Block until the snapshot value changes OR `shutdown()` is
+    /// called. Returns the new value, or `nullopt` on shutdown.
+    /// Multiple threads may wait concurrently; every waiter wakes
+    /// on a change event (NFR-SVC-005).
+    std::optional<bool> wait();
+
+    /// Wake any thread blocked in `wait()`. Subsequent `enabled()`
+    /// reflects the latest snapshot. Idempotent.
+    void shutdown();
+
+    /// Publish a new value for `services.<name>.state`. Best-effort:
+    /// wire-level failures log via ACE_ERROR and return without
+    /// throwing. Documented enum values: running / disabled /
+    /// starting / stopping / exited / conflict.
+    void publish_state(std::string_view s);
+
+    /// The bare daemon name passed to the ctor (e.g. "openvpn.client").
+    const std::string& name() const { return m_name; }
+
+    /// The full schema key the gate watches.
+    const std::string& enable_key() const { return m_enable_key; }
+    const std::string& state_key()  const { return m_state_key;  }
+
+private:
+    Client&                  m_client;
+    std::string              m_name;
+    std::string              m_enable_key;
+    std::string              m_state_key;
+
+    mutable std::mutex       m_mtx;
+    std::condition_variable  m_cv;
+    bool                     m_enabled  = true;   // schema default
+    std::uint64_t            m_version  = 0;      // bumped on every observed change
+    bool                     m_shutdown = false;
+
+    std::uint64_t            m_watch_handle = 0;  // 0 = not registered
+};
+
+} // namespace data_store
+
+#endif /* __data_store_service_gate_hpp__ */

--- a/modules/data-store/schemas/services.lua
+++ b/modules/data-store/schemas/services.lua
@@ -1,0 +1,47 @@
+-- services.* schema (L16/D1).
+--
+-- Operator-controlled enable/state plane for every iot daemon.
+-- Each gateable daemon (X) owns:
+--   services.X.enable   boolean default true   operator-flipped gate
+--   services.X.state    string  default "running"
+--                                  one of: running / disabled / starting /
+--                                  stopping / exited / conflict
+--
+-- ds-server is special: it cannot self-disable (the very socket
+-- carrying the command would go dead). services.ds.enable is
+-- intentionally OMITTED from this schema — ds-server's
+-- SchemaRegistry namespace-claimed-but-key-not-declared path
+-- rejects any set against it. The runtime state surface
+-- (services.ds.state, services.ds.uptime.sec) is still published
+-- so `ds-cli svc list` has a uniform shape (ENABLE column shows
+-- "n/a" for ds).
+--
+-- Install at /etc/iot/ds-schemas/services.lua (ds-server
+-- auto-loads on boot).
+
+return {
+  namespace = "services",
+  keys = {
+    -- ────────────── ds-server: state surface only ──────────────
+    ["services.ds.state"]                  = { type = "string",  default = "running" },
+    ["services.ds.uptime.sec"]             = { type = "integer", default = 0, min = 0 },
+
+    -- ────────────── net-router ──────────────
+    ["services.net.router.enable"]         = { type = "boolean", default = true },
+    ["services.net.router.state"]          = { type = "string",  default = "running" },
+
+    -- ────────────── openvpn-client ──────────────
+    ["services.openvpn.client.enable"]     = { type = "boolean", default = true },
+    ["services.openvpn.client.state"]      = { type = "string",  default = "running" },
+
+    -- ────────────── lwm2m-client / lwm2m-server ──────────────
+    ["services.lwm2m.client.enable"]       = { type = "boolean", default = true },
+    ["services.lwm2m.client.state"]        = { type = "string",  default = "running" },
+    ["services.lwm2m.server.enable"]       = { type = "boolean", default = true },
+    ["services.lwm2m.server.state"]        = { type = "string",  default = "running" },
+
+    -- ────────────── wifi-client ──────────────
+    ["services.wifi.client.enable"]        = { type = "boolean", default = true },
+    ["services.wifi.client.state"]         = { type = "string",  default = "running" },
+  },
+}

--- a/modules/data-store/src/client/service_gate.cpp
+++ b/modules/data-store/src/client/service_gate.cpp
@@ -1,0 +1,110 @@
+#include "data_store/service_gate.hpp"
+
+#include <utility>
+
+#include <ace/Log_Msg.h>
+
+#include "data_store/client.hpp"
+#include "data_store/value.hpp"
+
+namespace data_store {
+
+namespace {
+std::string make_enable_key(const std::string& name) {
+    return "services." + name + ".enable";
+}
+std::string make_state_key(const std::string& name) {
+    return "services." + name + ".state";
+}
+} // namespace
+
+ServiceGate::ServiceGate(Client& client, std::string name)
+    : m_client(client),
+      m_name(std::move(name)),
+      m_enable_key(make_enable_key(m_name)),
+      m_state_key(make_state_key(m_name)) {
+    // Prime synchronously via get(): the schema default of true
+    // populates the snapshot even when the key was never set.
+    std::vector<Client::GetResult> got;
+    auto gs = m_client.get(std::vector<std::string>{m_enable_key}, got);
+    if (gs.ok && !got.empty() && got[0].has_value) {
+        if (auto b = to_bool(got[0].value); b.has_value()) {
+            std::lock_guard<std::mutex> g(m_mtx);
+            m_enabled = *b;
+        }
+    } else if (!gs.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [svcgate:%t] %M %N:%l prime %C failed: %C "
+                            "(falling back to schema default true)\n"),
+                   m_enable_key.c_str(), gs.err.c_str()));
+    }
+
+    // Register a callback watch. The listener thread updates the
+    // snapshot under m_mtx and notifies every waiter on every
+    // observed change.
+    Client::WatchHandle handle = Client::kInvalidHandle;
+    auto ws = m_client.watch(
+        m_enable_key,
+        [this](const Client::Event& ev) {
+            if (auto b = to_bool(ev.value); b.has_value()) {
+                {
+                    std::lock_guard<std::mutex> g(m_mtx);
+                    m_enabled = *b;
+                    ++m_version;
+                }
+                m_cv.notify_all();
+            }
+        },
+        &handle);
+    if (!ws.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [svcgate:%t] %M %N:%l watch %C failed: %C "
+                            "(gate will not see future changes)\n"),
+                   m_enable_key.c_str(), ws.err.c_str()));
+    }
+    m_watch_handle = handle;
+}
+
+ServiceGate::~ServiceGate() {
+    shutdown();
+    if (m_watch_handle != Client::kInvalidHandle) {
+        m_client.unwatch(m_watch_handle, /*timeout_ms=*/200);
+        m_watch_handle = Client::kInvalidHandle;
+    }
+}
+
+bool ServiceGate::enabled() const {
+    std::lock_guard<std::mutex> g(m_mtx);
+    return m_enabled;
+}
+
+std::optional<bool> ServiceGate::wait() {
+    std::unique_lock<std::mutex> g(m_mtx);
+    const auto start_version = m_version;
+    m_cv.wait(g, [&] {
+        return m_shutdown || m_version != start_version;
+    });
+    if (m_shutdown) return std::nullopt;
+    return m_enabled;
+}
+
+void ServiceGate::shutdown() {
+    {
+        std::lock_guard<std::mutex> g(m_mtx);
+        if (m_shutdown) return;
+        m_shutdown = true;
+    }
+    m_cv.notify_all();
+}
+
+void ServiceGate::publish_state(std::string_view s) {
+    auto rs = m_client.set(m_state_key, std::string(s));
+    if (!rs.ok) {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [svcgate:%t] %M %N:%l set %C='%C' failed: %C\n"),
+                   m_state_key.c_str(), std::string(s).c_str(),
+                   rs.err.c_str()));
+    }
+}
+
+} // namespace data_store

--- a/modules/data-store/test/service_gate_test.cpp
+++ b/modules/data-store/test/service_gate_test.cpp
@@ -1,0 +1,302 @@
+/// L16/D1 — data_store::ServiceGate tests.
+///
+/// Spawns ds-server as a real subprocess on a per-test mkdtemp
+/// socket (matches production shape, avoids the in-process
+/// reactor threading complications the in-process-server harness
+/// has when callers want to do request/reply outside an async).
+///
+/// REQ-SVC-003 — construct primes via get(), then registers watch.
+/// REQ-SVC-004 — absent key → schema-default true; thread-safe under
+///               listener.
+/// REQ-SVC-005 — wait() returns on change OR shutdown.
+/// REQ-SVC-006 — publish_state() best-effort; no throw on failure.
+/// NFR-SVC-005 — multi-waiter wakeup (every blocked thread wakes).
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <future>
+#include <string>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <sys/wait.h>
+#include <signal.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "data_store/client.hpp"
+#include "data_store/proto.hpp"
+#include "data_store/service_gate.hpp"
+#include "data_store/value.hpp"
+
+namespace ds = data_store;
+
+namespace {
+
+std::string make_temp_dir() {
+    char tpl[64] = "/tmp/svcgate-XXXXXX";
+    if (char* d = mkdtemp(tpl)) return d;
+    ::mkdir("/tmp", 01777);
+    std::strcpy(tpl, "/tmp/svcgate-XXXXXX");
+    if (char* d = mkdtemp(tpl)) return d;
+    std::strcpy(tpl, "./svcgate-XXXXXX");
+    if (char* d = mkdtemp(tpl)) return d;
+    return {};
+}
+
+/// Locate ds-server binary. CTest cwd is the build dir, so
+/// `./ds-server` is the common path.
+std::string find_ds_server() {
+    const char* candidates[] = {
+        "./ds-server",
+        "../ds-server",
+        "modules/data-store/build/ds-server",
+        "/src/modules/data-store/build/ds-server",
+    };
+    for (auto p : candidates) {
+        struct ::stat st;
+        if (::stat(p, &st) == 0 && (st.st_mode & S_IXUSR)) return p;
+    }
+    return {};
+}
+
+/// Locate services.lua so the spawned ds-server can load the
+/// schema (and the gate's prime sees the schema default).
+std::string find_services_lua() {
+    const char* candidates[] = {
+        "../schemas/services.lua",
+        "../../schemas/services.lua",
+        "schemas/services.lua",
+        "modules/data-store/schemas/services.lua",
+        "/src/modules/data-store/schemas/services.lua",
+    };
+    for (auto p : candidates) {
+        std::ifstream in(p);
+        if (in.good()) return p;
+    }
+    return {};
+}
+
+/// Test harness: spawns ds-server as a subprocess, opens a
+/// Client against its socket. Reaps the server in the dtor.
+class GateFixture {
+public:
+    GateFixture() {
+        m_dir = make_temp_dir();
+        if (m_dir.empty()) return;
+
+        m_server_bin = find_ds_server();
+        if (m_server_bin.empty()) return;
+
+        auto services_lua = find_services_lua();
+        if (services_lua.empty()) return;
+
+        // Stage a per-test schema dir containing services.lua so
+        // the spawned server's `loaded N schema key(s)` line covers
+        // every services.* key the gate wants to prime.
+        m_schema_dir = m_dir + "/schemas";
+        ::mkdir(m_schema_dir.c_str(), 0755);
+        std::ifstream in(services_lua);
+        std::ofstream out(m_schema_dir + "/services.lua");
+        out << in.rdbuf();
+
+        m_sock  = m_dir + "/ds.sock";
+        m_store = m_dir + "/store.lua";
+
+        m_server_pid = ::fork();
+        if (m_server_pid < 0) return;
+        if (m_server_pid == 0) {
+            // Child: exec ds-server with our per-test paths.
+            std::string ds_sock_arg  = "ds-socket="     + m_sock;
+            std::string ds_store_arg = "ds-store="      + m_store;
+            std::string ds_sch_arg   = "ds-schema-dir=" + m_schema_dir;
+            ::execlp(m_server_bin.c_str(), m_server_bin.c_str(),
+                     ds_sock_arg.c_str(),
+                     ds_store_arg.c_str(),
+                     ds_sch_arg.c_str(),
+                     nullptr);
+            // exec failed.
+            ::_exit(127);
+        }
+
+        // Wait up to 2s for the socket to appear.
+        for (int i = 0; i < 100; ++i) {
+            struct ::stat st;
+            if (::stat(m_sock.c_str(), &st) == 0) break;
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+
+        auto cs = m_client.connect(m_sock);
+        if (!cs.ok) return;
+        m_ok = true;
+    }
+
+    ~GateFixture() {
+        m_client.close();
+        if (m_server_pid > 0) {
+            ::kill(m_server_pid, SIGTERM);
+            int status = 0;
+            for (int i = 0; i < 20; ++i) {
+                pid_t r = ::waitpid(m_server_pid, &status, WNOHANG);
+                if (r == m_server_pid) break;
+                std::this_thread::sleep_for(std::chrono::milliseconds(50));
+            }
+            ::kill(m_server_pid, SIGKILL);
+            ::waitpid(m_server_pid, &status, 0);
+        }
+    }
+
+    bool ok() const { return m_ok; }
+    ds::Client& client() { return m_client; }
+
+private:
+    std::string  m_dir;
+    std::string  m_server_bin;
+    std::string  m_schema_dir;
+    std::string  m_sock;
+    std::string  m_store;
+    pid_t        m_server_pid = -1;
+    ds::Client   m_client;
+    bool         m_ok = false;
+};
+
+} // namespace
+
+// ─────────────────────────── REQ-SVC-003/004 ───────────────────────
+
+TEST(SVC_REQ_SVC_003_constructor_primes_then_watches,
+     absent_key_resolves_to_default_true) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP() << "ds-server binary unavailable; skipping";
+    ds::ServiceGate gate(f.client(), "openvpn.client");
+    EXPECT_TRUE(gate.enabled());
+    EXPECT_EQ("services.openvpn.client.enable", gate.enable_key());
+    EXPECT_EQ("services.openvpn.client.state",  gate.state_key());
+}
+
+TEST(SVC_REQ_SVC_004_absent_key_resolves_to_default_true,
+     gate_observes_set_to_false_via_listener) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    ds::ServiceGate gate(f.client(), "net.router");
+    ASSERT_TRUE(gate.enabled());
+
+    auto rs = f.client().set("services.net.router.enable", false);
+    ASSERT_TRUE(rs.ok) << rs.err;
+
+    bool observed_false = false;
+    auto deadline = std::chrono::steady_clock::now()
+                  + std::chrono::seconds(2);
+    while (std::chrono::steady_clock::now() < deadline) {
+        if (!gate.enabled()) { observed_false = true; break; }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+    EXPECT_TRUE(observed_false);
+}
+
+// ─────────────────────────── REQ-SVC-005 ───────────────────────────
+
+TEST(SVC_REQ_SVC_005_wait_returns_on_change_or_shutdown,
+     wait_returns_new_value_on_change) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    ds::ServiceGate gate(f.client(), "wifi.client");
+    ASSERT_TRUE(gate.enabled());
+
+    auto waiter = std::async(std::launch::async,
+                             [&] { return gate.wait(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto rs = f.client().set("services.wifi.client.enable", false);
+    ASSERT_TRUE(rs.ok) << rs.err;
+
+    auto status = waiter.wait_for(std::chrono::seconds(2));
+    ASSERT_EQ(std::future_status::ready, status);
+    auto got = waiter.get();
+    ASSERT_TRUE(got.has_value());
+    EXPECT_FALSE(*got);
+}
+
+TEST(SVC_REQ_SVC_005_wait_returns_on_change_or_shutdown,
+     shutdown_returns_nullopt) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    ds::ServiceGate gate(f.client(), "lwm2m.client");
+
+    auto waiter = std::async(std::launch::async,
+                             [&] { return gate.wait(); });
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    gate.shutdown();
+
+    auto status = waiter.wait_for(std::chrono::seconds(2));
+    ASSERT_EQ(std::future_status::ready, status);
+    EXPECT_FALSE(waiter.get().has_value());
+}
+
+// ─────────────────────────── NFR-SVC-005 ───────────────────────────
+
+TEST(SVC_NFR_SVC_005_multi_waiter_wakeup,
+     all_blocked_waiters_wake_on_change) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    ds::ServiceGate gate(f.client(), "lwm2m.server");
+
+    constexpr int N = 4;
+    std::vector<std::future<std::optional<bool>>> futs;
+    futs.reserve(N);
+    for (int i = 0; i < N; ++i) {
+        futs.push_back(std::async(std::launch::async,
+                                  [&] { return gate.wait(); }));
+    }
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+
+    auto rs = f.client().set("services.lwm2m.server.enable", false);
+    ASSERT_TRUE(rs.ok) << rs.err;
+
+    int ready = 0;
+    auto deadline = std::chrono::steady_clock::now()
+                  + std::chrono::seconds(3);
+    while (std::chrono::steady_clock::now() < deadline && ready < N) {
+        ready = 0;
+        for (auto& f2 : futs) {
+            if (f2.wait_for(std::chrono::milliseconds(0))
+                == std::future_status::ready) ++ready;
+        }
+        if (ready < N) {
+            std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        }
+    }
+    EXPECT_EQ(N, ready);
+    for (auto& f2 : futs) {
+        auto v = f2.get();
+        ASSERT_TRUE(v.has_value());
+        EXPECT_FALSE(*v);
+    }
+}
+
+// ─────────────────────────── REQ-SVC-006 ───────────────────────────
+
+TEST(SVC_REQ_SVC_006_publish_state_no_throw_on_failure,
+     publish_state_succeeds_and_lands) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    ds::ServiceGate gate(f.client(), "openvpn.client");
+    EXPECT_NO_THROW(gate.publish_state("running"));
+    EXPECT_NO_THROW(gate.publish_state("disabled"));
+    EXPECT_NO_THROW(gate.publish_state("stopping"));
+
+    std::vector<ds::Client::GetResult> got;
+    auto rs = f.client().get({"services.openvpn.client.state"}, got);
+    ASSERT_TRUE(rs.ok);
+    ASSERT_EQ(1u, got.size());
+    ASSERT_TRUE(got[0].has_value);
+    auto s = ds::to_string(got[0].value);
+    ASSERT_TRUE(s.has_value());
+    EXPECT_EQ("stopping", *s);
+}


### PR DESCRIPTION
## Summary
First D-phase of L16. Lands the central `services.*` schema + the shared `data_store::ServiceGate` helper every daemon's Supervisor will compose into its event loop.

## Files
- **`modules/data-store/schemas/services.lua`** — 12 keys: 6 daemons × `enable`/`state`. `services.ds.enable` intentionally omitted (substrate can't self-disable; D2 ratifies via the namespace-claimed-but-key-not-declared rejection path). Schema defaults: `enable=true`, `state="running"`.
- **`modules/data-store/inc/data_store/service_gate.hpp`** + **`src/client/service_gate.cpp`** — wraps the `(prime → watch → cv-notify)` pattern openvpn-client's WAN gate already proves:
  ```cpp
  ServiceGate gate(client, "openvpn.client");
  if (!gate.enabled()) park;
  auto v = gate.wait();             // blocks until change OR shutdown()
  gate.publish_state("disabled");   // best-effort set
  ```
  Listener thread updates `m_enabled` under mutex, bumps a version counter, `cv.notify_all()`. `wait()` blocks on cv until version changes OR `m_shutdown`. `publish_state()` logs on wire failure but doesn't throw.

## Wiring
- Added to `datastore_client` static lib so every existing downstream (apps/lwm2m, openvpn-client, net-router, wifi-client, ds-cli) gets it for free.
- `services.lua` install rule ships next to `iot.lua` to `/etc/iot/ds-schemas/`.

## Tests (6 new cases; 50/50 total ds-tests green)
- REQ-SVC-003: ctor primes from schema default (absent key → `enabled()==true`)
- REQ-SVC-004: listener-thread snapshot update on wire set
- REQ-SVC-005 ×2: `wait()` returns new value on change; `shutdown()` returns `nullopt`
- REQ-SVC-006: `publish_state` round-trip lands in ds-server (`services.openvpn.client.state="stopping"`)
- NFR-SVC-005: 4 concurrent waiters all wake on one change

Test harness spawns `ds-server` as a subprocess on a per-test mkdtemp socket. Matches production shape and sidesteps the in-process-server reactor threading the existing `server_integration_test` runs into when callers want sync request/reply outside an `async`.

## Test plan
- [x] `cmake -DBUILD_DATA_STORE_TESTS=ON && make ds-tests && ./ds-tests --gtest_filter=SVC_*` → 6/6 green
- [x] Full `./ds-tests` → 50/50 green (no regressions)
- [x] `services.lua` ships via `make install`

Closes REQ-SVC-001..006, NFR-SVC-005.

🤖 Generated with [Claude Code](https://claude.com/claude-code)