### PR TITLE
fix(ci): build vendored tinydtls in cloud image before lwm2m

### DIFF
--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -6,7 +6,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 
 RUN apt-get -o Acquire::Check-Date=false update && \
     apt-get install -y --no-install-recommends \
-    build-essential cmake ninja-build pkg-config \
+    build-essential cmake ninja-build pkg-config autoconf \
     libssl-dev zlib1g-dev libreadline-dev \
     liblua5.3-dev lua5.3 wget ca-certificates \
     && rm -rf /var/lib/apt/lists/*
@@ -71,6 +71,18 @@ RUN mkdir -p /tmp/bcloud && cd /tmp/bcloud && \
     -DACE_ROOT=/usr/local/ACE_TAO-7.0.0 \
     -DDATASTORE_LIB=/tmp/bds/libdatastore_client.a \
     && make -j2
+
+# Build vendored tinydtls — produces libtinydtls.a, which the lwm2m
+# target links. autoconf → autoheader → configure → make libtinydtls.a.
+# The repo .gitignore excludes apps/3rdparty/tinydtls/doc/, so its
+# autoconf inputs (doc/Makefile.in, doc/Doxyfile.in) aren't in the build
+# context; stub them so configure completes (we don't build the docs).
+RUN cd /src/apps/3rdparty/tinydtls && \
+    mkdir -p doc && \
+    [ -f doc/Makefile.in ] || : > doc/Makefile.in && \
+    [ -f doc/Doxyfile.in ] || : > doc/Doxyfile.in && \
+    autoconf && autoheader && ./configure && \
+    make libtinydtls.a -j$(nproc)
 
 # Build LwM2M binary (reused in server role for BS + DM).
 # IOT_ENABLE_MONGO=OFF is now cleanly supported by apps/CMakeLists.txt


### PR DESCRIPTION
Follow-up to #86. With the Dockerfile path corrected, the cloud image build advanced to the `lwm2m` step and failed:

```
ninja: error: '/src/apps/3rdparty/tinydtls/libtinydtls.a', needed by 'lwm2m', missing and no known rule to make it
```

The Dockerfile copies the vendored tinydtls source but never builds the static lib the `lwm2m` target links (the device `docker/Dockerfile` does: autoconf → autoheader → configure → make).

## Fix
- **apps/cloud/Dockerfile**: add `autoconf`, and build `libtinydtls.a` before the lwm2m cmake/ninja step. The repo `.gitignore` excludes `apps/3rdparty/tinydtls/doc/`, so its autoconf inputs (`doc/Makefile.in`, `doc/Doxyfile.in`) aren't in the build context — stub them (guarded, so real files aren't clobbered) so `configure` completes; the docs aren't built.

## Verification
- Built `libtinydtls.a` (667 KB) from the **committed** source (`git archive`) in a clean `ubuntu:22.04` + `autoconf` container: `configure rc=0`, `make rc=0`.
- tinydtls is vendored (105 committed files), not a submodule, so no checkout change is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)