### PR TITLE
fix(ui+ci): center-align telemetry columns; run.sh prefers docker + auto-resets config volume

### DIFF
--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
-# run.sh — Run the IoT Cloud Server (multi-service via docker-compose).
+# run.sh — Run the IoT Cloud Server (multi-service via docker compose).
 #
 # Spawns ds-server, iot-cloudd, and iot-httpd as separate containers
-# communicating through a shared Unix socket volume. Uses podman or docker.
+# communicating through a shared Unix socket volume. Prefers docker
+# (falls back to podman only if docker is absent).
+#
+# On start it refreshes the iot-etc config volume from the image so
+# schema/config changes always take effect (RESET_CONFIG=0 to keep it).
 #
 # Usage:
 #   ./run.sh                    # start all services on http://localhost:8080
@@ -32,15 +36,21 @@ VPN_SUBNET="${VPN_SUBNET:-10.9.0.0/24}"
 PROXY_START="${PROXY_START:-5001}"
 PROXY_END="${PROXY_END:-6000}"
 HTTP_WORKERS="${HTTP_WORKERS:-4}"
+# Reset the iot-etc config volume on start so the latest schema/config
+# from the image is always loaded (set to 0 to preserve manual edits).
+RESET_CONFIG="${RESET_CONFIG:-1}"
+# Compose project name → deterministic volume names (cloud_iot-etc, …).
+PROJECT="${COMPOSE_PROJECT_NAME:-cloud}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 log_section() { echo -e "\n${GREEN}=== $1 ===${NC}"; }
 log_info()    { echo -e "${YELLOW} → $1${NC}"; }
 
 detect_runtime() {
-    if command -v podman &>/dev/null; then echo "podman"
-    elif command -v docker &>/dev/null; then echo "docker"
-    else echo "ERROR: podman or docker required" >&2; exit 1; fi
+    # Prefer docker; fall back to podman only if docker is unavailable.
+    if command -v docker &>/dev/null; then echo "docker"
+    elif command -v podman &>/dev/null; then echo "podman"
+    else echo "ERROR: docker required (podman also accepted)" >&2; exit 1; fi
 }
 
 CR=$(detect_runtime)
@@ -51,6 +61,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 export CLOUD_IMAGE="$IMAGE"
 export HTTP_PORT HTTP_WORKERS
 export VPN_SUBNET PROXY_START PROXY_END
+export COMPOSE_PROJECT_NAME="$PROJECT"
 
 case "${1:-start}" in
     build)
@@ -65,8 +76,8 @@ case "${1:-start}" in
         ;;
 
     start|up)
-        # Pull if not present
-        if ! $CR image exists "$IMAGE" 2>/dev/null; then
+        # Pull if not present (image inspect works on both docker + podman)
+        if ! $CR image inspect "$IMAGE" >/dev/null 2>&1; then
             log_info "Pulling $IMAGE..."
             $CR pull "$IMAGE"
         fi
@@ -74,6 +85,21 @@ case "${1:-start}" in
         # Stop old single-container if running (migration from v1)
         $CR stop iot-cloud 2>/dev/null && log_info "Stopped legacy iot-cloud container" || true
         $CR rm iot-cloud 2>/dev/null || true
+
+        # Always reload schemas/config from the image. The iot-etc volume
+        # (/etc/iot) holds image-provided static config — Lua schemas +
+        # apps/config. Persisting it across image rebuilds causes stale
+        # schemas: new data-store keys get rejected and silently read null
+        # (e.g. the L22 services.*.cpu.permille telemetry, where only
+        # ds-server — which writes in-process, bypassing schema — showed
+        # data). Dropping it forces a repopulate from the current image.
+        # Persisted data (/var/lib/iot) and VPN PKI (/etc/iot/vpn,
+        # /run/secrets) live in separate volumes and are untouched.
+        if [ "$RESET_CONFIG" = "1" ]; then
+            log_info "Refreshing config volume ${PROJECT}_iot-etc (set RESET_CONFIG=0 to keep)"
+            $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" down --remove-orphans 2>/dev/null || true
+            $CR volume rm "${PROJECT}_iot-etc" 2>/dev/null || true
+        fi
 
         log_section "Starting IoT Cloud"
         $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" up -d

--- a/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
+++ b/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
@@ -26,11 +26,11 @@ interface SvcRow {
       <clr-datagrid style="margin-top:16px;">
         <clr-dg-column>Service</clr-dg-column>
         <clr-dg-column>State</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'"
+        <clr-dg-column [style.text-align]="'center'"
           title="Percent of one host CPU core (per container)">CPU %</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'">Memory</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'">FDs</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'">Threads</clr-dg-column>
+        <clr-dg-column [style.text-align]="'center'">Memory</clr-dg-column>
+        <clr-dg-column [style.text-align]="'center'">FDs</clr-dg-column>
+        <clr-dg-column [style.text-align]="'center'">Threads</clr-dg-column>
         <clr-dg-column>Enabled</clr-dg-column>
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
 
@@ -72,7 +72,7 @@ interface SvcRow {
     .page { padding: 24px; }
     h3 { color: #333; margin: 0 0 16px 0; font-size: 16px; font-weight: 600; }
     .hint { color: #888; font-weight: normal; font-size: 11px; }
-    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    .num { text-align: center; font-variant-numeric: tabular-nums; }
     code { background: none; }
     .info-card {
       background: #f0f5ff; border: 1px solid #b3d4ff; border-radius: 4px;

--- a/iot-ui/src/app/services/services-list/services-list.component.ts
+++ b/iot-ui/src/app/services/services-list/services-list.component.ts
@@ -14,11 +14,11 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
       <clr-datagrid>
         <clr-dg-column>Service</clr-dg-column>
         <clr-dg-column>State</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'"
+        <clr-dg-column [style.text-align]="'center'"
           title="Percent of one host CPU core (per container)">CPU %</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'">Memory</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'">FDs</clr-dg-column>
-        <clr-dg-column [style.text-align]="'right'">Threads</clr-dg-column>
+        <clr-dg-column [style.text-align]="'center'">Memory</clr-dg-column>
+        <clr-dg-column [style.text-align]="'center'">FDs</clr-dg-column>
+        <clr-dg-column [style.text-align]="'center'">Threads</clr-dg-column>
         <clr-dg-column>Enabled</clr-dg-column>
         <clr-dg-column>Uptime</clr-dg-column>
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
@@ -50,7 +50,7 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
   `,
   styles: [`
     .page { padding: 24px; } h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 20px 0; }
-    .num { text-align: right; font-variant-numeric: tabular-nums; }
+    .num { text-align: center; font-variant-numeric: tabular-nums; }
     .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
     .hint { font-size: 12px; color: #757575; margin-top: 16px; }
   `]


### PR DESCRIPTION
## UI
Center-align the **CPU % / Memory / FDs / Threads** columns (headers + cells) on both the cloud and device Services pages.

## run.sh
- **Prefer docker** over podman (falls back to podman only if docker is absent); use `image inspect` instead of the podman-only `image exists`.
- **Auto-refresh the `iot-etc` config volume on start** so schema/config changes from a new image always take effect.

### Why the config-volume reset
The `iot-etc` volume (`/etc/iot`) holds image-provided static config (Lua schemas + `apps/config`). Persisting it across image rebuilds caused stale schemas: new data-store keys were rejected and silently read `null`. This is exactly why the L22 telemetry showed values only for **ds-server** (which writes in-process, bypassing schema validation) while iot-cloudd/httpd/lwm2m showed `—` (they write via the schema-validated `Client`). Dropping the volume forces a repopulate from the current image.

Persisted data (`/var/lib/iot`) and the VPN PKI (`/etc/iot/vpn`, `/run/secrets`) live in **separate** volumes and are untouched. `RESET_CONFIG=0` preserves manual `/etc/iot` edits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)