### PR TITLE
feat(lwm2m): L16/D5a — services.lwm2m.{client,server}.enable gate (startup)

### DIFF
--- a/apps/inc/ds_config.hpp
+++ b/apps/inc/ds_config.hpp
@@ -42,6 +42,8 @@
 #include <optional>
 #include <string>
 
+namespace data_store { class Client; }   // forward decl
+
 namespace iot {
 
 class DsConfig {
@@ -79,6 +81,12 @@ public:
     /// data_store::Client's listener thread — keep it short, don't
     /// block on locks the main thread might hold.
     void on_change(ChangeCallback cb);
+
+    /// Access the underlying data_store::Client so the L16/D5
+    /// ServiceGate can share one socket + listener thread between
+    /// the iot.* watch and the services.lwm2m.{client,server}.enable
+    /// watch. nullptr when !connected().
+    data_store::Client* client();
 
     /// Default socket path when none is supplied. Tracks ds-server's
     /// kDefaultSocketPath, duplicated here so the public header stays

--- a/apps/src/ds_config.cpp
+++ b/apps/src/ds_config.cpp
@@ -121,6 +121,11 @@ DsConfig::~DsConfig() {
     m_impl->client.close();
 }
 
+data_store::Client* DsConfig::client() {
+    if (!m_ok || !m_impl) return nullptr;
+    return &m_impl->client;
+}
+
 std::optional<std::string> DsConfig::endpoint() const {
     if (!m_ok) return std::nullopt;
     std::lock_guard<std::mutex> g(m_impl->mtx);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -12,6 +12,8 @@
 
 #include <ace/Log_Msg.h>
 
+#include "data_store/service_gate.hpp"
+
 #include "app.hpp"
 #include "readline.hpp"
 
@@ -603,6 +605,30 @@ int main(std::int32_t argc, char *argv[]) {
         ACE_DEBUG((LM_INFO,
                    ACE_TEXT("%D [iot:%t] %M %N:%l endpoint from data-store: %C\n"),
                    endpoint.c_str()));
+    }
+
+    // L16/D5 — services.lwm2m.{client,server}.enable gate. Minimal
+    // cut: publish state at startup, park if disabled, return when
+    // re-enabled (which the operator will follow with a daemon
+    // restart for the registration to take effect). Full
+    // mid-session Deregister + drop-observations machinery is FUP
+    // (this is the L16 plan §D5 "split into D5a/D5b if it grows
+    // past one PR" — we ship D5a here).
+    std::unique_ptr<data_store::ServiceGate> svc_gate;
+    if (auto* cli = ds.client()) {
+        const std::string svc_name =
+            (UDPAdapter::CLIENT == role) ? "lwm2m.client" : "lwm2m.server";
+        svc_gate = std::make_unique<data_store::ServiceGate>(*cli, svc_name);
+        if (!svc_gate->enabled()) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [iot:%t] %M %N:%l services.%C.enable=false "
+                                "at startup; parking until re-enabled\n"),
+                       svc_name.c_str()));
+            svc_gate->publish_state("disabled");
+            auto v = svc_gate->wait();
+            if (!v.has_value()) return 0;   // shutdown
+        }
+        svc_gate->publish_state("running");
     }
 
     ClientPlumbing clientPlumbing;


### PR DESCRIPTION
## Summary
Minimal cut of D5 — the startup gate for `lwm2m-client` + `lwm2m-server`. The L16 plan §D5 explicitly risk-budgets this phase ("split into D5a/D5b if it grows past one PR"); this is **D5a**. D5b will add mid-session Deregister + drop-observations once the lwm2m registration FSM is opened up.

## What this PR lands
- `DsConfig::client()` accessor (matching D3/D4/D6 shape) → ServiceGate shares one socket + listener thread with the existing iot.* watch.
- `main.cpp` constructs `ServiceGate` right after `DsConfig`, keyed by role (`lwm2m.client` / `lwm2m.server`). If `!enabled()` at startup, publish `state="disabled"` and park via `gate.wait()` until re-enabled. On enable (or normal start), publish `state="running"` and fall through to the existing bootstrap → register → reactor loop.

## What's deferred to D5b (documented FUP)
- Mid-session disable: send Deregister, drop active observations, keep CoAP socket listening.
- Mid-session re-enable: re-Register from scratch.
- lwm2m-server: stop accepting Register requests while disabled (`lwm2m_registration_server.cpp` surgery).

## Test plan
- [x] `cmake apps && make lwm2m` builds clean with D5a wired
- [x] `DsConfig::client()` accessor returns nullptr when ds not connected (existing fallback path preserved)
- [ ] Wire-level startup-disable round-trip via container smoke (covered by L16/D8 pattern for net-router; lwm2m variant is FUP)

Closes REQ-SVC-014, REQ-SVC-015 (startup gate only; FUP-L16-D5b for mid-session).

🤖 Generated with [Claude Code](https://claude.com/claude-code)