### PR TITLE
feat(openvpn-client): L16/D4 — services.openvpn.client.enable gate

### DIFF
--- a/modules/openvpn/client/src/ds_bridge.cpp
+++ b/modules/openvpn/client/src/ds_bridge.cpp
@@ -335,6 +335,11 @@ void DsBridge::set_bound_iface(const std::string& s) {
 
 // ─────────────────────── on_change registration ─────────────────────
 
+data_store::Client* DsBridge::client() {
+    if (!m_ok || !m_impl) return nullptr;
+    return &m_impl->client;
+}
+
 void DsBridge::on_change(ChangeCallback cb) {
     if (!m_impl) return;
     std::lock_guard<std::mutex> g(m_impl->mtx);

--- a/modules/openvpn/client/src/ds_bridge.hpp
+++ b/modules/openvpn/client/src/ds_bridge.hpp
@@ -27,6 +27,8 @@
 #include <string>
 #include <vector>
 
+namespace data_store { class Client; }   // forward decl
+
 namespace openvpn_client {
 
 class DsBridge {
@@ -123,6 +125,13 @@ public:
     /// on_change(): runs on the listener thread, do not block on the
     /// daemon's main-thread mutex.
     void on_wan_change(WanCallback cb);
+
+    /// Access the underlying data_store::Client. Used by the L16
+    /// ServiceGate (and any future shared helper) to share one
+    /// listener thread + one socket connection across both the
+    /// vpn.* watch and the services.openvpn.client.enable watch.
+    /// nullptr when !connected().
+    data_store::Client* client();
 
     /// Default ds-server socket path. Duplicated from
     /// data_store::proto::kDefaultSocketPath so this header stays

--- a/modules/openvpn/client/src/supervisor.cpp
+++ b/modules/openvpn/client/src/supervisor.cpp
@@ -1,5 +1,7 @@
 #include "supervisor.hpp"
 
+#include "data_store/service_gate.hpp"
+
 #include <chrono>
 #include <cstdint>
 #include <sstream>
@@ -59,9 +61,39 @@ bool connect_mgmt(std::uint16_t port,
 } // namespace
 
 Supervisor::Supervisor(DsBridge& ds, Options opt)
-  : m_ds(ds), m_opt(std::move(opt)) {}
+  : m_ds(ds), m_opt(std::move(opt)) {
+    // L16/D4 — services.openvpn.client.enable gate. We construct it
+    // lazily here (DsBridge already owns the Client + listener) and
+    // spawn a tiny watcher thread that forwards gate transitions
+    // into m_cv so the existing wait_for_event() handles both WAN
+    // events AND enable flips through the same code path.
+    if (auto* cli = m_ds.client()) {
+        m_svc = std::make_unique<data_store::ServiceGate>(*cli,
+                                                          "openvpn.client");
+        m_svc_watcher = std::thread([this] {
+            for (;;) {
+                auto v = m_svc->wait();
+                if (!v.has_value()) return;     // shutdown
+                {
+                    std::lock_guard<std::mutex> g(m_mtx);
+                    m_svc_dirty.store(true);
+                    if (m_shutdown) return;
+                }
+                m_cv.notify_all();
+            }
+        });
+    }
+}
 
-Supervisor::~Supervisor() = default;
+Supervisor::~Supervisor() {
+    {
+        std::lock_guard<std::mutex> g(m_mtx);
+        m_shutdown = true;
+    }
+    m_cv.notify_all();
+    if (m_svc) m_svc->shutdown();
+    if (m_svc_watcher.joinable()) m_svc_watcher.join();
+}
 
 void Supervisor::on_wan_event(const std::optional<std::string>& target) {
     {
@@ -80,7 +112,11 @@ std::optional<std::string> Supervisor::drain_target() {
 
 bool Supervisor::wait_for_event() {
     std::unique_lock<std::mutex> g(m_mtx);
-    m_cv.wait(g, [&]{ return m_shutdown || m_wan_dirty; });
+    m_cv.wait(g, [&]{
+        return m_shutdown
+            || m_wan_dirty
+            || m_svc_dirty.load(std::memory_order_acquire);
+    });
     return !m_shutdown;
 }
 
@@ -145,6 +181,16 @@ bool Supervisor::serve_one_session(const std::string& iface) {
                        iface.c_str()));
             break;
         }
+        // L16/D4 — gate dominates: if operator disables mid-session,
+        // tear down within one event-loop tick (NFR-SVC-001).
+        if (m_svc && !m_svc->enabled()) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l services."
+                                "openvpn.client.enable=false during "
+                                "session on iface=%C; tearing down\n"),
+                       iface.c_str()));
+            break;
+        }
         {
             std::lock_guard<std::mutex> g(m_mtx);
             if (m_shutdown) break;
@@ -186,6 +232,7 @@ Status Supervisor::run() {
     m_ds.set_state("disconnected");
     m_ds.set_gate_reason("wan_down");
     m_ds.set_bound_iface("");
+    if (m_svc) m_svc->publish_state("running");
 
     // Prime: the snapshot may already hold an iface (net-router was
     // running before us). Treat it as the first event.
@@ -193,6 +240,26 @@ Status Supervisor::run() {
 
     while (true) {
         if (!wait_for_event()) break;          // shutdown
+
+        // L16/D4 composition: enable=false dominates WAN. Even if
+        // the WAN is up, do not spawn openvpn; park at
+        // gate.reason="disabled" until the gate flips true.
+        m_svc_dirty.store(false, std::memory_order_release);
+        if (m_svc && !m_svc->enabled()) {
+            // serve_one_session reaped its own child on the way
+            // out; the Gate is in note_terminated state if we got
+            // here mid-session. Reflect the disabled state.
+            if (m_gate.running()) m_gate.note_terminated();
+            m_ds.set_state("disabled");
+            m_ds.set_gate_reason("disabled");
+            m_ds.set_bound_iface("");
+            m_svc->publish_state("disabled");
+            continue;
+        }
+        // Gate is open. If we just came back from a disabled state,
+        // publish state="starting" before the WAN evaluation below.
+        if (m_svc) m_svc->publish_state("running");
+
         auto target = drain_target();
         const bool target_up = target.has_value() && !target->empty();
 

--- a/modules/openvpn/client/src/supervisor.hpp
+++ b/modules/openvpn/client/src/supervisor.hpp
@@ -18,14 +18,19 @@
 /// into the main thread that runs the mgmt event-loop. The event-loop's
 /// 250 ms recv timeout doubles as the WAN-event polling interval.
 
+#include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <string>
+#include <thread>
 
 #include "client.hpp"
 #include "ds_bridge.hpp"
 #include "gate.hpp"
+
+namespace data_store { class ServiceGate; }   // forward decl
 
 namespace openvpn_client {
 
@@ -56,6 +61,14 @@ private:
     DsBridge& m_ds;
     Options   m_opt;
     Gate      m_gate;
+
+    /// L16/D4 — services.openvpn.client.enable gate. Composes with
+    /// the WAN gate; the composition rule is "disable dominates":
+    /// when m_svc->enabled() is false, the WAN target is ignored and
+    /// the Supervisor parks at gate.reason="disabled".
+    std::unique_ptr<data_store::ServiceGate> m_svc;
+    std::thread                              m_svc_watcher;
+    std::atomic<bool>                        m_svc_dirty{false};
 
     std::mutex                 m_mtx;
     std::condition_variable    m_cv;


### PR DESCRIPTION
## Summary
Wires `data_store::ServiceGate` (D1) into openvpn-client's Supervisor. Composition rule: `enable=false` dominates `wan_down` — even with the WAN up, a disabled service stays parked at `gate.reason="disabled"`.

## Files
- `DsBridge::client()` accessor (matching net-router's D3 shape) so the Supervisor shares one socket + listener thread between the `vpn.*` watch and the `services.openvpn.client.enable` watch.
- `Supervisor` adds:
  - `std::unique_ptr<data_store::ServiceGate> m_svc`
  - `std::thread m_svc_watcher` — small thread that loops on `m_svc->wait()` and forwards transitions into `m_cv` via `m_svc_dirty`
  - dtor signals shutdown + joins cleanly
- `run()` loop checks the gate before evaluating WAN; disabled-state publishes `state="disabled"` + `gate.reason="disabled"`.
- `serve_one_session()` inner mgmt event-loop also breaks on `!m_svc->enabled()` so an operator disable mid-tunnel reaps openvpn within one 200ms recv tick.

## Composition rule
```
if (!m_svc->enabled()) {
    state="disabled"; gate.reason="disabled"          # disable dominates
    park
} else {
    ... existing WAN-gate evaluation ...
}
```

## Tests
All 48 existing openvpn-client unit tests still pass. The wiring change touches the Supervisor's outer + inner loops, exercised end-to-end by `log/L16/smoke.sh` (D8) — same trade-off the L13 WAN-gate addition took.

## Test plan
- [x] `make openvpn-client && make openvpn-client-tests && ./openvpn-client-tests` → 48/48 green
- [ ] Wire-level disable/enable round-trip exercised by D8 smoke

Closes REQ-SVC-011, REQ-SVC-012, REQ-SVC-013. NFR-SVC-001/002/004 implied via existing primitives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)