### PR TITLE
feat(net-router): L16/D3 — services.net.router.enable gate

### DIFF
--- a/modules/net/router/src/daemon.cpp
+++ b/modules/net/router/src/daemon.cpp
@@ -14,6 +14,8 @@
 #include "nft_rules.hpp"
 #include "shell.hpp"
 
+#include "data_store/service_gate.hpp"
+
 #include <atomic>
 #include <chrono>
 #include <csignal>
@@ -172,6 +174,17 @@ Status run_daemon(const std::string& socketPath,
     std::atomic_bool wake{false};
     ds.on_change([&wake](DsBridge::Key) { wake.store(true); });
 
+    // L16/D3 — services.net.router.enable gate. When operator flips
+    // it to false: stop iface_monitor, clear net.iface.active="",
+    // publish services.net.router.state="disabled". Re-enable
+    // resumes the iface_monitor loop from scratch — same effect as
+    // a daemon restart, just without the systemctl round-trip.
+    std::unique_ptr<data_store::ServiceGate> svc;
+    if (auto* cli = ds.client()) {
+        svc = std::make_unique<data_store::ServiceGate>(*cli, "net.router");
+        svc->publish_state("running");
+    }
+
     const auto names = ordered_iface_names(ds);
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("%D [netr:%t] %M %N:%l daemon up; priority ifaces: "
@@ -179,7 +192,45 @@ Status run_daemon(const std::string& socketPath,
                names.empty() ? "(none)" : names.front().c_str(),
                static_cast<unsigned>(names.size())));
 
+    bool was_enabled = true;   // schema default
     while (g_run.load()) {
+        const bool enabled = svc ? svc->enabled() : true;
+
+        if (!enabled) {
+            // Transition true -> false: tear down nft + clear
+            // net.iface.active, publish state="disabled". Then
+            // park on the gate until re-enabled.
+            if (was_enabled) {
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D [netr:%t] %M %N:%l services."
+                                    "net.router.enable=false; "
+                                    "tearing down\n")));
+                svc->publish_state("stopping");
+                ds.set_iface_active("");
+                ds.set_state("disabled");
+                // NB: nft rules previously installed by us stay in
+                // the kernel until re-enable refreshes them (the
+                // ruleset is idempotent), or until an operator flushes
+                // manually. Documented in DEPLOY.md (D8).
+                svc->publish_state("disabled");
+                was_enabled = false;
+            }
+            // Block on the gate; resumes on enable transition OR
+            // shutdown (which the dtor wakes via shutdown()).
+            auto next = svc->wait();
+            if (!next.has_value()) break;     // shutdown
+            continue;                          // loop re-evaluates
+        }
+
+        if (!was_enabled) {
+            // false -> true: announce, re-run the lifecycle on
+            // the next tick (lc.step pulls a fresh snapshot).
+            svc->publish_state("starting");
+            ds.set_state("running");
+            was_enabled = true;
+            svc->publish_state("running");
+        }
+
         const auto ifaces = iface::probe_all(names, shell_runner);
         auto in = snapshot_inputs(ds, ifaces);
         lc.step(in);
@@ -195,6 +246,8 @@ Status run_daemon(const std::string& socketPath,
         // Short-sleep loop so SIGTERM + on_change wake reasonably fast.
         for (unsigned slept = 0; slept < interval && g_run.load(); ++slept) {
             if (wake.exchange(false)) break;
+            // Also bail out fast if the gate flips closed mid-sleep.
+            if (svc && !svc->enabled()) break;
             std::this_thread::sleep_for(std::chrono::seconds(1));
         }
     }

--- a/modules/net/router/src/ds_bridge.cpp
+++ b/modules/net/router/src/ds_bridge.cpp
@@ -243,6 +243,11 @@ void DsBridge::set_last_apply_unix(std::uint32_t t) {
     m_impl->client.set(kLastApplyUnix, t);
 }
 
+data_store::Client* DsBridge::client() {
+    if (!m_ok || !m_impl) return nullptr;
+    return &m_impl->client;
+}
+
 void DsBridge::on_change(ChangeCallback cb) {
     if (!m_impl) return;
     std::lock_guard<std::mutex> g(m_impl->mtx);

--- a/modules/net/router/src/ds_bridge.hpp
+++ b/modules/net/router/src/ds_bridge.hpp
@@ -20,6 +20,8 @@
 #include <string>
 #include <vector>
 
+namespace data_store { class Client; }   // forward decl
+
 namespace net_router {
 
 class DsBridge {
@@ -75,6 +77,13 @@ public:
     void set_last_apply_unix(std::uint32_t t);
 
     void on_change(ChangeCallback cb);
+
+    /// Access the underlying data_store::Client. Used by the L16
+    /// ServiceGate (and any future shared helper) to share one
+    /// listener thread + one socket connection across both the
+    /// net.* watch and the services.net.router.enable watch.
+    /// nullptr when !connected().
+    data_store::Client* client();
 
     /// Default ds-server socket path. Duplicated from
     /// data_store::proto::kDefaultSocketPath so this header stays


### PR DESCRIPTION
## Summary
Wires the shared `data_store::ServiceGate` (D1) into net-router's `run_daemon` loop.

## Mechanics
`DsBridge` gains a `data_store::Client* client()` accessor (forward decl in header) so the daemon can construct `ServiceGate` against the same Client + listener thread DsBridge already owns. One socket, one watch thread, two watches: `net.*` via DsBridge, `services.net.router.enable` via ServiceGate.

`run_daemon` state machine:
```
was_enabled = true   (initial)
loop:
  enabled = svc.enabled()
  if !enabled and was_enabled:       # transition true→false
      publish state="stopping"
      clear net.iface.active=""
      set net.state="disabled"
      publish state="disabled"
      was_enabled = false
  if !enabled:
      svc.wait()                       # block until enable or shutdown
      continue
  if !was_enabled and enabled:       # transition false→true
      publish state="starting" → state="running" → publish "running"
      was_enabled = true
  probe + lc.step + sleep with early-out on gate-flip
```

The sleep short-loop breaks early when `svc->enabled()` flips mid-sleep so a disable lands within ~1s even when `net.poll.interval.sec` is 5s+.

## Documented limitation
nft rules previously installed stay in the kernel across a disable cycle (the daemon stops driving updates, doesn't issue a flush). Re-enable refreshes; manual operator flush is the workaround for "fully clean teardown." D8's DEPLOY.md section documents this.

## Tests
All 50 existing net-router unit tests still pass. The wiring change touches `run_daemon` only, exercised end-to-end by `log/L16/smoke.sh` (D8). Same trade-off openvpn-client took at L13's WAN-gate addition.

## Test plan
- [x] `make net-router && make net-router-tests && ./net-router-tests` → 50/50 green
- [ ] Wire-level disable/enable round-trip exercised by D8 smoke

Closes REQ-SVC-009, REQ-SVC-010, NFR-SVC-001/004.

🤖 Generated with [Claude Code](https://claude.com/claude-code)