### PR TITLE
feat(L22): add #CPU (core count) column; left-align metric columns

### DIFF
--- a/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
+++ b/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
@@ -8,7 +8,7 @@ interface SvcRow {
   state: string; enabled: boolean; restarting: boolean;
   state_key?: string;   // explicit state key for services without .enable counterpart
   // L22 — resource telemetry (per-container cgroup + /proc/self/fd).
-  cpu_permille?: number; mem_kb?: number; fd_count?: number; threads?: number;
+  cpu_permille?: number; cpu_count?: number; mem_kb?: number; fd_count?: number; threads?: number;
 }
 
 @Component({
@@ -26,11 +26,13 @@ interface SvcRow {
       <clr-datagrid style="margin-top:16px;">
         <clr-dg-column>Service</clr-dg-column>
         <clr-dg-column>State</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'"
-          title="Percent of one host CPU core (per container)">CPU %</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'">Memory</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'">FDs</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'">Threads</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'"
+          title="Percent of one CPU core; can exceed 100% across multiple cores">CPU %</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'"
+          title="Cores available to the container">#CPU</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'">Memory</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'">FDs</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'">Threads</clr-dg-column>
         <clr-dg-column>Enabled</clr-dg-column>
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
 
@@ -41,6 +43,7 @@ interface SvcRow {
               [state]="s.state||''"></app-status-badge>
           </clr-dg-cell>
           <clr-dg-cell class="num">{{ fmtCpu(s.cpu_permille) }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ s.cpu_count ?? '—' }}</clr-dg-cell>
           <clr-dg-cell class="num">{{ fmtKb(s.mem_kb) }}</clr-dg-cell>
           <clr-dg-cell class="num">{{ s.fd_count ?? '—' }}</clr-dg-cell>
           <clr-dg-cell class="num">{{ s.threads ?? '—' }}</clr-dg-cell>
@@ -72,7 +75,7 @@ interface SvcRow {
     .page { padding: 24px; }
     h3 { color: #333; margin: 0 0 16px 0; font-size: 16px; font-weight: 600; }
     .hint { color: #888; font-weight: normal; font-size: 11px; }
-    .num { text-align: center; font-variant-numeric: tabular-nums; }
+    .num { text-align: left; font-variant-numeric: tabular-nums; }
     code { background: none; }
     .info-card {
       background: #f0f5ff; border: 1px solid #b3d4ff; border-radius: 4px;
@@ -139,7 +142,7 @@ export class ServicesListComponent implements OnInit, OnDestroy {
         if (s.enable_key) keys.push(s.enable_key);
       }
       const p = this.statsPrefix(s);
-      keys.push(p + '.cpu.permille', p + '.mem.rss.kb', p + '.fd.count', p + '.threads');
+      keys.push(p + '.cpu.permille', p + '.cpu.count', p + '.mem.rss.kb', p + '.fd.count', p + '.threads');
     }
     this.http.dbGet(keys).subscribe({
       next: (r) => this.applyState(r),
@@ -168,6 +171,7 @@ export class ServicesListComponent implements OnInit, OnDestroy {
         }
         const p = this.statsPrefix(s);
         s.cpu_permille = num(p + '.cpu.permille');
+        s.cpu_count    = num(p + '.cpu.count');
         s.mem_kb       = num(p + '.mem.rss.kb');
         s.fd_count     = num(p + '.fd.count');
         s.threads      = num(p + '.threads');

--- a/iot-ui/src/app/services/services-list/services-list.component.ts
+++ b/iot-ui/src/app/services/services-list/services-list.component.ts
@@ -14,11 +14,13 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
       <clr-datagrid>
         <clr-dg-column>Service</clr-dg-column>
         <clr-dg-column>State</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'"
-          title="Percent of one host CPU core (per container)">CPU %</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'">Memory</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'">FDs</clr-dg-column>
-        <clr-dg-column [style.text-align]="'center'">Threads</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'"
+          title="Percent of one CPU core; can exceed 100% across multiple cores">CPU %</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'"
+          title="Cores available to the container">#CPU</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'">Memory</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'">FDs</clr-dg-column>
+        <clr-dg-column [style.text-align]="'left'">Threads</clr-dg-column>
         <clr-dg-column>Enabled</clr-dg-column>
         <clr-dg-column>Uptime</clr-dg-column>
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
@@ -27,6 +29,7 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
           <clr-dg-cell><code>{{ s.label }}</code></clr-dg-cell>
           <clr-dg-cell><app-status-badge [label]="s.info.state||'unknown'" [state]="s.info.state||''"></app-status-badge></clr-dg-cell>
           <clr-dg-cell class="num">{{ fmtCpu(s.info.cpu_permille) }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ s.info.cpu_count ?? '—' }}</clr-dg-cell>
           <clr-dg-cell class="num">{{ fmtKb(s.info.mem_kb) }}</clr-dg-cell>
           <clr-dg-cell class="num">{{ s.info.fd_count ?? '—' }}</clr-dg-cell>
           <clr-dg-cell class="num">{{ s.info.threads ?? '—' }}</clr-dg-cell>
@@ -50,7 +53,7 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
   `,
   styles: [`
     .page { padding: 24px; } h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 20px 0; }
-    .num { text-align: center; font-variant-numeric: tabular-nums; }
+    .num { text-align: left; font-variant-numeric: tabular-nums; }
     .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
     .hint { font-size: 12px; color: #757575; margin-top: 16px; }
   `]

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -53,6 +53,7 @@ export interface ServiceInfo {
   uptime_sec?: number;
   // L22 — per-container resource telemetry (cgroup + /proc/self/fd).
   cpu_permille?: number;
+  cpu_count?: number;
   mem_kb?: number;
   fd_count?: number;
   threads?: number;

--- a/log/L22/design.md
+++ b/log/L22/design.md
@@ -53,10 +53,17 @@ precedent (typed `integer`, `min = 0`, `access = "Viewer"`).
 ```
 services.<name>.cpu.permille   integer  default 0  min 0   -- parts-per-1000
                                                             --   123 = 12.3 %
+services.<name>.cpu.count      integer  default 0  min 0   -- cores the % is
+                                                            --   normalised against
 services.<name>.mem.rss.kb     integer  default 0  min 0   -- resident set, KB
 services.<name>.fd.count       integer  default 0  min 0   -- open file descriptors
 services.<name>.threads        integer  default 0  min 0   -- live threads
 ```
+
+`cpu.permille` is whole-host normalised (one fully-busy core = 1000 ‰ = 100 %),
+so it can exceed 100 % on multi-core hosts. `cpu.count` is the denominator —
+the cgroup v2 `cpu.max` quota when set, else online CPUs — so the UI can show
+how many cores the percentage is measured against.
 
 `cpu.permille` (not `cpu.percent`) keeps the value an **integer** while
 preserving one decimal of resolution — ds has no float type, and 12.3 % must

--- a/modules/data-store/inc/data_store/stats_publisher.hpp
+++ b/modules/data-store/inc/data_store/stats_publisher.hpp
@@ -50,6 +50,7 @@ enum class CgVersion { v2, v1, none };
 /// unreadable metrics report 0 (never negative).
 struct StatsSample {
     std::int32_t cpu_permille = 0;   // parts-per-1000 of one host-second
+    std::int32_t cpu_count    = 0;   // cores the % is normalised against
     std::int32_t mem_rss_kb   = 0;
     std::int32_t fd_count     = 0;
     std::int32_t threads      = 0;
@@ -127,6 +128,8 @@ namespace stats_detail {
     std::int32_t read_mem_kb (const StatsRoots&, CgVersion);
     std::int32_t read_pids   (const StatsRoots&, CgVersion);
     std::int32_t count_fds   (const StatsRoots&);
+    /// Cores available: cgroup v2 cpu.max quota if set, else online CPUs.
+    std::int32_t read_ncpu   (const StatsRoots&, CgVersion);
     /// permille of one host-second of CPU over [prev,now] across dt_sec.
     /// Clamps to 0 on counter reset / non-positive dt.
     std::int32_t cpu_permille(unsigned long long prev_usec,

--- a/modules/data-store/schemas/services.lua
+++ b/modules/data-store/schemas/services.lua
@@ -121,6 +121,7 @@ local stats_services = {
 }
 for _, s in ipairs(stats_services) do
   keys[s .. ".cpu.permille"] = { access = "Viewer", type = "integer", default = 0, min = 0 }
+  keys[s .. ".cpu.count"]    = { access = "Viewer", type = "integer", default = 0, min = 0 }
   keys[s .. ".mem.rss.kb"]   = { access = "Viewer", type = "integer", default = 0, min = 0 }
   keys[s .. ".fd.count"]     = { access = "Viewer", type = "integer", default = 0, min = 0 }
   keys[s .. ".threads"]      = { access = "Viewer", type = "integer", default = 0, min = 0 }

--- a/modules/data-store/src/stats_publisher.cpp
+++ b/modules/data-store/src/stats_publisher.cpp
@@ -9,11 +9,13 @@
 
 #include <dirent.h>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <atomic>
 #include <cerrno>
 #include <cmath>
 #include <cstdint>
+#include <cstdlib>
 #include <ctime>
 #include <fstream>
 #include <limits>
@@ -119,6 +121,24 @@ std::int32_t count_fds(const StatsRoots& r) {
     return n;
 }
 
+std::int32_t read_ncpu(const StatsRoots& r, CgVersion cg) {
+    // Prefer the cgroup CPU quota (effective cores the container may use).
+    if (cg == CgVersion::v2) {
+        std::ifstream ifs(r.cgroup_root + "/cpu.max");
+        std::string quota, period;
+        if ((ifs >> quota >> period) && quota != "max") {
+            char* e1 = nullptr; char* e2 = nullptr;
+            long long q = std::strtoll(quota.c_str(),  &e1, 10);
+            long long p = std::strtoll(period.c_str(), &e2, 10);
+            if (q > 0 && p > 0)
+                return clamp_i32(static_cast<unsigned long long>((q + p - 1) / p));
+        }
+    }
+    // Unlimited / v1 / none → online processors.
+    long n = ::sysconf(_SC_NPROCESSORS_ONLN);
+    return static_cast<std::int32_t>(n < 1 ? 1 : n);
+}
+
 std::int32_t cpu_permille(unsigned long long prev_usec,
                           unsigned long long now_usec, double dt_sec) {
     if (dt_sec <= 0.0 || now_usec < prev_usec) return 0;  // reset / bad dt
@@ -208,6 +228,7 @@ StatsSample StatsPublisher::sample() {
     s.mem_rss_kb = stats_detail::read_mem_kb(m_roots, m_cg);
     s.threads    = stats_detail::read_pids(m_roots, m_cg);
     s.fd_count   = stats_detail::count_fds(m_roots);
+    s.cpu_count  = stats_detail::read_ncpu(m_roots, m_cg);
 
     unsigned long long usage = 0;
     const bool have = stats_detail::read_cpu_usec(m_roots, m_cg, usage);
@@ -230,8 +251,9 @@ StatsSample StatsPublisher::sample() {
 void StatsPublisher::publish(const StatsSample& s) {
     if (!m_sink) return;
     std::vector<KV> kv;
-    kv.reserve(5);
+    kv.reserve(6);
     kv.emplace_back(m_prefix + ".cpu.permille", Value{s.cpu_permille});
+    kv.emplace_back(m_prefix + ".cpu.count",    Value{s.cpu_count});
     kv.emplace_back(m_prefix + ".mem.rss.kb",   Value{s.mem_rss_kb});
     kv.emplace_back(m_prefix + ".fd.count",     Value{s.fd_count});
     kv.emplace_back(m_prefix + ".threads",      Value{s.threads});

--- a/modules/data-store/test/stats_publisher_test.cpp
+++ b/modules/data-store/test/stats_publisher_test.cpp
@@ -44,6 +44,7 @@ ds::StatsRoots make_cgroup_v2(const std::string& root,
     write_file(root + "/cpu.stat",
                "usage_usec " + std::to_string(usage_usec) +
                "\nuser_usec 1\nsystem_usec 1\n");
+    write_file(root + "/cpu.max", "max 100000\n");   // unlimited by default
     write_file(root + "/memory.current", std::to_string(mem_bytes) + "\n");
     write_file(root + "/pids.current",   std::to_string(pids) + "\n");
     ds::StatsRoots r;
@@ -127,6 +128,20 @@ TEST(StatsParseV1, cpu_ns_to_usec) {
     EXPECT_EQ(usec, 2000000ULL);
 }
 
+// ── cpu count ───────────────────────────────────────────────────────
+TEST(StatsCpuCount, from_cgroup_v2_quota) {
+    auto dir = make_tmpdir();
+    auto r = make_cgroup_v2(dir, 0, 0, 0);
+    write_file(dir + "/cpu.max", "200000 100000\n");   // quota/period = 2
+    EXPECT_EQ(sd::read_ncpu(r, ds::CgVersion::v2), 2);
+}
+
+TEST(StatsCpuCount, unlimited_falls_back_to_online) {
+    auto dir = make_tmpdir();
+    auto r = make_cgroup_v2(dir, 0, 0, 0);            // cpu.max = "max 100000"
+    EXPECT_GE(sd::read_ncpu(r, ds::CgVersion::v2), 1);  // >= 1 online CPU
+}
+
 // ── cpu math ────────────────────────────────────────────────────────
 TEST(StatsCpu, half_core)   { EXPECT_EQ(sd::cpu_permille(1000000, 1500000, 1.0), 500); }
 TEST(StatsCpu, two_cores)   { EXPECT_EQ(sd::cpu_permille(0, 2000000, 1.0), 2000); }
@@ -193,17 +208,18 @@ TEST(StatsPublish, sink_receives_four_metrics_plus_version) {
 
     pub.handle_timeout(ACE_Time_Value::zero, nullptr);
 
-    ASSERT_EQ(got.size(), 5u);
-    bool cpu=false, mem=false, fd=false, thr=false, ver=false;
+    ASSERT_EQ(got.size(), 6u);
+    bool cpu=false, ncpu=false, mem=false, fd=false, thr=false, ver=false;
     for (auto& kv : got) {
         const std::string& k = kv.first;
         if (k == "services.test.cpu.permille") cpu = true;
+        else if (k == "services.test.cpu.count")  { ncpu = true; EXPECT_GE(ds::to_int32(kv.second).value_or(0), 1); }
         else if (k == "services.test.mem.rss.kb") { mem = true; EXPECT_EQ(ds::to_int32(kv.second).value_or(-1), 40960); }
         else if (k == "services.test.fd.count")   { fd  = true; EXPECT_EQ(ds::to_int32(kv.second).value_or(-1), 9); }
         else if (k == "services.test.threads")    { thr = true; EXPECT_EQ(ds::to_int32(kv.second).value_or(-1), 6); }
         else if (k == "services.stats.version")   { ver = true; EXPECT_GT(ds::to_int32(kv.second).value_or(0), 0); }
     }
-    EXPECT_TRUE(cpu && mem && fd && thr && ver);
+    EXPECT_TRUE(cpu && ncpu && mem && fd && thr && ver);
 }
 
 // ── timer lifecycle (ACE active object) ─────────────────────────────

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -405,17 +405,23 @@ void install_handlers(Router& router,
                 "services.lwm2m.server.state",
                 "services.wifi.client.enable", "services.wifi.client.state",
                 // L22 — per-container resource telemetry.
-                "services.ds.cpu.permille", "services.ds.mem.rss.kb",
+                "services.ds.cpu.permille", "services.ds.cpu.count",
+                "services.ds.mem.rss.kb",
                 "services.ds.fd.count", "services.ds.threads",
-                "services.net.router.cpu.permille", "services.net.router.mem.rss.kb",
+                "services.net.router.cpu.permille", "services.net.router.cpu.count",
+                "services.net.router.mem.rss.kb",
                 "services.net.router.fd.count", "services.net.router.threads",
-                "services.openvpn.client.cpu.permille", "services.openvpn.client.mem.rss.kb",
+                "services.openvpn.client.cpu.permille", "services.openvpn.client.cpu.count",
+                "services.openvpn.client.mem.rss.kb",
                 "services.openvpn.client.fd.count", "services.openvpn.client.threads",
-                "services.lwm2m.client.cpu.permille", "services.lwm2m.client.mem.rss.kb",
+                "services.lwm2m.client.cpu.permille", "services.lwm2m.client.cpu.count",
+                "services.lwm2m.client.mem.rss.kb",
                 "services.lwm2m.client.fd.count", "services.lwm2m.client.threads",
-                "services.lwm2m.server.cpu.permille", "services.lwm2m.server.mem.rss.kb",
+                "services.lwm2m.server.cpu.permille", "services.lwm2m.server.cpu.count",
+                "services.lwm2m.server.mem.rss.kb",
                 "services.lwm2m.server.fd.count", "services.lwm2m.server.threads",
-                "services.wifi.client.cpu.permille", "services.wifi.client.mem.rss.kb",
+                "services.wifi.client.cpu.permille", "services.wifi.client.cpu.count",
+                "services.wifi.client.mem.rss.kb",
                 "services.wifi.client.fd.count", "services.wifi.client.threads",
             }, got);
             json resp;
@@ -493,26 +499,32 @@ void install_handlers(Router& router,
 
                 // L22 — resource telemetry per service.
                 else if (k == "services.ds.cpu.permille")             services["ds"]["cpu_permille"] = iv();
+                else if (k == "services.ds.cpu.count")                services["ds"]["cpu_count"] = iv();
                 else if (k == "services.ds.mem.rss.kb")               services["ds"]["mem_kb"] = iv();
                 else if (k == "services.ds.fd.count")                 services["ds"]["fd_count"] = iv();
                 else if (k == "services.ds.threads")                  services["ds"]["threads"] = iv();
                 else if (k == "services.net.router.cpu.permille")     services["net_router"]["cpu_permille"] = iv();
+                else if (k == "services.net.router.cpu.count")        services["net_router"]["cpu_count"] = iv();
                 else if (k == "services.net.router.mem.rss.kb")       services["net_router"]["mem_kb"] = iv();
                 else if (k == "services.net.router.fd.count")         services["net_router"]["fd_count"] = iv();
                 else if (k == "services.net.router.threads")          services["net_router"]["threads"] = iv();
                 else if (k == "services.openvpn.client.cpu.permille") services["openvpn_client"]["cpu_permille"] = iv();
+                else if (k == "services.openvpn.client.cpu.count")    services["openvpn_client"]["cpu_count"] = iv();
                 else if (k == "services.openvpn.client.mem.rss.kb")   services["openvpn_client"]["mem_kb"] = iv();
                 else if (k == "services.openvpn.client.fd.count")     services["openvpn_client"]["fd_count"] = iv();
                 else if (k == "services.openvpn.client.threads")      services["openvpn_client"]["threads"] = iv();
                 else if (k == "services.lwm2m.client.cpu.permille")   services["lwm2m_client"]["cpu_permille"] = iv();
+                else if (k == "services.lwm2m.client.cpu.count")      services["lwm2m_client"]["cpu_count"] = iv();
                 else if (k == "services.lwm2m.client.mem.rss.kb")     services["lwm2m_client"]["mem_kb"] = iv();
                 else if (k == "services.lwm2m.client.fd.count")       services["lwm2m_client"]["fd_count"] = iv();
                 else if (k == "services.lwm2m.client.threads")        services["lwm2m_client"]["threads"] = iv();
                 else if (k == "services.lwm2m.server.cpu.permille")   services["lwm2m_server"]["cpu_permille"] = iv();
+                else if (k == "services.lwm2m.server.cpu.count")      services["lwm2m_server"]["cpu_count"] = iv();
                 else if (k == "services.lwm2m.server.mem.rss.kb")     services["lwm2m_server"]["mem_kb"] = iv();
                 else if (k == "services.lwm2m.server.fd.count")       services["lwm2m_server"]["fd_count"] = iv();
                 else if (k == "services.lwm2m.server.threads")        services["lwm2m_server"]["threads"] = iv();
                 else if (k == "services.wifi.client.cpu.permille")    services["wifi_client"]["cpu_permille"] = iv();
+                else if (k == "services.wifi.client.cpu.count")       services["wifi_client"]["cpu_count"] = iv();
                 else if (k == "services.wifi.client.mem.rss.kb")      services["wifi_client"]["mem_kb"] = iv();
                 else if (k == "services.wifi.client.fd.count")        services["wifi_client"]["fd_count"] = iv();
                 else if (k == "services.wifi.client.threads")         services["wifi_client"]["threads"] = iv();


### PR DESCRIPTION
## Why
`CPU %` is whole-host normalised (one fully-busy core = 100%), so it legitimately exceeds 100% on multi-core hosts (e.g. ds-server showed **109.2%**). This adds a **#CPU** column showing the denominator — the cores the percentage is measured against — so the number reads correctly.

## Changes
- **StatsPublisher**: `StatsSample.cpu_count` + `stats_detail::read_ncpu` — cgroup v2 `cpu.max` quota when set, else `sysconf(_SC_NPROCESSORS_ONLN)`. Publishes `services.<svc>.cpu.count`.
- **schema** (`services.lua`): `services.<svc>.cpu.count` (Viewer integer, min 0).
- **`/api/v1/status`**: emit `cpu_count` per device service (the device UI is snapshot-driven).
- **cloud + device Services UIs**: add the **#CPU** column; also **left-align** the CPU%/#CPU/Memory/FDs/Threads columns (was center, per request).
- **tests**: `read_ncpu` (cgroup quota → 2; unlimited → online CPU fallback); publish batch now carries 6 keys incl. `cpu.count`.

## Verification
- **22 `Stats*` gtests pass** (was 20).
- `iot-httpd` compiles; both cloud and device UIs build green (`ng build --configuration production`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)