### PR TITLE
feat(ui): Angular 14 SPA scaffold — login, dashboard, podman dev workflow

### DIFF
--- a/iot-ui/Containerfile
+++ b/iot-ui/Containerfile
@@ -1,0 +1,15 @@
+# iot-ui dev/build container.
+# podman build -t iot-ui-dev . && podman run --rm -p 4200:4200 -v "$PWD:/app:Z" iot-ui-dev
+FROM node:18-slim
+
+WORKDIR /app
+
+# Install Angular CLI 14 globally
+RUN npm install -g @angular/cli@14
+
+EXPOSE 4200
+
+# Default: run the Angular dev server, binding to all interfaces so the
+# host can reach port 4200.  Live-reload works because the source is
+# bind-mounted.
+CMD ["ng", "serve", "--host", "0.0.0.0", "--poll", "2000"]

--- a/iot-ui/angular.json
+++ b/iot-ui/angular.json
@@ -1,0 +1,66 @@
+{
+  "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
+  "version": 1,
+  "newProjectRoot": "projects",
+  "projects": {
+    "iot-ui": {
+      "projectType": "application",
+      "root": "",
+      "sourceRoot": "src",
+      "prefix": "app",
+      "architect": {
+        "build": {
+          "builder": "@angular-devkit/build-angular:browser",
+          "options": {
+            "outputPath": "dist/iot-ui",
+            "index": "src/index.html",
+            "main": "src/main.ts",
+            "polyfills": "src/polyfills.ts",
+            "tsConfig": "tsconfig.app.json",
+            "assets": ["src/favicon.svg", "src/assets"],
+            "styles": [
+              "node_modules/@clr/ui/clr-ui.min.css",
+              "node_modules/@clr/icons/clr-icons.min.css",
+              "src/styles.scss"
+            ],
+            "scripts": [
+              "node_modules/@webcomponents/custom-elements/custom-elements.min.js",
+              "node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"
+            ]
+          },
+          "configurations": {
+            "production": {
+              "budgets": [
+                { "type": "initial", "maximumWarning": "2mb", "maximumError": "5mb" }
+              ],
+              "fileReplacements": [
+                { "replace": "src/environments/environment.ts", "with": "src/environments/environment.prod.ts" }
+              ],
+              "outputHashing": "all"
+            },
+            "development": {
+              "buildOptimizer": false,
+              "optimization": false,
+              "vendorChunk": true,
+              "extractLicenses": false,
+              "sourceMap": true,
+              "namedChunks": true
+            }
+          },
+          "defaultConfiguration": "production"
+        },
+        "serve": {
+          "builder": "@angular-devkit/build-angular:dev-server",
+          "configurations": {
+            "production": { "browserTarget": "iot-ui:build:production" },
+            "development": { "browserTarget": "iot-ui:build:development" }
+          },
+          "defaultConfiguration": "development",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          }
+        }
+      }
+    }
+  }
+}

--- a/iot-ui/package.json
+++ b/iot-ui/package.json
@@ -1,0 +1,46 @@
+{
+  "name": "iot-ui",
+  "version": "0.1.0",
+  "scripts": {
+    "ng": "ng",
+    "start": "ng serve",
+    "build": "ng build",
+    "watch": "ng build --watch --configuration development",
+    "test": "ng test"
+  },
+  "private": true,
+  "dependencies": {
+    "@angular/animations": "^14.1.0",
+    "@angular/common": "^14.1.0",
+    "@angular/compiler": "^14.1.0",
+    "@angular/core": "^14.1.0",
+    "@angular/forms": "^14.1.0",
+    "@angular/platform-browser": "^14.1.0",
+    "@angular/platform-browser-dynamic": "^14.1.0",
+    "@angular/router": "^14.1.0",
+    "@cds/angular": "^6.1.0",
+    "@cds/core": "^6.1.0",
+    "@clr/angular": "^13.8.0",
+    "@clr/core": "^4.0.15",
+    "@clr/icons": "^13.0.2",
+    "@clr/ui": "^13.8.0",
+    "@webcomponents/custom-elements": "^1.0.0",
+    "@webcomponents/webcomponentsjs": "^2.6.0",
+    "rxjs": "~7.5.0",
+    "tslib": "^2.3.0",
+    "zone.js": "~0.11.4"
+  },
+  "devDependencies": {
+    "@angular-devkit/build-angular": "^14.1.0",
+    "@angular/cli": "^14.1.0",
+    "@angular/compiler-cli": "^14.1.0",
+    "@types/jasmine": "~4.0.0",
+    "jasmine-core": "~4.3.0",
+    "karma": "~6.4.0",
+    "karma-chrome-launcher": "~3.1.0",
+    "karma-coverage": "~2.2.0",
+    "karma-jasmine": "~5.1.0",
+    "karma-jasmine-html-reporter": "~2.0.0",
+    "typescript": "~4.7.0"
+  }
+}

--- a/iot-ui/proxy.conf.json
+++ b/iot-ui/proxy.conf.json
@@ -1,0 +1,3 @@
+{
+  "/api": { "target": "http://localhost:8080", "secure": false }
+}

--- a/iot-ui/serve.sh
+++ b/iot-ui/serve.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# serve.sh — Run the iot-ui Angular dev server inside podman.
+#
+# No local Node.js install needed.  The source tree is bind-mounted so
+# live-reload picks up edits instantly.
+#
+# Usage:
+#   ./serve.sh              # dev server on http://localhost:4200
+#   ./serve.sh build        # production build → dist/iot-ui/
+#
+# The first run builds the iot-ui-dev image (~5 min); subsequent runs
+# are instant.
+
+set -euo pipefail
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+IMAGE="iot-ui-dev:latest"
+
+detect_runtime() {
+    if command -v podman &>/dev/null; then echo "podman"
+    elif command -v docker &>/dev/null; then echo "docker"
+    else echo "ERROR: podman or docker required" >&2; exit 1; fi
+}
+
+CR=$(detect_runtime)
+
+case "${1:-serve}" in
+    build)
+        echo "=== Building iot-ui (production) ==="
+        $CR run --rm \
+            -v "$SCRIPT_DIR:/app:Z" \
+            "$IMAGE" \
+            ng build --configuration production
+        echo "Output: $SCRIPT_DIR/dist/iot-ui/"
+        ;;
+    install)
+        echo "=== Installing dependencies ==="
+        $CR run --rm \
+            -v "$SCRIPT_DIR:/app:Z" \
+            "$IMAGE" \
+            npm install
+        ;;
+    serve|*)
+        # Build the dev image on first run
+        if ! $CR image exists "$IMAGE" 2>/dev/null; then
+            echo "=== Building $IMAGE (first run) ==="
+            $CR build -t "$IMAGE" -f "$SCRIPT_DIR/Containerfile" "$SCRIPT_DIR"
+        fi
+        echo "=== iot-ui dev server → http://localhost:4200 ==="
+        $CR run --rm -it \
+            -p 4200:4200 \
+            -v "$SCRIPT_DIR:/app:Z" \
+            "$IMAGE"
+        ;;
+esac

--- a/iot-ui/src/app/app-routing.module.ts
+++ b/iot-ui/src/app/app-routing.module.ts
@@ -1,0 +1,31 @@
+import { NgModule } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+import { LoginComponent } from './login/login.component';
+import { MainComponent } from './main/main.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { SsoAuthGuard } from '../common/sso-auth.guard';
+
+const routes: Routes = [
+  { path: '', pathMatch: 'full', redirectTo: 'main' },
+  { path: 'login', component: LoginComponent },
+  {
+    path: 'main', component: MainComponent,
+    canActivate: [SsoAuthGuard],
+    children: [
+      { path: '', component: DashboardComponent },
+      // Child routes for feature pages (Phase 3):
+      // { path: 'vpn',       component: VpnConfigComponent },
+      // { path: 'wan',       component: WanComponent },
+      // { path: 'routing',   component: RoutingComponent },
+      // { path: 'lwm2m',     component: Lwm2mComponent },
+      // { path: 'services',  component: ServicesComponent },
+    ]
+  },
+  { path: '**', redirectTo: 'main' }
+];
+
+@NgModule({
+  imports: [RouterModule.forRoot(routes)],
+  exports: [RouterModule]
+})
+export class AppRoutingModule { }

--- a/iot-ui/src/app/app.component.ts
+++ b/iot-ui/src/app/app.component.ts
@@ -1,0 +1,7 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-root',
+  template: `<router-outlet></router-outlet>`
+})
+export class AppComponent {}

--- a/iot-ui/src/app/app.module.ts
+++ b/iot-ui/src/app/app.module.ts
@@ -1,0 +1,42 @@
+import { APP_INITIALIZER, NgModule } from '@angular/core';
+import { BrowserModule } from '@angular/platform-browser';
+import { HTTP_INTERCEPTORS, HttpClientModule } from '@angular/common/http';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
+import { ClarityModule } from '@clr/angular';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { AppRoutingModule } from './app-routing.module';
+import { AppComponent } from './app.component';
+import { MainComponent } from './main/main.component';
+import { LoginComponent } from './login/login.component';
+import { DashboardComponent } from './dashboard/dashboard.component';
+import { StatusBadgeComponent } from './common/status-badge/status-badge.component';
+
+import { SsoAuthInterceptor } from '../common/sso-auth.interceptor';
+import { SessionService, initSession } from '../common/session.service';
+
+@NgModule({
+  declarations: [
+    AppComponent,
+    MainComponent,
+    LoginComponent,
+    DashboardComponent,
+    StatusBadgeComponent,
+  ],
+  imports: [
+    BrowserModule,
+    AppRoutingModule,
+    BrowserAnimationsModule,
+    ClarityModule,
+    FormsModule,
+    ReactiveFormsModule,
+    HttpClientModule,
+  ],
+  providers: [
+    { provide: HTTP_INTERCEPTORS, useClass: SsoAuthInterceptor, multi: true },
+    { provide: APP_INITIALIZER, useFactory: initSession,
+      deps: [SessionService], multi: true },
+  ],
+  bootstrap: [AppComponent]
+})
+export class AppModule { }

--- a/iot-ui/src/app/common/status-badge/status-badge.component.ts
+++ b/iot-ui/src/app/common/status-badge/status-badge.component.ts
@@ -1,0 +1,59 @@
+import { Component, Input } from '@angular/core';
+
+/// Reusable status badge — green/yellow/red/grey pill with a label.
+/// Mirrors xpmile status-badge pattern.
+@Component({
+  selector: 'app-status-badge',
+  template: `
+    <span class="status-badge" [ngClass]="stateClass">
+      <span class="status-dot"></span>
+      {{ label }}
+    </span>
+  `,
+  styles: [`
+    .status-badge {
+      display: inline-flex;
+      align-items: center;
+      gap: 5px;
+      padding: 2px 10px;
+      border-radius: 12px;
+      font-size: 12px;
+      font-weight: 500;
+    }
+    .status-dot {
+      width: 7px; height: 7px;
+      border-radius: 50%;
+      display: inline-block;
+    }
+    .connected, .running {
+      background: rgba(46,125,50,0.15); color: #2e7d32;
+    }
+    .connected .status-dot, .running .status-dot { background: #2e7d32; }
+    .disconnected, .exited, .error {
+      background: rgba(198,40,40,0.12); color: #c62828;
+    }
+    .disconnected .status-dot, .exited .status-dot, .error .status-dot { background: #c62828; }
+    .starting, .connecting, .wait {
+      background: rgba(249,168,37,0.15); color: #f57f17;
+    }
+    .starting .status-dot, .connecting .status-dot, .wait .status-dot { background: #f57f17; }
+    .disabled {
+      background: rgba(158,158,158,0.12); color: #757575;
+    }
+    .disabled .status-dot { background: #9e9e9e; }
+  `]
+})
+export class StatusBadgeComponent {
+  @Input() label = '';
+  @Input() state = '';
+
+  get stateClass(): string {
+    const s = this.state.toLowerCase();
+    if (s === 'running' || s === 'connected' || s === 'bound') return 'running';
+    if (s === 'exited' || s === 'disconnected' || s === 'error' || s === 'conflict') return 'exited';
+    if (s === 'starting' || s === 'connecting' || s === 'wait' ||
+        s === 'associating' || s === 'requesting' || s === 'monitoring') return 'starting';
+    if (s === 'disabled' || s === 'idle') return 'disabled';
+    return '';
+  }
+}

--- a/iot-ui/src/app/dashboard/dashboard.component.html
+++ b/iot-ui/src/app/dashboard/dashboard.component.html
@@ -1,0 +1,95 @@
+<div class="dashboard">
+  <h3>Connection Status</h3>
+
+  <!-- Status cards row -->
+  <div class="clr-row">
+    <!-- VPN card -->
+    <div class="clr-col-lg-3 clr-col-md-6 clr-col-12">
+      <div class="card status-card" [ngClass]="vpnClass()">
+        <clr-icon shape="network-globe" size="36"></clr-icon>
+        <div class="card-value">{{ status?.vpn?.state || '—' | uppercase }}</div>
+        <div class="card-label">OpenVPN Client</div>
+        <div class="card-detail" *ngIf="status?.vpn?.ip">
+          {{ status?.vpn?.ip }}
+        </div>
+      </div>
+    </div>
+
+    <!-- WiFi card -->
+    <div class="clr-col-lg-3 clr-col-md-6 clr-col-12">
+      <div class="card status-card" [ngClass]="wifiClass()">
+        <clr-icon shape="wifi" size="36"></clr-icon>
+        <div class="card-value">{{ status?.wifi?.ssid || '—' }}</div>
+        <div class="card-label">WiFi — {{ status?.wifi?.state || 'unknown' }}</div>
+        <div class="card-detail" *ngIf="status?.wifi?.rssi != null">
+          {{ status?.wifi?.rssi }} dBm
+          <span class="signal-bars">
+            <span class="bar"
+                  *ngFor="let b of [1,2,3,4]"
+                  [class.active]="(status?.wifi?.rssi || -100) > (-80 + b*5)"
+                  [style.height.px]="4 + b * 3">
+            </span>
+          </span>
+        </div>
+      </div>
+    </div>
+
+    <!-- WAN card -->
+    <div class="clr-col-lg-3 clr-col-md-6 clr-col-12">
+      <div class="card status-card" [ngClass]="wanClass()">
+        <clr-icon shape="world" size="36"></clr-icon>
+        <div class="card-value">{{ status?.wan?.active_iface || 'none' }}</div>
+        <div class="card-label">Active WAN Interface</div>
+        <div class="card-detail" *ngIf="status?.wan?.tun_ip">
+          tun: {{ status?.wan?.tun_ip }}
+        </div>
+      </div>
+    </div>
+
+    <!-- LwM2M card -->
+    <div class="clr-col-lg-3 clr-col-md-6 clr-col-12">
+      <div class="card status-card" [ngClass]="cardClass(lwm2mState(), ['configured'])">
+        <clr-icon shape="devices" size="36"></clr-icon>
+        <div class="card-value">{{ status?.lwm2m?.server_uri || '—' }}</div>
+        <div class="card-label">LwM2M Server</div>
+        <div class="card-detail" *ngIf="status?.lwm2m?.endpoint">
+          EP: {{ status?.lwm2m?.endpoint }}
+        </div>
+      </div>
+    </div>
+  </div>
+
+  <!-- Service overview table -->
+  <h3 style="margin-top: 32px;">Services</h3>
+  <table class="table" *ngIf="status?.services">
+    <thead>
+      <tr>
+        <th>Service</th>
+        <th>State</th>
+        <th>Enabled</th>
+        <th>Details</th>
+      </tr>
+    </thead>
+    <tbody>
+      <tr *ngFor="let k of serviceKeys()">
+        <td><code>{{ svcLabel(k) }}</code></td>
+        <td>
+          <app-status-badge
+            [label]="svcInfo(k).state || 'unknown'"
+            [state]="svcInfo(k).state || ''">
+          </app-status-badge>
+        </td>
+        <td>
+          <clr-icon [attr.shape]="svcInfo(k).enable ? 'check-circle' : 'times-circle'"
+                    [style.color]="svcInfo(k).enable ? '#2e7d32' : '#c62828'">
+          </clr-icon>
+        </td>
+        <td>
+          <span *ngIf="svcInfo(k).uptime_sec != null">
+            uptime {{ svcInfo(k).uptime_sec }}s
+          </span>
+        </td>
+      </tr>
+    </tbody>
+  </table>
+</div>

--- a/iot-ui/src/app/dashboard/dashboard.component.scss
+++ b/iot-ui/src/app/dashboard/dashboard.component.scss
@@ -1,0 +1,32 @@
+.dashboard {
+  padding: 24px;
+}
+
+h3 {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e0e0e0;
+  margin: 0 0 16px 0;
+}
+
+.card-detail {
+  font-size: 12px;
+  opacity: 0.7;
+  margin-top: 4px;
+}
+
+.signal-bars {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 16px;
+  margin-left: 6px;
+  vertical-align: middle;
+
+  .bar {
+    width: 3px;
+    background: #555;
+    border-radius: 1px;
+    &.active { background: #2e7d32; }
+  }
+}

--- a/iot-ui/src/app/dashboard/dashboard.component.ts
+++ b/iot-ui/src/app/dashboard/dashboard.component.ts
@@ -1,0 +1,70 @@
+import { Component, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { PubSubService } from '../../common/pubsubsvc.service';
+import { StatusSnapshot, ServicesStatus, VpnStatus, WifiStatus, WanStatus } from '../../common/app-globals';
+
+@Component({
+  selector: 'app-dashboard',
+  templateUrl: './dashboard.component.html',
+  styleUrls: ['./dashboard.component.scss']
+})
+export class DashboardComponent implements OnDestroy {
+  status: StatusSnapshot | null = null;
+  loading = true;
+  private subs = new Subscription();
+
+  constructor(private http: HttpsvcService, private pubsub: PubSubService) {}
+
+  ngOnInit(): void {
+    // Initial load
+    this.http.getStatus().subscribe({
+      next: (s) => { this.status = s; this.loading = false; },
+      error: () => { this.loading = false; }
+    });
+    // Live updates from the main component's pubsub
+    this.subs.add(
+      this.pubsub.on<StatusSnapshot>('status').subscribe(s => {
+        this.status = s;
+      })
+    );
+  }
+
+  ngOnDestroy(): void { this.subs.unsubscribe(); }
+
+  // ── Helpers ─────────────────────────────────────────────────────
+
+  cardClass(state: string | undefined, upStates: string[]): string {
+    if (!state) return 'disconnected';
+    return upStates.includes(state.toLowerCase()) ? 'connected' : 'disconnected';
+  }
+
+  vpnClass(): string {
+    return this.cardClass(this.status?.vpn?.state, ['connected']);
+  }
+  wifiClass(): string {
+    return this.cardClass(this.status?.wifi?.state, ['connected']);
+  }
+  wanClass(): string {
+    const a = this.status?.wan?.active_iface;
+    return a && a.length > 0 ? 'connected' : 'disconnected';
+  }
+
+  lwm2mState(): string {
+    return this.status?.lwm2m?.server_uri ? 'configured' : 'unconfigured';
+  }
+
+  serviceKeys(): string[] {
+    if (!this.status?.services) return [];
+    return Object.keys(this.status.services).sort();
+  }
+
+  svcLabel(key: string): string {
+    return key.replace(/_/g, '.');
+  }
+
+  svcInfo(key: string) {
+    const svcs = this.status?.services as Record<string, { enable?: boolean; state?: string }> | undefined;
+    return svcs?.[key] || {};
+  }
+}

--- a/iot-ui/src/app/login/login.component.html
+++ b/iot-ui/src/app/login/login.component.html
@@ -1,0 +1,46 @@
+<div class="login-wrapper">
+  <div class="login-card">
+    <!-- IoT logo -->
+    <div class="logo">
+      <img src="assets/iot-logo.svg" alt="IoT Manager" width="120" height="120" />
+    </div>
+    <h2 class="title">IoT Manager</h2>
+    <p class="subtitle">LwM2M Device Management</p>
+
+    <form (ngSubmit)="onLogin()" class="login-form">
+      <div class="clr-form-control">
+        <label for="login-id" class="clr-control-label">User ID</label>
+        <div class="clr-control-container">
+          <input type="text" id="login-id" class="clr-input"
+                 [(ngModel)]="id" name="id" required
+                 placeholder="admin" />
+        </div>
+      </div>
+
+      <div class="clr-form-control">
+        <label for="login-pw" class="clr-control-label">Password</label>
+        <div class="clr-control-container">
+          <input type="password" id="login-pw" class="clr-input"
+                 [(ngModel)]="password" name="password" required
+                 placeholder="Enter password" />
+        </div>
+      </div>
+
+      <div *ngIf="error" class="alert alert-danger" style="margin-top: 12px;">
+        <div class="alert-items">
+          <div class="alert-item static">
+            <div class="alert-icon-wrapper">
+              <clr-icon class="alert-icon" shape="exclamation-circle"></clr-icon>
+            </div>
+            <span class="alert-text">{{ error }}</span>
+          </div>
+        </div>
+      </div>
+
+      <button type="submit" class="btn btn-primary btn-block"
+              [disabled]="loggingIn" style="margin-top: 20px; width: 100%;">
+        {{ loggingIn ? 'Signing in…' : 'Sign in' }}
+      </button>
+    </form>
+  </div>
+</div>

--- a/iot-ui/src/app/login/login.component.scss
+++ b/iot-ui/src/app/login/login.component.scss
@@ -1,0 +1,76 @@
+.login-wrapper {
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  min-height: 100vh;
+  background: #1a1a2e;
+}
+
+.login-card {
+  background: #16213e;
+  border-radius: 8px;
+  padding: 40px 32px;
+  width: 360px;
+  text-align: center;
+  box-shadow: 0 4px 24px rgba(0,0,0,0.4);
+}
+
+.logo {
+  margin-bottom: 8px;
+}
+
+.title {
+  color: #e0e0e0;
+  font-size: 22px;
+  font-weight: 600;
+  margin: 0 0 4px 0;
+}
+
+.subtitle {
+  color: #757575;
+  font-size: 13px;
+  margin: 0 0 24px 0;
+}
+
+.login-form {
+  text-align: left;
+}
+
+.clr-form-control {
+  margin-bottom: 12px;
+}
+
+.clr-control-label {
+  display: block;
+  color: #bdbdbd;
+  font-size: 12px;
+  margin-bottom: 4px;
+}
+
+.clr-input {
+  width: 100%;
+  background: #0f3460;
+  border: 1px solid #1a5276;
+  color: #e0e0e0;
+  padding: 8px 12px;
+  border-radius: 4px;
+  font-size: 14px;
+
+  &:focus {
+    outline: none;
+    border-color: #2e7d32;
+  }
+}
+
+.btn-primary {
+  background: #2e7d32;
+  border: none;
+  color: #fff;
+  padding: 10px;
+  border-radius: 4px;
+  font-size: 14px;
+  cursor: pointer;
+
+  &:hover { background: #388e3c; }
+  &:disabled { opacity: 0.5; cursor: not-allowed; }
+}

--- a/iot-ui/src/app/login/login.component.ts
+++ b/iot-ui/src/app/login/login.component.ts
@@ -1,0 +1,46 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+
+@Component({
+  selector: 'app-login',
+  templateUrl: './login.component.html',
+  styleUrls: ['./login.component.scss']
+})
+export class LoginComponent {
+  id = 'admin';
+  password = '';
+  error = '';
+  loggingIn = false;
+
+  constructor(
+    private http: HttpsvcService,
+    private session: SessionService,
+    private router: Router
+  ) {}
+
+  onLogin(): void {
+    if (!this.id || !this.password) {
+      this.error = 'ID and password are required';
+      return;
+    }
+    this.loggingIn = true;
+    this.error = '';
+    this.http.login({ id: this.id, password: this.password }).subscribe({
+      next: (r) => {
+        this.loggingIn = false;
+        if (r.ok) {
+          this.session.setFromLogin();
+          this.router.navigate(['/main']);
+        } else {
+          this.error = r.err || 'Login failed';
+        }
+      },
+      error: (err) => {
+        this.loggingIn = false;
+        this.error = err?.error?.err || 'Connection failed — is iot-httpd running?';
+      }
+    });
+  }
+}

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -1,0 +1,79 @@
+<clr-main-container>
+  <!-- ── Header ─────────────────────────────────────────────────── -->
+  <clr-header>
+    <div class="branding">
+      <a class="nav-link nav-text" (click)="onMenuSelect('dashboard')"
+         style="cursor: pointer;">
+        <img src="assets/iot-logo.svg" width="28" height="28"
+             style="vertical-align: middle; margin-right: 6px;" />
+        <span class="title">IoT Manager</span>
+      </a>
+    </div>
+
+    <div class="header-nav" style="cursor: pointer;">
+      <a *ngFor="let m of menus"
+         class="nav-link nav-text"
+         [class.active]="selectedMenu === m.id"
+         (click)="onMenuSelect(m.id)">
+        {{ m.label }}
+      </a>
+    </div>
+
+    <div class="header-actions">
+      <clr-dropdown>
+        <button type="button" class="nav-icon" clrDropdownTrigger
+                aria-label="toggle user menu">
+          <clr-icon shape="user"></clr-icon>
+        </button>
+        <clr-dropdown-menu *clrIfOpen clrPosition="bottom-right">
+          <a clrDropdownItem style="cursor: pointer" (click)="onLogout()">
+            Sign out
+          </a>
+        </clr-dropdown-menu>
+      </clr-dropdown>
+    </div>
+  </clr-header>
+
+  <!-- ── Live subnav ────────────────────────────────────────────── -->
+  <nav class="live-subnav">
+    <div class="live-strip">
+      <div class="live-tag">
+        <span class="live-pulse"></span>
+        <span class="live-label">LIVE</span>
+      </div>
+
+      <div class="live-date-chip">
+        <clr-icon shape="calendar"></clr-icon>
+        <span>{{ today }}</span>
+      </div>
+
+      <app-status-badge [label]="'VPN ' + vpnState" [state]="vpnState">
+      </app-status-badge>
+      <app-status-badge [label]="'WiFi ' + wifiState" [state]="wifiState">
+      </app-status-badge>
+
+      <div class="stat-chip" title="Active WAN interface">
+        <clr-icon shape="world"></clr-icon>
+        <span class="stat-num">{{ wanIface }}</span>
+        <span class="stat-lbl">WAN</span>
+      </div>
+      <div class="stat-chip" title="Running services">
+        <clr-icon shape="cog"></clr-icon>
+        <span class="stat-num">{{ serviceCount }}</span>
+        <span class="stat-lbl">services</span>
+      </div>
+
+      <div class="live-spacer"></div>
+
+      <button class="live-refresh-btn" (click)="refreshStatus()"
+              title="Refresh now">
+        <clr-icon shape="sync"></clr-icon>
+      </button>
+    </div>
+  </nav>
+
+  <!-- ── Content area ───────────────────────────────────────────── -->
+  <div class="content-container">
+    <router-outlet></router-outlet>
+  </div>
+</clr-main-container>

--- a/iot-ui/src/app/main/main.component.scss
+++ b/iot-ui/src/app/main/main.component.scss
@@ -1,0 +1,10 @@
+:host {
+  display: block;
+  height: 100vh;
+}
+
+.branding .title {
+  font-size: 16px;
+  font-weight: 600;
+  color: #e0e0e0;
+}

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -1,0 +1,88 @@
+import { Component } from '@angular/core';
+import { Router } from '@angular/router';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+import { PubSubService } from '../../common/pubsubsvc.service';
+import { StatusSnapshot } from '../../common/app-globals';
+
+@Component({
+  selector: 'app-main',
+  templateUrl: './main.component.html',
+  styleUrls: ['./main.component.scss']
+})
+export class MainComponent {
+  selectedMenu = 'dashboard';
+  selectedSubNav = '';
+  today = new Date().toLocaleDateString('en-US', {
+    weekday: 'short', year: 'numeric', month: 'short', day: 'numeric'
+  });
+
+  status: StatusSnapshot | null = null;
+
+  // Top-level nav items
+  menus = [
+    { id: 'dashboard', label: 'Dashboard', icon: 'dashboard' },
+    { id: 'vpn',       label: 'VPN',       icon: 'network-globe' },
+    { id: 'wan',       label: 'WAN',       icon: 'world' },
+    { id: 'routing',   label: 'Routing',   icon: 'arrow-switch' },
+    { id: 'lwm2m',     label: 'LwM2M',     icon: 'devices' },
+    { id: 'services',  label: 'Services',  icon: 'cog' },
+  ];
+
+  constructor(
+    private http: HttpsvcService,
+    private session: SessionService,
+    private router: Router,
+    private pubsub: PubSubService
+  ) {}
+
+  ngOnInit(): void {
+    this.refreshStatus();
+  }
+
+  onMenuSelect(menuId: string): void {
+    this.selectedMenu = menuId;
+    this.selectedSubNav = '';
+    this.pubsub.publish('menu', menuId);
+  }
+
+  onSubNavSelect(item: string): void {
+    this.selectedSubNav = item;
+    this.pubsub.publish('subnav', { menu: this.selectedMenu, item });
+  }
+
+  refreshStatus(): void {
+    this.http.getStatus().subscribe({
+      next: (s) => {
+        this.status = s;
+        this.pubsub.publish('status', s);
+      }
+    });
+  }
+
+  onLogout(): void {
+    this.http.logout().subscribe({
+      next: () => {
+        this.session.clear();
+        this.router.navigate(['/login']);
+      },
+      error: () => {
+        this.session.clear();
+        this.router.navigate(['/login']);
+      }
+    });
+  }
+
+  // Quick status helpers
+  get vpnState(): string { return this.status?.vpn?.state || 'unknown'; }
+  get wifiState(): string { return this.status?.wifi?.state || 'unknown'; }
+  get wanIface(): string { return this.status?.wan?.active_iface || '-'; }
+  get serviceCount(): number {
+    if (!this.status?.services) return 0;
+    let n = 0;
+    for (const s of Object.values(this.status.services)) {
+      if (s?.state === 'running') n++;
+    }
+    return n;
+  }
+}

--- a/iot-ui/src/assets/iot-logo.svg
+++ b/iot-ui/src/assets/iot-logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
+  <!-- Outer rings -->
+  <circle cx="80" cy="80" r="74" fill="none" stroke="#2e7d32" stroke-width="3"
+          stroke-dasharray="10 4" opacity="0.3"/>
+  <circle cx="80" cy="80" r="56" fill="none" stroke="#2e7d32" stroke-width="2.5"
+          stroke-dasharray="6 3" opacity="0.5"/>
+  <circle cx="80" cy="80" r="38" fill="none" stroke="#43a047" stroke-width="2"
+          opacity="0.6"/>
+  <!-- Device hexagon -->
+  <polygon points="80,28 106,48 106,112 80,132 54,112 54,48"
+           fill="#1b5e20" stroke="#2e7d32" stroke-width="2"/>
+  <!-- Inner core -->
+  <circle cx="80" cy="80" r="14" fill="#43a047"/>
+  <circle cx="80" cy="80" r="7" fill="#a5d6a7"/>
+  <!-- Signal nodes -->
+  <circle cx="80" cy="28" r="4" fill="#66bb6a"/>
+  <circle cx="106" cy="48" r="4" fill="#66bb6a"/>
+  <circle cx="54" cy="48" r="4" fill="#66bb6a"/>
+  <circle cx="106" cy="112" r="4" fill="#66bb6a"/>
+  <circle cx="54" cy="112" r="4" fill="#66bb6a"/>
+  <!-- Link lines -->
+  <line x1="80" y1="28" x2="80" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
+  <line x1="106" y1="48" x2="94" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
+  <line x1="54" y1="48" x2="66" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
+  <line x1="106" y1="112" x2="94" y2="94" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
+  <line x1="54" y1="112" x2="66" y2="94" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
+  <!-- IoT label -->
+  <text x="80" y="156" text-anchor="middle" font-family="monospace"
+        font-size="16" font-weight="bold" fill="#c8e6c9" letter-spacing="6">IoT</text>
+</svg>

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -1,0 +1,170 @@
+// ── TypeScript interfaces mirroring the iot data-store schemas ──────
+
+export interface StatusSnapshot {
+  ok: boolean;
+  lwm2m:    Lwm2mStatus;
+  vpn:      VpnStatus;
+  wifi:     WifiStatus;
+  wan:      WanStatus;
+  routing:  RoutingStatus;
+  services: ServicesStatus;
+}
+
+export interface Lwm2mStatus {
+  server_uri?: string;
+  endpoint?: string;
+}
+
+export interface VpnStatus {
+  state?: string;
+  ip?: string;
+  gateway?: string;
+  netmask?: string;
+  dns?: string;
+  pid?: number;
+  exit_code?: number;
+  gate_reason?: string;
+  bound_iface?: string;
+}
+
+export interface WifiStatus {
+  state?: string;
+  ssid?: string;
+  rssi?: number;
+  dhcp_state?: string;
+  dhcp_ip?: string;
+}
+
+export interface WanStatus {
+  active_iface?: string;
+  iface_priority?: string;
+  tun_ip?: string;
+}
+
+export interface RoutingStatus {
+  state?: string;
+  rules_applied?: number;
+  last_apply_unix?: number;
+}
+
+export interface ServiceInfo {
+  enable?: boolean;
+  state?: string;
+  uptime_sec?: number;
+}
+
+export interface ServicesStatus {
+  ds?: ServiceInfo;
+  net_router?: ServiceInfo;
+  openvpn_client?: ServiceInfo;
+  lwm2m_client?: ServiceInfo;
+  lwm2m_server?: ServiceInfo;
+  wifi_client?: ServiceInfo;
+}
+
+// ── Auth types ──────────────────────────────────────────────────────
+
+export interface LoginRequest {
+  id: string;
+  password: string;
+}
+
+export interface LoginResponse {
+  ok: boolean;
+  role?: string;
+  err?: string;
+}
+
+export interface SessionInfo {
+  role: string;
+}
+
+// ── Db types ────────────────────────────────────────────────────────
+
+export interface DbGetRequest {
+  keys: string[];
+}
+
+export interface DbGetResponse {
+  ok: boolean;
+  data?: Record<string, unknown>;
+  err?: string;
+}
+
+export interface DbSetPair {
+  key: string;
+  value: unknown;
+}
+
+export interface DbSetRequest {
+  pairs: DbSetPair[];
+}
+
+export interface DbSetResponse {
+  ok: boolean;
+  changed?: number;
+  err?: string;
+}
+
+// ── Service restart ─────────────────────────────────────────────────
+
+export interface ServiceRestartRequest {
+  service: string;
+}
+
+export interface ServiceRestartResponse {
+  ok: boolean;
+  service?: string;
+  err?: string;
+}
+
+// ── WiFi scan ───────────────────────────────────────────────────────
+
+export interface WifiScanResponse {
+  ok: boolean;
+  scan_request?: number;
+  err?: string;
+}
+
+// ── VPN config (read/write keys) ────────────────────────────────────
+
+export interface VpnConfig {
+  remote_host?: string;
+  remote_port?: number;
+  remote_proto?: string;
+  cert_path?: string;
+  key_path?: string;
+  ca_path?: string;
+  cipher?: string;
+  dev?: string;
+  mgmt_port?: number;
+}
+
+// ── WiFi networks (stored as JSON string in wifi.networks) ──────────
+
+export interface WifiNetwork {
+  ssid: string;
+  psk: string;
+  priority?: number;
+  key_mgmt?: string;
+}
+
+// ── LwM2M config ────────────────────────────────────────────────────
+
+export interface Lwm2mConfig {
+  server_uri?: string;
+  endpoint?: string;
+  binding?: string;
+  lifetime?: number;
+  observable?: boolean;
+}
+
+// ── Net / routing config ────────────────────────────────────────────
+
+export interface NetConfig {
+  lwm2m_target_ip?: string;
+  lwm2m_target_port?: number;
+  forward_ports?: string;    // comma-joined
+  iface_priority?: string;   // comma-joined
+  custom_rules?: string;     // JSON array
+}

--- a/iot-ui/src/common/httpsvc.service.ts
+++ b/iot-ui/src/common/httpsvc.service.ts
@@ -1,0 +1,89 @@
+import { Injectable } from '@angular/core';
+import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { Observable } from 'rxjs';
+import { environment } from '../environments/environment';
+import {
+  StatusSnapshot,
+  LoginRequest, LoginResponse,
+  DbGetRequest, DbGetResponse,
+  DbSetRequest, DbSetResponse,
+  ServiceRestartRequest, ServiceRestartResponse,
+  WifiScanResponse
+} from './app-globals';
+
+@Injectable({ providedIn: 'root' })
+export class HttpsvcService {
+
+  private api = environment.apiUrl;
+
+  constructor(private http: HttpClient) {}
+
+  private jsonHeaders(): HttpHeaders {
+    return new HttpHeaders({ 'Content-Type': 'application/json' });
+  }
+
+  // ── Auth ──────────────────────────────────────────────────────────
+
+  login(body: LoginRequest): Observable<LoginResponse> {
+    return this.http.post<LoginResponse>(
+      `${this.api}/api/v1/auth/login`, body,
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
+  logout(): Observable<{ ok: boolean }> {
+    return this.http.post<{ ok: boolean }>(
+      `${this.api}/api/v1/auth/logout`, {},
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
+  // ── Status ────────────────────────────────────────────────────────
+
+  getStatus(): Observable<StatusSnapshot> {
+    return this.http.get<StatusSnapshot>(
+      `${this.api}/api/v1/status`, { withCredentials: true });
+  }
+
+  // ── Data store ────────────────────────────────────────────────────
+
+  dbGet(keys: string[]): Observable<DbGetResponse> {
+    return this.http.post<DbGetResponse>(
+      `${this.api}/api/v1/db/get`, { keys },
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
+  dbSet(pairs: { key: string; value: unknown }[]): Observable<DbSetResponse> {
+    return this.http.post<DbSetResponse>(
+      `${this.api}/api/v1/db/set`, { pairs },
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
+  // Long-poll a single key.  Returns as soon as the value changes or
+  // the timeout expires (no change → value reflects current state).
+  dbGetLongPoll(key: string, timeoutSec = 30): Observable<{
+    changed: boolean; key: string; value: unknown; prev?: unknown;
+  }> {
+    const params = new HttpParams()
+      .set('key', key)
+      .set('timeout', timeoutSec.toString());
+    return this.http.get<{
+      changed: boolean; key: string; value: unknown; prev?: unknown;
+    }>(`${this.api}/api/v1/db/get`, { params, withCredentials: true });
+  }
+
+  // ── WiFi scan ─────────────────────────────────────────────────────
+
+  triggerScan(): Observable<WifiScanResponse> {
+    return this.http.post<WifiScanResponse>(
+      `${this.api}/api/v1/wifi/scan`, {},
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
+  // ── Service restart ───────────────────────────────────────────────
+
+  restartService(service: string): Observable<ServiceRestartResponse> {
+    const body: ServiceRestartRequest = { service };
+    return this.http.post<ServiceRestartResponse>(
+      `${this.api}/api/v1/service/restart`, body,
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+}

--- a/iot-ui/src/common/pubsubsvc.service.ts
+++ b/iot-ui/src/common/pubsubsvc.service.ts
@@ -1,0 +1,31 @@
+import { Injectable } from '@angular/core';
+import { Subject, Subscription } from 'rxjs';
+import { filter, map } from 'rxjs/operators';
+
+/// Lightweight pub-sub for cross-component communication.
+/// Components subscribe to named events; anything can publish.
+/// Mirrors the xpmile PubSubService pattern exactly.
+@Injectable({ providedIn: 'root' })
+export class PubSubService {
+
+  private subjects = new Map<string, Subject<unknown>>();
+
+  private getSubject(name: string): Subject<unknown> {
+    let s = this.subjects.get(name);
+    if (!s) {
+      s = new Subject<unknown>();
+      this.subjects.set(name, s);
+    }
+    return s;
+  }
+
+  publish(name: string, payload?: unknown): void {
+    this.getSubject(name).next(payload ?? null);
+  }
+
+  on<T = unknown>(name: string): import('rxjs').Observable<T> {
+    return this.getSubject(name).asObservable().pipe(
+      map(v => v as T)
+    );
+  }
+}

--- a/iot-ui/src/common/session.service.ts
+++ b/iot-ui/src/common/session.service.ts
@@ -1,0 +1,51 @@
+import { Injectable } from '@angular/core';
+import { firstValueFrom, Observable, of } from 'rxjs';
+import { catchError, tap } from 'rxjs/operators';
+import { HttpsvcService } from './httpsvc.service';
+import { SessionInfo } from './app-globals';
+
+/// Holds the current auth session for the SPA.
+/// Adapted from xpmile SessionService — same pattern: load once at
+/// APP_INITIALIZER, cache, guard reads the cache.
+@Injectable({ providedIn: 'root' })
+export class SessionService {
+
+  private session: SessionInfo | null = null;
+
+  constructor(private http: HttpsvcService) {}
+
+  get isAuthenticated(): boolean {
+    return this.session !== null;
+  }
+
+  get role(): string | undefined {
+    return this.session?.role;
+  }
+
+  clear(): void {
+    this.session = null;
+  }
+
+  /// Try to get a session from the backend.  A 401 (no session cookie)
+  /// resolves to null — not an error — so the guard can redirect to login.
+  loadSession(): Observable<SessionInfo | null> {
+    // We don't have GET /api/v1/auth/session yet, so we probe by
+    // calling /api/v1/status which returns 401 when unauthenticated.
+    return this.http.getStatus().pipe(
+      tap(() => { this.session = { role: 'admin' }; }),
+      catchError(() => { this.session = null; return of(null); })
+    );
+  }
+
+  /// Called after a successful login — cache the session so the guard
+  /// doesn't need another round trip.
+  setFromLogin(): void {
+    this.session = { role: 'admin' };
+  }
+}
+
+/// APP_INITIALIZER factory — loads the session once before the app
+/// bootstraps, so a reload of an authenticated page isn't bounced to /login.
+export function initSession(session: SessionService): () => Promise<unknown> {
+  return () => firstValueFrom(session.loadSession());
+}

--- a/iot-ui/src/common/sso-auth.guard.ts
+++ b/iot-ui/src/common/sso-auth.guard.ts
@@ -1,0 +1,23 @@
+import { Injectable } from '@angular/core';
+import { CanActivate, Router, UrlTree } from '@angular/router';
+import { map, Observable, of } from 'rxjs';
+import { SessionService } from './session.service';
+
+/// Route guard for authenticated areas.  Allows the route when a
+/// session is already cached; otherwise loads the session (covering a
+/// login that happened without a page reload) and either allows or
+/// redirects to /login.
+@Injectable({ providedIn: 'root' })
+export class SsoAuthGuard implements CanActivate {
+
+  constructor(private session: SessionService, private router: Router) {}
+
+  canActivate(): Observable<boolean | UrlTree> {
+    if (this.session.isAuthenticated) {
+      return of(true);
+    }
+    return this.session.loadSession().pipe(
+      map(s => s ? true : this.router.createUrlTree(['/login']))
+    );
+  }
+}

--- a/iot-ui/src/common/sso-auth.interceptor.ts
+++ b/iot-ui/src/common/sso-auth.interceptor.ts
@@ -1,0 +1,33 @@
+import { Injectable } from '@angular/core';
+import {
+  HttpInterceptor, HttpRequest, HttpHandler,
+  HttpEvent, HttpErrorResponse
+} from '@angular/common/http';
+import { Observable, throwError } from 'rxjs';
+import { catchError } from 'rxjs/operators';
+import { Router } from '@angular/router';
+import { SessionService } from './session.service';
+
+/// Catches 401 responses, clears the cached session, and redirects to
+/// /login.  Non-401 errors pass through unchanged.
+@Injectable()
+export class SsoAuthInterceptor implements HttpInterceptor {
+
+  constructor(private session: SessionService, private router: Router) {}
+
+  intercept(req: HttpRequest<unknown>, next: HttpHandler):
+      Observable<HttpEvent<unknown>> {
+    return next.handle(req).pipe(
+      catchError((err: HttpErrorResponse) => {
+        if (err.status === 401) {
+          this.session.clear();
+          // Don't redirect if we're already on the login page
+          if (!window.location.pathname.startsWith('/login')) {
+            this.router.navigate(['/login']);
+          }
+        }
+        return throwError(() => err);
+      })
+    );
+  }
+}

--- a/iot-ui/src/environments/environment.prod.ts
+++ b/iot-ui/src/environments/environment.prod.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: true,
+  apiUrl: ''   // SPA is served by iot-httpd itself on the same origin
+};

--- a/iot-ui/src/environments/environment.ts
+++ b/iot-ui/src/environments/environment.ts
@@ -1,0 +1,4 @@
+export const environment = {
+  production: false,
+  apiUrl: ''   // proxied through Angular dev server
+};

--- a/iot-ui/src/favicon.svg
+++ b/iot-ui/src/favicon.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
+  <!-- Outer ring — network -->
+  <circle cx="32" cy="32" r="30" fill="none" stroke="#2e7d32" stroke-width="2.5"
+          stroke-dasharray="8 3" opacity="0.5"/>
+  <circle cx="32" cy="32" r="22" fill="none" stroke="#2e7d32" stroke-width="2"
+          stroke-dasharray="5 2" opacity="0.7"/>
+  <!-- Device node — central hexagon -->
+  <polygon points="32,12 48,22 48,42 32,52 16,42 16,22"
+           fill="#1b5e20" stroke="#2e7d32" stroke-width="1.5"/>
+  <!-- Inner dot — connected -->
+  <circle cx="32" cy="32" r="6" fill="#66bb6a"/>
+  <circle cx="32" cy="32" r="3" fill="#c8e6c9"/>
+  <!-- Signal arcs -->
+  <path d="M16 26 Q24 18 32 26" fill="none" stroke="#66bb6a" stroke-width="1.5"
+        stroke-linecap="round" opacity="0.8"/>
+  <path d="M32 38 Q40 46 48 38" fill="none" stroke="#66bb6a" stroke-width="1.5"
+        stroke-linecap="round" opacity="0.8"/>
+</svg>

--- a/iot-ui/src/index.html
+++ b/iot-ui/src/index.html
@@ -1,0 +1,13 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>IoT Manager</title>
+  <base href="/">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+</head>
+<body>
+  <app-root></app-root>
+</body>
+</html>

--- a/iot-ui/src/main.ts
+++ b/iot-ui/src/main.ts
@@ -1,0 +1,11 @@
+import { enableProdMode } from '@angular/core';
+import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
+import { AppModule } from './app/app.module';
+import { environment } from './environments/environment';
+
+if (environment.production) {
+  enableProdMode();
+}
+
+platformBrowserDynamic().bootstrapModule(AppModule)
+  .catch(err => console.error(err));

--- a/iot-ui/src/polyfills.ts
+++ b/iot-ui/src/polyfills.ts
@@ -1,0 +1,2 @@
+// Zone.js required by Angular
+import 'zone.js';

--- a/iot-ui/src/styles.scss
+++ b/iot-ui/src/styles.scss
@@ -1,0 +1,113 @@
+// ── Clarity overrides for the iot management UI ────────────────────────
+
+// Status colours used by the status-badge and live-pulse
+$iot-green:  #2e7d32;
+$iot-yellow: #f9a825;
+$iot-red:    #c62828;
+$iot-grey:   #9e9e9e;
+
+// Live subnav — mirrors xpmile main.component.scss
+.live-subnav {
+  background: #1a1a2e;
+  color: #e0e0e0;
+  padding: 0 1rem;
+  height: 40px;
+  display: flex;
+  align-items: center;
+
+  .live-strip {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    width: 100%;
+  }
+
+  .live-tag {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+  }
+
+  .live-pulse {
+    width: 8px;
+    height: 8px;
+    border-radius: 50%;
+    background: $iot-green;
+    animation: pulse 2s infinite;
+  }
+
+  @keyframes pulse {
+    0%, 100% { opacity: 1; }
+    50% { opacity: 0.3; }
+  }
+
+  .live-label {
+    font-size: 11px;
+    font-weight: 600;
+    letter-spacing: 1px;
+    color: $iot-green;
+  }
+
+  .live-date-chip {
+    display: flex;
+    align-items: center;
+    gap: 4px;
+    font-size: 12px;
+  }
+
+  .stat-chip {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 2px 8px;
+    border-radius: 4px;
+    font-size: 12px;
+    background: rgba(255,255,255,0.08);
+
+    .stat-num { font-weight: 600; }
+    .stat-lbl { opacity: 0.7; }
+  }
+
+  .live-spacer { flex: 1; }
+
+  .live-refresh-btn {
+    background: none;
+    border: none;
+    color: inherit;
+    cursor: pointer;
+    padding: 4px;
+    &:hover { opacity: 0.7; }
+  }
+}
+
+// Dashboard cards
+.status-card {
+  text-align: center;
+  padding: 1.5rem;
+
+  .card-label { font-size: 13px; opacity: 0.7; margin-top: 8px; }
+  .card-value { font-size: 20px; font-weight: 600; }
+
+  &.connected   { border-top: 3px solid $iot-green; }
+  &.disconnected { border-top: 3px solid $iot-red; }
+  &.starting    { border-top: 3px solid $iot-yellow; }
+  &.disabled    { border-top: 3px solid $iot-grey; }
+}
+
+// Signal-strength bars
+.signal-bars {
+  display: inline-flex;
+  align-items: flex-end;
+  gap: 1px;
+  height: 16px;
+
+  .bar {
+    width: 3px;
+    background: $iot-grey;
+    border-radius: 1px;
+
+    &.active { background: $iot-green; }
+    &.weak   { background: $iot-yellow; }
+    &.none   { background: $iot-grey; }
+  }
+}

--- a/iot-ui/tsconfig.app.json
+++ b/iot-ui/tsconfig.app.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": { "outDir": "./out-tsc/app", "types": [] },
+  "files": ["src/main.ts", "src/polyfills.ts"],
+  "include": ["src/**/*.d.ts"]
+}

--- a/iot-ui/tsconfig.json
+++ b/iot-ui/tsconfig.json
@@ -1,0 +1,32 @@
+{
+  "compileOnSave": false,
+  "compilerOptions": {
+    "baseUrl": "./",
+    "outDir": "./dist/out-tsc",
+    "forceConsistentCasingInFileNames": true,
+    "strict": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "sourceMap": true,
+    "declaration": false,
+    "downlevelIteration": true,
+    "experimentalDecorators": true,
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "target": "es2020",
+    "module": "es2020",
+    "lib": ["es2020", "dom"],
+    "paths": {
+      "@app/*": ["src/app/*"],
+      "@common/*": ["src/common/*"]
+    }
+  },
+  "angularCompilerOptions": {
+    "enableI18nLegacyMessageIdFormat": false,
+    "strictInjectionParameters": true,
+    "strictInputAccessModifiers": true,
+    "strictTemplates": true
+  }
+}

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -52,8 +52,29 @@ CACHE_IMAGE=docker.io/<you>/iot-yocto-builder:cache IOT_USE_CACHE=1 ./build.sh
 
 **5. Flash + deploy** to the Pi — see *Deploy to a Raspberry Pi 3B* below.
 
-Reset for a fully clean rebuild: `podman volume rm iot-yocto-sstate
-iot-yocto-downloads`.
+Reset for a **fully clean rebuild** (nuclear — wipes everything):
+```sh
+podman volume rm iot-yocto-sstate iot-yocto-downloads
+```
+
+### Per-recipe clean rebuilds
+
+When only the iot recipe (or its source at `SRCREV`) changes, you can
+clean just that recipe without nuking the entire build.  Both commands
+use the containerised build — pass bitbake targets through `TARGET`:
+
+```sh
+# Re-fetch + re-patch + re-configure iot (keeps downloads, wipes sstate for iot).
+# Use when: the recipe .bb, a patch file, or the upstream git source changed.
+TARGET="-c cleansstate iot" MACHINE=raspberrypi3-64 ./build.sh
+
+# Nuclear clean — also deletes the fetched git tree under WORKDIR.
+# Use when: cleansstate doesn't pick up a new commit (rare with SRCREV=AUTOREV).
+TARGET="-c cleanall iot" MACHINE=raspberrypi3-64 ./build.sh
+```
+
+After either command, run the normal `./build.sh` to rebuild from the
+cleaned state.
 
 ### Shareable cache image (skip the distro compile on a fresh machine)
 


### PR DESCRIPTION
## Summary

Phase 2 of the IoT management UI — Angular 14 + Clarity Design System SPA following xpmile patterns. Podman-based dev workflow (no local Node.js needed).

## What's included

### Common services (ported from xpmile)
- `HttpsvcService` — wraps all `/api/v1/*` endpoints (login, status, db get/set, scan, restart)
- `SessionService` — auth session cache, `APP_INITIALIZER` bootstrap
- `SsoAuthGuard` — route guard redirects unauthenticated to /login
- `SsoAuthInterceptor` — catches 401, clears session, redirects
- `PubSubService` — cross-component event bus
- `StatusBadgeComponent` — green/yellow/red/grey state pill

### Core pages
- **Login** — IoT hexagon-node logo, ID/password form, error display, dark themed
- **Main layout** — Clarity header with top nav (Dashboard | VPN | WAN | Routing | LwM2M | Services), live subnav bar with real-time VPN/WiFi/WAN/service status badges
- **Dashboard** — 4 status cards (VPN, WiFi, WAN, LwM2M) + service overview table with state badges and enable/disable indicators

### Assets
- `favicon.svg` — IoT node icon (rings + hexagon + green core)
- `assets/iot-logo.svg` — larger logo for login page

### Podman workflow
\`\`\`bash
./serve.sh          # ng serve → http://localhost:4200 (proxy /api → :8080)
./serve.sh install  # npm install
./serve.sh build    # production build → dist/iot-ui/
\`\`\`</br>
No local Node.js install needed — everything runs in a node:18-slim container with Angular CLI 14.

## Coming next (Phase 3)
- VPN config form + live status panel
- WAN/WiFi management (ethernet, scan results, network config)
- Routing port-forward + custom rules
- LwM2M endpoint configuration
- Service enable/disable toggles + restart buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)