### PR TITLE
feat(L22): per-daemon CPU/mem/fd/thread telemetry

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -23,6 +23,7 @@
 #include <ace/Log_Msg.h>
 
 #include "data_store/log_buffer.hpp"
+#include "data_store/stats_publisher.hpp"
 
 #include <atomic>
 #include <csignal>
@@ -168,6 +169,20 @@ int main(int argc, char** argv) {
     // Called at startup, on watch events, and on periodic timeout ticks.
     g_log.apply_level(ds);
     g_log.flush(ds);  // push startup logs immediately
+
+    // ── Resource telemetry (L22) ──────────────────────────────────
+    // Publish this container's CPU/mem/fd/threads to ds every 10s for the
+    // cloud UI Services page. openvpn-server runs inside this same
+    // container, so its usage is already folded into cloudd's cgroup
+    // totals — we publish under services.cloud.iot.cloudd only.
+    data_store::StatsPublisher g_stats(
+        "services.cloud.iot.cloudd",
+        [&ds](const std::vector<data_store::KV>& kv) { ds.set(kv); });
+    if (g_stats.open() != 0) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l stats publisher "
+                            "open failed\n")));
+    }
 
     // ── Main loop ─────────────────────────────────────────────────
     // Block on recv_event() up to sync_interval seconds.  A provision

--- a/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
+++ b/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
@@ -7,6 +7,8 @@ interface SvcRow {
   key: string; label: string; desc: string; enable_key: string;
   state: string; enabled: boolean; restarting: boolean;
   state_key?: string;   // explicit state key for services without .enable counterpart
+  // L22 — resource telemetry (per-container cgroup + /proc/self/fd).
+  cpu_permille?: number; mem_kb?: number; fd_count?: number; threads?: number;
 }
 
 @Component({
@@ -16,78 +18,81 @@ interface SvcRow {
       <h3>Service Management</h3>
 
       <div class="info-card">
-        <p>Cloud daemons self-report their state to the data store.
-        Toggle enable to stop/start a service.  ds-server cannot be
-        disabled (the IPC socket would go dead).</p>
+        <p>Cloud daemons self-report their state and resource usage to the
+        data store. Toggle enable to stop/start a service.  ds-server cannot
+        be disabled (the IPC socket would go dead).</p>
       </div>
 
-      <div class="svc-grid" style="margin-top:24px;">
-        <div class="svc-card" *ngFor="let s of services">
-          <div class="svc-header">
-            <code class="svc-name">{{ s.label }}</code>
+      <clr-datagrid style="margin-top:16px;">
+        <clr-dg-column>Service</clr-dg-column>
+        <clr-dg-column>State</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'"
+          title="Percent of one host CPU core (per container)">CPU %</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'">Memory</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'">FDs</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'">Threads</clr-dg-column>
+        <clr-dg-column>Enabled</clr-dg-column>
+        <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let s of services">
+          <clr-dg-cell><code>{{ s.label }}</code></clr-dg-cell>
+          <clr-dg-cell>
             <app-status-badge [label]="s.state||'unknown'"
               [state]="s.state||''"></app-status-badge>
-          </div>
-          <p class="svc-desc">{{ s.desc }}</p>
-
-          <div class="svc-actions">
-            <clr-checkbox-wrapper *ngIf="s.key !== 'ds' && s.key !== 'lwm2m.bs' && s.key !== 'lwm2m.dm'">
+          </clr-dg-cell>
+          <clr-dg-cell class="num">{{ fmtCpu(s.cpu_permille) }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ fmtKb(s.mem_kb) }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ s.fd_count ?? '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ s.threads ?? '—' }}</clr-dg-cell>
+          <clr-dg-cell>
+            <clr-checkbox-wrapper *ngIf="gateable(s)">
               <input type="checkbox" clrCheckbox
                 [checked]="s.enabled"
                 [disabled]="!isAdmin"
                 (change)="toggleEnable(s)" />
-              <label>Enabled</label>
+              <label></label>
             </clr-checkbox-wrapper>
-            <span *ngIf="s.key === 'ds' || s.key === 'lwm2m.bs' || s.key === 'lwm2m.dm'" class="hint">always on</span>
-
-            <button *ngIf="s.key !== 'ds' && s.key !== 'lwm2m.bs' && s.key !== 'lwm2m.dm' && isAdmin"
+            <span *ngIf="!gateable(s)" class="hint">always on</span>
+          </clr-dg-cell>
+          <clr-dg-cell *ngIf="isAdmin">
+            <button *ngIf="gateable(s)"
               class="btn btn-sm" [disabled]="s.restarting"
               (click)="restart(s)">
               {{ s.restarting ? '…' : 'Restart' }}
             </button>
-          </div>
-        </div>
-      </div>
+            <span *ngIf="!gateable(s)" class="hint">—</span>
+          </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>{{ services.length }} services</clr-dg-footer>
+      </clr-datagrid>
     </div>
   `,
   styles: [`
     .page { padding: 24px; }
     h3 { color: #333; margin: 0 0 16px 0; font-size: 16px; font-weight: 600; }
     .hint { color: #888; font-weight: normal; font-size: 11px; }
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    code { background: none; }
     .info-card {
       background: #f0f5ff; border: 1px solid #b3d4ff; border-radius: 4px;
       padding: 12px 16px; font-size: 13px; color: #333;
     }
     .info-card code { background: #d0e4ff; padding: 1px 4px; border-radius: 2px; font-size: 12px; }
-    .svc-grid { display: grid; grid-template-columns: repeat(2, 1fr); gap: 16px; }
-    @media (max-width: 900px) { .svc-grid { grid-template-columns: 1fr; } }
-    .svc-card {
-      background: #fff; border: 1px solid #e0e0e0; border-radius: 6px;
-      padding: 16px;
-    }
-    .svc-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 8px; }
-    .svc-name { font-size: 14px; font-weight: 600; color: #1a1a2e; background: none; }
-    .svc-desc { font-size: 12px; color: #757575; margin: 0 0 12px 0; }
-    .svc-actions { display: flex; align-items: center; gap: 12px; }
     .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
 
-    body.dark-theme {
-      .svc-card { background: #1a1a2e; border-color: #2a2a4a; }
-      .svc-name { color: #e0e0e0; }
-      .svc-desc { color: #9e9e9e; }
-      .info-card { background: rgba(46,125,50,0.08); border-color: rgba(46,125,50,0.25); color: #bdbdbd; }
-      .info-card code { background: rgba(46,125,50,0.15); color: #a5d6a7; }
-    }
+    body.dark-theme .info-card { background: rgba(46,125,50,0.08); border-color: rgba(46,125,50,0.25); color: #bdbdbd; }
+    body.dark-theme .info-card code { background: rgba(46,125,50,0.15); color: #a5d6a7; }
   `]
 })
 export class ServicesListComponent implements OnInit, OnDestroy {
   services: SvcRow[] = [
-    { key: 'ds',             label: 'ds-server',        desc: 'Data store — IPC backbone. Schema-enforced, Lua-backed key/value store.', enable_key: '', state: 'stopped', enabled: true,  restarting: false },
-    { key: 'iot.cloudd',     label: 'iot-cloudd',        desc: 'Cloud daemon — LwM2M BS/DM, VPN registry, endpoint provisioning.',        enable_key: 'services.cloud.iot.cloudd.enable',       state: 'stopped', enabled: true,  restarting: false },
-    { key: 'iot.httpd',      label: 'iot-httpd',         desc: 'REST API + Cloud UI server. Serves /webui/ + /api/v1/* endpoints.',       enable_key: 'services.cloud.iot.httpd.enable',        state: 'stopped', enabled: true,  restarting: false },
-    { key: 'openvpn.server', label: 'openvpn-server',    desc: 'OpenVPN server — manages per-device tunnels on 10.9.0.0/24 subnet.',       enable_key: 'services.cloud.openvpn.server.enable',   state: 'stopped', enabled: true,  restarting: false },
-    { key: 'lwm2m.bs',       label: 'lwm2m-bs',          desc: 'LwM2M Bootstrap Server — CoAPs endpoint on port 5684.',                   enable_key: '', state: 'stopped', enabled: true, restarting: false, state_key: 'services.cloud.lwm2m.bs.state' },
-    { key: 'lwm2m.dm',       label: 'lwm2m-dm',          desc: 'LwM2M Device Management — CoAPs endpoint on port 5683.',                  enable_key: '', state: 'stopped', enabled: true, restarting: false, state_key: 'services.cloud.lwm2m.dm.state' },
+    { key: 'ds',             label: 'ds-server',        desc: 'Data store — IPC backbone.',                       enable_key: '', state: 'stopped', enabled: true,  restarting: false },
+    { key: 'iot.cloudd',     label: 'iot-cloudd',        desc: 'Cloud daemon — LwM2M BS/DM, VPN, provisioning.',  enable_key: 'services.cloud.iot.cloudd.enable',       state: 'stopped', enabled: true,  restarting: false },
+    { key: 'iot.httpd',      label: 'iot-httpd',         desc: 'REST API + Cloud UI server.',                     enable_key: 'services.cloud.iot.httpd.enable',        state: 'stopped', enabled: true,  restarting: false },
+    { key: 'openvpn.server', label: 'openvpn-server',    desc: 'OpenVPN server — per-device tunnels.',            enable_key: 'services.cloud.openvpn.server.enable',   state: 'stopped', enabled: true,  restarting: false },
+    { key: 'lwm2m.bs',       label: 'lwm2m-bs',          desc: 'LwM2M Bootstrap Server (CoAPs 5684).',            enable_key: '', state: 'stopped', enabled: true, restarting: false, state_key: 'services.cloud.lwm2m.bs.state' },
+    { key: 'lwm2m.dm',       label: 'lwm2m-dm',          desc: 'LwM2M Device Management (CoAPs 5683).',           enable_key: '', state: 'stopped', enabled: true, restarting: false, state_key: 'services.cloud.lwm2m.dm.state' },
   ];
   private active = true;
 
@@ -99,21 +104,42 @@ export class ServicesListComponent implements OnInit, OnDestroy {
     private toast: ToastService
   ) {}
 
-  private pollIdx = 0;  // round-robin index for long-poll keys
-
   ngOnInit(): void { this.fetchAll(); }
 
-  /// Fetch all service state/enable keys via POST, then start long-poll.
+  /// Services that can be enabled/disabled + restarted (have an enable key).
+  gateable(s: SvcRow): boolean { return !!s.enable_key; }
+
+  /// ds key prefix for a service's L22 telemetry keys.
+  private statsPrefix(s: SvcRow): string {
+    return s.key === 'ds' ? 'services.ds' : 'services.cloud.' + s.key;
+  }
+
+  fmtCpu(permille?: number): string {
+    if (permille == null) return '—';
+    return (permille / 10).toFixed(1) + ' %';
+  }
+
+  fmtKb(kb?: number): string {
+    if (kb == null) return '—';
+    if (kb < 1024) return kb + ' KB';
+    return (kb / 1024).toFixed(1) + ' MB';
+  }
+
+  private stateKeyOf(s: SvcRow): string {
+    return s.state_key || s.enable_key.replace('.enable', '.state');
+  }
+
+  /// Fetch all state/enable + telemetry keys via POST, then start long-poll.
   private fetchAll(): void {
     if (!this.active) return;
-    const keys = ['services.ds.state'];
+    const keys: string[] = ['services.ds.state'];
     for (const s of this.services) {
-      if (s.key === 'ds') continue;
-      if (s.state_key) {
-        keys.push(s.state_key);
-      } else if (s.enable_key) {
-        keys.push(s.enable_key, s.enable_key.replace('.enable', '.state'));
+      if (s.key !== 'ds') {
+        keys.push(this.stateKeyOf(s));
+        if (s.enable_key) keys.push(s.enable_key);
       }
+      const p = this.statsPrefix(s);
+      keys.push(p + '.cpu.permille', p + '.mem.rss.kb', p + '.fd.count', p + '.threads');
     }
     this.http.dbGet(keys).subscribe({
       next: (r) => this.applyState(r),
@@ -124,38 +150,40 @@ export class ServicesListComponent implements OnInit, OnDestroy {
   private applyState(r: { ok: boolean; data?: Record<string, unknown> }): void {
     if (r.ok && r.data) {
       const d = r.data as Record<string, unknown>;
-      const dsState = d['services.ds.state'];
-      if (typeof dsState === 'string') this.services[0].state = dsState;
+      const num = (k: string): number | undefined => {
+        const v = d[k];
+        return typeof v === 'number' ? v : undefined;
+      };
       for (const s of this.services) {
-        if (s.key === 'ds') continue;
-        const stateKey = s.state_key || s.enable_key.replace('.enable', '.state');
-        const sv = d[stateKey];
-        if (typeof sv === 'string') s.state = sv;
-        if (s.enable_key) {
-          const ev = d[s.enable_key];
-          if (typeof ev === 'boolean') s.enabled = ev;
+        if (s.key === 'ds') {
+          const sv = d['services.ds.state'];
+          if (typeof sv === 'string') s.state = sv;
+        } else {
+          const sv = d[this.stateKeyOf(s)];
+          if (typeof sv === 'string') s.state = sv;
+          if (s.enable_key) {
+            const ev = d[s.enable_key];
+            if (typeof ev === 'boolean') s.enabled = ev;
+          }
         }
+        const p = this.statsPrefix(s);
+        s.cpu_permille = num(p + '.cpu.permille');
+        s.mem_kb       = num(p + '.mem.rss.kb');
+        s.fd_count     = num(p + '.fd.count');
+        s.threads      = num(p + '.threads');
       }
     }
     this.scheduleLongPoll();
   }
 
-  /// Long-poll one state key at a time (round-robin). When any key
-  /// changes or the poll times out, refresh all keys via POST.
+  /// Long-poll the single services.stats.version bump key — every daemon
+  /// bumps it on each ~10s flush (and the http handler bumps on state
+  /// changes), so one wake refreshes all rows (state + enable + telemetry).
   private scheduleLongPoll(): void {
     if (!this.active) return;
-    // Collect all state keys for round-robin
-    const stateKeys: string[] = ['services.ds.state'];
-    for (const s of this.services) {
-      if (s.key === 'ds') continue;
-      stateKeys.push(s.state_key || s.enable_key.replace('.enable', '.state'));
-    }
-    const key = stateKeys[this.pollIdx % stateKeys.length];
-    this.pollIdx++;
-
-    this.http.dbGetLongPoll(key, 30).subscribe({
+    this.http.dbGetLongPoll('services.stats.version', 30).subscribe({
       next: () => this.fetchAll(),
-      error: () => this.fetchAll()
+      error: () => { if (this.active) setTimeout(() => this.fetchAll(), 5000); }
     });
   }
 

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -14,6 +14,7 @@
 #include <ace/Log_Msg.h>
 
 #include "data_store/log_buffer.hpp"
+#include "data_store/stats_publisher.hpp"
 
 #include "data_store/client.hpp"
 #include "data_store/service_gate.hpp"
@@ -663,6 +664,31 @@ int main(std::int32_t argc, char *argv[]) {
     if (auto* cli = ds.client()) {
         g_log.apply_level(*cli);
         g_log.flush(*cli);  // push startup logs immediately
+    }
+
+    // ── Resource telemetry (L22) ──────────────────────────────────
+    // Publish this container's CPU/mem/fd/threads every 10s. The lwm2m
+    // binary runs the singleton reactor on the udpAdapter ACE_Task thread,
+    // so the timer fires there — no extra thread (run_reactor_thread=false).
+    // Prefix tracks role: cloud bs/dm instance, else device client/server.
+    const std::string stats_prefix =
+        !lwm2m_instance.empty()
+            ? ("services.cloud.lwm2m." + lwm2m_instance)
+            : (UDPAdapter::Role_t::CLIENT == role ? "services.lwm2m.client"
+                                                  : "services.lwm2m.server");
+    data_store::StatsPublisher g_stats(
+        stats_prefix,
+        [&ds](const std::vector<data_store::KV>& kv) {
+            if (auto* c = ds.client()) c->set(kv);
+        });
+    if (auto* cli = ds.client()) {
+        if (g_stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC,
+                         /*run_reactor_thread=*/false) != 0) {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l stats publisher "
+                                "open failed\n")));
+        }
+        (void)cli;
     }
 
     // Background thread that flushes the log ring-buffer every 10 s.

--- a/iot-ui/src/app/routing/port-forward/port-forward.component.ts
+++ b/iot-ui/src/app/routing/port-forward/port-forward.component.ts
@@ -93,7 +93,7 @@ export class PortForwardComponent implements OnInit, OnDestroy {
   }
 
   saveDnat(): void {
-    this.savingDnat = true; this.msg = '';
+    this.savingDnat = true;
     this.http.dbSet([
       { key: 'net.lwm2m.target.ip',   value: this.targetIp },
       { key: 'net.lwm2m.target.port', value: this.targetPort },
@@ -104,7 +104,7 @@ export class PortForwardComponent implements OnInit, OnDestroy {
   }
 
   savePorts(): void {
-    this.savingPorts = true; this.msg = '';
+    this.savingPorts = true;
     this.http.dbSet([
       { key: 'net.forward.ports', value: this.forwardPorts },
     ]).subscribe({
@@ -112,4 +112,6 @@ export class PortForwardComponent implements OnInit, OnDestroy {
       error: () => { this.savingPorts = false; this.toast.error('Port save failed'); }
     });
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 }

--- a/iot-ui/src/app/services/services-list/services-list.component.ts
+++ b/iot-ui/src/app/services/services-list/services-list.component.ts
@@ -14,6 +14,11 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
       <clr-datagrid>
         <clr-dg-column>Service</clr-dg-column>
         <clr-dg-column>State</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'"
+          title="Percent of one host CPU core (per container)">CPU %</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'">Memory</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'">FDs</clr-dg-column>
+        <clr-dg-column [style.text-align]="'right'">Threads</clr-dg-column>
         <clr-dg-column>Enabled</clr-dg-column>
         <clr-dg-column>Uptime</clr-dg-column>
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
@@ -21,6 +26,10 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
         <clr-dg-row *clrDgItems="let s of services">
           <clr-dg-cell><code>{{ s.label }}</code></clr-dg-cell>
           <clr-dg-cell><app-status-badge [label]="s.info.state||'unknown'" [state]="s.info.state||''"></app-status-badge></clr-dg-cell>
+          <clr-dg-cell class="num">{{ fmtCpu(s.info.cpu_permille) }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ fmtKb(s.info.mem_kb) }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ s.info.fd_count ?? '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ s.info.threads ?? '—' }}</clr-dg-cell>
           <clr-dg-cell>
             <input type="checkbox" [checked]="s.info.enable" [disabled]="!isAdmin" (change)="toggleEnable(s)" />
           </clr-dg-cell>
@@ -41,7 +50,7 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
   `,
   styles: [`
     .page { padding: 24px; } h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 20px 0; }
-    
+    .num { text-align: right; font-variant-numeric: tabular-nums; }
     .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
     .hint { font-size: 12px; color: #757575; margin-top: 16px; }
   `]
@@ -60,6 +69,17 @@ export class ServicesListComponent implements OnInit, OnDestroy {
     get isAdmin(): boolean { return this.session.isAdmin; }
 
   constructor(private http: HttpsvcService, private session: SessionService) {}
+
+  fmtCpu(permille?: number): string {
+    if (permille == null) return '—';
+    return (permille / 10).toFixed(1) + ' %';
+  }
+
+  fmtKb(kb?: number): string {
+    if (kb == null) return '—';
+    if (kb < 1024) return kb + ' KB';
+    return (kb / 1024).toFixed(1) + ' MB';
+  }
 
   private active = true;
 

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -51,6 +51,11 @@ export interface ServiceInfo {
   enable?: boolean;
   state?: string;
   uptime_sec?: number;
+  // L22 — per-container resource telemetry (cgroup + /proc/self/fd).
+  cpu_permille?: number;
+  mem_kb?: number;
+  fd_count?: number;
+  threads?: number;
   [key: string]: unknown;
 }
 

--- a/log/L22/design.md
+++ b/log/L22/design.md
@@ -1,0 +1,419 @@
+# L22 — Per-Daemon CPU & Memory Telemetry
+
+> **Status:** Draft — design phase. TDD to follow after approval.
+
+## 1. Overview
+
+Each iot daemon running inside its container self-reports its own CPU and
+memory usage to the data store, exactly the way it already self-reports its
+log output (`LogBuffer`) and ds-server reports `services.ds.uptime.sec`. The
+cloud UI **Services** page then shows the live numbers as two extra columns,
+converting the current card grid into a `clr-datagrid` table that reuses the
+**Endpoints** page pattern.
+
+```
+┌──────────┐  cgroup +    ┌───────────────┐  long-poll  ┌──────────────┐
+│  daemon  │  /proc/self  │ StatsPublisher│ ──────────→ │  ds-server   │
+│ (cloudd, │ ───────────→ │  (lib class)  │  ds->set    │  services.*  │
+│  httpd,  │   sample     └───────────────┘             └──────┬───────┘
+│  lwm2m…) │   every 10s                                       │
+└──────────┘                                            ┌──────┴───────┐
+                                                        │  iot-httpd   │
+                                                        │  /db/get     │
+                                                        └──────┬───────┘
+                                                               │
+                                                    ┌──────────┴─────────┐
+                                                    │ Cloud UI  Services │
+                                                    │  clr-datagrid      │
+                                                    │  + CPU% + Memory   │
+                                                    └────────────────────┘
+```
+
+**Container-scoped self-instrumentation** — one daemon per container
+(confirmed: ds-server / iot-cloudd / lwm2m-bs / lwm2m-dm / iot-httpd each run
+as their own container in `apps/cloud/docker-compose.yml`), so per-daemon
+usage *is* per-container usage. Each daemon reads its **own container's
+cgroup** (`/sys/fs/cgroup/…`, mounted inside the container and scoped to that
+cgroup) for CPU / memory / task count, and `/proc/self/fd` for the
+descriptor count. No central collector, no daemon-to-daemon IPC, no
+cross-namespace `/proc` access — everything flows through ds-server (see
+`apps/cloud/CLAUDE.md` — "No HTTP between daemons").
+
+Because cgroup CPU/memory/pids are accounted for the whole cgroup, any
+**child process** the daemon spawns (e.g. openvpn-client → `openvpn(8)`,
+wifi-client → `wpa_supplicant`) is automatically included in its container's
+totals — no separate per-child sampling needed.
+
+## 2. Schema (`modules/data-store/schemas/services.lua`) — L22
+
+Typed numeric keys, four per daemon, slotted next to the existing
+`.state` / `.uptime.sec` keys. Follows the `services.ds.uptime.sec`
+precedent (typed `integer`, `min = 0`, `access = "Viewer"`).
+
+```
+services.<name>.cpu.permille   integer  default 0  min 0   -- parts-per-1000
+                                                            --   123 = 12.3 %
+services.<name>.mem.rss.kb     integer  default 0  min 0   -- resident set, KB
+services.<name>.fd.count       integer  default 0  min 0   -- open file descriptors
+services.<name>.threads        integer  default 0  min 0   -- live threads
+```
+
+`cpu.permille` (not `cpu.percent`) keeps the value an **integer** while
+preserving one decimal of resolution — ds has no float type, and 12.3 % must
+not round to 12. The UI divides by 10 for display.
+
+Plus one global bump counter (mirrors `log.version`) so the UI long-polls a
+**single** key instead of round-robining every daemon's two keys:
+
+```
+services.stats.version         integer  default 0           -- bumped on flush
+```
+
+### Per-daemon key set (mirrors existing service names)
+
+Each service gets the same four-key set (`.cpu.permille`, `.mem.rss.kb`,
+`.fd.count`, `.threads`):
+
+| Service name (existing `.state` key) | New keys |
+|--------------------------------------|----------|
+| `services.ds`                  | `services.ds.cpu.permille`, `…mem.rss.kb`, `…fd.count`, `…threads` |
+| `services.net.router`          | `…net.router.*` |
+| `services.openvpn.client`      | `…openvpn.client.*` |
+| `services.lwm2m.client`        | `…lwm2m.client.*` |
+| `services.lwm2m.server`        | `…lwm2m.server.*` |
+| `services.wifi.client`         | `…wifi.client.*` |
+| `services.cloud.iot.cloudd`    | `…cloud.iot.cloudd.*` |
+| `services.cloud.iot.httpd`     | `…cloud.iot.httpd.*` |
+| `services.cloud.openvpn.server`| `…cloud.openvpn.server.*` |
+| `services.cloud.lwm2m.bs`      | `…cloud.lwm2m.bs.*` |
+| `services.cloud.lwm2m.dm`      | `…cloud.lwm2m.dm.*` |
+
+Naming stays **dots-only** per `apps/cloud/CLAUDE.md`.
+
+## 3. Reusable sampler — `data_store::StatsPublisher`
+
+New lib class, sibling to `LogBuffer`, in the data-store module:
+
+- `modules/data-store/inc/data_store/stats_publisher.hpp`
+- `modules/data-store/src/stats_publisher.cpp`
+
+**ACE-native, singleton reactor.** Per the project convention (ACE for
+timers/threads, see `feedback_ace_logging`), `StatsPublisher` is an
+`ACE_Event_Handler` whose `handle_timeout` does the sampling, driven by the
+**`ACE_Reactor` singleton** (`ACE_Reactor::instance()`) — the reactor ACE
+already provides; we reuse it rather than constructing a new one. Most iot
+daemons block on `Client::recv_event` and never run the reactor loop, so
+`StatsPublisher::open()` spawns **one** ACE thread (an `ACE_Task<ACE_MT_SYNCH>`)
+that takes reactor ownership and runs `run_reactor_event_loop()`; the timer is
+scheduled on that same singleton. `close()` cancels the timer and ends the
+loop. (ds-server already runs the singleton reactor in `main` for
+`UptimePublisher`, so when its self-report is wired in §7 it schedules the
+timer only — no extra thread.) This keeps the daemon side a two-line wire-up:
+construct + `open()`.
+
+```cpp
+namespace data_store {
+
+/// Whole-process resource snapshot. All fields are int32 to match the
+/// ds integer type; -1 is never used — unreadable metrics report 0.
+struct StatsSample {
+    std::int32_t cpu_permille = 0;   // parts-per-1000 of one host-second
+    std::int32_t mem_rss_kb   = 0;
+    std::int32_t fd_count     = 0;
+    std::int32_t threads      = 0;
+};
+
+/// Test seam: where to read cgroup + proc from. Production defaults.
+struct StatsRoots {
+    std::string cgroup_root = "/sys/fs/cgroup";
+    std::string proc_self   = "/proc/self";
+};
+
+/// Sink that writes the sampled key/value pairs (4 metrics + the
+/// services.stats.version bump) to wherever they belong. A Client-backed
+/// daemon passes `[&ds](const std::vector<KV>& kv){ ds.set(kv); }`; ds-server
+/// passes a lambda over its in-process DataStore; tests capture into a
+/// vector. Decoupling from Client keeps publish() unit-testable with no
+/// server and no reactor, and lets ds-server (which has no Client) report.
+using StatsSink = std::function<void(const std::vector<KV>&)>;
+
+/// Periodically samples the calling process's container cgroup (CPU,
+/// memory, task count) plus its own open-fd count, and publishes them via
+/// the sink on an ACE reactor timer. One instance per daemon.
+///
+///   data_store::StatsPublisher g_stats(
+///       "services.cloud.iot.cloudd",
+///       [&ds](const std::vector<data_store::KV>& kv){ ds.set(kv); });
+///   g_stats.open();         // spawns the ACE timer thread (every 10s)
+///   ...                     // daemon does its normal recv_event loop
+///   g_stats.close();        // stop timer + join thread (also in dtor)
+///
+class StatsPublisher : public ACE_Event_Handler {
+public:
+    /// @param prefix  ds key prefix, e.g. "services.cloud.iot.cloudd".
+    ///                Writes "<prefix>.cpu.permille", "<prefix>.mem.rss.kb",
+    ///                "<prefix>.fd.count", "<prefix>.threads", and bumps
+    ///                "services.stats.version".
+    /// @param sink    publishes the sampled KV batch (see StatsSink).
+    /// @param roots   override cgroup/proc roots (tests only).
+    StatsPublisher(std::string prefix, StatsSink sink, StatsRoots roots = {});
+    ~StatsPublisher() override;
+
+    /// Schedule the recurring timer on ACE_Reactor::instance() and spawn
+    /// one ACE thread to run that singleton reactor's event loop.
+    /// @param interval_sec  flush cadence (default STATS_FLUSH_SEC = 10).
+    int  open(int interval_sec = STATS_FLUSH_SEC);
+    /// Cancel the timer, end the reactor loop, join the thread. Idempotent.
+    void close();
+
+    /// Read cgroup + /proc/self/fd and compute CPU% since the previous
+    /// sample. The FIRST call records the CPU baseline (cpu=0). Pure of the
+    /// data store — unit-tested directly with fixture roots.
+    StatsSample sample();
+
+    /// ACE timer callback — calls sample() then publish().
+    int handle_timeout(const ACE_Time_Value&, const void*) override;
+
+    static constexpr int STATS_FLUSH_SEC = 10;
+
+private:
+    void publish(const StatsSample&);   // write 4 keys + bump version
+
+    struct Impl;                        // ACE_Task thread running the
+    std::unique_ptr<Impl>              m_impl;   // singleton reactor loop
+    std::string                        m_prefix;
+    StatsSink                          m_sink;
+    StatsRoots                         m_roots;
+    enum class Cg { v2, v1, none } m_cg = Cg::none;   // probed once in ctor
+    unsigned long long m_last_usage_usec = 0;
+    std::chrono::steady_clock::time_point m_last_t{};
+    bool m_have_baseline = false;
+};
+
+}  // namespace data_store
+```
+
+The thread is encapsulated in `Impl` (an `ACE_Task<ACE_MT_SYNCH>` whose
+`svc()` calls `ACE_Reactor::instance()->owner(ACE_OS::thr_self())` then
+`run_reactor_event_loop()`), so the public header stays ACE-light behind the
+pimpl, same discipline as `client.hpp`.
+
+The pure parsing/math live as free functions in a `stats_detail` namespace
+(declared in the header) so the unit test drives them without a reactor or a
+data store:
+
+```cpp
+enum class CgVersion { v2, v1, none };   // namespace data_store
+
+namespace stats_detail {
+    CgVersion    detect_cgroup(const StatsRoots&);
+    bool         read_cpu_usec(const StatsRoots&, CgVersion,
+                               unsigned long long& out_usec);  // false if N/A
+    std::int32_t read_mem_kb (const StatsRoots&, CgVersion);
+    std::int32_t read_pids   (const StatsRoots&, CgVersion);
+    std::int32_t count_fds   (const StatsRoots&);
+    std::int32_t cpu_permille(unsigned long long prev_usec,
+                              unsigned long long now_usec, double dt_sec);
+}
+```
+
+### Sampling math
+
+cgroup layout is **probed once** in the constructor: if
+`<cgroup_root>/cgroup.controllers` exists → **v2 (unified)**; else if
+`<cgroup_root>/cpu.stat`-style v1 controller dirs exist → **v1**; else
+`none` (publish zeros, never throw).
+
+- **CPU** —
+  - v2: `usage_usec` line of `<cgroup_root>/cpu.stat` (cumulative µs).
+  - v1: `<cgroup_root>/cpuacct/cpuacct.usage` (cumulative ns).
+  Over wall interval `dt`: `percent = (Δusage_sec / dt_sec) * 100`, then
+  `permille = lround(percent * 10)`, clamped to `>= 0`. (Whole-host percent:
+  one fully-busy core = 1000 ‰ = 100 %.)
+- **Memory** —
+  - v2: `<cgroup_root>/memory.current` (bytes).
+  - v1: `<cgroup_root>/memory/memory.usage_in_bytes` (bytes).
+  `mem_kb = bytes / 1024`. Note this is the cgroup total (incl. page cache);
+  for a single-process container it tracks the daemon's footprint closely.
+- **Threads / tasks** —
+  - v2: `<cgroup_root>/pids.current`.
+  - v1: `<cgroup_root>/pids/pids.current`.
+  This is the live task (thread) count for the whole cgroup — includes any
+  child processes, which is the desired "everything in this container" number.
+- **FD count** — number of entries in `<proc_self>/fd/` (a `readdir` scan,
+  minus `.`/`..`). cgroups expose no fd metric, so this is the daemon's *own*
+  open descriptors. Cheap, and only every ~10s.
+
+CPU% is normalized to **whole-host** percent (a fully-busy single core =
+100%; an 8-core box maxed = 800%). Document this in the UI tooltip.
+
+## 4. Wiring per daemon
+
+Each daemon constructs one `StatsPublisher(prefix, sink)` after its ds
+connection succeeds and calls `open()`; `close()` runs on shutdown (also from
+the dtor). The `UptimePublisher` in `modules/data-store/src/server/main.cpp:47`
+is the precedent for the `ACE_Event_Handler` + `handle_timeout` shape.
+
+**`run_reactor_thread` per daemon.** `open(interval, run_reactor_thread)`
+decides whether `StatsPublisher` spawns its own ACE_Task thread to run the
+singleton reactor, or just schedules the timer on a reactor the daemon already
+pumps:
+
+| Daemon | already runs singleton reactor? | `run_reactor_thread` |
+|--------|---------------------------------|----------------------|
+| iot-cloudd | no — blocks on `Client::recv_event` | **true** (spawns thread) |
+| iot-httpd | yes — `handle_events` in main loop | **false** |
+| lwm2m (bs/dm/client/server) | yes — `udpAdapter` ACE_Task runs it | **false** |
+| ds-server | yes — `handle_events` in `main` | **false** |
+
+ds-server has no `Client` (it *is* the store), so its sink writes via the
+in-process `DataStore::set`; the others pass `[&ds](kv){ ds.set(kv); }`.
+
+**Status:** wired for every daemon — cloud: `services.ds` (ds-server),
+`services.cloud.iot.cloudd`, `services.cloud.iot.httpd`,
+`services.cloud.lwm2m.bs`, `services.cloud.lwm2m.dm`; device:
+`services.net.router` (net-router), `services.openvpn.client`
+(openvpn-client), `services.wifi.client` (wifi-client),
+`services.lwm2m.client` / `services.lwm2m.server` (device-role lwm2m). The
+device daemons run blocking poll loops with no ACE reactor, so they use
+`run_reactor_thread=true` (StatsPublisher spawns the ACE_Task reactor thread).
+The only service with no separate publisher is `openvpn-server`: it runs
+inside cloudd's container, so its usage is folded into cloudd's cgroup totals
+(its `services.cloud.openvpn.server.*` keys stay 0).
+
+| Daemon | main.cpp | Prefix |
+|--------|----------|--------|
+| ds-server | `modules/data-store/src/server/main.cpp` | `services.ds` |
+| iot-cloudd | `apps/cloud/server/src/main.cpp` | `services.cloud.iot.cloudd` |
+| iot-httpd | `modules/http-server/src/main.cpp` | `services.cloud.iot.httpd` (device: `services` n/a — see §7) |
+| lwm2m (bs/dm/client/server) | `apps/src/main.cpp` | role-dependent (`services.cloud.lwm2m.bs`, `…dm`, `services.lwm2m.client`, `services.lwm2m.server`) |
+| openvpn-client | `modules/openvpn/client/src/main.cpp` | `services.openvpn.client` |
+| net-router | `modules/net/router/src/main.cpp` | `services.net.router` |
+| wifi-client | `modules/wan/wifi/client/src/main.cpp` | `services.wifi.client` |
+
+The lwm2m binary already picks its `log.lwm2m.*` key by role (`lwm2m-instance=bs|dm`,
+client vs server) — the stats prefix is selected by the same switch.
+
+**openvpn(8) / wpa_supplicant** — these third-party children run *inside the
+same container* as their managing daemon (openvpn-client / wifi-client), so
+the cgroup CPU/memory/pids totals already include them. No extra
+`StatsPublisher` instance needed. (FD count is the managing daemon's own
+descriptors only — a known, acceptable limitation, since the child's fds
+live in its own `/proc/<child>/fd`.)
+
+### Cadence
+
+One fixed ACE reactor-timer interval, **`STATS_FLUSH_SEC = 10`**
+(`StatsPublisher::STATS_FLUSH_SEC`, scheduled on `ACE_Reactor::instance()` via
+`schedule_timer` with a 10 s repeat `ACE_Time_Value`). Rationale:
+- cgroup + one `readdir` is microseconds of work — frequency is not a cost
+  concern; the limit is signal usefulness and ds write churn.
+- 10 s gives a stable CPU% average (CPU is a *delta over the interval*, so a
+  shorter window is noisier; a longer one lags). It comfortably feeds the
+  cloud-UI Services refresh (≈5 s long-poll today — see `apps/cloud/CLAUDE.md`).
+- The bump key `services.stats.version` moves at most once per flush, so the
+  UI long-poll wakes ~every 10 s regardless of how many daemons there are.
+
+Optional (deferred): make it runtime-tunable via a ds key
+`services.stats.interval.sec` (default 10), hot-reloaded on watch — same
+pattern as `log.level`. Not needed for v1; the constant is enough.
+
+## 5. HTTP / API
+
+No new endpoint. The cloud UI already reads ds keys directly through
+`POST /api/v1/db/get` and long-polls via `GET /api/v1/db/get?key=…`. The
+Services page simply adds the new keys to the batch it already fetches and
+switches its long-poll target to `services.stats.version`.
+
+(Optional, deferred: enrich the `/api/v1/status` `services{}` block in
+`modules/http-server/src/handler.cpp` with `cpu_permille` / `mem_kb` so the
+Dashboard can show aggregates. Not required for this feature.)
+
+## 6. Cloud UI — Services page
+
+File: `apps/cloud/ui/src/app/services/services-list/services-list.component.ts`
+
+Convert the `.svc-grid` card layout to a Clarity `clr-datagrid`, reusing the
+structure of `apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts`.
+
+Columns:
+
+| Column | Source |
+|--------|--------|
+| Service | `s.label` (code-formatted) |
+| State | `<app-status-badge [state]="s.state">` (reused) |
+| CPU % | `s.cpu_permille / 10` → e.g. `12.3 %` |
+| Memory | `s.mem_kb` → humanized (`fmtKb`: KB / MB) |
+| FDs | `s.fd_count` |
+| Threads | `s.threads` |
+| Enabled | existing enable checkbox (admin-gated) |
+| Actions | existing Restart button (admin-gated) |
+
+```
+┌──────────────────────────────────────────────────────────────────────────────┐
+│ Service Management                                                             │
+│  clr-datagrid:                                                                 │
+│  ┌────────────┬─────────┬───────┬─────────┬─────┬─────────┬─────────┬────────┐ │
+│  │ Service    │ State   │ CPU % │ Memory  │ FDs │ Threads │ Enabled │ Action │ │
+│  │ ds-server  │ running │  0.4  │ 4.1 MB  │  12 │    4    │ on(—)   │ on     │ │
+│  │ iot-cloudd │ running │  1.2  │ 12.8 MB │  23 │    7    │ ☑       │[Restart]│ │
+│  │ iot-httpd  │ running │  0.8  │  9.0 MB │  18 │    6    │ ☑       │[Restart]│ │
+│  └────────────┴─────────┴───────┴─────────┴─────┴─────────┴─────────┴────────┘ │
+└──────────────────────────────────────────────────────────────────────────────┘
+```
+
+Data plumbing (extends existing `fetchAll` / `applyState`):
+
+- `SvcRow` gains `cpu_permille?: number; mem_kb?: number; fd_count?: number; threads?: number;`.
+- `fetchAll()` adds the four `services.<name>.{cpu.permille,mem.rss.kb,fd.count,threads}`
+  keys for every row to the `dbGet` batch.
+- `applyState()` reads the four numbers into each row.
+- `scheduleLongPoll()` replaces the round-robin over `.state` keys with a
+  single long-poll on `services.stats.version` (the bump key already moves on
+  every flush, ~10s, which also reflects state changes if we bump on state
+  writes — otherwise keep one `.state` poll in parallel). **Decision for
+  TDD:** keep the existing per-state round-robin AND add the version poll, or
+  consolidate. Simplest correct: long-poll `services.stats.version`, and on
+  each tick re-`fetchAll()` (which already re-reads state + enable too).
+
+No backend change needed for the UI; everything is ds-key driven.
+
+## 7. Device UI note
+
+`iot-ui/src/app/services/services-list/services-list.component.ts` is the
+device-side twin. The same column additions apply verbatim if/when desired —
+the device daemons (ds, lwm2m client, openvpn-client, net-router,
+wifi-client) publish the same `services.<name>.*` keys. **v1 targets the
+cloud UI only** (per request); the device UI change is a trivial follow-up.
+
+## 8. Reuse summary
+
+| Existing thing | Reused as |
+|----------------|-----------|
+| `LogBuffer` (lib pattern) | shape for `StatsPublisher` |
+| `UptimePublisher` reactor timer | shape for the flush timer |
+| `read_meminfo()` `/proc` reader | small-file `/proc`/`/sys` read idiom |
+| `log.version` single-key long-poll | `services.stats.version` |
+| `services.ds.uptime.sec` typed key | shape for `cpu.permille` / `mem.rss.kb` |
+| Endpoints `clr-datagrid` | Services table |
+| `app-status-badge` | State column |
+
+## 9. TDD plan (next step)
+
+1. **StatsPublisher unit test** — point `Roots` at fixture dirs: a fake
+   cgroup root (`cgroup.controllers` + `cpu.stat` with `usage_usec`,
+   `memory.current`, `pids.current`) and a fake `proc_self` with an `fd/`
+   directory. Assert CPU permille from a known `usage_usec` delta over a known
+   interval, `mem.rss.kb` from `memory.current`, `threads` from
+   `pids.current`, `fd.count` from the `fd/` entry count; assert first-call
+   baseline behavior (cpu = 0) and graceful zeros when files are absent
+   (`CgVersion::none`). Add a v1-layout fixture to cover the fallback.
+2. **Schema test** — load `services.lua`, assert the four new keys per service
+   exist with type=integer, min=0, access=Viewer.
+3. **Integration** — start ds-server + a daemon with StatsPublisher, wait one
+   flush, `ds-cli get services.<name>.{cpu.permille,mem.rss.kb,fd.count,threads}`
+   and `services.stats.version` are populated and version increments on the
+   next flush.
+4. **Cloud UI component test** — `ServicesListComponent` renders the datagrid,
+   maps the four numeric keys into the CPU%/Memory/FDs/Threads columns,
+   humanizes KB, and long-polls `services.stats.version`.

--- a/log/L22/tdd.md
+++ b/log/L22/tdd.md
@@ -1,0 +1,162 @@
+# L22 — TDD: Per-Daemon CPU & Memory Telemetry
+
+> Companion to `log/L22/design.md`. Test-first plan for `StatsPublisher`,
+> the `services.lua` schema, daemon wiring, and the cloud-UI Services table.
+> Tests build and run via podman against the toolchain image
+> `localhost/iot-httpd:lp` (gcc/g++, cmake, ACE 7.0.0, gtest, Lua 5.3).
+
+## 0. How to run the tests (podman)
+
+The gtest binary `ds-tests` builds out-of-tree against the working copy:
+
+```bash
+podman run --rm -v "$PWD":/src:ro localhost/iot-httpd:lp bash -lc '
+  cmake -S /src/modules/data-store -B /tmp/build -DBUILD_DATA_STORE_TESTS=ON &&
+  cmake --build /tmp/build --target ds-tests -j4 &&
+  /tmp/build/ds-tests --gtest_filter="Stats*:Services*"'
+```
+
+Read-only source mount + container-local `/tmp/build` keeps the host tree
+clean. The same image already builds the rest of `ds-tests` (verified).
+
+## 1. Unit under test
+
+`data_store::StatsPublisher` and its `stats_detail` free functions
+(`modules/data-store/inc/data_store/stats_publisher.hpp`,
+`modules/data-store/src/stats_publisher.cpp`).
+
+Design split that makes it testable without a reactor or a live ds:
+- **Pure parsers / math** in `stats_detail` — fed fixture directories via
+  `StatsRoots{cgroup_root, proc_self}`; no ACE, no Client.
+- **`sample()`** — composes the parsers + CPU delta using `steady_clock`.
+- **timer/thread** (`open()/close()/handle_timeout()`) — exercised by one
+  short integration test against an in-process ds-server (the
+  `LogBufferTest` harness pattern).
+
+## 2. Test file
+
+`modules/data-store/test/stats_publisher_test.cpp`, added to the `ds-tests`
+target (and `src/stats_publisher.cpp` to its sources) in
+`modules/data-store/CMakeLists.txt`.
+
+### 2.1 Fixtures (temp dirs, `mkdtemp` like `log_buffer_test.cpp`)
+
+A helper writes a fake cgroup + proc tree:
+
+```
+make_cgroup_v2(root, {usage_usec, mem_bytes, pids})
+   root/cgroup.controllers          "cpu memory pids\n"
+   root/cpu.stat                    "usage_usec 1500000\n..."
+   root/memory.current              "<mem_bytes>\n"
+   root/pids.current                "<pids>\n"
+
+make_cgroup_v1(root, {usage_ns, mem_bytes, pids})
+   root/cpuacct/cpuacct.usage       "<usage_ns>\n"
+   root/memory/memory.usage_in_bytes
+   root/pids/pids.current
+   (no root/cgroup.controllers)
+
+make_proc_self(root, n_fds)         creates root/fd/ with n symlink/files
+```
+
+### 2.2 Cases (red → green)
+
+**Parsers (v2)**
+1. `detect_cgroup` returns `v2` when `cgroup.controllers` exists.
+2. `parse_mem_kb` v2: `memory.current = 41943040` → `40960` (bytes/1024).
+3. `parse_pids`   v2: `pids.current = 7` → `7`.
+4. `parse_cpu_usec` v2: reads the `usage_usec` line of `cpu.stat`.
+
+**Parsers (v1 fallback)**
+5. `detect_cgroup` returns `v1` when no `cgroup.controllers` but
+   `cpuacct/cpuacct.usage` exists.
+6. `parse_mem_kb` v1 from `memory/memory.usage_in_bytes`.
+7. `parse_pids`   v1 from `pids/pids.current`.
+8. `parse_cpu_usec` v1 reads ns from `cpuacct.usage` and normalizes to µs.
+
+**CPU math (pure)**
+9. `cpu_permille(prev=1'000'000, now=1'500'000, dt=1.0)` → 500000 µs over
+   1 s = 0.5 host-core-second → **500 ‰** (50.0 %).
+10. `cpu_permille(prev=0, now=2'000'000, dt=1.0)` → 2.0 cores → **2000 ‰**.
+11. `cpu_permille(now < prev /* counter reset */, …)` → clamped **0**.
+12. `cpu_permille(dt <= 0)` → **0** (no divide-by-zero).
+
+**FD count**
+13. `count_fds` returns the number of entries in `fd/` (excludes `.`/`..`).
+14. `count_fds` on a missing `fd/` dir → **0** (graceful).
+
+**`sample()` behaviour**
+15. First `sample()` returns `cpu_permille == 0` (baseline only) but correct
+    `mem_rss_kb`, `fd_count`, `threads`.
+16. Second `sample()`, after rewriting `cpu.stat` with +500000 µs and ~the
+    test's elapsed wall time, returns a CPU permille in the expected band.
+    (Tolerate timing: assert `> 0` and `<= 1000 * ncpu`; the exact-math
+    assertion is covered by case 9–12 on the pure helper.)
+17. `StatsRoots` pointing at an empty dir (`Cg::none`) → all-zero sample,
+    no throw.
+
+**Publish (sink — no server, no reactor)**
+18. Construct `StatsPublisher("services.test", sink, fixture_roots)` where
+    `sink` captures the `std::vector<KV>` into a local. Call
+    `handle_timeout(ACE_Time_Value::zero, nullptr)` directly (simulates a
+    timer fire). Assert the captured batch contains
+    `services.test.cpu.permille`, `…mem.rss.kb`, `…fd.count`, `…threads`
+    (all int32) **and** `services.stats.version` (int32, non-zero). This
+    needs neither a ds-server nor a running reactor — the sink decoupling is
+    exactly what makes it a pure unit test.
+19. Two `handle_timeout` fires with `cpu.stat` advanced between them →
+    second batch carries a `cpu.permille > 0`.
+
+**Timer / thread lifecycle (ACE active object)**
+20. `open(1)` then `close()` fires the sink ≥1 time within ~1.3 s (sink
+    increments an atomic counter); `close()` joins the ACE_Task thread.
+    `close()` is idempotent and safe before `open()`; dtor after `open()`
+    without explicit `close()` still joins. To avoid contaminating the
+    shared `ACE_Reactor::instance()` used by other ds-tests (which pump it
+    via `handle_events`), this case calls
+    `ACE_Reactor::instance()->reset_reactor_event_loop()` after `close()`.
+    Kept minimal — the timer wiring mirrors `Worker`'s active-object pattern,
+    so the heavy assertions live in the pure/`sample()`/publish cases above.
+
+## 3. Schema test
+
+Extend `modules/data-store/test/schema_test.cpp` (or a focused
+`Services*` case): load `schemas/services.lua`, assert for a representative
+service (e.g. `services.cloud.iot.cloudd`) the four keys exist with
+`type == "integer"`, `min == 0`, `access == "Viewer"`, and that
+`services.stats.version` exists as a Viewer integer. (If the existing schema
+test harness only checks load-success, add a minimal key-presence assertion
+following its current style.)
+
+## 4. Daemon wiring (no new unit tests — covered by build + smoke)
+
+Each daemon constructs `StatsPublisher` after `connect()` and calls `open()`;
+verified by the existing per-daemon build and the `test-full-http.sh` /
+compose smoke path. A post-wiring manual check:
+
+```bash
+# in a running cloud stack
+ds-cli get services.cloud.iot.cloudd.cpu.permille
+ds-cli get services.cloud.iot.cloudd.mem.rss.kb
+ds-cli get services.stats.version    # increments every ~10s
+```
+
+## 5. Cloud-UI Services component test
+
+`apps/cloud/ui` (Angular + Jasmine/Karma). Update/extend the
+`ServicesListComponent` spec:
+- Renders a `clr-datagrid` (not the old `.svc-grid`).
+- Given a mocked `dbGet` returning `services.<svc>.cpu.permille = 123`,
+  `…mem.rss.kb = 40960`, `…fd.count = 18`, `…threads = 6`, the row shows
+  `12.3 %`, a humanized `40.0 MB`, `18`, `6`.
+- `scheduleLongPoll()` long-polls `services.stats.version`.
+
+(UI test runs in the Node UI image, not the C++ toolchain image.)
+
+## 6. Definition of done
+
+- `ds-tests --gtest_filter="Stats*:Services*"` green in podman.
+- `services.lua` carries the new keys; schema test green.
+- All daemons construct + `open()` a `StatsPublisher`; builds green.
+- Cloud-UI Services renders the datagrid with the four metric columns and
+  long-polls `services.stats.version`.

--- a/modules/data-store/CMakeLists.txt
+++ b/modules/data-store/CMakeLists.txt
@@ -52,7 +52,8 @@ add_library(datastore_client STATIC
     src/client/service_gate.cpp
     src/client/dep_watch.cpp
     src/proto/proto.cpp
-    src/log_buffer.cpp)
+    src/log_buffer.cpp
+    src/stats_publisher.cpp)
 
 target_include_directories(datastore_client
     PUBLIC ${DS_MODULE_DIR}/inc)
@@ -71,7 +72,8 @@ add_executable(ds-server
     src/server/schema.cpp
     src/server/worker.cpp
     src/server/worker_pool.cpp
-    src/proto/proto.cpp)
+    src/proto/proto.cpp
+    src/stats_publisher.cpp)
 
 target_link_libraries(ds-server
     ACE
@@ -107,7 +109,9 @@ if(BUILD_DATA_STORE_TESTS)
         test/service_gate_test.cpp
         test/dep_watch_test.cpp
         test/log_buffer_test.cpp
+        test/stats_publisher_test.cpp
         src/log_buffer.cpp
+        src/stats_publisher.cpp
         src/server/server.cpp
         src/server/session.cpp
         src/server/data_store.cpp

--- a/modules/data-store/inc/data_store/stats_publisher.hpp
+++ b/modules/data-store/inc/data_store/stats_publisher.hpp
@@ -1,0 +1,138 @@
+#ifndef __data_store_stats_publisher_hpp__
+#define __data_store_stats_publisher_hpp__
+
+/// Reusable per-daemon CPU / memory / fd / thread telemetry publisher.
+/// Sibling to LogBuffer.  Design: log/L22/design.md.
+///
+/// Each daemon constructs one instance with a ds key prefix
+/// ("services.cloud.iot.cloudd") and a sink that writes the sampled
+/// key/value batch, then calls open().  An ACE reactor timer — scheduled
+/// on ACE_Reactor::instance() and driven by an ACE_Task active-object
+/// thread — fires every STATS_FLUSH_SEC seconds and publishes:
+///
+///   <prefix>.cpu.permille   parts-per-1000 of one host-second (123 = 12.3%)
+///   <prefix>.mem.rss.kb     resident memory, KB
+///   <prefix>.fd.count       open file descriptors
+///   <prefix>.threads        live task / thread count
+///
+/// and bumps services.stats.version so the cloud UI long-polls one key.
+///
+/// CPU / memory / threads come from the process's own container cgroup
+/// (/sys/fs/cgroup — v2 with v1 fallback); the fd count from /proc/self/fd.
+/// One daemon per container, so these are effectively per-container totals.
+///
+/// Usage (one instance per daemon, after Client::connect):
+///
+///   data_store::StatsPublisher g_stats(
+///       "services.cloud.iot.cloudd",
+///       [&ds](const std::vector<data_store::KV>& kv){ ds.set(kv); });
+///   g_stats.open();      // spawns the ACE timer thread
+///   ...                  // daemon runs its normal recv_event loop
+///   g_stats.close();     // stop timer + join thread (also in dtor)
+
+#include <chrono>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ace/Event_Handler.h>
+
+#include "data_store/client.hpp"   // KV, Value
+
+namespace data_store {
+
+/// Detected cgroup hierarchy. Probed once at construction.
+enum class CgVersion { v2, v1, none };
+
+/// Whole-process resource snapshot. int32 to match the ds integer type;
+/// unreadable metrics report 0 (never negative).
+struct StatsSample {
+    std::int32_t cpu_permille = 0;   // parts-per-1000 of one host-second
+    std::int32_t mem_rss_kb   = 0;
+    std::int32_t fd_count     = 0;
+    std::int32_t threads      = 0;
+};
+
+/// Test seam: cgroup + proc mount roots. Production defaults.
+struct StatsRoots {
+    std::string cgroup_root = "/sys/fs/cgroup";
+    std::string proc_self   = "/proc/self";
+};
+
+/// Writes the sampled KV batch (4 metrics + services.stats.version) to
+/// wherever they belong. A Client-backed daemon passes
+/// `[&ds](const std::vector<KV>& kv){ ds.set(kv); }`; ds-server passes a
+/// lambda over its in-process DataStore; tests capture into a vector.
+using StatsSink = std::function<void(const std::vector<KV>&)>;
+
+class StatsPublisher : public ACE_Event_Handler {
+public:
+    static constexpr int STATS_FLUSH_SEC = 10;
+
+    StatsPublisher(std::string prefix, StatsSink sink,
+                   StatsRoots roots = StatsRoots{});
+    ~StatsPublisher() override;
+
+    StatsPublisher(const StatsPublisher&)            = delete;
+    StatsPublisher& operator=(const StatsPublisher&) = delete;
+
+    /// Schedule the recurring timer on ACE_Reactor::instance() and spawn
+    /// one ACE_Task thread to run that singleton reactor's event loop.
+    /// @param interval_sec        flush cadence (default STATS_FLUSH_SEC).
+    /// @param run_reactor_thread  true (default) spawns one ACE_Task thread
+    ///        to run the singleton reactor — for daemons that block elsewhere
+    ///        (e.g. Client::recv_event) and never pump the reactor. Pass
+    ///        false for daemons that already run the singleton reactor in
+    ///        their main loop (iot-httpd, ds-server); the timer then fires on
+    ///        their existing reactor thread.
+    int  open(int interval_sec = STATS_FLUSH_SEC,
+              bool run_reactor_thread = true);
+
+    /// Cancel the timer; if we spawned the reactor thread, end the loop and
+    /// join it. Idempotent.
+    void close();
+
+    /// Read cgroup + /proc/self/fd and compute CPU% since the previous
+    /// sample. The FIRST call records the CPU baseline (cpu=0). Pure of the
+    /// sink — unit-tested directly with fixture roots.
+    StatsSample sample();
+
+    /// ACE timer callback — sample() then publish().
+    int handle_timeout(const ACE_Time_Value&, const void*) override;
+
+private:
+    void publish(const StatsSample&);
+
+    struct Impl;                          // ACE_Task active-object thread
+    std::unique_ptr<Impl> m_impl;
+    std::string           m_prefix;
+    StatsSink             m_sink;
+    StatsRoots            m_roots;
+    CgVersion             m_cg = CgVersion::none;   // probed once in ctor
+    long                  m_timer_id = -1;
+    bool                  m_own_thread = false;     // we run the reactor loop
+    unsigned long long    m_last_usage_usec = 0;
+    std::chrono::steady_clock::time_point m_last_t{};
+    bool                  m_have_baseline = false;
+};
+
+/// Pure parsing / math, exposed for unit tests (no reactor, no sink).
+namespace stats_detail {
+    CgVersion    detect_cgroup(const StatsRoots&);
+    /// usage_usec for the cgroup. Returns false if unavailable.
+    bool         read_cpu_usec(const StatsRoots&, CgVersion,
+                               unsigned long long& out_usec);
+    std::int32_t read_mem_kb (const StatsRoots&, CgVersion);
+    std::int32_t read_pids   (const StatsRoots&, CgVersion);
+    std::int32_t count_fds   (const StatsRoots&);
+    /// permille of one host-second of CPU over [prev,now] across dt_sec.
+    /// Clamps to 0 on counter reset / non-positive dt.
+    std::int32_t cpu_permille(unsigned long long prev_usec,
+                              unsigned long long now_usec, double dt_sec);
+}  // namespace stats_detail
+
+}  // namespace data_store
+
+#endif  // __data_store_stats_publisher_hpp__

--- a/modules/data-store/schemas/services.lua
+++ b/modules/data-store/schemas/services.lua
@@ -23,9 +23,7 @@
 -- Install at /etc/iot/ds-schemas/services.lua (ds-server
 -- auto-loads on boot).
 
-return {
-  namespace = "services",
-  keys = {
+local keys = {
     -- ds-server: state surface only
     ["services.ds.state"]                  = {
         access  = "Viewer", type = "string",  default = "stopped" },
@@ -97,5 +95,43 @@ return {
         access  = "Viewer", type = "string",  default = "stopped" },
     ["services.cloud.lwm2m.dm.state"]       = {
         access  = "Viewer", type = "string",  default = "stopped" },
-  },
+}
+
+-- ── L22 — per-daemon resource telemetry ──────────────────────────────
+-- Four integer metrics per service, published every ~10s by each daemon's
+-- StatsPublisher (cgroup v2/v1 for cpu/mem/threads + /proc/self/fd for the
+-- descriptor count). Typed integers mirror services.ds.uptime.sec:
+--   <svc>.cpu.permille  parts-per-1000 of one host-second (123 = 12.3 %)
+--   <svc>.mem.rss.kb    resident memory, KB
+--   <svc>.fd.count      open file descriptors
+--   <svc>.threads       live task/thread count
+-- One service per container, so these are effectively per-container totals.
+local stats_services = {
+  "services.ds",
+  "services.net.router",
+  "services.openvpn.client",
+  "services.lwm2m.client",
+  "services.lwm2m.server",
+  "services.wifi.client",
+  "services.cloud.iot.cloudd",
+  "services.cloud.iot.httpd",
+  "services.cloud.openvpn.server",
+  "services.cloud.lwm2m.bs",
+  "services.cloud.lwm2m.dm",
+}
+for _, s in ipairs(stats_services) do
+  keys[s .. ".cpu.permille"] = { access = "Viewer", type = "integer", default = 0, min = 0 }
+  keys[s .. ".mem.rss.kb"]   = { access = "Viewer", type = "integer", default = 0, min = 0 }
+  keys[s .. ".fd.count"]     = { access = "Viewer", type = "integer", default = 0, min = 0 }
+  keys[s .. ".threads"]      = { access = "Viewer", type = "integer", default = 0, min = 0 }
+end
+
+-- Bumped by every daemon on each stats flush so the cloud UI long-polls a
+-- single key instead of round-robining all <svc>.* metric keys (mirrors
+-- log.version).
+keys["services.stats.version"] = { access = "Viewer", type = "integer", default = 0 }
+
+return {
+  namespace = "services",
+  keys = keys,
 }

--- a/modules/data-store/src/server/main.cpp
+++ b/modules/data-store/src/server/main.cpp
@@ -15,6 +15,7 @@
 #include "worker_pool.hpp"
 
 #include "data_store/proto.hpp"
+#include "data_store/stats_publisher.hpp"
 #include "data_store/value.hpp"
 
 #include <atomic>
@@ -175,6 +176,18 @@ int main(int argc, char** argv) {
         nullptr,
         /*delay=*/ACE_Time_Value(60),
         /*interval=*/ACE_Time_Value(60));
+
+    // L22 — resource telemetry. ds-server has no Client (it IS the store),
+    // so the sink writes directly via the in-process DataStore. The main
+    // thread already pumps the singleton reactor below, so the timer fires
+    // there (run_reactor_thread=false).
+    data_store::StatsPublisher stats(
+        "services.ds",
+        [&store](const std::vector<data_store::KV>& kv) {
+            for (const auto& p : kv) store->set(p.first, p.second);
+        });
+    stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC,
+               /*run_reactor_thread=*/false);
 
     ::signal(SIGINT,  on_signal);
     ::signal(SIGTERM, on_signal);

--- a/modules/data-store/src/stats_publisher.cpp
+++ b/modules/data-store/src/stats_publisher.cpp
@@ -1,0 +1,249 @@
+#include "data_store/stats_publisher.hpp"
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_Thread.h>
+#include <ace/Reactor.h>
+#include <ace/Synch_Traits.h>
+#include <ace/Task.h>
+#include <ace/Time_Value.h>
+
+#include <dirent.h>
+#include <sys/stat.h>
+
+#include <atomic>
+#include <cerrno>
+#include <cmath>
+#include <cstdint>
+#include <ctime>
+#include <fstream>
+#include <limits>
+#include <optional>
+#include <string>
+
+namespace data_store {
+
+// ── small /proc + /sys helpers ──────────────────────────────────────
+namespace {
+
+bool file_exists(const std::string& p) {
+    struct stat st {};
+    return ::stat(p.c_str(), &st) == 0;
+}
+
+std::optional<unsigned long long> read_uint_file(const std::string& path) {
+    std::ifstream ifs(path);
+    if (!ifs.is_open()) return std::nullopt;
+    unsigned long long v = 0;
+    if (ifs >> v) return v;
+    return std::nullopt;
+}
+
+// Clamp an unsigned count into the ds int32 domain.
+std::int32_t clamp_i32(unsigned long long v) {
+    constexpr unsigned long long kMax =
+        static_cast<unsigned long long>(std::numeric_limits<std::int32_t>::max());
+    return static_cast<std::int32_t>(v > kMax ? kMax : v);
+}
+
+}  // namespace
+
+// ── stats_detail: pure parsing / math (unit-tested directly) ─────────
+namespace stats_detail {
+
+CgVersion detect_cgroup(const StatsRoots& r) {
+    if (file_exists(r.cgroup_root + "/cgroup.controllers")) return CgVersion::v2;
+    if (file_exists(r.cgroup_root + "/cpuacct/cpuacct.usage") ||
+        file_exists(r.cgroup_root + "/cpu,cpuacct/cpuacct.usage"))
+        return CgVersion::v1;
+    return CgVersion::none;
+}
+
+bool read_cpu_usec(const StatsRoots& r, CgVersion cg,
+                   unsigned long long& out_usec) {
+    if (cg == CgVersion::v2) {
+        std::ifstream ifs(r.cgroup_root + "/cpu.stat");
+        if (!ifs.is_open()) return false;
+        std::string key;
+        unsigned long long val = 0;
+        while (ifs >> key >> val) {
+            if (key == "usage_usec") { out_usec = val; return true; }
+        }
+        return false;
+    }
+    if (cg == CgVersion::v1) {
+        // cpuacct.usage is nanoseconds; normalise to microseconds.
+        for (const char* sub : {"/cpuacct/cpuacct.usage",
+                                "/cpu,cpuacct/cpuacct.usage"}) {
+            if (auto ns = read_uint_file(r.cgroup_root + sub)) {
+                out_usec = *ns / 1000ULL;
+                return true;
+            }
+        }
+        return false;
+    }
+    return false;
+}
+
+std::int32_t read_mem_kb(const StatsRoots& r, CgVersion cg) {
+    std::optional<unsigned long long> bytes;
+    if (cg == CgVersion::v2)
+        bytes = read_uint_file(r.cgroup_root + "/memory.current");
+    else if (cg == CgVersion::v1)
+        bytes = read_uint_file(r.cgroup_root + "/memory/memory.usage_in_bytes");
+    if (!bytes) return 0;
+    return clamp_i32(*bytes / 1024ULL);
+}
+
+std::int32_t read_pids(const StatsRoots& r, CgVersion cg) {
+    std::optional<unsigned long long> n;
+    if (cg == CgVersion::v2)
+        n = read_uint_file(r.cgroup_root + "/pids.current");
+    else if (cg == CgVersion::v1)
+        n = read_uint_file(r.cgroup_root + "/pids/pids.current");
+    if (!n) return 0;
+    return clamp_i32(*n);
+}
+
+std::int32_t count_fds(const StatsRoots& r) {
+    DIR* d = ::opendir((r.proc_self + "/fd").c_str());
+    if (!d) return 0;
+    std::int32_t n = 0;
+    while (struct dirent* e = ::readdir(d)) {
+        const char* nm = e->d_name;
+        if (nm[0] == '.' &&
+            (nm[1] == '\0' || (nm[1] == '.' && nm[2] == '\0')))
+            continue;  // skip "." and ".."
+        ++n;
+    }
+    ::closedir(d);
+    return n;
+}
+
+std::int32_t cpu_permille(unsigned long long prev_usec,
+                          unsigned long long now_usec, double dt_sec) {
+    if (dt_sec <= 0.0 || now_usec < prev_usec) return 0;  // reset / bad dt
+    double busy_sec  = static_cast<double>(now_usec - prev_usec) / 1e6;
+    double cores     = busy_sec / dt_sec;          // fraction of one host core
+    double permille  = cores * 1000.0;
+    if (permille < 0.0) permille = 0.0;
+    return static_cast<std::int32_t>(std::llround(permille));
+}
+
+}  // namespace stats_detail
+
+// ── ACE active object: runs the singleton reactor loop ──────────────
+struct StatsPublisher::Impl : public ACE_Task<ACE_MT_SYNCH> {
+    std::atomic<bool> running{false};
+
+    int svc() override {
+        // Own the reactor on this thread, then pump until end_reactor_event_loop.
+        ACE_Reactor::instance()->owner(ACE_OS::thr_self());
+        ACE_Reactor::instance()->run_reactor_event_loop();
+        return 0;
+    }
+};
+
+// ── StatsPublisher ──────────────────────────────────────────────────
+StatsPublisher::StatsPublisher(std::string prefix, StatsSink sink,
+                               StatsRoots roots)
+    : m_impl(std::make_unique<Impl>()),
+      m_prefix(std::move(prefix)),
+      m_sink(std::move(sink)),
+      m_roots(std::move(roots)) {
+    m_cg = stats_detail::detect_cgroup(m_roots);
+}
+
+StatsPublisher::~StatsPublisher() { close(); }
+
+int StatsPublisher::open(int interval_sec, bool run_reactor_thread) {
+    if (!m_impl || m_timer_id != -1) return 0;     // already scheduled
+    if (interval_sec < 1) interval_sec = 1;
+
+    ACE_Time_Value iv(interval_sec);
+    long id = ACE_Reactor::instance()->schedule_timer(this, nullptr, iv, iv);
+    if (id == -1) {
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("%D stats:thread:%t %M %N:%l schedule_timer "
+                                   "failed for %C\n"),
+                          m_prefix.c_str()),
+                         -1);
+    }
+    m_timer_id = id;
+
+    if (run_reactor_thread) {
+        m_impl->running.store(true);
+        if (m_impl->activate(THR_NEW_LWP | THR_JOINABLE, 1) == -1) {
+            ACE_Reactor::instance()->cancel_timer(this);
+            m_timer_id = -1;
+            m_impl->running.store(false);
+            ACE_ERROR_RETURN((LM_ERROR,
+                              ACE_TEXT("%D stats:thread:%t %M %N:%l activate "
+                                       "failed for %C errno=%d\n"),
+                              m_prefix.c_str(), errno),
+                             -1);
+        }
+        m_own_thread = true;
+    }
+    return 0;
+}
+
+void StatsPublisher::close() {
+    if (!m_impl) return;
+    if (m_timer_id != -1) {
+        ACE_Reactor::instance()->cancel_timer(this);
+        m_timer_id = -1;
+    }
+    if (m_own_thread && m_impl->running.load()) {
+        // We own the loop — stop it and join. Daemons that pump the reactor
+        // themselves (run_reactor_thread=false) keep owning it.
+        ACE_Reactor::instance()->end_reactor_event_loop();
+        m_impl->wait();              // join the active-object thread
+        m_impl->running.store(false);
+        m_own_thread = false;
+    }
+}
+
+StatsSample StatsPublisher::sample() {
+    StatsSample s;
+    s.mem_rss_kb = stats_detail::read_mem_kb(m_roots, m_cg);
+    s.threads    = stats_detail::read_pids(m_roots, m_cg);
+    s.fd_count   = stats_detail::count_fds(m_roots);
+
+    unsigned long long usage = 0;
+    const bool have = stats_detail::read_cpu_usec(m_roots, m_cg, usage);
+    const auto now = std::chrono::steady_clock::now();
+    if (have) {
+        if (m_have_baseline) {
+            const double dt =
+                std::chrono::duration<double>(now - m_last_t).count();
+            s.cpu_permille =
+                stats_detail::cpu_permille(m_last_usage_usec, usage, dt);
+        } else {
+            m_have_baseline = true;     // first sample → baseline only
+        }
+        m_last_usage_usec = usage;
+        m_last_t = now;
+    }
+    return s;
+}
+
+void StatsPublisher::publish(const StatsSample& s) {
+    if (!m_sink) return;
+    std::vector<KV> kv;
+    kv.reserve(5);
+    kv.emplace_back(m_prefix + ".cpu.permille", Value{s.cpu_permille});
+    kv.emplace_back(m_prefix + ".mem.rss.kb",   Value{s.mem_rss_kb});
+    kv.emplace_back(m_prefix + ".fd.count",     Value{s.fd_count});
+    kv.emplace_back(m_prefix + ".threads",      Value{s.threads});
+    // Bump services.stats.version so the cloud UI long-poll wakes up.
+    const auto ts = static_cast<std::int32_t>(std::time(nullptr));
+    kv.emplace_back("services.stats.version", Value{ts});
+    m_sink(kv);
+}
+
+int StatsPublisher::handle_timeout(const ACE_Time_Value&, const void*) {
+    publish(sample());
+    return 0;
+}
+
+}  // namespace data_store

--- a/modules/data-store/test/stats_publisher_test.cpp
+++ b/modules/data-store/test/stats_publisher_test.cpp
@@ -1,0 +1,234 @@
+/// StatsPublisher gtest — cgroup v2/v1 + /proc/self/fd parsing, CPU math,
+/// sample() baseline, sink publish, and ACE timer lifecycle. See log/L22.
+
+#include <gtest/gtest.h>
+
+#include <ace/Reactor.h>
+#include <ace/Time_Value.h>
+
+#include <atomic>
+#include <chrono>
+#include <fstream>
+#include <string>
+#include <sys/stat.h>
+#include <thread>
+#include <unistd.h>
+#include <vector>
+
+#include "data_store/stats_publisher.hpp"
+
+namespace ds = data_store;
+namespace sd = data_store::stats_detail;
+
+namespace {
+
+std::string make_tmpdir() {
+    char tmpl[64] = "/tmp/ds-stats-XXXXXX";
+    if (char* d = ::mkdtemp(tmpl)) return d;
+    return {};
+}
+
+void write_file(const std::string& path, const std::string& content) {
+    std::ofstream ofs(path, std::ios::trunc);
+    ofs << content;
+}
+
+void mkdir_p(const std::string& path) { ::mkdir(path.c_str(), 0700); }
+
+// Build a cgroup v2 tree under root; cgroup_root == proc_self == root.
+ds::StatsRoots make_cgroup_v2(const std::string& root,
+                              unsigned long long usage_usec,
+                              unsigned long long mem_bytes,
+                              unsigned long long pids) {
+    write_file(root + "/cgroup.controllers", "cpu memory pids\n");
+    write_file(root + "/cpu.stat",
+               "usage_usec " + std::to_string(usage_usec) +
+               "\nuser_usec 1\nsystem_usec 1\n");
+    write_file(root + "/memory.current", std::to_string(mem_bytes) + "\n");
+    write_file(root + "/pids.current",   std::to_string(pids) + "\n");
+    ds::StatsRoots r;
+    r.cgroup_root = root;
+    r.proc_self   = root;
+    return r;
+}
+
+// Build a cgroup v1 tree (no cgroup.controllers → detected as v1).
+ds::StatsRoots make_cgroup_v1(const std::string& root,
+                              unsigned long long usage_ns,
+                              unsigned long long mem_bytes,
+                              unsigned long long pids) {
+    mkdir_p(root + "/cpuacct");
+    mkdir_p(root + "/memory");
+    mkdir_p(root + "/pids");
+    write_file(root + "/cpuacct/cpuacct.usage", std::to_string(usage_ns) + "\n");
+    write_file(root + "/memory/memory.usage_in_bytes",
+               std::to_string(mem_bytes) + "\n");
+    write_file(root + "/pids/pids.current", std::to_string(pids) + "\n");
+    ds::StatsRoots r;
+    r.cgroup_root = root;
+    r.proc_self   = root;
+    return r;
+}
+
+// Create root/fd/ with n entries.
+void make_fd_dir(const std::string& root, int n) {
+    mkdir_p(root + "/fd");
+    for (int i = 0; i < n; ++i) write_file(root + "/fd/" + std::to_string(i), "");
+}
+
+}  // namespace
+
+// ── detection ──────────────────────────────────────────────────────
+TEST(StatsDetect, v2_when_controllers_present) {
+    auto r = make_cgroup_v2(make_tmpdir(), 1000000, 1024, 3);
+    EXPECT_EQ(sd::detect_cgroup(r), ds::CgVersion::v2);
+}
+
+TEST(StatsDetect, v1_when_cpuacct_present) {
+    auto r = make_cgroup_v1(make_tmpdir(), 1000000, 1024, 3);
+    EXPECT_EQ(sd::detect_cgroup(r), ds::CgVersion::v1);
+}
+
+TEST(StatsDetect, none_when_empty) {
+    ds::StatsRoots r;
+    r.cgroup_root = make_tmpdir();
+    EXPECT_EQ(sd::detect_cgroup(r), ds::CgVersion::none);
+}
+
+// ── parsers v2 ──────────────────────────────────────────────────────
+TEST(StatsParseV2, mem_bytes_to_kb) {
+    auto r = make_cgroup_v2(make_tmpdir(), 0, 41943040ULL, 7);  // 40 MiB
+    EXPECT_EQ(sd::read_mem_kb(r, ds::CgVersion::v2), 40960);
+}
+
+TEST(StatsParseV2, pids) {
+    auto r = make_cgroup_v2(make_tmpdir(), 0, 0, 7);
+    EXPECT_EQ(sd::read_pids(r, ds::CgVersion::v2), 7);
+}
+
+TEST(StatsParseV2, cpu_usec_line) {
+    auto r = make_cgroup_v2(make_tmpdir(), 1500000ULL, 0, 0);
+    unsigned long long usec = 0;
+    ASSERT_TRUE(sd::read_cpu_usec(r, ds::CgVersion::v2, usec));
+    EXPECT_EQ(usec, 1500000ULL);
+}
+
+// ── parsers v1 ──────────────────────────────────────────────────────
+TEST(StatsParseV1, mem_and_pids) {
+    auto r = make_cgroup_v1(make_tmpdir(), 0, 41943040ULL, 4);
+    EXPECT_EQ(sd::read_mem_kb(r, ds::CgVersion::v1), 40960);
+    EXPECT_EQ(sd::read_pids(r, ds::CgVersion::v1), 4);
+}
+
+TEST(StatsParseV1, cpu_ns_to_usec) {
+    auto r = make_cgroup_v1(make_tmpdir(), 2000000000ULL, 0, 0);  // 2e9ns→2e6us
+    unsigned long long usec = 0;
+    ASSERT_TRUE(sd::read_cpu_usec(r, ds::CgVersion::v1, usec));
+    EXPECT_EQ(usec, 2000000ULL);
+}
+
+// ── cpu math ────────────────────────────────────────────────────────
+TEST(StatsCpu, half_core)   { EXPECT_EQ(sd::cpu_permille(1000000, 1500000, 1.0), 500); }
+TEST(StatsCpu, two_cores)   { EXPECT_EQ(sd::cpu_permille(0, 2000000, 1.0), 2000); }
+TEST(StatsCpu, reset_zero)  { EXPECT_EQ(sd::cpu_permille(2000000, 1000000, 1.0), 0); }
+TEST(StatsCpu, bad_dt_zero) { EXPECT_EQ(sd::cpu_permille(0, 1000000, 0.0), 0); }
+
+// ── fd count ────────────────────────────────────────────────────────
+TEST(StatsFds, counts_entries) {
+    auto dir = make_tmpdir();
+    make_fd_dir(dir, 5);
+    ds::StatsRoots r; r.proc_self = dir;
+    EXPECT_EQ(sd::count_fds(r), 5);
+}
+
+TEST(StatsFds, missing_dir_zero) {
+    ds::StatsRoots r; r.proc_self = make_tmpdir();  // no fd/
+    EXPECT_EQ(sd::count_fds(r), 0);
+}
+
+// ── sample() ────────────────────────────────────────────────────────
+TEST(StatsSample, first_call_cpu_zero_others_populated) {
+    auto dir = make_tmpdir();
+    auto r = make_cgroup_v2(dir, 1000000ULL, 41943040ULL, 6);
+    make_fd_dir(dir, 9);
+    ds::StatsPublisher pub("services.test", nullptr, r);
+    auto s = pub.sample();
+    EXPECT_EQ(s.cpu_permille, 0);
+    EXPECT_EQ(s.mem_rss_kb, 40960);
+    EXPECT_EQ(s.threads, 6);
+    EXPECT_EQ(s.fd_count, 9);
+}
+
+TEST(StatsSample, second_call_reports_cpu) {
+    auto dir = make_tmpdir();
+    auto r = make_cgroup_v2(dir, 1000000ULL, 1024, 1);
+    ds::StatsPublisher pub("services.test", nullptr, r);
+    (void)pub.sample();                                  // baseline
+    write_file(dir + "/cpu.stat", "usage_usec 1500000\n");
+    std::this_thread::sleep_for(std::chrono::milliseconds(50));
+    EXPECT_GT(pub.sample().cpu_permille, 0);
+}
+
+TEST(StatsSample, none_cgroup_all_zero) {
+    ds::StatsRoots r;
+    r.cgroup_root = make_tmpdir();
+    r.proc_self   = r.cgroup_root;
+    ds::StatsPublisher pub("services.test", nullptr, r);
+    auto s = pub.sample();
+    EXPECT_EQ(s.cpu_permille, 0);
+    EXPECT_EQ(s.mem_rss_kb, 0);
+    EXPECT_EQ(s.threads, 0);
+    EXPECT_EQ(s.fd_count, 0);
+}
+
+// ── publish (sink — no server, no reactor) ──────────────────────────
+TEST(StatsPublish, sink_receives_four_metrics_plus_version) {
+    auto dir = make_tmpdir();
+    auto r = make_cgroup_v2(dir, 1000000ULL, 41943040ULL, 6);
+    make_fd_dir(dir, 9);
+
+    std::vector<ds::KV> got;
+    ds::StatsPublisher pub("services.test",
+        [&](const std::vector<ds::KV>& kv) { got = kv; }, r);
+
+    pub.handle_timeout(ACE_Time_Value::zero, nullptr);
+
+    ASSERT_EQ(got.size(), 5u);
+    bool cpu=false, mem=false, fd=false, thr=false, ver=false;
+    for (auto& kv : got) {
+        const std::string& k = kv.first;
+        if (k == "services.test.cpu.permille") cpu = true;
+        else if (k == "services.test.mem.rss.kb") { mem = true; EXPECT_EQ(ds::to_int32(kv.second).value_or(-1), 40960); }
+        else if (k == "services.test.fd.count")   { fd  = true; EXPECT_EQ(ds::to_int32(kv.second).value_or(-1), 9); }
+        else if (k == "services.test.threads")    { thr = true; EXPECT_EQ(ds::to_int32(kv.second).value_or(-1), 6); }
+        else if (k == "services.stats.version")   { ver = true; EXPECT_GT(ds::to_int32(kv.second).value_or(0), 0); }
+    }
+    EXPECT_TRUE(cpu && mem && fd && thr && ver);
+}
+
+// ── timer lifecycle (ACE active object) ─────────────────────────────
+TEST(StatsTimer, open_fires_then_close_joins) {
+    auto dir = make_tmpdir();
+    auto r = make_cgroup_v2(dir, 1000000ULL, 1024, 1);
+    make_fd_dir(dir, 2);
+
+    std::atomic<int> fires{0};
+    ds::StatsPublisher pub("services.test",
+        [&](const std::vector<ds::KV>&) { fires.fetch_add(1); }, r);
+
+    ASSERT_EQ(pub.open(1), 0);                              // 1s interval
+    std::this_thread::sleep_for(std::chrono::milliseconds(1300));
+    pub.close();
+    EXPECT_GE(fires.load(), 1);
+
+    pub.close();                                            // idempotent
+
+    // Restore the shared singleton reactor for later ds-tests that pump it.
+    ACE_Reactor::instance()->reset_reactor_event_loop();
+}
+
+TEST(StatsTimer, close_before_open_safe) {
+    ds::StatsPublisher pub("services.test", nullptr);
+    pub.close();   // must not hang or crash
+    SUCCEED();
+}

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -404,6 +404,19 @@ void install_handlers(Router& router,
                 "services.lwm2m.server.enable",
                 "services.lwm2m.server.state",
                 "services.wifi.client.enable", "services.wifi.client.state",
+                // L22 — per-container resource telemetry.
+                "services.ds.cpu.permille", "services.ds.mem.rss.kb",
+                "services.ds.fd.count", "services.ds.threads",
+                "services.net.router.cpu.permille", "services.net.router.mem.rss.kb",
+                "services.net.router.fd.count", "services.net.router.threads",
+                "services.openvpn.client.cpu.permille", "services.openvpn.client.mem.rss.kb",
+                "services.openvpn.client.fd.count", "services.openvpn.client.threads",
+                "services.lwm2m.client.cpu.permille", "services.lwm2m.client.mem.rss.kb",
+                "services.lwm2m.client.fd.count", "services.lwm2m.client.threads",
+                "services.lwm2m.server.cpu.permille", "services.lwm2m.server.mem.rss.kb",
+                "services.lwm2m.server.fd.count", "services.lwm2m.server.threads",
+                "services.wifi.client.cpu.permille", "services.wifi.client.mem.rss.kb",
+                "services.wifi.client.fd.count", "services.wifi.client.threads",
             }, got);
             json resp;
             resp["ok"] = true;
@@ -477,6 +490,32 @@ void install_handlers(Router& router,
                 else if (k == "services.lwm2m.server.state")      services["lwm2m_server"]["state"] = sv();
                 else if (k == "services.wifi.client.enable")      services["wifi_client"]["enable"] = bv(true);
                 else if (k == "services.wifi.client.state")       services["wifi_client"]["state"] = sv();
+
+                // L22 — resource telemetry per service.
+                else if (k == "services.ds.cpu.permille")             services["ds"]["cpu_permille"] = iv();
+                else if (k == "services.ds.mem.rss.kb")               services["ds"]["mem_kb"] = iv();
+                else if (k == "services.ds.fd.count")                 services["ds"]["fd_count"] = iv();
+                else if (k == "services.ds.threads")                  services["ds"]["threads"] = iv();
+                else if (k == "services.net.router.cpu.permille")     services["net_router"]["cpu_permille"] = iv();
+                else if (k == "services.net.router.mem.rss.kb")       services["net_router"]["mem_kb"] = iv();
+                else if (k == "services.net.router.fd.count")         services["net_router"]["fd_count"] = iv();
+                else if (k == "services.net.router.threads")          services["net_router"]["threads"] = iv();
+                else if (k == "services.openvpn.client.cpu.permille") services["openvpn_client"]["cpu_permille"] = iv();
+                else if (k == "services.openvpn.client.mem.rss.kb")   services["openvpn_client"]["mem_kb"] = iv();
+                else if (k == "services.openvpn.client.fd.count")     services["openvpn_client"]["fd_count"] = iv();
+                else if (k == "services.openvpn.client.threads")      services["openvpn_client"]["threads"] = iv();
+                else if (k == "services.lwm2m.client.cpu.permille")   services["lwm2m_client"]["cpu_permille"] = iv();
+                else if (k == "services.lwm2m.client.mem.rss.kb")     services["lwm2m_client"]["mem_kb"] = iv();
+                else if (k == "services.lwm2m.client.fd.count")       services["lwm2m_client"]["fd_count"] = iv();
+                else if (k == "services.lwm2m.client.threads")        services["lwm2m_client"]["threads"] = iv();
+                else if (k == "services.lwm2m.server.cpu.permille")   services["lwm2m_server"]["cpu_permille"] = iv();
+                else if (k == "services.lwm2m.server.mem.rss.kb")     services["lwm2m_server"]["mem_kb"] = iv();
+                else if (k == "services.lwm2m.server.fd.count")       services["lwm2m_server"]["fd_count"] = iv();
+                else if (k == "services.lwm2m.server.threads")        services["lwm2m_server"]["threads"] = iv();
+                else if (k == "services.wifi.client.cpu.permille")    services["wifi_client"]["cpu_permille"] = iv();
+                else if (k == "services.wifi.client.mem.rss.kb")      services["wifi_client"]["mem_kb"] = iv();
+                else if (k == "services.wifi.client.fd.count")        services["wifi_client"]["fd_count"] = iv();
+                else if (k == "services.wifi.client.threads")         services["wifi_client"]["threads"] = iv();
             }
             resp["lwm2m"]    = lwm2m;
             resp["vpn"]      = vpn;

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -36,6 +36,7 @@
 #include <ace/Log_Msg.h>
 
 #include "data_store/log_buffer.hpp"
+#include "data_store/stats_publisher.hpp"
 #include <ace/Reactor.h>
 #include <ace/SOCK_Acceptor.h>
 #include <ace/Time_Value.h>
@@ -267,6 +268,20 @@ int main(int argc, char** argv) {
 
     // Push startup logs immediately so the cloud UI can tail them.
     g_log.flush(ds);
+
+    // ── Resource telemetry (L22) ──────────────────────────────────
+    // Publish this container's CPU/mem/fd/threads every 10s. iot-httpd
+    // already pumps the singleton reactor in the loop below, so the timer
+    // fires there — no extra thread (run_reactor_thread=false).
+    data_store::StatsPublisher g_stats(
+        "services.cloud.iot.httpd",
+        [&ds](const std::vector<data_store::KV>& kv) { ds.set(kv); });
+    if (g_stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC,
+                     /*run_reactor_thread=*/false) != 0) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D httpd:thread:%t %M %N:%l stats publisher "
+                            "open failed\n")));
+    }
 
     // The listening socket is polled directly via non-blocking accept() in
     // the loop below; only the per-connection sessions are registered with

--- a/modules/net/router/src/daemon.cpp
+++ b/modules/net/router/src/daemon.cpp
@@ -15,6 +15,7 @@
 #include "shell.hpp"
 
 #include "data_store/service_gate.hpp"
+#include "data_store/stats_publisher.hpp"
 
 #include <atomic>
 #include <chrono>
@@ -184,6 +185,16 @@ Status run_daemon(const std::string& socketPath,
         svc = std::make_unique<data_store::ServiceGate>(*cli, "net.router");
         svc->publish_state("running");
     }
+
+    // L22 — resource telemetry. This daemon runs a blocking poll loop (no
+    // ACE reactor), so StatsPublisher spawns its own ACE_Task thread to run
+    // the singleton reactor timer (run_reactor_thread=true, the default).
+    data_store::StatsPublisher stats(
+        "services.net.router",
+        [&ds](const std::vector<data_store::KV>& kv) {
+            if (auto* c = ds.client()) c->set(kv);
+        });
+    if (ds.client()) stats.open();
 
     const auto names = ordered_iface_names(ds);
     ACE_DEBUG((LM_INFO,

--- a/modules/openvpn/client/src/main_impl.cpp
+++ b/modules/openvpn/client/src/main_impl.cpp
@@ -3,6 +3,9 @@
 #include "ds_bridge.hpp"
 #include "supervisor.hpp"
 
+#include "data_store/client.hpp"
+#include "data_store/stats_publisher.hpp"
+
 #include <cstdint>
 #include <optional>
 #include <sstream>
@@ -80,6 +83,17 @@ Status run_daemon(const std::string& socketPath,
         Status s; s.ok = false; s.code = 2;
         s.err = "missing required vpn.* keys"; return s;
     }
+
+    // L22 — resource telemetry. Blocking supervisor loop (no ACE reactor),
+    // so StatsPublisher spawns its own ACE_Task thread for the singleton
+    // reactor timer (run_reactor_thread=true, the default). openvpn(8) runs
+    // in this container, so its usage is folded into these cgroup totals.
+    data_store::StatsPublisher stats(
+        "services.openvpn.client",
+        [&ds](const std::vector<data_store::KV>& kv) {
+            if (auto* c = ds.client()) c->set(kv);
+        });
+    if (ds.client()) stats.open();
 
     Supervisor::Options opt;
     opt.openvpn_path = openvpn_path;

--- a/modules/wan/wifi/client/src/main_impl.cpp
+++ b/modules/wan/wifi/client/src/main_impl.cpp
@@ -20,6 +20,9 @@
 #include "ds_bridge.hpp"
 #include "supervisor.hpp"
 
+#include "data_store/client.hpp"
+#include "data_store/stats_publisher.hpp"
+
 namespace wifi_client {
 
 namespace {
@@ -142,6 +145,17 @@ Status run_daemon(const std::string& socketPath,
                ACE_TEXT("%D [wifi:%t] %M %N:%l starting on iface=%C "
                         "wpa=%C ctrl_dir=%C\n"),
                iface.c_str(), wpa_path.c_str(), ctrl_dir.c_str()));
+
+    // L22 — resource telemetry. Blocking supervisor loop (no ACE reactor),
+    // so StatsPublisher spawns its own ACE_Task thread for the singleton
+    // reactor timer (run_reactor_thread=true, the default). wpa_supplicant +
+    // udhcpc run in this container, folded into these cgroup totals.
+    data_store::StatsPublisher stats(
+        "services.wifi.client",
+        [&ds](const std::vector<data_store::KV>& kv) {
+            if (auto* c = ds.client()) c->set(kv);
+        });
+    if (ds.client()) stats.open();
 
     SupervisorOptions opt;
     opt.wpa_path  = wpa_path;


### PR DESCRIPTION
## Summary

Adds per-daemon resource telemetry, surfaced in the cloud-UI **Services** page (now a `clr-datagrid` reusing the Endpoints layout) with **CPU % / Memory / FDs / Threads** columns.

Each daemon self-reports its own **container** usage to the data store every 10s:
- **CPU / memory / threads** from the process's own cgroup (`/sys/fs/cgroup`, v2 with v1 fallback)
- **fd count** from `/proc/self/fd` (cgroups have no fd metric)

One daemon per container, so these are effectively per-container totals.

## What's included

- **Schema** (`services.lua`): `services.<svc>.{cpu.permille,mem.rss.kb,fd.count,threads}` (typed integers) + a single `services.stats.version` bump key for single-key long-poll (mirrors `log.version`), generated via a Lua loop.
- **Lib** `data_store::StatsPublisher` (sibling to `LogBuffer`): an **ACE active object** (`ACE_Task` + `activate`) driving a timer on the **`ACE_Reactor` singleton**. Publishes via a `StatsSink` callback — decoupling from `Client` lets ds-server publish through its in-process `DataStore` and lets tests capture without a server. `open(interval, run_reactor_thread)`: daemons that already pump the reactor (httpd/lwm2m/ds-server) pass `false`; blocking-loop daemons (cloudd/net-router/openvpn-client/wifi-client) spawn the reactor thread.
- **Wiring:** ds-server, iot-cloudd, iot-httpd, lwm2m (bs/dm/client/server by role), net-router, openvpn-client, wifi-client.
- **Cloud UI:** Services page converted from card grid → `clr-datagrid` with the four metric columns, long-polling `services.stats.version`.
- **Docs:** `log/L22/{design,tdd}.md`.

`openvpn-server` runs inside cloudd's container, so its usage is folded into cloudd's cgroup totals (no separate publisher; its keys stay 0).

## Testing

- **20 `Stats*` gtests** pass (cgroup v2/v1 parsers, CPU math, fd count, `sample()` baseline, sink publish, ACE timer lifecycle).
- All wired daemons compile and link cleanly (ds-server, iot-httpd, iot-cloudd, lwm2m, net-router, openvpn-client, wifi-client), built via the podman toolchain image.
- Cloud UI builds clean (`ng build --configuration production`).
- Pre-existing `DEP_*` / `LogBufferTest` failures in the podman env are unrelated (confirmed against a clean `git stash`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)