### PR TITLE
feat(yocto): add meta-iot layer with containerized multi-arch build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,6 @@ log/L9/.cli-zip-big.json
 
 # CMake test build artifacts
 apps/test/build/
+
+# Yocto build output
+yocto/build/

--- a/yocto/Containerfile
+++ b/yocto/Containerfile
@@ -1,0 +1,109 @@
+# Containerfile — Yocto build container for the iot LwM2M stack
+#
+# Builds the entire iot stack inside a container. No host Yocto install
+# needed — only podman or docker.
+#
+# The container:
+#   1. Installs Yocto host dependencies
+#   2. Clones poky + meta-openembedded at Scarthgap (5.0 LTS)
+#   3. Copies the local meta-iot layer
+#   4. Sets up the bitbake build environment
+#   5. Runs bitbake to produce .ipk packages
+#
+# Use build.sh as the host entrypoint — it builds this image, runs the
+# container, and copies the output artifacts to yocto/build/<machine>/.
+
+FROM ubuntu:22.04
+
+# ── Yocto host dependencies ────────────────────────────────────────
+# From https://docs.yoctoproject.org/ref-manual/system-requirements.html
+# (Ubuntu 22.04 row). Added: git-lfs (some layers need it), file,
+# locales (bitbake wants en_US.UTF-8).
+RUN apt-get update -qq && \
+    apt-get install -y -qq \
+        gawk wget git diffstat unzip texinfo \
+        gcc g++ make cmake \
+        build-essential chrpath cpio debianutils \
+        iputils-ping python3 python3-pip python3-pexpect \
+        xz-utils debianutils locales \
+        zstd liblz4-tool file \
+        libssl-dev libgmp-dev libmpc-dev \
+        zlib1g-dev \
+    && apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
+
+# Locale — bitbake checks LANG
+RUN locale-gen en_US.UTF-8
+ENV LANG=en_US.UTF-8
+
+# ── Build user ─────────────────────────────────────────────────────
+# Yocto refuses to run as root. Create a non-privileged user.
+RUN useradd -m -s /bin/bash builduser && \
+    mkdir -p /home/builduser/yocto && \
+    chown -R builduser:builduser /home/builduser
+
+USER builduser
+WORKDIR /home/builduser/yocto
+
+# ── Clone Yocto layers ─────────────────────────────────────────────
+# Cloned at build time so they're baked into the image. Override with
+# volume mounts for development iteration.
+ARG POKY_BRANCH=scarthgap
+ARG OE_BRANCH=scarthgap
+
+RUN git clone --depth=1 -b ${POKY_BRANCH} \
+        https://git.yoctoproject.org/poky && \
+    git clone --depth=1 -b ${OE_BRANCH} \
+        https://git.openembedded.org/meta-openembedded
+
+# ── Copy the meta-iot layer ────────────────────────────────────────
+# Copied at build time. During development, mount over it:
+#   podman run -v ./yocto/meta-iot:/home/builduser/yocto/meta-iot:Z ...
+COPY --chown=builduser:builduser meta-iot/ /home/builduser/yocto/meta-iot/
+
+# ── Initialise the build directory ─────────────────────────────────
+# Creates build/conf/local.conf and build/conf/bblayers.conf
+RUN cd /home/builduser/yocto && \
+    . poky/oe-init-build-env build && \
+    # Add required layers to bblayers.conf
+    bitbake-layers add-layer ../meta-openembedded/meta-oe && \
+    bitbake-layers add-layer ../meta-iot
+
+# ── Configure local.conf ───────────────────────────────────────────
+# Write a minimal local.conf fragment that bitbake reads.
+# The full conf is in build/conf/local.conf; we append.
+RUN cat >> /home/builduser/yocto/build/conf/local.conf <<'YOCONF'
+
+# ── iot stack configuration ────────────────────────────────────────
+
+# Accept CLOSED license for iot recipes
+LICENSE_FLAGS_ACCEPTED += "CLOSED"
+
+# systemd as init manager (required for DynamicUser=, RuntimeDirectory=)
+INIT_MANAGER = "systemd"
+
+# Machine — override via MACHINE env var at container run time
+MACHINE ??= "qemux86-64"
+
+# Target packages
+IMAGE_INSTALL:append = " packagegroup-iot-core"
+
+# Disable the mongo PACKAGECONFIG for faster builds in CI.
+# Remove this line for production builds that need RegistryMirror.
+PACKAGECONFIG:remove:pn-lwm2m = "mongo"
+YOCONF
+
+# ── Build entrypoint ───────────────────────────────────────────────
+# The container runs bitbake for the requested target. MACHINE can be
+# overridden at run time:
+#   podman run -e MACHINE=qemuarm64 iot-yocto-builder
+#
+# Output lands in /home/builduser/yocto/build/tmp/deploy/.
+# Mount a host directory to extract artifacts:
+#   podman run -v ./build:/home/builduser/yocto/build/tmp/deploy:Z ...
+
+COPY --chown=builduser:builduser entrypoint.sh /home/builduser/yocto/
+RUN chmod +x /home/builduser/yocto/entrypoint.sh
+
+ENTRYPOINT ["/home/builduser/yocto/entrypoint.sh"]
+CMD ["packagegroup-iot-core"]

--- a/yocto/Containerfile
+++ b/yocto/Containerfile
@@ -3,22 +3,20 @@
 # Builds the entire iot stack inside a container. No host Yocto install
 # needed — only podman or docker.
 #
-# The container:
-#   1. Installs Yocto host dependencies
-#   2. Clones poky + meta-openembedded at Scarthgap (5.0 LTS)
-#   3. Copies the local meta-iot layer
-#   4. Sets up the bitbake build environment
-#   5. Runs bitbake to produce .ipk packages
+# The container image bakes in:
+#   1. Yocto host dependencies (compilers, python3, etc.)
+#   2. poky + meta-openembedded at Scarthgap (5.0 LTS)
+#   3. The local meta-iot layer
+#   4. An entrypoint that sets up the build dir and runs bitbake
 #
 # Use build.sh as the host entrypoint — it builds this image, runs the
-# container, and copies the output artifacts to yocto/build/<machine>/.
+# container, and `podman cp`s the output artifacts to yocto/build/<machine>/.
 
 FROM ubuntu:22.04
 
 # ── Yocto host dependencies ────────────────────────────────────────
 # From https://docs.yoctoproject.org/ref-manual/system-requirements.html
-# (Ubuntu 22.04 row). Added: git-lfs (some layers need it), file,
-# locales (bitbake wants en_US.UTF-8).
+# (Ubuntu 22.04 row).
 RUN apt-get update -qq && \
     apt-get install -y -qq \
         gawk wget git diffstat unzip texinfo \
@@ -38,7 +36,8 @@ ENV LANG=en_US.UTF-8
 
 # ── Build user ─────────────────────────────────────────────────────
 # Yocto refuses to run as root. Create a non-privileged user.
-RUN useradd -m -s /bin/bash builduser && \
+# uid 1000 so host-volume mounts Just Work on most Linux hosts.
+RUN useradd -m -u 1000 -s /bin/bash builduser && \
     mkdir -p /home/builduser/yocto && \
     chown -R builduser:builduser /home/builduser
 
@@ -46,8 +45,7 @@ USER builduser
 WORKDIR /home/builduser/yocto
 
 # ── Clone Yocto layers ─────────────────────────────────────────────
-# Cloned at build time so they're baked into the image. Override with
-# volume mounts for development iteration.
+# Baked into the image so they don't need fetching at run time.
 ARG POKY_BRANCH=scarthgap
 ARG OE_BRANCH=scarthgap
 
@@ -57,53 +55,14 @@ RUN git clone --depth=1 -b ${POKY_BRANCH} \
         https://git.openembedded.org/meta-openembedded
 
 # ── Copy the meta-iot layer ────────────────────────────────────────
-# Copied at build time. During development, mount over it:
-#   podman run -v ./yocto/meta-iot:/home/builduser/yocto/meta-iot:Z ...
+# Copied at build time. For development, mount over it:
+#   podman run -v ./meta-iot:/home/builduser/yocto/meta-iot:Z ...
 COPY --chown=builduser:builduser meta-iot/ /home/builduser/yocto/meta-iot/
 
-# ── Initialise the build directory ─────────────────────────────────
-# Creates build/conf/local.conf and build/conf/bblayers.conf.
-# oe-init-build-env must be sourced from the poky directory.
-# TEMPLATECONF is unset so we get the default poky local.conf template.
-RUN cd /home/builduser/yocto/poky && \
-    TEMPLATECONF="" . ./oe-init-build-env ../build && \
-    # Add required layers to bblayers.conf
-    bitbake-layers add-layer ../../meta-openembedded/meta-oe && \
-    bitbake-layers add-layer ../../meta-iot
-
-# ── Configure local.conf ───────────────────────────────────────────
-# Write a minimal local.conf fragment that bitbake reads.
-# The full conf is in build/conf/local.conf; we append.
-RUN cat >> /home/builduser/yocto/build/conf/local.conf <<'YOCONF'
-
-# ── iot stack configuration ────────────────────────────────────────
-
-# Accept CLOSED license for iot recipes
-LICENSE_FLAGS_ACCEPTED += "CLOSED"
-
-# systemd as init manager (required for DynamicUser=, RuntimeDirectory=)
-INIT_MANAGER = "systemd"
-
-# Machine — override via MACHINE env var at container run time
-MACHINE ??= "qemux86-64"
-
-# Target packages
-IMAGE_INSTALL:append = " packagegroup-iot-core"
-
-# Disable the mongo PACKAGECONFIG for faster builds in CI.
-# Remove this line for production builds that need RegistryMirror.
-PACKAGECONFIG:remove:pn-lwm2m = "mongo"
-YOCONF
-
-# ── Build entrypoint ───────────────────────────────────────────────
-# The container runs bitbake for the requested target. MACHINE can be
-# overridden at run time:
-#   podman run -e MACHINE=qemuarm64 iot-yocto-builder
-#
-# Output lands in /home/builduser/yocto/build/tmp/deploy/.
-# Mount a host directory to extract artifacts:
-#   podman run -v ./build:/home/builduser/yocto/build/tmp/deploy:Z ...
-
+# ── Entrypoint ─────────────────────────────────────────────────────
+# The entrypoint does all setup + build at container run time
+# (oe-init-build-env, add layers, configure, bitbake).
+# This keeps the build directory writable by the container user.
 COPY --chown=builduser:builduser entrypoint.sh /home/builduser/yocto/
 RUN chmod +x /home/builduser/yocto/entrypoint.sh
 

--- a/yocto/Containerfile
+++ b/yocto/Containerfile
@@ -54,6 +54,13 @@ RUN git clone --depth=1 -b ${POKY_BRANCH} \
     git clone --depth=1 -b ${OE_BRANCH} \
         https://git.openembedded.org/meta-openembedded
 
+# ── Workaround: podman overlayfs doesn't support --preserve=xattr ──
+# The oe.path.copyhardlinktree function uses cp -afl --preserve=xattr
+# which fails on podman's overlay filesystem (macOS host). Strip the
+# xattr flag so sstate operations use plain cp -afl instead.
+RUN sed -i "s/cp -afl --preserve=xattr/cp -afl/" \
+    /home/builduser/yocto/poky/meta/lib/oe/path.py
+
 # ── Copy the meta-iot layer ────────────────────────────────────────
 # Copied at build time. For development, mount over it:
 #   podman run -v ./meta-iot:/home/builduser/yocto/meta-iot:Z ...

--- a/yocto/Containerfile
+++ b/yocto/Containerfile
@@ -62,12 +62,14 @@ RUN git clone --depth=1 -b ${POKY_BRANCH} \
 COPY --chown=builduser:builduser meta-iot/ /home/builduser/yocto/meta-iot/
 
 # ── Initialise the build directory ─────────────────────────────────
-# Creates build/conf/local.conf and build/conf/bblayers.conf
-RUN cd /home/builduser/yocto && \
-    . poky/oe-init-build-env build && \
+# Creates build/conf/local.conf and build/conf/bblayers.conf.
+# oe-init-build-env must be sourced from the poky directory.
+# TEMPLATECONF is unset so we get the default poky local.conf template.
+RUN cd /home/builduser/yocto/poky && \
+    TEMPLATECONF="" . ./oe-init-build-env ../build && \
     # Add required layers to bblayers.conf
-    bitbake-layers add-layer ../meta-openembedded/meta-oe && \
-    bitbake-layers add-layer ../meta-iot
+    bitbake-layers add-layer ../../meta-openembedded/meta-oe && \
+    bitbake-layers add-layer ../../meta-iot
 
 # ── Configure local.conf ───────────────────────────────────────────
 # Write a minimal local.conf fragment that bitbake reads.

--- a/yocto/Containerfile
+++ b/yocto/Containerfile
@@ -74,4 +74,4 @@ COPY --chown=builduser:builduser entrypoint.sh /home/builduser/yocto/
 RUN chmod +x /home/builduser/yocto/entrypoint.sh
 
 ENTRYPOINT ["/home/builduser/yocto/entrypoint.sh"]
-CMD ["packagegroup-iot"]
+CMD ["packagegroup-iot", "lwm2m"]

--- a/yocto/Containerfile
+++ b/yocto/Containerfile
@@ -67,4 +67,4 @@ COPY --chown=builduser:builduser entrypoint.sh /home/builduser/yocto/
 RUN chmod +x /home/builduser/yocto/entrypoint.sh
 
 ENTRYPOINT ["/home/builduser/yocto/entrypoint.sh"]
-CMD ["packagegroup-iot-core"]
+CMD ["packagegroup-iot"]

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -1,31 +1,30 @@
 #!/bin/bash
 # build.sh — Containerised multi-arch Yocto build for the iot LwM2M stack
 #
-# Builds the entire iot stack inside a podman/docker container. The host
-# needs only podman or docker — no Yocto install, no kas, nothing else.
+# Builds inside a podman/docker container, then copies artifacts to the
+# host. No Yocto install needed on the host — just podman or docker.
 #
 # Usage:
-#   ./build.sh                        # Build default machine (qemux86-64)
-#   MACHINE=qemuarm64 ./build.sh      # Build for ARM64 / aarch64
-#   MACHINE=qemuarm ./build.sh        # Build for ARMv7 / armhf
-#   ./build.sh all                    # Build all supported architectures
+#   ./build.sh                        # qemux86-64 (default)
+#   MACHINE=qemuarm64 ./build.sh      # ARM64 / aarch64
+#   MACHINE=qemuarm ./build.sh        # ARMv7 / armhf
+#   ./build.sh all                    # All three architectures
 #
 # Output per machine:
-#   yocto/build/<machine>/ipk/        *.ipk packages (opkg-installable)
+#   yocto/build/<machine>/ipk/        *.ipk packages
 #   yocto/build/<machine>/images/     rootfs / kernel images
 #
 # Requirements:
 #   - podman or docker
-#   - ~30 GB free disk space (Yocto builds are large)
+#   - ~30 GB free disk space (Yocto downloads + build)
 #   - Internet access (first build fetches ~8 GB of sources)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
-BUILD_DIR="$SCRIPT_DIR/build"
+OUT_DIR="$SCRIPT_DIR/build"
 IMAGE_NAME="${IMAGE_NAME:-iot-yocto-builder:latest}"
-CONTAINER_CMD="${CONTAINER_CMD:-podman}"
 
 # Supported architectures
 MACHINES=(
@@ -43,50 +42,56 @@ log_error()   { echo -e "${RED}ERROR: $1${NC}" >&2; }
 # ── Detect container runtime ──────────────────────────────────────────
 detect_runtime() {
     if command -v podman &>/dev/null; then
-        CONTAINER_CMD="podman"
+        echo "podman"
     elif command -v docker &>/dev/null; then
-        CONTAINER_CMD="docker"
+        echo "docker"
     else
-        log_error "Neither podman nor docker found. Install one to continue."
+        log_error "Neither podman nor docker found."
         exit 1
     fi
-    log_info "Container runtime: $CONTAINER_CMD"
 }
 
-# ── Build the container image (one time) ──────────────────────────────
+# ── Build the container image ─────────────────────────────────────────
 build_image() {
     log_section "Building container image: $IMAGE_NAME"
-    $CONTAINER_CMD build \
-        -t "$IMAGE_NAME" \
-        -f "$SCRIPT_DIR/Containerfile" \
-        "$SCRIPT_DIR"
+    $CR build -t "$IMAGE_NAME" -f "$SCRIPT_DIR/Containerfile" "$SCRIPT_DIR"
     log_info "Image ready: $IMAGE_NAME"
 }
 
-# ── Run the build inside the container ────────────────────────────────
-run_build() {
+# ── Build one architecture ────────────────────────────────────────────
+build_machine() {
     local machine="$1"
-    local out_dir="$BUILD_DIR/$machine"
-    mkdir -p "$out_dir"
+    local out="$OUT_DIR/$machine"
+    local container="iot-build-${machine//./-}"
+    mkdir -p "$out"
 
     log_section "Building for $machine"
 
-    # Run the container. Mount the per-machine output directory so
-    # deploy artifacts (ipk/, images/) land on the host.
-    $CONTAINER_CMD run --rm \
+    # Remove any stale container with the same name
+    $CR rm -f "$container" &>/dev/null || true
+
+    # Run the build. The container stays around after exit so we can
+    # copy artifacts out.
+    $CR run --name "$container" \
         -e "MACHINE=$machine" \
-        -v "$out_dir:/home/builduser/yocto/build/tmp/deploy:Z" \
         "$IMAGE_NAME" \
         packagegroup-iot-core
 
-    log_info "Artifacts: $out_dir/"
+    # Copy artifacts from the container to the host
+    log_info "Copying artifacts to $out ..."
+    $CR cp "$container:/home/builduser/yocto/build/tmp/deploy/." "$out/"
+
+    # Clean up the container
+    $CR rm "$container"
+
+    log_info "Done: $out/"
 }
 
 # ── Print summary ─────────────────────────────────────────────────────
 print_summary() {
     log_section "Build summary"
     for machine in "${MACHINES[@]}"; do
-        local d="$BUILD_DIR/$machine/ipk"
+        local d="$OUT_DIR/$machine/ipk"
         if [ -d "$d" ]; then
             local iot_count=$(find "$d" -name 'iot-*.ipk' -type f 2>/dev/null | wc -l)
             local total=$(find "$d" -name '*.ipk' -type f 2>/dev/null | wc -l)
@@ -101,25 +106,27 @@ print_summary() {
     done
     echo ""
     echo "  Install on target (example for ARM64):"
-    echo "    scp $BUILD_DIR/qemuarm64/ipk/*/iot-*.ipk root@<target>:/tmp/"
+    echo "    scp $OUT_DIR/qemuarm64/ipk/*/iot-*.ipk root@<target>:/tmp/"
     echo "    ssh root@<target> opkg install /tmp/iot-ds-server_*.ipk /tmp/iot-lwm2m_*.ipk /tmp/iot-config_*.ipk"
     echo ""
 }
 
 # ── Main ──────────────────────────────────────────────────────────────
 main() {
-    detect_runtime
+    CR=$(detect_runtime)
+    log_info "Container runtime: $CR"
+
     build_image
 
     local target="${1:-${MACHINE:-qemux86-64}}"
 
     if [ "$target" = "all" ]; then
         for machine in "${MACHINES[@]}"; do
-            run_build "$machine"
+            build_machine "$machine"
         done
         print_summary
     else
-        run_build "$target"
+        build_machine "$target"
         print_summary
     fi
 }

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -75,7 +75,7 @@ build_machine() {
     $CR run --name "$container" \
         -e "MACHINE=$machine" \
         "$IMAGE_NAME" \
-        packagegroup-iot-core
+        packagegroup-iot
 
     # Copy artifacts from the container to the host
     log_info "Copying artifacts to $out ..."

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -1,50 +1,46 @@
 #!/bin/bash
-# build.sh — Containerised Yocto build for the iot LwM2M stack
+# build.sh — Containerised multi-arch Yocto build for the iot LwM2M stack
 #
-# Runs the entire Yocto build inside the ghcr.io/siemens/kas/kas
-# container image. The host needs only podman or docker — no native
-# Yocto install, no kas CLI.
+# Builds the entire iot stack inside a podman/docker container. The host
+# needs only podman or docker — no Yocto install, no kas, nothing else.
 #
 # Usage:
-#   ./build.sh                      # Build default machine (qemux86-64)
-#   MACHINE=qemuarm64 ./build.sh    # Build for ARM64
-#   MACHINE=raspberrypi4-64 ./build.sh  # Build for Raspberry Pi 4
-#   ./build.sh all                  # Build all supported architectures
+#   ./build.sh                        # Build default machine (qemux86-64)
+#   MACHINE=qemuarm64 ./build.sh      # Build for ARM64 / aarch64
+#   MACHINE=qemuarm ./build.sh        # Build for ARMv7 / armhf
+#   ./build.sh all                    # Build all supported architectures
 #
-# Output:
-#   yocto/build/deploy/ipk/         *.ipk packages (installable on target)
-#   yocto/build/deploy/images/      rootfs images
+# Output per machine:
+#   yocto/build/<machine>/ipk/        *.ipk packages (opkg-installable)
+#   yocto/build/<machine>/images/     rootfs / kernel images
 #
 # Requirements:
 #   - podman or docker
-#   - Internet access (to fetch kas image + Yocto layers)
+#   - ~30 GB free disk space (Yocto builds are large)
+#   - Internet access (first build fetches ~8 GB of sources)
 
 set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 BUILD_DIR="$SCRIPT_DIR/build"
-KAS_IMAGE="${KAS_IMAGE:-ghcr.io/siemens/kas/kas:latest}"
+IMAGE_NAME="${IMAGE_NAME:-iot-yocto-builder:latest}"
 CONTAINER_CMD="${CONTAINER_CMD:-podman}"
 
-# Supported architectures — mirrored in kas-iot.yml
+# Supported architectures
 MACHINES=(
     "qemux86-64"
     "qemuarm64"
     "qemuarm"
 )
 
-# ── Colour helpers ──────────────────────────────────────────────────
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Colour
-
+# ── Helpers ───────────────────────────────────────────────────────────
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 log_section() { echo -e "\n${GREEN}═══ $1 ═══${NC}"; }
 log_info()    { echo -e "${YELLOW} → $1${NC}"; }
 log_error()   { echo -e "${RED}ERROR: $1${NC}" >&2; }
 
-# ── Detect container runtime ────────────────────────────────────────
+# ── Detect container runtime ──────────────────────────────────────────
 detect_runtime() {
     if command -v podman &>/dev/null; then
         CONTAINER_CMD="podman"
@@ -54,71 +50,76 @@ detect_runtime() {
         log_error "Neither podman nor docker found. Install one to continue."
         exit 1
     fi
-    log_info "Using container runtime: $CONTAINER_CMD"
+    log_info "Container runtime: $CONTAINER_CMD"
 }
 
-# ── Pull kas image ──────────────────────────────────────────────────
-pull_kas() {
-    log_section "Pulling kas container image"
-    $CONTAINER_CMD pull "$KAS_IMAGE"
+# ── Build the container image (one time) ──────────────────────────────
+build_image() {
+    log_section "Building container image: $IMAGE_NAME"
+    $CONTAINER_CMD build \
+        -t "$IMAGE_NAME" \
+        -f "$SCRIPT_DIR/Containerfile" \
+        "$SCRIPT_DIR"
+    log_info "Image ready: $IMAGE_NAME"
 }
 
-# ── Build one machine ───────────────────────────────────────────────
-build_machine() {
+# ── Run the build inside the container ────────────────────────────────
+run_build() {
     local machine="$1"
-    local deploy_dir="$BUILD_DIR/$machine"
+    local out_dir="$BUILD_DIR/$machine"
+    mkdir -p "$out_dir"
 
     log_section "Building for $machine"
-    mkdir -p "$deploy_dir"
 
-    # kas-container runs kas inside the container. We bind-mount:
-    #   - the repo root at /work (so kas finds yocto/kas-iot.yml)
-    #   - a per-machine build dir so caches don't collide
+    # Run the container. Mount the per-machine output directory so
+    # deploy artifacts (ipk/, images/) land on the host.
     $CONTAINER_CMD run --rm \
-        -v "$REPO_ROOT:/work:Z" \
-        -v "$deploy_dir:/work/yocto/build:Z" \
-        -e MACHINE="$machine" \
-        -e KAS_BUILD_DIR="/work/yocto/build" \
-        "$KAS_IMAGE" \
-        kas build /work/yocto/kas-iot.yml
+        -e "MACHINE=$machine" \
+        -v "$out_dir:/home/builduser/yocto/build/tmp/deploy:Z" \
+        "$IMAGE_NAME" \
+        packagegroup-iot-core
 
-    log_info "Artifacts for $machine: $deploy_dir/deploy/"
+    log_info "Artifacts: $out_dir/"
 }
 
-# ── Print summary ───────────────────────────────────────────────────
+# ── Print summary ─────────────────────────────────────────────────────
 print_summary() {
-    log_section "Build complete"
-    echo ""
-    echo "  Deploy directory: $BUILD_DIR/"
-    echo ""
+    log_section "Build summary"
     for machine in "${MACHINES[@]}"; do
-        local d="$BUILD_DIR/$machine/deploy"
-        if [ -d "$d/ipk" ]; then
-            local count=$(find "$d/ipk" -name '*.ipk' -type f 2>/dev/null | wc -l)
-            echo "  $machine  →  $(find "$d/ipk" -name 'iot-*.ipk' -type f 2>/dev/null | wc -l) iot .ipk packages ($count total)"
+        local d="$BUILD_DIR/$machine/ipk"
+        if [ -d "$d" ]; then
+            local iot_count=$(find "$d" -name 'iot-*.ipk' -type f 2>/dev/null | wc -l)
+            local total=$(find "$d" -name '*.ipk' -type f 2>/dev/null | wc -l)
+            if [ "$iot_count" -gt 0 ]; then
+                echo "  ✅ $machine  →  $iot_count iot .ipk packages ($total total)"
+            else
+                echo "  ⚠️  $machine  →  build completed (no iot .ipk found yet)"
+            fi
+        else
+            echo "  ⬜ $machine  —  not built"
         fi
     done
     echo ""
-    echo "  Install on target:"
-    echo "    scp $BUILD_DIR/qemuarm64/deploy/ipk/cortexa57/iot-*.ipk root@<target>:/tmp/"
+    echo "  Install on target (example for ARM64):"
+    echo "    scp $BUILD_DIR/qemuarm64/ipk/*/iot-*.ipk root@<target>:/tmp/"
     echo "    ssh root@<target> opkg install /tmp/iot-ds-server_*.ipk /tmp/iot-lwm2m_*.ipk /tmp/iot-config_*.ipk"
     echo ""
 }
 
-# ── Main ────────────────────────────────────────────────────────────
+# ── Main ──────────────────────────────────────────────────────────────
 main() {
     detect_runtime
-    pull_kas
+    build_image
 
     local target="${1:-${MACHINE:-qemux86-64}}"
 
     if [ "$target" = "all" ]; then
         for machine in "${MACHINES[@]}"; do
-            build_machine "$machine"
+            run_build "$machine"
         done
         print_summary
     else
-        build_machine "$target"
+        run_build "$target"
         print_summary
     fi
 }

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+# build.sh — Containerised Yocto build for the iot LwM2M stack
+#
+# Runs the entire Yocto build inside the ghcr.io/siemens/kas/kas
+# container image. The host needs only podman or docker — no native
+# Yocto install, no kas CLI.
+#
+# Usage:
+#   ./build.sh                      # Build default machine (qemux86-64)
+#   MACHINE=qemuarm64 ./build.sh    # Build for ARM64
+#   MACHINE=raspberrypi4-64 ./build.sh  # Build for Raspberry Pi 4
+#   ./build.sh all                  # Build all supported architectures
+#
+# Output:
+#   yocto/build/deploy/ipk/         *.ipk packages (installable on target)
+#   yocto/build/deploy/images/      rootfs images
+#
+# Requirements:
+#   - podman or docker
+#   - Internet access (to fetch kas image + Yocto layers)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+BUILD_DIR="$SCRIPT_DIR/build"
+KAS_IMAGE="${KAS_IMAGE:-ghcr.io/siemens/kas/kas:latest}"
+CONTAINER_CMD="${CONTAINER_CMD:-podman}"
+
+# Supported architectures — mirrored in kas-iot.yml
+MACHINES=(
+    "qemux86-64"
+    "qemuarm64"
+    "qemuarm"
+)
+
+# ── Colour helpers ──────────────────────────────────────────────────
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Colour
+
+log_section() { echo -e "\n${GREEN}═══ $1 ═══${NC}"; }
+log_info()    { echo -e "${YELLOW} → $1${NC}"; }
+log_error()   { echo -e "${RED}ERROR: $1${NC}" >&2; }
+
+# ── Detect container runtime ────────────────────────────────────────
+detect_runtime() {
+    if command -v podman &>/dev/null; then
+        CONTAINER_CMD="podman"
+    elif command -v docker &>/dev/null; then
+        CONTAINER_CMD="docker"
+    else
+        log_error "Neither podman nor docker found. Install one to continue."
+        exit 1
+    fi
+    log_info "Using container runtime: $CONTAINER_CMD"
+}
+
+# ── Pull kas image ──────────────────────────────────────────────────
+pull_kas() {
+    log_section "Pulling kas container image"
+    $CONTAINER_CMD pull "$KAS_IMAGE"
+}
+
+# ── Build one machine ───────────────────────────────────────────────
+build_machine() {
+    local machine="$1"
+    local deploy_dir="$BUILD_DIR/$machine"
+
+    log_section "Building for $machine"
+    mkdir -p "$deploy_dir"
+
+    # kas-container runs kas inside the container. We bind-mount:
+    #   - the repo root at /work (so kas finds yocto/kas-iot.yml)
+    #   - a per-machine build dir so caches don't collide
+    $CONTAINER_CMD run --rm \
+        -v "$REPO_ROOT:/work:Z" \
+        -v "$deploy_dir:/work/yocto/build:Z" \
+        -e MACHINE="$machine" \
+        -e KAS_BUILD_DIR="/work/yocto/build" \
+        "$KAS_IMAGE" \
+        kas build /work/yocto/kas-iot.yml
+
+    log_info "Artifacts for $machine: $deploy_dir/deploy/"
+}
+
+# ── Print summary ───────────────────────────────────────────────────
+print_summary() {
+    log_section "Build complete"
+    echo ""
+    echo "  Deploy directory: $BUILD_DIR/"
+    echo ""
+    for machine in "${MACHINES[@]}"; do
+        local d="$BUILD_DIR/$machine/deploy"
+        if [ -d "$d/ipk" ]; then
+            local count=$(find "$d/ipk" -name '*.ipk' -type f 2>/dev/null | wc -l)
+            echo "  $machine  →  $(find "$d/ipk" -name 'iot-*.ipk' -type f 2>/dev/null | wc -l) iot .ipk packages ($count total)"
+        fi
+    done
+    echo ""
+    echo "  Install on target:"
+    echo "    scp $BUILD_DIR/qemuarm64/deploy/ipk/cortexa57/iot-*.ipk root@<target>:/tmp/"
+    echo "    ssh root@<target> opkg install /tmp/iot-ds-server_*.ipk /tmp/iot-lwm2m_*.ipk /tmp/iot-config_*.ipk"
+    echo ""
+}
+
+# ── Main ────────────────────────────────────────────────────────────
+main() {
+    detect_runtime
+    pull_kas
+
+    local target="${1:-${MACHINE:-qemux86-64}}"
+
+    if [ "$target" = "all" ]; then
+        for machine in "${MACHINES[@]}"; do
+            build_machine "$machine"
+        done
+        print_summary
+    else
+        build_machine "$target"
+        print_summary
+    fi
+}
+
+main "$@"

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -13,12 +13,15 @@
 set -eo pipefail
 
 MACHINE="${MACHINE:-qemux86-64}"
-TARGET="${*:-packagegroup-iot lwm2m}"
+# Default targets if none specified
+if [ $# -eq 0 ]; then
+    set -- packagegroup-iot lwm2m
+fi
 
 echo "═══════════════════════════════════════════════════════════════"
 echo "  iot Yocto build"
 echo "  Machine:  $MACHINE"
-echo "  Target:   $TARGET"
+echo "  Targets:  $@"
 echo "═══════════════════════════════════════════════════════════════"
 
 cd /home/builduser/yocto
@@ -64,10 +67,10 @@ fi
 
 # ── 5. Run bitbake ─────────────────────────────────────────────────
 echo ""
-echo "→ Starting bitbake $TARGET for $MACHINE ..."
+echo "→ Starting bitbake for $MACHINE: $@ ..."
 echo ""
 
-bitbake "$TARGET"
+bitbake "$@"
 
 # ── 6. Report ──────────────────────────────────────────────────────
 echo ""

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -60,6 +60,11 @@ PACKAGECONFIG:remove:pn-lwm2m = "mongo"
 # Filesystem may not support hardlinks (macOS podman host).
 # Disable sstate hardlinking to avoid cp -afl failures.
 SSTATE_HARDLINK = "0"
+
+# Limit parallelism for constrained VMs (4 GB RAM default).
+# Override with -e BB_THREADS=4 -e PARALLEL_MAKE=-j4 at run time.
+BB_NUMBER_THREADS = "${BB_THREADS:-2}"
+PARALLEL_MAKE = "${PARALLEL_MAKE:--j2}"
 YOCONF
 
 # ── 4. Override MACHINE ────────────────────────────────────────────

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -13,7 +13,7 @@
 set -eo pipefail
 
 MACHINE="${MACHINE:-qemux86-64}"
-TARGET="${1:-packagegroup-iot-core}"
+TARGET="${1:-packagegroup-iot lwm2m}"
 
 echo "═══════════════════════════════════════════════════════════════"
 echo "  iot Yocto build"

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -13,7 +13,7 @@
 set -eo pipefail
 
 MACHINE="${MACHINE:-qemux86-64}"
-TARGET="${1:-packagegroup-iot lwm2m}"
+TARGET="${*:-packagegroup-iot lwm2m}"
 
 echo "═══════════════════════════════════════════════════════════════"
 echo "  iot Yocto build"

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -51,6 +51,10 @@ IMAGE_INSTALL:append = " packagegroup-iot-core"
 # Disable mongo PACKAGECONFIG for faster builds (RegistryMirror).
 # Remove to enable the MongoDB registration mirror feature.
 PACKAGECONFIG:remove:pn-lwm2m = "mongo"
+
+# Filesystem may not support hardlinks (macOS podman host).
+# Disable sstate hardlinking to avoid cp -afl failures.
+SSTATE_HARDLINK = "0"
 YOCONF
 
 # ── 4. Override MACHINE ────────────────────────────────────────────

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -62,9 +62,10 @@ PACKAGECONFIG:remove:pn-lwm2m = "mongo"
 SSTATE_HARDLINK = "0"
 
 # Limit parallelism for constrained VMs (4 GB RAM default).
-# Override with -e BB_THREADS=4 -e PARALLEL_MAKE=-j4 at run time.
-BB_NUMBER_THREADS = "${BB_THREADS:-2}"
-PARALLEL_MAKE = "${PARALLEL_MAKE:--j2}"
+# Override at run time with -e BB_NUMBER_THREADS=4 and
+# -e PARALLEL_MAKE=-j4.
+BB_NUMBER_THREADS ?= "2"
+PARALLEL_MAKE ?= "-j2"
 YOCONF
 
 # ── 4. Override MACHINE ────────────────────────────────────────────

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -1,14 +1,16 @@
 #!/bin/bash
 # entrypoint.sh — run inside the Yocto build container
 #
-# Sources the bitbake environment and runs the build. MACHINE can be
-# set via the environment at `podman run` time. Default: qemux86-64.
+# Sets up the bitbake build directory, adds the required layers,
+# writes local.conf, and runs bitbake. All at container run time
+# so permissions are correct (no volume-mount conflicts).
 #
 # Usage:
-#   podman run -e MACHINE=qemuarm64 iot-yocto-builder
-#   podman run -e MACHINE=qemuarm64 iot-yocto-builder packagegroup-iot-full
+#   podman run --name iot-build -e MACHINE=qemuarm64 iot-yocto-builder
+#   podman cp iot-build:/home/builduser/yocto/build/tmp/deploy ./build/qemuarm64/
+#   podman rm iot-build
 
-set -euo pipefail
+set -eo pipefail
 
 MACHINE="${MACHINE:-qemux86-64}"
 TARGET="${1:-packagegroup-iot-core}"
@@ -21,27 +23,55 @@ echo "════════════════════════�
 
 cd /home/builduser/yocto
 
-# Source the bitbake build environment from the poky directory
-# shellcheck disable=SC1091
-cd /home/builduser/yocto/poky
-. ./oe-init-build-env ../build
+# ── 1. Initialise the build directory ──────────────────────────────
+echo "→ Setting up build directory ..."
+cd poky
+TEMPLATECONF="" . ./oe-init-build-env ../build
+cd /home/builduser/yocto/build
 
-# Override MACHINE in local.conf if passed via env
+# ── 2. Add layers ──────────────────────────────────────────────────
+echo "→ Adding layers ..."
+bitbake-layers add-layer ../meta-openembedded/meta-oe
+bitbake-layers add-layer ../meta-iot
+
+# ── 3. Configure local.conf ────────────────────────────────────────
+cat >> conf/local.conf <<'YOCONF'
+
+# ── iot stack configuration ────────────────────────────────────────
+
+# Accept CLOSED license for iot recipes
+LICENSE_FLAGS_ACCEPTED += "CLOSED"
+
+# systemd as init manager (required for DynamicUser=, RuntimeDirectory=)
+INIT_MANAGER = "systemd"
+
+# Target packages
+IMAGE_INSTALL:append = " packagegroup-iot-core"
+
+# Disable mongo PACKAGECONFIG for faster builds (RegistryMirror).
+# Remove to enable the MongoDB registration mirror feature.
+PACKAGECONFIG:remove:pn-lwm2m = "mongo"
+YOCONF
+
+# ── 4. Override MACHINE ────────────────────────────────────────────
 if [ "$MACHINE" != "qemux86-64" ]; then
     echo "MACHINE = \"$MACHINE\"" >> conf/local.conf
 fi
 
+# ── 5. Run bitbake ─────────────────────────────────────────────────
 echo ""
-echo "→ Starting bitbake $TARGET ..."
+echo "→ Starting bitbake $TARGET for $MACHINE ..."
 echo ""
 
 bitbake "$TARGET"
 
+# ── 6. Report ──────────────────────────────────────────────────────
 echo ""
 echo "═══════════════════════════════════════════════════════════════"
-echo "  Build complete"
-echo "  Artifacts: tmp/deploy/ipk/"
+echo "  Build complete — $MACHINE"
+echo "  Artifacts: build/tmp/deploy/"
 echo "═══════════════════════════════════════════════════════════════"
-
-# List the built iot packages
 find tmp/deploy/ipk -name 'iot-*.ipk' -type f 2>/dev/null | sort || true
+echo ""
+echo "On the host, extract with:"
+echo "  podman cp <container>:/home/builduser/yocto/build/tmp/deploy ./build/$MACHINE/"

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -35,6 +35,8 @@ cd /home/builduser/yocto/build
 # ── 2. Add layers ──────────────────────────────────────────────────
 echo "→ Adding layers ..."
 bitbake-layers add-layer ../meta-openembedded/meta-oe
+bitbake-layers add-layer ../meta-openembedded/meta-python
+bitbake-layers add-layer ../meta-openembedded/meta-networking
 bitbake-layers add-layer ../meta-iot
 
 # ── 3. Configure local.conf ────────────────────────────────────────

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -1,0 +1,46 @@
+#!/bin/bash
+# entrypoint.sh — run inside the Yocto build container
+#
+# Sources the bitbake environment and runs the build. MACHINE can be
+# set via the environment at `podman run` time. Default: qemux86-64.
+#
+# Usage:
+#   podman run -e MACHINE=qemuarm64 iot-yocto-builder
+#   podman run -e MACHINE=qemuarm64 iot-yocto-builder packagegroup-iot-full
+
+set -euo pipefail
+
+MACHINE="${MACHINE:-qemux86-64}"
+TARGET="${1:-packagegroup-iot-core}"
+
+echo "═══════════════════════════════════════════════════════════════"
+echo "  iot Yocto build"
+echo "  Machine:  $MACHINE"
+echo "  Target:   $TARGET"
+echo "═══════════════════════════════════════════════════════════════"
+
+cd /home/builduser/yocto
+
+# Source the bitbake build environment
+# shellcheck disable=SC1091
+. poky/oe-init-build-env build
+
+# Override MACHINE in local.conf if passed via env
+if [ "$MACHINE" != "qemux86-64" ]; then
+    echo "MACHINE = \"$MACHINE\"" >> conf/local.conf
+fi
+
+echo ""
+echo "→ Starting bitbake $TARGET ..."
+echo ""
+
+bitbake "$TARGET"
+
+echo ""
+echo "═══════════════════════════════════════════════════════════════"
+echo "  Build complete"
+echo "  Artifacts: tmp/deploy/ipk/"
+echo "═══════════════════════════════════════════════════════════════"
+
+# List the built iot packages
+find tmp/deploy/ipk -name 'iot-*.ipk' -type f 2>/dev/null | sort || true

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -21,9 +21,10 @@ echo "════════════════════════�
 
 cd /home/builduser/yocto
 
-# Source the bitbake build environment
+# Source the bitbake build environment from the poky directory
 # shellcheck disable=SC1091
-. poky/oe-init-build-env build
+cd /home/builduser/yocto/poky
+. ./oe-init-build-env ../build
 
 # Override MACHINE in local.conf if passed via env
 if [ "$MACHINE" != "qemux86-64" ]; then

--- a/yocto/kas-iot.yml
+++ b/yocto/kas-iot.yml
@@ -1,0 +1,68 @@
+# kas-iot.yml — Yocto build configuration for the iot LwM2M stack
+#
+# Uses kas (https://github.com/siemens/kas) to fetch all layers and
+# drive bitbake. Run inside the kas container:
+#
+#   cd yocto
+#   ./build.sh                    # builds default machine (qemux86-64)
+#   MACHINE=qemuarm64 ./build.sh  # builds for ARM64
+#   ./build.sh all                # builds all supported architectures
+#
+# Supported machines:
+#   qemux86-64       x86-64 (default, CI verification)
+#   qemuarm64        ARM64 / aarch64
+#   qemuarm          ARMv7 / armhf
+#   raspberrypi4-64  Raspberry Pi 4 (64-bit)
+#
+# For a physical board, set MACHINE in the env or add a kas include.
+
+header:
+  version: 14
+
+# Default values — override via environment or --target
+defaults:
+  repos:
+    refspec: scarthgap
+
+# Layer repositories fetched by kas
+repos:
+  # Poky — the Yocto reference distro
+  poky:
+    url: https://git.yoctoproject.org/poky
+    refspec: scarthgap
+    layers:
+      meta:
+      meta-poky:
+
+  # meta-openembedded — lua, nlohmann-json, gtest
+  meta-openembedded:
+    url: https://git.openembedded.org/meta-openembedded
+    refspec: scarthgap
+    layers:
+      meta-oe:
+
+# The iot layer is local (not fetched) — it lives in yocto/meta-iot/
+# relative to the repo root. kas resolves this at build time.
+
+# Build configuration
+local_conf_header:
+  iot-base: |
+    # Accept the CLOSED license for iot recipes
+    LICENSE_FLAGS_ACCEPTED += "CLOSED"
+
+    # Systemd as init manager (required for DynamicUser=, RuntimeDirectory=)
+    INIT_MANAGER = "systemd"
+
+    # Image features
+    EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
+
+  iot-packages: |
+    # Packages to install in the target image
+    IMAGE_INSTALL:append = " packagegroup-iot-core"
+
+# Target machine — override via MACHINE env var or --target
+machine: "${MACHINE:-qemux86-64}"
+
+# Target recipe to build
+target:
+  - packagegroup-iot-core

--- a/yocto/kas-iot.yml
+++ b/yocto/kas-iot.yml
@@ -42,7 +42,9 @@ repos:
       meta-oe:
 
 # The iot layer is local (not fetched) — it lives in yocto/meta-iot/
-# relative to the repo root. kas resolves this at build time.
+# relative to the repo root. When running via build.sh, the repo is
+# mounted at /work inside the kas container, so the absolute path is
+# /work/yocto/meta-iot.
 
 # Build configuration
 local_conf_header:
@@ -59,6 +61,10 @@ local_conf_header:
   iot-packages: |
     # Packages to install in the target image
     IMAGE_INSTALL:append = " packagegroup-iot-core"
+
+bblayers_conf_header:
+  meta-iot: |
+    BBLAYERS += "${TOPDIR}/../meta-iot"
 
 # Target machine — override via MACHINE env var or --target
 machine: "${MACHINE:-qemux86-64}"

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -1,0 +1,82 @@
+# meta-iot — Yocto Layer for the iot LwM2M Stack
+
+Yocto/OpenEmbedded layer that builds the iot LwM2M 1.1.1 device management
+stack and all its third-party dependencies. Six daemons are delivered as
+separate installable packages so embedded images pull only what they need.
+
+## Quick-start (containerised build — no host Yocto install)
+
+```sh
+cd yocto
+./build.sh
+```
+
+`build.sh` runs the entire Yocto build inside the
+[ghcr.io/siemens/kas/kas](https://github.com/siemens/kas) container image.
+The host needs only **podman** or **docker**. Output packages land in
+`yocto/build/deploy/ipk/`.
+
+## What this layer provides
+
+| Recipe                   | Produces                                                    |
+|--------------------------|-------------------------------------------------------------|
+| `lwm2m_git.bb`           | Six sub-packages: `iot-ds-server`, `iot-ds-cli`, `iot-lwm2m`, `iot-openvpn-client`, `iot-net-router`, `iot-wifi-client`, `iot-config` |
+| `ace-tao_7.0.0.bb`       | `libACE.so.7.0.0`, `libACE_SSL.so.7.0.0`, dev headers       |
+| `tinydtls_git.bb`        | `libtinydtls.a` (static archive)                             |
+| `mongo-c-driver_1.19.bb` | `libbson-1.0.so`, `libmongoc-1.0.so`                        |
+| `mongo-cxx-driver_3.6.bb`| `libbsoncxx.so`, `libmongocxx.so`                            |
+| `packagegroup-iot.bb`    | Meta-packages: `packagegroup-iot-core`, `-full`, `-debug`   |
+
+## Package groups
+
+| Group                      | Contents                                                    |
+|----------------------------|-------------------------------------------------------------|
+| `packagegroup-iot-core`    | ds-server + lwm2m + ds-cli + config (minimal device/fleet)  |
+| `packagegroup-iot-full`    | core + openvpn-client + net-router + wifi-client + runtime deps |
+| `packagegroup-iot-debug`   | full + test binaries (when PACKAGECONFIG[gtest] is on)      |
+
+## PACKAGECONFIG options (lwm2m recipe)
+
+| Option   | Default | Effect                                                      |
+|----------|---------|-------------------------------------------------------------|
+| `mongo`  | ON      | Links mongocxx/bsoncxx/mongoc/bson (~15 MB). RegistryMirror.|
+| `gtest`  | OFF     | Builds unit-test binaries.                                  |
+| `systemd`| ON      | Installs systemd units + env files. OFF for sysvinit images.|
+
+Override in `local.conf` or kas config:
+
+```
+PACKAGECONFIG:remove:pn-lwm2m = "mongo"
+```
+
+## Using on a target
+
+Once the `.ipk` packages are installed on the target:
+
+```sh
+# Edit env files to point at your LwM2M server
+vi /etc/iot/lwm2m-client.env
+
+# Enable and start
+systemctl enable --now iot-ds.service iot-lwm2m-client.service
+
+# Verify
+ds-cli --socket=/run/iot/data_store.sock get iot.endpoint
+```
+
+## Layer dependencies
+
+- `poky` (scarthgap branch) — core layer
+- `meta-openembedded` (scarthgap branch) — provides lua, nlohmann-json, gtest
+
+These are fetched automatically by `kas-iot.yml` when using the containerised
+build.
+
+## Target machines
+
+Default machine is `qemux86-64` for CI/verification. For a physical device,
+override `MACHINE` in a kas include or `local.conf`:
+
+```sh
+MACHINE=raspberrypi4-64 ./build.sh
+```

--- a/yocto/meta-iot/conf/layer.conf
+++ b/yocto/meta-iot/conf/layer.conf
@@ -11,6 +11,9 @@ BBFILE_COLLECTIONS += "iot"
 BBFILE_PATTERN_iot := "^${LAYERDIR}/"
 BBFILE_PRIORITY_iot = "6"
 
+BBFILES += "${LAYERDIR}/recipes-*/*/*.bb \
+            ${LAYERDIR}/recipes-*/*/*.bbappend"
+
 LAYERDEPENDS_iot = "core openembedded-layer"
 LAYERSERIES_COMPAT_iot = "scarthgap"
 

--- a/yocto/meta-iot/conf/layer.conf
+++ b/yocto/meta-iot/conf/layer.conf
@@ -1,0 +1,17 @@
+# meta-iot — Yocto layer for the iot LwM2M 1.1.1 stack
+#
+# Provides recipes for lwm2m, ds-server, ds-cli, openvpn-client,
+# net-router, wifi-client, and their third-party dependencies
+# (ACE_TAO 7.0.0, tinydtls, mongo-c/cxx drivers).
+#
+# Layer dependencies: poky (core) + meta-openembedded (openembedded-layer).
+# Target Yocto release: Scarthgap (5.0 LTS).
+
+BBFILE_COLLECTIONS += "iot"
+BBFILE_PATTERN_iot := "^${LAYERDIR}/"
+BBFILE_PRIORITY_iot = "6"
+
+LAYERDEPENDS_iot = "core openembedded-layer"
+LAYERSERIES_COMPAT_iot = "scarthgap"
+
+LICENSE_PATH += "${LAYERDIR}/recipes-iot/lwm2m/files"

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/0001-cmake-use-yocto-sysroot-paths.patch
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/0001-cmake-use-yocto-sysroot-paths.patch
@@ -1,0 +1,304 @@
+From: iot-yocto-build
+Subject: [PATCH] cmake: use Yocto sysroot paths for cross-compilation
+
+Make all five CMakeLists.txt files Yocto/OE sysroot-aware so the
+lwm2m recipe can cross-compile without hardcoded host paths.
+
+Changes (apps/CMakeLists.txt):
+- ACE_ROOT:   find_path() in STAGING_DIR_HOST instead of hardcoded
+              /usr/local/ACE_TAO-7.0.0, overridable via -DACE_ROOT.
+- Lua:        search in sysroot lib dirs for the static archive.
+- MongoDB:    guarded by option(IOT_ENABLE_MONGO). When ON, include
+              dirs come from MONGOCXX_INCLUDE_DIR/BSONCXX_INCLUDE_DIR
+              cache vars (set by the recipe's EXTRA_OECMAKE).
+- tinydtls:   find_library(TINYDTLS_LIBRARY) in sysroot, with the
+              vendored submodule path as fallback.
+- Link:       bsoncxx/mongocxx conditional on IOT_ENABLE_MONGO.
+- Install:    systemd units respect CMAKE_INSTALL_PREFIX for the
+              tmpfiles.d path.
+
+Changes (modules/*/CMakeLists.txt):
+- ACE_ROOT:   same find_path() pattern as apps/CMakeLists.txt.
+- Lua (data-store only): same sysroot-aware static-lib search.
+
+Upstream-status: Inappropriate [Yocto-specific cross-compilation support]
+
+---
+ apps/CMakeLists.txt                     | 49 +++++++++++++++++++++-------
+ modules/data-store/CMakeLists.txt       | 25 +++++++++-----
+ modules/net/router/CMakeLists.txt       | 13 ++++++--
+ modules/openvpn/client/CMakeLists.txt   | 13 ++++++--
+ modules/wan/wifi/client/CMakeLists.txt  | 13 ++++++--
+ 5 files changed, 85 insertions(+), 28 deletions(-)
+
+diff --git a/apps/CMakeLists.txt b/apps/CMakeLists.txt
+index 430be92..8f4c2a1 100644
+--- a/apps/CMakeLists.txt
++++ b/apps/CMakeLists.txt
+@@ -10,10 +10,19 @@ add_definitions(-DLWM2M_LITTLE_ENDIAN)
+
+ # ACE_TAO install prefix — kept in sync with xpmile (see ../../xpmile/CMakeLists.txt).
+ # Override on the command line with -DACE_ROOT=/some/other/prefix if needed.
++# When cross-compiling for Yocto, the recipe passes -DACE_ROOT=${STAGING_DIR_HOST}/usr
++# so ACE headers and libs resolve against the sysroot.
+ if(NOT DEFINED ACE_ROOT)
+-    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    find_path(ACE_INCLUDE_DIR ace/Log_Msg.h
++              HINTS ${CMAKE_SYSROOT}/usr/include
++                    /usr/local/ACE_TAO-7.0.0/include)
++    if(ACE_INCLUDE_DIR)
++        get_filename_component(ACE_ROOT ${ACE_INCLUDE_DIR} DIRECTORY)
++    else()
++        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    endif()
+ endif()
+
+ # Lua — required for apps/src/lua_config.cpp which now backs the
+ # apps/config/**/*.lua object-resource files (see apps/docs/cli.md).
+ # Prefer the static archive so the iot binary doesn't need
+@@ -22,10 +31,11 @@ endif()
+ # find_package(Lua) hands us if the .a isn't on disk.
+ find_package(Lua REQUIRED)
+ find_library(LUA_STATIC_LIB
+              NAMES liblua5.3.a liblua.a
+              PATHS /usr/lib/aarch64-linux-gnu
+                    /usr/lib/x86_64-linux-gnu
++                   ${CMAKE_SYSROOT}/usr/lib
+                    /usr/lib
+                    /usr/local/lib
+              NO_DEFAULT_PATH)
+ if(LUA_STATIC_LIB)
+     message(STATUS "Lua: static-linking ${LUA_STATIC_LIB}")
+@@ -35,13 +45,24 @@ else()
+     set(LUA_LINK_LIBS ${LUA_LIBRARIES})
+ endif()
+
+ # Include External cmake file
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/json/single_include)
+-include_directories(/usr/local/include/mongocxx/v_noabi)
+-include_directories(/usr/local/include/bsoncxx/v_noabi)
+ include_directories(${ACE_ROOT}/include)
+ include_directories(${LUA_INCLUDE_DIR})
+
++# MongoDB — optional, guarded by IOT_ENABLE_MONGO. The Yocto recipe
++# sets -DIOT_ENABLE_MONGO=OFF via PACKAGECONFIG[mongo] for embedded
++# targets that don't need the registration mirror feature.
++option(IOT_ENABLE_MONGO "Enable MongoDB registration mirror support" ON)
++if(IOT_ENABLE_MONGO)
++    if(NOT DEFINED MONGOCXX_INCLUDE_DIR)
++        set(MONGOCXX_INCLUDE_DIR /usr/local/include/mongocxx/v_noabi)
++    endif()
++    if(NOT DEFINED BSONCXX_INCLUDE_DIR)
++        set(BSONCXX_INCLUDE_DIR /usr/local/include/bsoncxx/v_noabi)
++    endif()
++    include_directories(${MONGOCXX_INCLUDE_DIR})
++    include_directories(${BSONCXX_INCLUDE_DIR})
++endif()
++
+ include_directories(inc)
+
+ # Data-store client lib — sibling module under ../modules/data-store.
+@@ -77,25 +98,33 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/wan/wifi/client
+
+ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store/inc)
+
++# tinydtls — when cross-compiling, prefer the sysroot-provided
++# libtinydtls.a (installed by the tinydtls recipe). Fall back to
++# the vendored submodule build for native/standalone builds.
+ link_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)
++find_library(TINYDTLS_LIBRARY tinydtls
++             PATHS ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls
++             NO_DEFAULT_PATH)
++if(NOT TINYDTLS_LIBRARY)
++    find_library(TINYDTLS_LIBRARY tinydtls)
++endif()
++if(TINYDTLS_LIBRARY)
++    set(TINYDTLS_LINK_LIB ${TINYDTLS_LIBRARY})
++else()
++    set(TINYDTLS_LINK_LIB ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls/libtinydtls.a)
++endif()
+ link_directories(${ACE_ROOT}/lib)
+
+ #all files from src directory (recursive — picks up src/cli/**/*.cpp too).
+ file(GLOB_RECURSE SOURCES "src/*.cpp")
+
+ add_executable(lwm2m ${SOURCES})
+-target_link_libraries(lwm2m
+-                        ${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls/libtinydtls.a
+-                        datastore_client
+-                        ACE
+-                        z
+-                        readline
+-                        pthread
+-                        bsoncxx
+-                        mongocxx
+-                        ssl
+-                        crypto
+-                        ${LUA_LINK_LIBS})
++set(LWM2M_CORE_LIBS ${TINYDTLS_LINK_LIB} datastore_client ACE z readline pthread ssl crypto ${LUA_LINK_LIBS})
++if(IOT_ENABLE_MONGO)
++    target_link_libraries(lwm2m ${LWM2M_CORE_LIBS} bsoncxx mongocxx)
++else()
++    target_link_libraries(lwm2m ${LWM2M_CORE_LIBS})
++endif()
+
+ add_subdirectory(test)
+
+diff --git a/modules/data-store/CMakeLists.txt b/modules/data-store/CMakeLists.txt
+index 7e2ba59..3a5d8f1 100644
+--- a/modules/data-store/CMakeLists.txt
++++ b/modules/data-store/CMakeLists.txt
+@@ -6,10 +6,17 @@ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+ # ACE_TAO install prefix — same as apps/CMakeLists.txt.
+ if(NOT DEFINED ACE_ROOT)
+-    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    find_path(ACE_INCLUDE_DIR ace/Log_Msg.h
++              HINTS ${CMAKE_SYSROOT}/usr/include
++                    /usr/local/ACE_TAO-7.0.0/include)
++    if(ACE_INCLUDE_DIR)
++        get_filename_component(ACE_ROOT ${ACE_INCLUDE_DIR} DIRECTORY)
++    else()
++        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    endif()
+ endif()
+
+ set(DS_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+ # nlohmann::json header-only, vendored under apps/3rdparty/json/.
+ # Used by ds-server only — the client lib stays JSON-free.
+@@ -21,10 +28,11 @@ set(NLOHMANN_JSON_INCLUDE
+ # archive so the runtime image doesn't need liblua5.3.so.0.
+ find_package(Lua REQUIRED)
+ find_library(LUA_STATIC_LIB
+              NAMES liblua5.3.a liblua.a
+              PATHS /usr/lib/aarch64-linux-gnu
+                    /usr/lib/x86_64-linux-gnu
++                   ${CMAKE_SYSROOT}/usr/lib
+                    /usr/lib /usr/local/lib
+              NO_DEFAULT_PATH)
+ if(LUA_STATIC_LIB)
+     message(STATUS "data-store: static-linking ${LUA_STATIC_LIB}")
+     set(LUA_LINK_LIBS ${LUA_STATIC_LIB} dl m)
+@@ -139,13 +147,16 @@ install(TARGETS datastore_client
+ install(DIRECTORY inc/data_store
+         DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
+
+ # Ship the canonical iot.* schema to the ds-server default schema dir.
+ # FULL_SYSCONFDIR is /etc when --prefix=/usr (cmake's special case);
+ # the relative SYSCONFDIR would land at /usr/etc which ds-server won't
+ # scan.
+ install(FILES schemas/iot.lua
+-        DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
++        DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/iot/ds-schemas)
+
+-# services.* schema (L16/D1) — central control plane for every iot
+-# daemon's enable/state pair. Lives in data-store (not per-daemon)
+-# because the set of services is small + the shape is uniform; one
+-# enumerable source is what `ds-cli svc list` wants.
+ install(FILES schemas/services.lua
+-        DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
++        DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/iot/ds-schemas)
+diff --git a/modules/net/router/CMakeLists.txt b/modules/net/router/CMakeLists.txt
+index 7c461e6..2b3f7d8 100644
+--- a/modules/net/router/CMakeLists.txt
++++ b/modules/net/router/CMakeLists.txt
+@@ -5,10 +5,17 @@ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+ if(NOT DEFINED ACE_ROOT)
+-    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    find_path(ACE_INCLUDE_DIR ace/Log_Msg.h
++              HINTS ${CMAKE_SYSROOT}/usr/include
++                    /usr/local/ACE_TAO-7.0.0/include)
++    if(ACE_INCLUDE_DIR)
++        get_filename_component(ACE_ROOT ${ACE_INCLUDE_DIR} DIRECTORY)
++    else()
++        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    endif()
+ endif()
+
+ set(NET_ROUTER_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+ # Pull in the data-store client lib (and its public headers) the same
+ # way the openvpn/client module does. Skip the re-add when a parent
+@@ -52,12 +59,14 @@ if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+     install(TARGETS net-router
+             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+     install(FILES schemas/net.lua
+-            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
++            DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/iot/ds-schemas)
+ endif()
+
+ # ───────────────────────── Tests ───────────────────────────
+ option(BUILD_NET_ROUTER_TESTS "Build net-router gtest suite" OFF)
+ if(BUILD_NET_ROUTER_TESTS)
+     find_package(GTest REQUIRED)
+     enable_testing()
+diff --git a/modules/openvpn/client/CMakeLists.txt b/modules/openvpn/client/CMakeLists.txt
+index e1b3c25..9d6a4f1 100644
+--- a/modules/openvpn/client/CMakeLists.txt
++++ b/modules/openvpn/client/CMakeLists.txt
+@@ -5,10 +5,17 @@ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+ # ACE_TAO install prefix — same idiom as the data-store + apps cmake.
+ if(NOT DEFINED ACE_ROOT)
+-    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    find_path(ACE_INCLUDE_DIR ace/Log_Msg.h
++              HINTS ${CMAKE_SYSROOT}/usr/include
++                    /usr/local/ACE_TAO-7.0.0/include)
++    if(ACE_INCLUDE_DIR)
++        get_filename_component(ACE_ROOT ${ACE_INCLUDE_DIR} DIRECTORY)
++    else()
++        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    endif()
+ endif()
+
+ set(OVPN_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+ # Pull in the sibling data-store module so we get libdatastore_client +
+@@ -80,8 +87,8 @@ if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+     install(TARGETS openvpn-client
+             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+     # Ship the canonical vpn.* schema alongside iot.lua so ds-server
+     # auto-loads it from its default /etc/iot/ds-schemas/ dir.
+     install(FILES schemas/vpn.lua
+-            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
++            DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/iot/ds-schemas)
+ endif()
+diff --git a/modules/wan/wifi/client/CMakeLists.txt b/modules/wan/wifi/client/CMakeLists.txt
+index 1efb5f4..a2c4e5d 100644
+--- a/modules/wan/wifi/client/CMakeLists.txt
++++ b/modules/wan/wifi/client/CMakeLists.txt
+@@ -5,10 +5,17 @@ set(CMAKE_CXX_STANDARD 17)
+ set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+ # ACE_TAO install prefix — same idiom as data-store + openvpn-client cmake.
+ if(NOT DEFINED ACE_ROOT)
+-    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    find_path(ACE_INCLUDE_DIR ace/Log_Msg.h
++              HINTS ${CMAKE_SYSROOT}/usr/include
++                    /usr/local/ACE_TAO-7.0.0/include)
++    if(ACE_INCLUDE_DIR)
++        get_filename_component(ACE_ROOT ${ACE_INCLUDE_DIR} DIRECTORY)
++    else()
++        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
++    endif()
+ endif()
+
+ set(WIFI_MODULE_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+ # Pull in the sibling data-store module so we get libdatastore_client +
+@@ -82,9 +89,9 @@ if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+     install(TARGETS wifi-client
+             RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+     # Ship the canonical wifi.* schema alongside iot.lua/vpn.lua/net.lua
+     # so ds-server auto-loads it from /etc/iot/ds-schemas/.
+     if(EXISTS ${WIFI_MODULE_DIR}/schemas/wifi.lua)
+         install(FILES schemas/wifi.lua
+-                DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
++                DESTINATION ${CMAKE_INSTALL_SYSCONFDIR}/iot/ds-schemas)
+     endif()
+ endif()

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=IoT data-store daemon (ds-server, EMP over unix socket)
+Documentation=https://github.com/naushada/iot
+After=local-fs.target
+StartLimitBurst=3
+StartLimitIntervalSec=30s
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/ds-server \
+    ds-socket=/run/iot/data_store.sock \
+    ds-store=/var/lib/iot/data_store.lua \
+    ds-schema-dir=/etc/iot/ds-schemas
+
+DynamicUser=yes
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+StateDirectory=iot
+StateDirectoryMode=0750
+
+Restart=on-failure
+RestartSec=2s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-lwm2m-client.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-lwm2m-client.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=IoT LwM2M client (device role)
+Documentation=https://github.com/naushada/iot
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/lwm2m-client.env
+ExecStart=/usr/bin/lwm2m $LWM2M_ARGS
+
+DynamicUser=yes
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-lwm2m-server.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-lwm2m-server.service
@@ -1,0 +1,31 @@
+[Unit]
+Description=IoT LwM2M Bootstrap + DM server
+Documentation=https://github.com/naushada/iot
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/lwm2m-server.env
+ExecStart=/usr/bin/lwm2m $LWM2M_ARGS
+
+DynamicUser=yes
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-net-router.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-net-router.service
@@ -1,0 +1,34 @@
+[Unit]
+Description=IoT net-router (nftables + iproute2 network manager)
+Documentation=https://github.com/naushada/iot
+After=network-online.target iot-ds.service iot-openvpn-client.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/net-router.env
+ExecStart=/usr/bin/net-router $NET_ROUTER_ARGS
+
+DynamicUser=yes
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
+
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-openvpn-client.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-openvpn-client.service
@@ -1,0 +1,35 @@
+[Unit]
+Description=IoT OpenVPN client supervisor
+Documentation=https://github.com/naushada/iot
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/openvpn-client.env
+ExecStart=/usr/bin/openvpn-client $OPENVPN_CLIENT_ARGS
+
+DynamicUser=yes
+AmbientCapabilities=CAP_NET_ADMIN
+CapabilityBoundingSet=CAP_NET_ADMIN
+DeviceAllow=/dev/net/tun rw
+
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-wifi-client.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-wifi-client.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=IoT wifi-client (wpa_supplicant + DHCP supervisor)
+Documentation=https://github.com/naushada/iot
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+EnvironmentFile=/etc/iot/wifi-client.env
+ExecStart=/usr/bin/wifi-client $WIFI_CLIENT_ARGS
+
+DynamicUser=yes
+AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
+
+DeviceAllow=/dev/rfkill rw
+
+RuntimeDirectory=iot
+RuntimeDirectoryMode=0755
+
+Restart=on-failure
+RestartSec=5s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=no
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
@@ -1,0 +1,11 @@
+# tmpfiles.d entry for the iot socket and state directories.
+#
+# Belt-and-braces: the systemd units use RuntimeDirectory=iot and
+# StateDirectory=iot which already create and chown /run/iot/ and
+# /var/lib/iot/. This file exists as a fallback for hosts where
+# systemd-tmpfiles runs before the service starts (rare) and for
+# sysvinit shims where RuntimeDirectory= is not honoured.
+#
+# Type Path          Mode UID  GID Age Argument
+d      /run/iot      0755 root root -   -
+d      /var/lib/iot  0750 root root -   -

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-client.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-client.env
@@ -1,0 +1,14 @@
+# EnvironmentFile for iot-lwm2m-client.service.
+#
+# Edit LWM2M_ARGS to point at your bootstrap / DM server. Values below
+# match the smoke-harness defaults — they boot but sit in
+# AwaitingRegisterAck if no peer answers on bs=.
+#
+# Hot-reloadable via ds-cli (preferred):
+#   iot.endpoint    — endpoint name
+#   iot.lifetime    — registration lifetime (uint32 seconds)
+#   iot.server.uri  — DM server URI (live rebind)
+#
+# See /etc/iot/ds-schemas/iot.lua for type + range constraints.
+
+LWM2M_ARGS="role=client local=coap://0.0.0.0:5684 bs=coap://127.0.0.1:5683 config=/etc/iot/config ds-sock=/run/iot/data_store.sock"

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-server.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-server.env
@@ -1,0 +1,10 @@
+# EnvironmentFile for iot-lwm2m-server.service.
+#
+# Server mode binds two ports per the L9 wiring:
+#   - 5683  Device Management server (CoAP)
+#   - <local=port>  Bootstrap server — set below
+#
+# Match the default Leshan port pair so a vanilla Leshan client points
+# at the same endpoints without extra config.
+
+LWM2M_ARGS="role=server local=coap://0.0.0.0:5685 config=/etc/iot/config ds-sock=/run/iot/data_store.sock"

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/net-router.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/net-router.env
@@ -1,0 +1,20 @@
+# EnvironmentFile for iot-net-router.service.
+#
+# NET_ROUTER_ARGS is the literal argv tail passed to
+# /usr/bin/net-router. The net.* policy keys come from ds-server
+# via ds-cli — see /etc/iot/ds-schemas/net.lua for the schema.
+#
+# Hot-reloadable via ds-cli (preferred over editing this file):
+#   net.lwm2m.target.ip / net.forward.ports / net.custom.rules
+#   net.iface.priority / net.iface.{eth,wifi,cellular}.name
+#   net.poll.interval.sec
+#
+# Operator workflow (bare metal):
+#   systemctl enable --now iot-net-router.service
+#   ds-cli set net.lwm2m.target.ip '"192.168.10.5"'
+#   ds-cli set net.iface.eth.name '"eth0"'
+#   journalctl -u iot-net-router.service -f
+#
+# Required runtime: nftables (for nft), iproute2 (for ip).
+
+NET_ROUTER_ARGS="--daemon --ds-sock=/run/iot/data_store.sock --nft=/usr/sbin/nft"

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/openvpn-client.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/openvpn-client.env
@@ -1,0 +1,18 @@
+# EnvironmentFile for iot-openvpn-client.service.
+#
+# OPENVPN_CLIENT_ARGS is the literal argv tail passed to
+# /usr/bin/openvpn-client. The vpn.* config keys come from ds-server
+# via ds-cli — see /etc/iot/ds-schemas/vpn.lua for the schema.
+#
+# Hot-reloadable via ds-cli (preferred over editing this file):
+#   vpn.remote.host / vpn.remote.port / vpn.remote.proto
+#   vpn.cert.path / vpn.key.path / vpn.ca.path
+#   vpn.cipher / vpn.dev / vpn.mgmt.port
+#
+# Operator workflow (bare metal):
+#   systemctl enable --now iot-openvpn-client.service
+#   ds-cli set vpn.remote.host '"vpn.example.com"'
+#   ds-cli set vpn.cert.path '"/etc/iot/vpn/client.crt"'
+#   journalctl -u iot-openvpn-client.service -f
+
+OPENVPN_CLIENT_ARGS="--ds-sock=/run/iot/data_store.sock --openvpn=/usr/sbin/openvpn"

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/wifi-client.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/wifi-client.env
@@ -1,0 +1,25 @@
+# EnvironmentFile for iot-wifi-client.service.
+#
+# WIFI_CLIENT_ARGS is the literal argv tail passed to
+# /usr/bin/wifi-client. The wifi.* config keys come from ds-server
+# via ds-cli — see /etc/iot/ds-schemas/wifi.lua for the schema.
+#
+# Hot-reloadable via ds-cli (preferred over editing this file):
+#   wifi.networks       (JSON array of {ssid, psk, priority, key_mgmt})
+#   wifi.iface          (default "wlan0")
+#   wifi.ctrl.dir       (default "/run/wpa_supplicant")
+#   wifi.scan.interval.sec / wifi.scan.max.results / wifi.scan.request
+#   wifi.dhcp.client    ("udhcpc" / "dhclient" / "auto")
+#   wifi.dhcp.path      (override DHCP binary path)
+#
+# Operator workflow (bare metal):
+#   systemctl mask NetworkManager           # avoid conflict
+#   systemctl enable --now iot-wifi-client.service
+#   ds-cli set wifi.networks '[{"ssid":"HomeAP","psk":"correcthorse","priority":10}]'
+#   journalctl -u iot-wifi-client.service -f
+#
+# Plaintext PSK posture: wifi.networks values are stored in
+# /var/lib/iot/data_store.lua in plaintext. A secrets-vault store
+# is planned as a follow-up.
+
+WIFI_CLIENT_ARGS="--ds-sock=/run/iot/data_store.sock --wpa=/usr/sbin/wpa_supplicant --iface=wlan0 --ctrl-dir=/run/wpa_supplicant"

--- a/yocto/meta-iot/recipes-iot/lwm2m/lwm2m_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/lwm2m_git.bb
@@ -1,0 +1,262 @@
+SUMMARY = "IoT LwM2M 1.1.1 stack — device management daemons"
+DESCRIPTION = "C++17 OMA LwM2M 1.1.1 device management stack built on ACE, \
+CoAP, and DTLS (tinydtls). Delivers six daemons as separate installable \
+packages: ds-server (typed KV config plane), ds-cli (debug CLI), lwm2m \
+(combined client/server), openvpn-client, net-router, wifi-client. \
+Supports x86-64, ARM64, and ARMv7 targets via Yocto MACHINE selection."
+HOMEPAGE = "https://github.com/naushada/iot"
+LICENSE = "CLOSED"
+SECTION = "net"
+
+# ── Fetch ──────────────────────────────────────────────────────────
+# gitsm:// fetches the repo with its two git submodules:
+#   apps/3rdparty/json      → nlohmann/json (header-only)
+#   apps/3rdparty/tinydtls  → legatoproject/tinydtls (headers only —
+#                             the .a comes from the tinydtls recipe)
+SRC_URI = "\
+    gitsm://github.com/naushada/iot.git;protocol=https;branch=main \
+    file://0001-cmake-use-yocto-sysroot-paths.patch \
+    file://iot-ds.service \
+    file://iot-lwm2m-client.service \
+    file://iot-lwm2m-server.service \
+    file://iot-openvpn-client.service \
+    file://iot-net-router.service \
+    file://iot-wifi-client.service \
+    file://iot.conf \
+    file://lwm2m-client.env \
+    file://lwm2m-server.env \
+    file://openvpn-client.env \
+    file://net-router.env \
+    file://wifi-client.env \
+"
+SRCREV = "${AUTOREV}"
+
+S = "${WORKDIR}/git"
+B = "${WORKDIR}/build"
+
+# ── Dependencies ────────────────────────────────────────────────────
+# Core deps (always needed):
+#   ace-tao            ACE reactor + OS abstraction (libACE.so)
+#   tinydtls           DTLS static lib (libtinydtls.a)
+#   lua                Lua 5.3 (required by data-store + lwm2m config)
+#   openssl            SSL/crypto (DTLS, ACE_SSL, mongo TLS)
+#   zlib               Compression (readline, mongo)
+#   readline           Interactive CLI in lwm2m client mode
+#   nlohmann-json      Header-only JSON (vendored, but DEPENDS for clarity)
+DEPENDS = "\
+    ace-tao \
+    tinydtls \
+    lua \
+    openssl \
+    zlib \
+    readline \
+    nlohmann-json \
+"
+
+# ── PACKAGECONFIG ──────────────────────────────────────────────────
+# mongo:   Enables mongocxx/bsoncxx link (~15 MB in final image).
+#          Required for the RegistryMirror feature (db_adapter.cpp).
+#          Disable for resource-constrained embedded targets.
+# gtest:   Builds unit-test binaries. Dev-only; OFF by default.
+# systemd: Installs systemd unit files + env files + tmpfiles.d.
+#          Auto-detected from DISTRO_FEATURES.
+PACKAGECONFIG ??= "mongo \
+                   ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)} \
+"
+
+PACKAGECONFIG[mongo] = "\
+    -DIOT_ENABLE_MONGO=ON \
+      -DMONGOCXX_INCLUDE_DIR=${STAGING_INCDIR}/mongocxx/v_noabi \
+      -DBSONCXX_INCLUDE_DIR=${STAGING_INCDIR}/bsoncxx/v_noabi, \
+    -DIOT_ENABLE_MONGO=OFF, \
+    mongo-cxx-driver mongo-c-driver, \
+"
+
+PACKAGECONFIG[gtest] = "\
+    -DBUILD_DATA_STORE_TESTS=ON \
+      -DBUILD_OPENVPN_CLIENT_TESTS=ON \
+      -DBUILD_NET_ROUTER_TESTS=ON \
+      -DBUILD_WIFI_CLIENT_TESTS=ON, \
+    -DBUILD_DATA_STORE_TESTS=OFF \
+      -DBUILD_OPENVPN_CLIENT_TESTS=OFF \
+      -DBUILD_NET_ROUTER_TESTS=OFF \
+      -DBUILD_WIFI_CLIENT_TESTS=OFF, \
+    gtest, \
+"
+
+PACKAGECONFIG[systemd] = "\
+    -DIOT_PACKAGING_INSTALL=ON, \
+    -DIOT_PACKAGING_INSTALL=OFF, \
+    systemd, \
+"
+
+inherit ${@bb.utils.contains('PACKAGECONFIG', 'systemd', 'systemd', '', d)}
+inherit cmake pkgconfig
+
+# ── CMake configuration ─────────────────────────────────────────────
+# OECMAKE_SOURCEPATH points cmake at the apps/CMakeLists.txt.
+# Relative add_subdirectory() calls resolve against the full repo tree.
+OECMAKE_SOURCEPATH = "${S}/apps"
+
+# ACE_ROOT: set to sysroot /usr so include_directories(${ACE_ROOT}/include)
+# resolves to ${STAGING_DIR_HOST}/usr/include (where ace-tao installs).
+# tinydtls: the find_library() in our patch searches sysroot first.
+EXTRA_OECMAKE = "\
+    -DACE_ROOT=${STAGING_DIR_HOST}/usr \
+    -DLUA_INCLUDE_DIR=${STAGING_INCDIR} \
+    -DCMAKE_INSTALL_PREFIX=/usr \
+"
+
+# ── Sub-module cmake already uses GNUInstallDirs. Systemd + env files
+# are overridden below from our WORKDIR copies so ExecStart uses /usr/bin
+# rather than /usr/local/bin.
+do_install() {
+    cmake_do_install
+
+    # ── systemd units (overwrite cmake-installed copies) ──────────
+    if ${@bb.utils.contains('PACKAGECONFIG', 'systemd', 'true', 'false', d)}; then
+        install -d ${D}${systemd_system_unitdir}
+        install -m 0644 ${WORKDIR}/iot-ds.service            ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-lwm2m-client.service   ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-lwm2m-server.service   ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-openvpn-client.service ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-net-router.service     ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-wifi-client.service    ${D}${systemd_system_unitdir}/
+
+        # tmpfiles.d fallback
+        install -d ${D}${nonarch_libdir}/tmpfiles.d
+        install -m 0644 ${WORKDIR}/iot.conf ${D}${nonarch_libdir}/tmpfiles.d/
+
+        # EnvironmentFile for each daemon
+        install -d ${D}${sysconfdir}/iot
+        install -m 0644 ${WORKDIR}/lwm2m-client.env   ${D}${sysconfdir}/iot/
+        install -m 0644 ${WORKDIR}/lwm2m-server.env   ${D}${sysconfdir}/iot/
+        install -m 0644 ${WORKDIR}/openvpn-client.env ${D}${sysconfdir}/iot/
+        install -m 0644 ${WORKDIR}/net-router.env     ${D}${sysconfdir}/iot/
+        install -m 0644 ${WORKDIR}/wifi-client.env    ${D}${sysconfdir}/iot/
+    fi
+}
+
+# ── Package split — one per daemon ─────────────────────────────────
+# Images pull only what they need. A minimal LwM2M device needs only
+# iot-ds-server + iot-lwm2m + iot-config. Gateway-class devices add
+# iot-openvpn-client + iot-net-router + iot-wifi-client.
+
+PACKAGE_BEFORE_PN = "\
+    ${PN}-ds-server \
+    ${PN}-ds-cli \
+    ${PN}-lwm2m \
+    ${PN}-openvpn-client \
+    ${PN}-net-router \
+    ${PN}-wifi-client \
+    ${PN}-config \
+"
+
+# Main package: shared library + dev artefacts
+FILES:${PN} = "\
+    ${libdir}/libdatastore_client.a \
+    ${includedir}/data_store \
+"
+
+# ds-server — the AF_UNIX config-plane daemon (required by all others)
+FILES:${PN}-ds-server = "\
+    ${bindir}/ds-server \
+"
+RDEPENDS:${PN}-ds-server = "\
+    ace-tao \
+    lua \
+"
+
+# ds-cli — operator debug/admin CLI
+FILES:${PN}-ds-cli = "\
+    ${bindir}/ds-cli \
+"
+RDEPENDS:${PN}-ds-cli = "ace-tao"
+
+# lwm2m — combined LwM2M client + server binary (role selected at CLI)
+FILES:${PN}-lwm2m = "\
+    ${bindir}/lwm2m \
+"
+RDEPENDS:${PN}-lwm2m = "\
+    ace-tao \
+    lua \
+    zlib \
+    readline \
+    openssl \
+    tinydtls-staticdev \
+    ${@bb.utils.contains('PACKAGECONFIG', 'mongo', \
+        'mongo-cxx-driver-bsoncxx mongo-cxx-driver mongo-c-driver-bson mongo-c-driver', \
+        '', d)} \
+"
+RRECOMMENDS:${PN}-lwm2m = "\
+    ${PN}-ds-server \
+    ${PN}-config \
+"
+
+# openvpn-client — OpenVPN tunnel supervisor
+FILES:${PN}-openvpn-client = "\
+    ${bindir}/openvpn-client \
+"
+RDEPENDS:${PN}-openvpn-client = "ace-tao openvpn"
+RRECOMMENDS:${PN}-openvpn-client = "\
+    ${PN}-ds-server \
+    ${PN}-config \
+"
+
+# net-router — nftables + iproute2 network daemon
+FILES:${PN}-net-router = "\
+    ${bindir}/net-router \
+"
+RDEPENDS:${PN}-net-router = "\
+    ace-tao \
+    nftables \
+    iproute2 \
+"
+RRECOMMENDS:${PN}-net-router = "\
+    ${PN}-ds-server \
+    ${PN}-config \
+"
+
+# wifi-client — wpa_supplicant + DHCP supervisor
+FILES:${PN}-wifi-client = "\
+    ${bindir}/wifi-client \
+"
+RDEPENDS:${PN}-wifi-client = "\
+    ace-tao \
+    wpa-supplicant \
+"
+RRECOMMENDS:${PN}-wifi-client = "\
+    ${PN}-ds-server \
+    ${PN}-config \
+    busybox-udhcpc \
+"
+
+# config — schema files, env files, config templates (shared substrate)
+FILES:${PN}-config = "\
+    ${sysconfdir}/iot \
+"
+
+# ── systemd ─────────────────────────────────────────────────────────
+SYSTEMD_SERVICE:${PN}-ds-server = "iot-ds.service"
+SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service"
+SYSTEMD_SERVICE:${PN}-openvpn-client = "iot-openvpn-client.service"
+SYSTEMD_SERVICE:${PN}-net-router = "iot-net-router.service"
+SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
+
+# Only ds-server auto-starts. Role units are enabled by the operator
+# after writing the matching .env file — see DEPLOY.md.
+SYSTEMD_AUTO_ENABLE:${PN}-ds-server = "enable"
+SYSTEMD_AUTO_ENABLE:${PN}-lwm2m = "disable"
+SYSTEMD_AUTO_ENABLE:${PN}-openvpn-client = "disable"
+SYSTEMD_AUTO_ENABLE:${PN}-net-router = "disable"
+SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "disable"
+
+# ── Sanity checks ──────────────────────────────────────────────────
+# Inhibit the "binary already stripped" QA warning — we build with -g
+# and cmake may strip at install. Let Yocto's packaging handle it.
+INSANE_SKIP:${PN}-lwm2m = "already-stripped"
+INSANE_SKIP:${PN}-ds-server = "already-stripped"
+INSANE_SKIP:${PN}-ds-cli = "already-stripped"
+INSANE_SKIP:${PN}-openvpn-client = "already-stripped"
+INSANE_SKIP:${PN}-net-router = "already-stripped"
+INSANE_SKIP:${PN}-wifi-client = "already-stripped"

--- a/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
+++ b/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
@@ -1,0 +1,43 @@
+SUMMARY = "IoT LwM2M stack package groups"
+DESCRIPTION = "Tiered package groups for IoT LwM2M deployments. \
+'core' installs the minimal device-side daemons. 'full' adds VPN, \
+NAT/routing, and Wi-Fi management for gateway-class devices."
+LICENSE = "MIT"
+
+inherit packagegroup
+
+# ── Core: minimal LwM2M device ────────────────────────────────────
+# ds-server + lwm2m + ds-cli + config. Suitable for resource-constrained
+# endpoints that only need CoAP device management.
+RDEPENDS:${PN}-core = "\
+    iot-ds-server \
+    iot-lwm2m \
+    iot-ds-cli \
+    iot-config \
+"
+RRECOMMENDS:${PN}-core = "\
+    kernel-module-tun \
+"
+
+# ── Full: gateway-class device ────────────────────────────────────
+# Adds OpenVPN, nftables NAT/routing, and Wi-Fi management.
+RDEPENDS:${PN}-full = "\
+    ${PN}-core \
+    iot-openvpn-client \
+    iot-net-router \
+    iot-wifi-client \
+    openvpn \
+    nftables \
+    iproute2 \
+    wpa-supplicant \
+    wireless-tools \
+"
+
+# ── Debug: includes test binaries ─────────────────────────────────
+# For CI and developer images.
+RDEPENDS:${PN}-debug = "\
+    ${PN}-full \
+"
+# Note: test binaries (lwm2m_test, ds-tests, etc.) are not yet split
+# into a separate iot-test package. Add them here when PACKAGECONFIG[gtest]
+# packaging is completed.

--- a/yocto/meta-iot/recipes-support/ace-tao/ace-tao_7.0.0.bb
+++ b/yocto/meta-iot/recipes-support/ace-tao/ace-tao_7.0.0.bb
@@ -1,0 +1,88 @@
+SUMMARY = "ACE/TAO 7.0.0 — Adaptive Communication Environment"
+DESCRIPTION = "ACE reactor and OS-abstraction library used by all iot daemons. \
+Builds the core ACE library (not TAO, Kokyu, or other upper services). \
+Uses its own GNUmakefile build system; the recipe writes config.h and \
+platform_macros.GNU at configure time then drives `make -C ace`."
+HOMEPAGE = "https://github.com/DOCGroup/ACE_TAO"
+LICENSE = "DOC-ACE"
+LIC_FILES_CHKSUM = "file://ACE-INSTALL.html;beginline=102;endline=115;md5=668a2e2fd4837f04043230c2c7e1ffa0"
+SECTION = "libs"
+
+# Fetch the official GitHub release tarball (~40 MB) rather than a git
+# clone of the full repo (~1.2 GB). The tarball is the same artefact
+# used in docker/Dockerfile.
+SRC_URI = "https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_0/ACE+TAO-7.0.0.tar.gz"
+SRC_URI[sha256sum] = "0e4d4a32ad295613ef663d3d0ae45b4e94a53e19f67c0b4a6156e7e5c32321e3"
+
+S = "${WORKDIR}/ACE_wrappers"
+
+DEPENDS = "openssl"
+
+# ACE's GNUmakefile system respects CC/CXX from the environment but needs
+# them as make variables. The standard autotools/cmake classes don't apply.
+EXTRA_OEMAKE = "\
+    ACE_ROOT='${S}' \
+    INSTALL_PREFIX='${D}${prefix}' \
+    ssl=1 \
+    SSL_ROOT='${STAGING_INCDIR}/openssl' \
+    CC='${CC}' \
+    CXX='${CXX}' \
+    AR='${AR}' \
+    LD='${CXX}' \
+    RANLIB='${RANLIB}' \
+    CFLAGS='${CFLAGS}' \
+    CXXFLAGS='${CXXFLAGS}' \
+    LDFLAGS='${LDFLAGS}' \
+    debug=0 \
+    optimize=0 \
+"
+
+do_configure() {
+    # ACE bootstraps its build by reading ace/config.h and
+    # include/makeinclude/platform_macros.GNU. Both are tiny includes
+    # that delegate to ACE's built-in platform definitions.
+    echo '#include "ace/config-linux.h"' > ${S}/ace/config.h
+    cat > ${S}/include/makeinclude/platform_macros.GNU <<EOF
+include \$(ACE_ROOT)/include/makeinclude/platform_linux.GNU
+ssl=1
+debug=0
+optimize=0
+EOF
+}
+
+do_compile() {
+    oe_runmake -C ${S}/ace
+}
+
+do_install() {
+    oe_runmake -C ${S}/ace install
+
+    # Remove TAO, Kokyu, and other services we don't need.
+    rm -rf ${D}${prefix}/include/tao
+    rm -rf ${D}${prefix}/include/orbsvcs
+    rm -rf ${D}${prefix}/share
+}
+
+# ── Package split ──────────────────────────────────────────────────────
+# libACE.so.7.0.0 + libACE_SSL.so.7.0.0 are the runtime surface.
+# Headers and .so symlinks go in -dev; static archives in -staticdev.
+
+PACKAGES = "${PN} ${PN}-dev ${PN}-staticdev ${PN}-dbg"
+
+FILES:${PN} = "\
+    ${libdir}/libACE.so.* \
+    ${libdir}/libACE_SSL.so.* \
+"
+
+FILES:${PN}-dev = "\
+    ${includedir}/ace \
+    ${libdir}/libACE.so \
+    ${libdir}/libACE_SSL.so \
+"
+
+FILES:${PN}-staticdev = "\
+    ${libdir}/libACE.a \
+    ${libdir}/libACE_SSL.a \
+"
+
+BBCLASSEXTEND = "native nativesdk"

--- a/yocto/meta-iot/recipes-support/mongo-c-driver/mongo-c-driver_1.19.0.bb
+++ b/yocto/meta-iot/recipes-support/mongo-c-driver/mongo-c-driver_1.19.0.bb
@@ -1,0 +1,50 @@
+SUMMARY = "mongo-c-driver 1.19.0 — MongoDB C driver"
+DESCRIPTION = "Official MongoDB C driver (libbson + libmongoc). Required by \
+mongo-cxx-driver and optionally by the lwm2m binary for its RegistryMirror \
+feature. Disable the `mongo` PACKAGECONFIG in the lwm2m recipe to drop this \
+dependency for embedded targets that don't need registration mirroring."
+HOMEPAGE = "https://github.com/mongodb/mongo-c-driver"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=3b83ef96387f14655fc854ddc3c6bd57"
+SECTION = "libs"
+
+SRC_URI = "git://github.com/mongodb/mongo-c-driver.git;protocol=https;branch=r1.19"
+SRCREV = "f74f20e82f2e1dc8f8e5c5b924ca835b2e095c7b"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig
+
+DEPENDS = "openssl zlib"
+
+EXTRA_OECMAKE = "\
+    -DENABLE_AUTOMATIC_INIT_AND_CLEANUP=OFF \
+    -DENABLE_SSL=OPENSSL \
+    -DENABLE_SASL=OFF \
+    -DENABLE_SRV=OFF \
+    -DENABLE_TESTS=OFF \
+    -DENABLE_EXAMPLES=OFF \
+    -DENABLE_UNINSTALL=OFF \
+    -DCMAKE_SKIP_RPATH=ON \
+"
+
+PACKAGE_BEFORE_PN = "${PN}-bson"
+
+FILES:${PN}-bson = "\
+    ${libdir}/libbson-1.0.so.* \
+"
+
+FILES:${PN} = "\
+    ${libdir}/libmongoc-1.0.so.* \
+"
+
+FILES:${PN}-dev = "\
+    ${includedir}/libbson-1.0 \
+    ${includedir}/libmongoc-1.0 \
+    ${libdir}/libbson-1.0.so \
+    ${libdir}/libbson-static-1.0.a \
+    ${libdir}/libmongoc-1.0.so \
+    ${libdir}/libmongoc-static-1.0.a \
+    ${libdir}/pkgconfig \
+    ${libdir}/cmake \
+"

--- a/yocto/meta-iot/recipes-support/mongo-cxx-driver/mongo-cxx-driver_3.6.0.bb
+++ b/yocto/meta-iot/recipes-support/mongo-cxx-driver/mongo-cxx-driver_3.6.0.bb
@@ -1,0 +1,51 @@
+SUMMARY = "mongo-cxx-driver 3.6.0 — MongoDB C++ driver"
+DESCRIPTION = "Official MongoDB C++ driver (bsoncxx + mongocxx). Required by \
+the lwm2m binary for its RegistryMirror feature. Disable the `mongo` \
+PACKAGECONFIG in the lwm2m recipe to drop this dependency for embedded \
+targets that don't need registration mirroring."
+HOMEPAGE = "https://github.com/mongodb/mongo-cxx-driver"
+LICENSE = "Apache-2.0"
+LIC_FILES_CHKSUM = "file://LICENSE;md5=3b83ef96387f14655fc854ddc3c6bd57"
+SECTION = "libs"
+
+SRC_URI = "git://github.com/mongodb/mongo-cxx-driver.git;protocol=https;branch=releases/v3.6"
+SRCREV = "34497fb71af5c2bcee1da6ca4ac24fcad3523f62"
+
+S = "${WORKDIR}/git"
+
+inherit cmake pkgconfig
+
+DEPENDS = "mongo-c-driver openssl"
+
+# BSONCXX_POLY_USE_MNMLSTC=1 is load-bearing. The upstream cmake
+# defaults to BSONCXX_POLY_USE_STD on C++17, but the iot Dockerfile
+# explicitly sets MNMLSTC. Changing this causes ABI breakage in
+# headers included from db_adapter.cpp.
+EXTRA_OECMAKE = "\
+    -DBSONCXX_POLY_USE_MNMLSTC=1 \
+    -DCMAKE_BUILD_TYPE=Release \
+    -DBSONCXX_OUTPUT_NAME=bsoncxx \
+    -DMONGOCXX_OUTPUT_NAME=mongocxx \
+    -DENABLE_TESTS=OFF \
+    -DENABLE_EXAMPLES=OFF \
+    -DCMAKE_SKIP_RPATH=ON \
+"
+
+PACKAGE_BEFORE_PN = "${PN}-bsoncxx"
+
+FILES:${PN}-bsoncxx = "\
+    ${libdir}/libbsoncxx.so.* \
+"
+
+FILES:${PN} = "\
+    ${libdir}/libmongocxx.so.* \
+"
+
+FILES:${PN}-dev = "\
+    ${includedir}/bsoncxx \
+    ${includedir}/mongocxx \
+    ${libdir}/libbsoncxx.so \
+    ${libdir}/libmongocxx.so \
+    ${libdir}/pkgconfig \
+    ${libdir}/cmake \
+"

--- a/yocto/meta-iot/recipes-support/tinydtls/files/0001-security-and-uthash-fixes.patch
+++ b/yocto/meta-iot/recipes-support/tinydtls/files/0001-security-and-uthash-fixes.patch
@@ -1,0 +1,107 @@
+From: iot-yocto-build
+Subject: [PATCH] tinydtls: security and uthash fixes
+
+Backport of the fixes carried in apps/patch/tinydtls.patch:
+
+1. dtls.c — bounds-check session_id.size before memcmp in
+   check_server_hello(), add NULL-guard on peer pointer in
+   handle_handshake(), guard handshake pointer dereference in
+   handle_ccs().
+2. prng.h  — switch from rand() to /dev/urandom for cryptographic
+   random number generation.
+3. uthash.h — fix integer division bug in ideal_chain_maxlen that
+   caused expand_mult to be recomputed incorrectly on every insert.
+
+Upstream-status: Inappropriate [legatoproject fork — fixes submitted
+to the vendor fork used by this project]
+
+---
+ dtls.c   | 7 +++++--
+ prng.h   | 9 +++++++--
+ uthash.h | 4 +++-
+ 3 files changed, 15 insertions(+), 5 deletions(-)
+
+diff --git a/dtls.c b/dtls.c
+index 2ed7473..b3da253 100644
+--- a/dtls.c
++++ b/dtls.c
+@@ -2685,7 +2685,9 @@ check_server_hello(dtls_context_t *ctx,
+   if (*data) {
+     peer->session_id.size = *data;
+     if (peer->resumption) {
+-      if (0 == memcmp(peer->session_id.id, data + 1, peer->session_id.size)) {
++      if (peer->session_id.size >= 0
++              && peer->session_id.size <= sizeof(peer->session_id.id)
++              && 0 == memcmp(peer->session_id.id, data + 1, peer->session_id.size)) {
+         dtls_info("server is willing to resume the session\n");
+         return 0; /* session resume, no need to init security parameters */
+       }
+@@ -3661,7 +3663,8 @@ handle_handshake(dtls_context_t *ctx, dtls_peer_t *peer, session_t *session,
+   dtls_debug("received handshake packet of type: %s (%i)\n",
+              dtls_handshake_type_to_name(hs_header->msg_type), hs_header->msg_type);
+
+-  if ((peer->state == DTLS_STATE_CONNECTED)
++  if (peer
++   && (peer->state == DTLS_STATE_CONNECTED)
+     && (hs_header->msg_type == DTLS_HT_CLIENT_HELLO)
+     && (peer->role == DTLS_CLIENT))
+    {
+@@ -3772,7 +3775,7 @@ handle_ccs(dtls_context_t *ctx, dtls_peer_t *peer,
+            uint8 *record_header, uint8 *data, size_t data_length)
+ {
+   int err;
+-  dtls_handshake_parameters_t *handshake = peer->handshake_params;
++  dtls_handshake_parameters_t *handshake;
+   (void)record_header;
+
+   /* A CCS message is handled after a KeyExchange message was
+diff --git a/prng.h b/prng.h
+index 8a82173..db49cb3 100644
+--- a/prng.h
++++ b/prng.h
+@@ -33,6 +33,7 @@
+
+ #ifndef WITH_CONTIKI
+ #include <stdlib.h>
++#include <stdio.h>
+
+ #ifdef __RTOS__
+
+@@ -74,14 +75,18 @@ static void dtls_prng_init(unsigned short seed)
+  */
+ static inline int
+ dtls_prng(unsigned char *buf, size_t len) {
+-  while (len--)
+-    *buf++ = rand() & 0xFF;
+-  return 1;
++  FILE *urandom = fopen("/dev/urandom", "r");
++  if (urandom == NULL) {
++    return -1;
++  }
++  int status = (fread(buf, 1, len, urandom) == len)? 1: -1;
++  fclose(urandom);
++  return status;
+ }
+
+ static inline void
+ dtls_prng_init(unsigned short seed) {
+-       srand(seed);
++  /* urandom initialized at system level */
+ }
+ #endif /* __RTOS__ */
+
+diff --git a/uthash.h b/uthash.h
+index 07b29db..650bac5 100644
+--- a/uthash.h
++++ b/uthash.h
+@@ -965,7 +965,9 @@ do {
+         _he_newbkt = &(_he_new_buckets[_he_bkt]);                                \
+         if (++(_he_newbkt->count) > (tbl)->ideal_chain_maxlen) {                 \
+           (tbl)->nonideal_items++;                                               \
+-          _he_newbkt->expand_mult = _he_newbkt->count / (tbl)->ideal_chain_maxlen; \
++          if (_he_newbkt->count > _he_newbkt->expand_mult * (tbl)->ideal_chain_maxlen) { \
++            _he_newbkt->expand_mult++;                                           \
++          }                                                                      \
+         }                                                                        \
+         _he_thh->hh_prev = NULL;                                                 \
+         _he_thh->hh_next = _he_newbkt->hh_head;                                  \

--- a/yocto/meta-iot/recipes-support/tinydtls/tinydtls_git.bb
+++ b/yocto/meta-iot/recipes-support/tinydtls/tinydtls_git.bb
@@ -37,9 +37,9 @@ do_install() {
     install -m 0644 ${S}/*.h ${D}${includedir}/tinydtls/
 }
 
-# tinydtls is a static-library-only recipe. The main iot recipe links
-# it statically; no .so is produced.
-PACKAGES = "${PN}-staticdev ${PN}-dev"
+# tinydtls is a static-library-only recipe. Keep the default ${PN}
+# package (even though empty) so the recipe target resolves correctly.
+ALLOW_EMPTY:${PN} = "1"
 
 FILES:${PN}-staticdev = "\
     ${libdir}/libtinydtls.a \

--- a/yocto/meta-iot/recipes-support/tinydtls/tinydtls_git.bb
+++ b/yocto/meta-iot/recipes-support/tinydtls/tinydtls_git.bb
@@ -1,0 +1,50 @@
+SUMMARY = "tinydtls 0.8.6 — lightweight DTLS library"
+DESCRIPTION = "Eclipse tinydtls is a minimal DTLS 1.2 implementation for \
+constrained devices. The iot LwM2M stack links it statically for CoAPs \
+(CoAP over DTLS-PSK) transport. This recipe fetches from the \
+legatoproject fork — the same source pinned in apps/3rdparty/tinydtls/."
+HOMEPAGE = "https://github.com/legatoproject/tinydtls"
+LICENSE = "EPL-1.0 | EDL-1.0"
+LIC_FILES_CHKSUM = "file://COPYING;md5=815ca599c9df247a0c7f619bab123dad"
+SECTION = "libs"
+
+# Fetch from the same legatoproject fork that .gitmodules pins.
+# The SRCREV should match the submodule pin in the iot repo. When the
+# submodule advances, update this SRCREV.
+SRC_URI = "git://github.com/legatoproject/tinydtls.git;protocol=https;branch=master \
+           file://0001-security-and-uthash-fixes.patch \
+          "
+SRCREV = "3bdb972e3f4f832bada96839c9d36501eb8e299b"
+
+S = "${WORKDIR}/git"
+
+inherit autotools
+
+# tinydtls ships without a pre-built configure script. Generate it at
+# configure time (matches the autoconf && autoheader step in Dockerfile).
+do_configure:prepend() {
+    cd ${S}
+    autoconf
+    autoheader
+}
+
+# tinydtls only produces a static library.
+do_install() {
+    install -d ${D}${libdir}
+    install -m 0644 ${B}/libtinydtls.a ${D}${libdir}/libtinydtls.a
+    # Install headers so dependent recipes can find them via sysroot.
+    install -d ${D}${includedir}/tinydtls
+    install -m 0644 ${S}/*.h ${D}${includedir}/tinydtls/
+}
+
+# tinydtls is a static-library-only recipe. The main iot recipe links
+# it statically; no .so is produced.
+PACKAGES = "${PN}-staticdev ${PN}-dev"
+
+FILES:${PN}-staticdev = "\
+    ${libdir}/libtinydtls.a \
+"
+
+FILES:${PN}-dev = "\
+    ${includedir}/tinydtls \
+"


### PR DESCRIPTION
## Summary

Adds a complete **Yocto/OpenEmbedded layer** (`meta-iot`) that builds the iot LwM2M stack and all its third-party dependencies as proper bitbake recipes. The build runs **inside a podman/docker container** (no host Yocto install needed) and supports **multi-architecture** output (x86-64, ARM64, ARMv7).

## What's included

### 7 custom bitbake recipes

| Recipe | Source | Build | Produces |
|--------|--------|-------|----------|
| `ace-tao_7.0.0.bb` | GitHub release tarball (~40 MB) | GNUmakefile, ssl=1 | `libACE.so.7.0.0`, `libACE_SSL.so` |
| `tinydtls_git.bb` | legatoproject/tinydtls | autotools | `libtinydtls.a` + security patch |
| `mongo-c-driver_1.19.0.bb` | mongodb/mongo-c-driver | cmake | `libbson-1.0.so`, `libmongoc-1.0.so` |
| `mongo-cxx-driver_3.6.0.bb` | mongodb/mongo-cxx-driver | cmake | `libbsoncxx.so`, `libmongocxx.so` |
| `lwm2m_git.bb` | **this repo** (gitsm://) | cmake + sysroot patch | 7 sub-packages (see below) |
| `packagegroup-iot.bb` | — | — | Tiered groups: core / full / debug |
| `kas-iot.yml` | — | — | kas config for containerised build |

### Package split — one per daemon

`lwm2m_git.bb` produces 7 installable sub-packages so images pull only what they need:

| Package | Contents | Runtime deps |
|---------|----------|-------------|
| `iot-ds-server` | `/usr/bin/ds-server` | ACE, Lua |
| `iot-ds-cli` | `/usr/bin/ds-cli` | ACE |
| `iot-lwm2m` | `/usr/bin/lwm2m` (client + server) | ACE, Lua, OpenSSL, tinydtls, ±mongo |
| `iot-openvpn-client` | `/usr/bin/openvpn-client` | ACE, openvpn |
| `iot-net-router` | `/usr/bin/net-router` | ACE, nftables, iproute2 |
| `iot-wifi-client` | `/usr/bin/wifi-client` | ACE, wpa-supplicant, udhcpc |
| `iot-config` | `/etc/iot/` (schemas, env, config templates) | — |

### PACKAGECONFIG toggles

| Option | Default | Effect |
|--------|---------|--------|
| `mongo` | ON | Links mongocxx/bsoncxx (~15 MB). RegistryMirror feature. Turn OFF for constrained IoT. |
| `gtest` | OFF | Builds unit-test binaries |
| `systemd` | ON | Installs systemd units + env files + tmpfiles.d |

### CMake sysroot patch

A single `.patch` modifies all 5 CMakeLists.txt files to be Yocto sysroot-aware:

1. **ACE_ROOT** — `find_path()` in `$STAGING_DIR_HOST` instead of hardcoded `/usr/local/ACE_TAO-7.0.0`
2. **Lua** — sysroot-aware static-lib search
3. **MongoDB** — `option(IOT_ENABLE_MONGO)` guard with overridable include dirs
4. **tinydtls** — `find_library()` from sysroot, vendored submodule as fallback
5. **Schema installs** — `CMAKE_INSTALL_SYSCONFDIR` (relative) for DESTDIR safety

### Multi-architecture support

`build.sh` accepts `MACHINE=` and `all`:

```sh
cd yocto
./build.sh                      # qemux86-64 (default)
MACHINE=qemuarm64 ./build.sh    # ARM64
MACHINE=qemuarm ./build.sh      # ARMv7
./build.sh all                  # all three sequentially
```

Deploy artifacts land in `yocto/build/<machine>/deploy/ipk/`.

### Systemd integration

All 6 daemons ship with corrected systemd unit files (`/usr/bin/` paths, Yocto-compatible). Only `iot-ds.service` auto-enables; role units are operator-enabled after writing their `.env` file.

### Verification

```sh
# On host (podman required):
cd yocto && ./build.sh

# On target (qemu or hardware):
scp yocto/build/qemuarm64/deploy/ipk/cortexa57/iot-*.ipk root@<target>:/tmp/
ssh root@<target> opkg install /tmp/iot-ds-server_*.ipk /tmp/iot-lwm2m_*.ipk /tmp/iot-config_*.ipk
ssh root@<target> systemctl enable --now iot-ds iot-lwm2m-client
```

## Files changed

- `.gitignore` — added `yocto/build/`
- `yocto/` — 24 new files (layer, recipes, patches, systemd units, env files, kas config, build script)

🤖 Generated with [Claude Code](https://claude.com/claude-code)