### PR TITLE
feat(data-store): L16/D2 — ds-server self-publishes; rejects ds.enable

### DIFF
--- a/modules/data-store/src/server/main.cpp
+++ b/modules/data-store/src/server/main.cpp
@@ -8,20 +8,25 @@
 /// Defaults come from data_store::proto::kDefaultSocketPath and
 /// kDefaultStorePath. Both are operator-overridable.
 
+#include "data_store.hpp"
 #include "lua_persistor.hpp"
 #include "schema.hpp"
 #include "server.hpp"
 #include "worker_pool.hpp"
 
 #include "data_store/proto.hpp"
+#include "data_store/value.hpp"
 
 #include <atomic>
+#include <chrono>
 #include <csignal>
+#include <cstdint>
 #include <cstring>
 #include <memory>
 #include <string>
 #include <string_view>
 
+#include <ace/Event_Handler.h>
 #include <ace/Log_Msg.h>
 #include <ace/Reactor.h>
 #include <ace/Time_Value.h>
@@ -34,6 +39,31 @@ void on_signal(int /*sig*/) {
     g_stop.store(true);
     ACE_Reactor::instance()->end_reactor_event_loop();
 }
+
+/// L16/D2 — periodic services.ds.uptime.sec publisher. Reactor
+/// timer fires every 60s and bumps the key directly via the
+/// in-process DataStore::set (no socket round-trip). The handler
+/// owns no resources; lifetime is tied to the main() stack.
+class UptimePublisher : public ACE_Event_Handler {
+public:
+    UptimePublisher(data_store::server::DataStore& store,
+                    std::chrono::steady_clock::time_point started)
+        : m_store(store), m_started(started) {}
+
+    int handle_timeout(const ACE_Time_Value& /*now*/,
+                       const void* /*act*/) override {
+        auto elapsed = std::chrono::steady_clock::now() - m_started;
+        auto sec = std::chrono::duration_cast<std::chrono::seconds>(elapsed);
+        std::int32_t sec_i32 = static_cast<std::int32_t>(sec.count());
+        if (sec_i32 < 0) sec_i32 = 0;
+        m_store.set("services.ds.uptime.sec", data_store::Value{sec_i32});
+        return 0;
+    }
+
+private:
+    data_store::server::DataStore&        m_store;
+    std::chrono::steady_clock::time_point m_started;
+};
 
 /// Parse `key=value` args. Reused shape from apps/src/main.cpp.
 std::string arg_value(int argc, char** argv, std::string_view key) {
@@ -120,6 +150,22 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    // L16/D2 — publish services.ds.* runtime state. state is set
+    // once the server is open; uptime ticks every 60s thereafter.
+    // ds-server is the substrate so it can't gate ITSELF on
+    // services.ds.enable (services.lua omits the enable key); the
+    // state surface still exists for `ds-cli svc list` symmetry.
+    const auto started = std::chrono::steady_clock::now();
+    store->set("services.ds.state",
+               data_store::Value{std::string("running")});
+    store->set("services.ds.uptime.sec", data_store::Value{std::int32_t{0}});
+    UptimePublisher uptime(*store, started);
+    long uptime_timer_id = ACE_Reactor::instance()->schedule_timer(
+        &uptime,
+        nullptr,
+        /*delay=*/ACE_Time_Value(60),
+        /*interval=*/ACE_Time_Value(60));
+
     ::signal(SIGINT,  on_signal);
     ::signal(SIGTERM, on_signal);
     ::signal(SIGPIPE, SIG_IGN);
@@ -139,6 +185,13 @@ int main(int argc, char** argv) {
                 break;
             }
         }
+    }
+
+    // Best-effort: publish exited state before tearing down.
+    store->set("services.ds.state",
+               data_store::Value{std::string("exited")});
+    if (uptime_timer_id != -1) {
+        ACE_Reactor::instance()->cancel_timer(uptime_timer_id);
     }
 
     server.close();

--- a/modules/data-store/src/server/schema.cpp
+++ b/modules/data-store/src/server/schema.cpp
@@ -120,6 +120,18 @@ void SchemaRegistry::load_one(const std::string& path) {
         throw std::runtime_error("top-level return is not a table");
     }
 
+    // Capture the `namespace` declaration so validate_set can reject
+    // sets on undeclared keys whose namespace IS claimed by some
+    // loaded schema (the "services.ds.enable is intentionally absent"
+    // pattern from L16/D2). Missing namespace = no claim.
+    lua_getfield(L.get(), -1, "namespace");
+    if (lua_isstring(L.get(), -1)) {
+        std::size_t nlen = 0;
+        const char* nc = lua_tolstring(L.get(), -1, &nlen);
+        m_namespaces.emplace(nc, nlen);
+    }
+    lua_pop(L.get(), 1);
+
     lua_getfield(L.get(), -1, "keys");
     if (!lua_istable(L.get(), -1)) {
         throw std::runtime_error("schema missing `keys` table");
@@ -210,10 +222,34 @@ const SchemaEntry* SchemaRegistry::find(const std::string& key) const {
     return (it == m_entries.end()) ? nullptr : &it->second;
 }
 
+std::string SchemaRegistry::first_segment(const std::string& key) {
+    auto dot = key.find('.');
+    if (dot == std::string::npos) return {};
+    return key.substr(0, dot);
+}
+
+bool SchemaRegistry::is_namespace_claimed(const std::string& key) const {
+    auto ns = first_segment(key);
+    if (ns.empty()) return false;
+    return m_namespaces.count(ns) > 0;
+}
+
 std::optional<std::string> SchemaRegistry::validate_set(
         const std::string& key, const Value& value) const {
     auto it = m_entries.find(key);
-    if (it == m_entries.end()) return std::nullopt;  // passthrough
+    if (it == m_entries.end()) {
+        // Key not declared. If its namespace IS claimed by some
+        // loaded schema, reject — every owner is expected to fully
+        // enumerate its surface (L16/D2 "intentionally absent
+        // services.ds.enable" pattern). Otherwise passthrough
+        // (REQ-DS-023 unknown-keys-pass).
+        if (is_namespace_claimed(key)) {
+            return "schema(" + key + "): namespace '" +
+                   first_segment(key) +
+                   "' is claimed but this key is not declared";
+        }
+        return std::nullopt;
+    }
     const SchemaEntry& e = it->second;
 
     // monostate (null) is always accepted — used to clear a key.

--- a/modules/data-store/src/server/schema.hpp
+++ b/modules/data-store/src/server/schema.hpp
@@ -33,6 +33,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 
 #include "data_store/value.hpp"
 
@@ -77,14 +78,27 @@ public:
     /// no default (or no entry at all).
     std::optional<Value> default_for(const std::string& key) const;
 
+    /// Is the first dot-segment of `key` claimed by some loaded
+    /// schema file's `namespace="..."` declaration? Used by
+    /// validate_set to reject sets on undeclared keys when their
+    /// namespace IS owned (L16/D2 — supports the
+    /// "services.ds.enable is intentionally absent" pattern).
+    bool is_namespace_claimed(const std::string& key) const;
+
     std::size_t size() const { return m_entries.size(); }
+    std::size_t namespace_count() const { return m_namespaces.size(); }
 
 private:
     /// Parse one schema file. Throws std::runtime_error on
     /// fundamental problems; caller catches + skips.
     void load_one(const std::string& path);
 
+    /// Pull the first dot-segment out of `key` (e.g. "services.ds.enable"
+    /// -> "services"). Empty when the key has no dots.
+    static std::string first_segment(const std::string& key);
+
     std::unordered_map<std::string, SchemaEntry> m_entries;
+    std::unordered_set<std::string>              m_namespaces;
 };
 
 } // namespace data_store::server

--- a/modules/data-store/test/schema_test.cpp
+++ b/modules/data-store/test/schema_test.cpp
@@ -162,3 +162,59 @@ return { keys = { ["dup"] = { type="integer", default=2 } } })");
     ::unlink((dir + "/b.lua").c_str());
     ::rmdir(dir.c_str());
 }
+
+// ─────────────────── L16/D2 namespace-claimed rejection ─────────────
+
+TEST(Schema, SVC_REQ_SVC_008_undeclared_key_in_claimed_namespace_rejected) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP();
+    // services namespace owned; only services.ds.state declared.
+    // services.ds.enable is intentionally absent — set must reject.
+    write_file(dir + "/services.lua", R"(
+return {
+  namespace = "services",
+  keys = {
+    ["services.ds.state"] = { type = "string", default = "running" },
+  },
+})");
+
+    ds::SchemaRegistry r;
+    ASSERT_EQ(1u, r.load_directory(dir));
+    EXPECT_EQ(1u, r.namespace_count());
+    EXPECT_TRUE(r.is_namespace_claimed("services.ds.enable"));
+    EXPECT_TRUE(r.is_namespace_claimed("services.foo.bar"));
+    EXPECT_FALSE(r.is_namespace_claimed("other.key"));
+
+    // A bool set against an undeclared key in a claimed namespace
+    // MUST be rejected.
+    auto err = r.validate_set("services.ds.enable", Value{true});
+    ASSERT_TRUE(err.has_value());
+    EXPECT_NE(std::string::npos, err->find("services.ds.enable"));
+    EXPECT_NE(std::string::npos, err->find("not declared"));
+
+    // Unrelated namespace still passes through.
+    EXPECT_FALSE(r.validate_set("other.foo", Value{std::string("v")})
+                     .has_value());
+
+    ::unlink((dir + "/services.lua").c_str());
+    ::rmdir(dir.c_str());
+}
+
+TEST(Schema, SVC_REQ_SVC_008_declared_key_in_claimed_namespace_accepted) {
+    auto dir = make_tmpdir();
+    if (dir.empty()) GTEST_SKIP();
+    write_file(dir + "/services.lua", R"(
+return {
+  namespace = "services",
+  keys = {
+    ["services.net.router.enable"] = { type = "boolean", default = true },
+  },
+})");
+    ds::SchemaRegistry r;
+    ASSERT_EQ(1u, r.load_directory(dir));
+    // Declared key with matching type → accepted.
+    EXPECT_FALSE(r.validate_set("services.net.router.enable",
+                                Value{false}).has_value());
+    ::unlink((dir + "/services.lua").c_str());
+    ::rmdir(dir.c_str());
+}

--- a/modules/data-store/test/service_gate_test.cpp
+++ b/modules/data-store/test/service_gate_test.cpp
@@ -280,6 +280,59 @@ TEST(SVC_NFR_SVC_005_multi_waiter_wakeup,
     }
 }
 
+// ─────────────────────────── REQ-SVC-007 ───────────────────────────
+// ds-server self-publishes services.ds.state="running" on boot.
+
+TEST(SVC_REQ_SVC_007_ds_publishes_state_and_uptime,
+     state_running_visible_after_boot) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    std::vector<ds::Client::GetResult> got;
+    auto rs = f.client().get({"services.ds.state"}, got);
+    ASSERT_TRUE(rs.ok);
+    ASSERT_EQ(1u, got.size());
+    ASSERT_TRUE(got[0].has_value);
+    auto s = ds::to_string(got[0].value);
+    ASSERT_TRUE(s.has_value());
+    EXPECT_EQ("running", *s);
+}
+
+TEST(SVC_REQ_SVC_007_ds_publishes_state_and_uptime,
+     uptime_seeded_to_zero) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    std::vector<ds::Client::GetResult> got;
+    auto rs = f.client().get({"services.ds.uptime.sec"}, got);
+    ASSERT_TRUE(rs.ok);
+    ASSERT_EQ(1u, got.size());
+    ASSERT_TRUE(got[0].has_value);
+    // The 60s timer hasn't fired yet for a freshly-spawned server,
+    // so the value is the seed 0. The periodic tick is verified at
+    // the smoke level (D8) since waiting 60s in a unit test is
+    // wasteful.
+    auto n = ds::to_int32(got[0].value);
+    ASSERT_TRUE(n.has_value());
+    EXPECT_EQ(0, *n);
+}
+
+// ─────────────────────────── REQ-SVC-008 ───────────────────────────
+// Set on services.ds.enable is rejected by ds-server (the key is
+// intentionally absent from services.lua; namespace-claimed-but-
+// not-declared rejection kicks in).
+
+TEST(SVC_REQ_SVC_008_ds_enable_set_rejected,
+     set_services_ds_enable_returns_schema_error) {
+    GateFixture f;
+    if (!f.ok()) GTEST_SKIP();
+    auto rs = f.client().set("services.ds.enable", true);
+    EXPECT_FALSE(rs.ok)
+        << "expected ds-server to reject services.ds.enable; rs.err='"
+        << rs.err << "'";
+    if (!rs.ok) {
+        EXPECT_NE(std::string::npos, rs.err.find("services.ds.enable"));
+    }
+}
+
 // ─────────────────────────── REQ-SVC-006 ───────────────────────────
 
 TEST(SVC_REQ_SVC_006_publish_state_no_throw_on_failure,


### PR DESCRIPTION
## Summary
Two coupled pieces for L16/D2:

### 1. SchemaRegistry namespace-claimed rejection
- `load_one` now captures the `namespace = "..."` declaration into `m_namespaces`.
- `validate_set` learns: key not declared BUT first dot-segment is a claimed namespace → reject with `"schema(K): namespace 'NS' is claimed but this key is not declared"`. Otherwise unknown-keys still passthrough (REQ-DS-023 preserved).
- Public `is_namespace_claimed(key)` + `namespace_count()` for tests + future ds-cli schema-dump op (D7).

### 2. ds-server self-publishes runtime state
- On startup the daemon directly writes (via in-process `DataStore::set`):
  ```
  services.ds.state      = "running"
  services.ds.uptime.sec = 0
  ```
- `UptimePublisher` ACE_Event_Handler fires every 60s, bumps `services.ds.uptime.sec` to `(now - start)` seconds. Reactor timer; cancelled on SIGTERM.
- On graceful exit, best-effort `services.ds.state = "exited"`.

`services.ds.enable` is INTENTIONALLY absent from `services.lua`. The new rejection branch is what catches `ds-cli set services.ds.enable false` — substrate-self-disable is a trap (the socket carrying the command would go dead).

## Tests (5 new; 55/55 total ds-tests green)
- REQ-SVC-007 ×2: `state="running"` visible after boot; `uptime.sec` seeded to 0
- REQ-SVC-008 ×3: namespace-claimed undeclared-key rejected, declared-key still accepted, end-to-end set on `services.ds.enable` fails with err containing the key name

The 60s periodic uptime tick is beyond unit test scope; D8 smoke covers it.

Closes REQ-SVC-007, REQ-SVC-008.

🤖 Generated with [Claude Code](https://claude.com/claude-code)