### PR TITLE
fix(ci): point cloud-image workflow at apps/cloud/Dockerfile

### DIFF
--- a/.github/workflows/cloud-image.yml
+++ b/.github/workflows/cloud-image.yml
@@ -42,7 +42,7 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           context: .
-          file: apps/cloud/Containerfile
+          file: apps/cloud/Dockerfile
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
The `Build & Push Cloud Image` workflow referenced `apps/cloud/Containerfile`, which doesn't exist (the file is `apps/cloud/Dockerfile`). Every push to `main` failed at the **Build and push** step:

```
ERROR: failed to read dockerfile: open Containerfile: no such file or directory
```

so the image was never published to Docker Hub. This one-line fix points the build at the real Dockerfile, matching the documented build in `apps/cloud/CLAUDE.md` (`podman build -f apps/cloud/Dockerfile .`). Docker Hub login already succeeds (secrets are configured), so this should unblock the push to `naushada/iot-cloud`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)