### PR TITLE
fix(L22): private reactor for StatsPublisher timer (fixes lwm2m zero metrics) + INSTALL guide

### DIFF
--- a/apps/cloud/INSTALL.md
+++ b/apps/cloud/INSTALL.md
@@ -1,0 +1,203 @@
+# IoT Cloud — Installation Guide
+
+How to bring up the **IoT Cloud Server** (ds-server, iot-cloudd, iot-httpd,
+lwm2m-bs, lwm2m-dm) on a fresh machine. Everything is driven by one script:
+`apps/cloud/run.sh`.
+
+There are two paths:
+
+- **A. Run the prebuilt image** from Docker Hub (`naushada/iot-cloud`) —
+  fastest, no local compile. Recommended for most installs.
+- **B. Build the image locally** from source — for development or air-gapped
+  hosts.
+
+Both start the same multi-container stack via `docker compose`.
+
+---
+
+## 1. Prerequisites
+
+- **Linux host** (x86-64 or arm64). A VM/cloud instance is fine.
+- **Docker Engine** + the **Compose plugin** (`docker compose`, v2).
+  `run.sh` prefers `docker`; it falls back to `podman` only if docker is
+  absent.
+  ```bash
+  # Ubuntu/Debian quick install:
+  curl -fsSL https://get.docker.com | sh
+  sudo usermod -aG docker "$USER"   # log out/in so docker runs without sudo
+  docker compose version            # verify the compose plugin is present
+  ```
+- **git** (to clone the repo for `run.sh` + compose file).
+- **Open ports** on the host (defaults; configurable, see §5):
+
+  | Port | Proto | Purpose |
+  |------|-------|---------|
+  | 8080 | tcp | Cloud UI + REST API |
+  | 5684 | udp | LwM2M Bootstrap (CoAPs) |
+  | 5683 | udp | LwM2M Device Management (CoAPs) |
+  | 1194 | udp | OpenVPN (device tunnels, served by iot-cloudd) |
+
+---
+
+## 2. Clone the repo
+
+```bash
+git clone https://github.com/naushada/iot.git
+cd iot/apps/cloud
+```
+
+> The vendored `tinydtls` lib is committed in-tree, so a plain clone is
+> enough — no `git submodule` step is needed.
+
+`run.sh` and `docker-compose.yml` live here in `apps/cloud/`. Run all commands
+below from this directory.
+
+---
+
+## 3A. Install — run the prebuilt image (recommended)
+
+`run.sh` pulls `docker.io/naushada/iot-cloud:latest` automatically if it isn't
+present locally:
+
+```bash
+./run.sh
+```
+
+That's it. To pull explicitly first (e.g. to refresh `:latest`):
+
+```bash
+docker pull docker.io/naushada/iot-cloud:latest
+./run.sh
+```
+
+## 3B. Install — build the image locally
+
+```bash
+./run.sh build      # builds docker.io/naushada/iot-cloud:latest from source
+./run.sh            # start the stack
+```
+
+`./run.sh nocache` forces a clean rebuild. The build compiles ACE, the C++
+daemons, tinydtls, and the Angular UI inside the image (multi-stage), so the
+first build takes several minutes.
+
+---
+
+## 4. Verify it's up
+
+```bash
+./run.sh ps         # list the 5 containers (should be Up / healthy)
+./run.sh logs       # daemon log tail + service states
+```
+
+Then open the dashboard:
+
+- **Cloud UI:** http://<host-ip>:8080
+- **Login:** `admin` / `admin`
+
+The **Services** page shows each daemon's state plus live CPU % / #CPU /
+Memory / FDs / Threads.
+
+---
+
+## 5. Configuration (env vars)
+
+Override on the command line — they pass through to `docker-compose.yml`:
+
+| Variable | Default | Meaning |
+|----------|---------|---------|
+| `HTTP_PORT` | `8080` | Cloud UI / REST port |
+| `VPN_SUBNET` | `10.9.0.0/24` | OpenVPN tunnel subnet |
+| `PROXY_START` / `PROXY_END` | `5001` / `6000` | Device-UI reverse-proxy port pool |
+| `HTTP_WORKERS` | `4` | iot-httpd handler threads |
+| `CLOUD_IMAGE` | `docker.io/naushada/iot-cloud:latest` | Image to run |
+| `RESET_CONFIG` | `1` | Reload schema/config from the image on each start (see §7). `0` keeps manual `/etc/iot` edits |
+
+Example:
+
+```bash
+HTTP_PORT=8443 VPN_SUBNET=10.8.0.0/24 ./run.sh
+```
+
+---
+
+## 6. Day-to-day commands
+
+```bash
+./run.sh            # start (pulls image if missing)
+./run.sh stop       # stop + remove containers (volumes kept)
+./run.sh ps         # status
+./run.sh logs       # logs + service states
+./run.sh restart    # restart services
+./run.sh build      # rebuild image from source
+```
+
+---
+
+## 7. Updating to a new version
+
+```bash
+git pull                                   # latest run.sh / compose / schemas
+docker pull docker.io/naushada/iot-cloud:latest   # or: ./run.sh build
+./run.sh
+```
+
+On start, `run.sh` **refreshes the `iot-etc` config volume** from the image so
+new data-store schemas always take effect. Without this, a named volume from a
+prior run keeps the old schema and newly added keys are silently rejected
+(e.g. the per-service CPU/memory telemetry would read blank). Persisted data
+(`/var/lib/iot`) and the VPN PKI (`/etc/iot/vpn`, CA key) live in **separate**
+volumes and are preserved across updates. Set `RESET_CONFIG=0` to opt out.
+
+---
+
+## 8. Persistence & volumes
+
+| Volume | Mount | Content | Reset on start? |
+|--------|-------|---------|-----------------|
+| `cloud_iot-etc` | `/etc/iot` | Lua schemas + config (from image) | **Yes** (RESET_CONFIG=1) |
+| `cloud_iot-lib` | `/var/lib/iot` | Persisted data store | No |
+| `cloud_iot-run` | `/var/run/iot` | ds-server Unix socket | No |
+| `cloud_iot-vpn` | `/etc/iot/vpn` | OpenVPN server certs / PKI | No |
+| `cloud_iot-ca-key` | `/run/secrets/iot-ca-key` | CA private key (auto-generated first run) | No |
+
+To wipe **everything** and start fresh (also drops persisted data + PKI):
+
+```bash
+./run.sh stop
+docker volume rm cloud_iot-etc cloud_iot-lib cloud_iot-run cloud_iot-vpn cloud_iot-ca-key
+./run.sh
+```
+
+---
+
+## 9. Uninstall
+
+```bash
+./run.sh stop
+docker volume rm cloud_iot-etc cloud_iot-lib cloud_iot-run cloud_iot-vpn cloud_iot-ca-key 2>/dev/null
+docker rmi docker.io/naushada/iot-cloud:latest
+```
+
+---
+
+## 10. Troubleshooting
+
+- **Metrics blank for some services** — stale config volume with an old
+  schema. The default `RESET_CONFIG=1` fixes this on the next `./run.sh`; or
+  manually: `./run.sh stop && docker volume rm cloud_iot-etc && ./run.sh`.
+  (`openvpn-server` shows blank by design — it runs inside iot-cloudd's
+  container, so its usage is folded into cloudd's totals.)
+- **UI not reachable** — check `./run.sh ps`, confirm port 8080 is open in any
+  host firewall / cloud security group, and that `HTTP_PORT` matches.
+- **`docker compose` not found** — install the Compose v2 plugin (it ships
+  with Docker Desktop; on servers `apt-get install docker-compose-plugin`).
+- **Permission denied talking to docker** — add your user to the `docker`
+  group (`sudo usermod -aG docker $USER`) and re-login.
+- **Inspect the data store directly:**
+  ```bash
+  docker exec iot-ds-server ds-cli --socket=/var/run/iot/data_store.sock \
+    get services.cloud.iot.cloudd.state
+  ```
+
+See `apps/cloud/CLAUDE.md` for architecture and data-store key reference.

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -668,8 +668,9 @@ int main(std::int32_t argc, char *argv[]) {
 
     // ── Resource telemetry (L22) ──────────────────────────────────
     // Publish this container's CPU/mem/fd/threads every 10s. The lwm2m
-    // binary runs the singleton reactor on the udpAdapter ACE_Task thread,
-    // so the timer fires there — no extra thread (run_reactor_thread=false).
+    // binary's udpAdapter owns the singleton reactor on its OWN thread, so a
+    // timer scheduled here wouldn't dispatch — StatsPublisher uses its own
+    // private reactor + thread (run_reactor_thread=true, the default).
     // Prefix tracks role: cloud bs/dm instance, else device client/server.
     const std::string stats_prefix =
         !lwm2m_instance.empty()
@@ -682,14 +683,14 @@ int main(std::int32_t argc, char *argv[]) {
             if (auto* c = ds.client()) c->set(kv);
         });
     if (auto* cli = ds.client()) {
-        if (g_stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC,
-                         /*run_reactor_thread=*/false) != 0) {
+        if (g_stats.open() != 0) {   // run_reactor_thread=true (own reactor)
             ACE_ERROR((LM_ERROR,
                        ACE_TEXT("%D lwm2m:thread:%t %M %N:%l stats publisher "
                                 "open failed\n")));
         }
         (void)cli;
     }
+
 
     // Background thread that flushes the log ring-buffer every 10 s.
     // The lwm2m binary blocks on ACE_Reactor::run_reactor_event_loop()

--- a/modules/data-store/inc/data_store/stats_publisher.hpp
+++ b/modules/data-store/inc/data_store/stats_publisher.hpp
@@ -41,6 +41,8 @@
 
 #include "data_store/client.hpp"   // KV, Value
 
+class ACE_Reactor;   // global ACE type — forward decl keeps header ACE-light
+
 namespace data_store {
 
 /// Detected cgroup hierarchy. Probed once at construction.
@@ -80,14 +82,16 @@ public:
     StatsPublisher& operator=(const StatsPublisher&) = delete;
 
     /// Schedule the recurring timer on ACE_Reactor::instance() and spawn
-    /// one ACE_Task thread to run that singleton reactor's event loop.
+    /// the timer on a reactor and (optionally) runs it on a dedicated thread.
     /// @param interval_sec        flush cadence (default STATS_FLUSH_SEC).
-    /// @param run_reactor_thread  true (default) spawns one ACE_Task thread
-    ///        to run the singleton reactor — for daemons that block elsewhere
-    ///        (e.g. Client::recv_event) and never pump the reactor. Pass
-    ///        false for daemons that already run the singleton reactor in
-    ///        their main loop (iot-httpd, ds-server); the timer then fires on
-    ///        their existing reactor thread.
+    /// @param run_reactor_thread  true (default) → use a PRIVATE ACE_Reactor
+    ///        and run it on one dedicated ACE_Task thread. Self-contained: no
+    ///        dependency on (or contention with) the daemon's own reactor —
+    ///        right for daemons that block elsewhere (iot-cloudd on
+    ///        Client::recv_event) or run the singleton reactor on a *different*
+    ///        thread (lwm2m's udpAdapter). false → schedule on
+    ///        ACE_Reactor::instance() and rely on the caller's own loop to
+    ///        dispatch it (iot-httpd, ds-server pump the singleton in-thread).
     int  open(int interval_sec = STATS_FLUSH_SEC,
               bool run_reactor_thread = true);
 
@@ -114,6 +118,8 @@ private:
     CgVersion             m_cg = CgVersion::none;   // probed once in ctor
     long                  m_timer_id = -1;
     bool                  m_own_thread = false;     // we run the reactor loop
+    ACE_Reactor*          m_reactor = nullptr;      // reactor the timer is on
+    ACE_Reactor*          m_priv_reactor = nullptr; // owned iff run_reactor_thread
     unsigned long long    m_last_usage_usec = 0;
     std::chrono::steady_clock::time_point m_last_t{};
     bool                  m_have_baseline = false;

--- a/modules/data-store/src/stats_publisher.cpp
+++ b/modules/data-store/src/stats_publisher.cpp
@@ -151,14 +151,15 @@ std::int32_t cpu_permille(unsigned long long prev_usec,
 
 }  // namespace stats_detail
 
-// ── ACE active object: runs the singleton reactor loop ──────────────
+// ── ACE active object: runs a reactor's event loop on its own thread ─
 struct StatsPublisher::Impl : public ACE_Task<ACE_MT_SYNCH> {
     std::atomic<bool> running{false};
+    ACE_Reactor*      reactor = nullptr;   // the reactor this thread drives
 
     int svc() override {
-        // Own the reactor on this thread, then pump until end_reactor_event_loop.
-        ACE_Reactor::instance()->owner(ACE_OS::thr_self());
-        ACE_Reactor::instance()->run_reactor_event_loop();
+        // Take ownership on this thread, then pump until end_reactor_event_loop.
+        reactor->owner(ACE_OS::thr_self());
+        reactor->run_reactor_event_loop();
         return 0;
     }
 };
@@ -179,9 +180,20 @@ int StatsPublisher::open(int interval_sec, bool run_reactor_thread) {
     if (!m_impl || m_timer_id != -1) return 0;     // already scheduled
     if (interval_sec < 1) interval_sec = 1;
 
+    // run_reactor_thread → a PRIVATE reactor we drive on our own thread, so
+    // the timer never depends on which thread owns the singleton. Otherwise
+    // schedule on the singleton and let the caller's loop dispatch it.
+    if (run_reactor_thread) {
+        m_priv_reactor = new ACE_Reactor();
+        m_reactor = m_priv_reactor;
+    } else {
+        m_reactor = ACE_Reactor::instance();
+    }
+
     ACE_Time_Value iv(interval_sec);
-    long id = ACE_Reactor::instance()->schedule_timer(this, nullptr, iv, iv);
+    long id = m_reactor->schedule_timer(this, nullptr, iv, iv);
     if (id == -1) {
+        delete m_priv_reactor; m_priv_reactor = nullptr; m_reactor = nullptr;
         ACE_ERROR_RETURN((LM_ERROR,
                           ACE_TEXT("%D stats:thread:%t %M %N:%l schedule_timer "
                                    "failed for %C\n"),
@@ -191,11 +203,13 @@ int StatsPublisher::open(int interval_sec, bool run_reactor_thread) {
     m_timer_id = id;
 
     if (run_reactor_thread) {
+        m_impl->reactor = m_reactor;
         m_impl->running.store(true);
         if (m_impl->activate(THR_NEW_LWP | THR_JOINABLE, 1) == -1) {
-            ACE_Reactor::instance()->cancel_timer(this);
+            m_reactor->cancel_timer(this);
             m_timer_id = -1;
             m_impl->running.store(false);
+            delete m_priv_reactor; m_priv_reactor = nullptr; m_reactor = nullptr;
             ACE_ERROR_RETURN((LM_ERROR,
                               ACE_TEXT("%D stats:thread:%t %M %N:%l activate "
                                        "failed for %C errno=%d\n"),
@@ -209,18 +223,22 @@ int StatsPublisher::open(int interval_sec, bool run_reactor_thread) {
 
 void StatsPublisher::close() {
     if (!m_impl) return;
-    if (m_timer_id != -1) {
-        ACE_Reactor::instance()->cancel_timer(this);
+    if (m_timer_id != -1 && m_reactor) {
+        m_reactor->cancel_timer(this);
         m_timer_id = -1;
     }
     if (m_own_thread && m_impl->running.load()) {
-        // We own the loop — stop it and join. Daemons that pump the reactor
-        // themselves (run_reactor_thread=false) keep owning it.
-        ACE_Reactor::instance()->end_reactor_event_loop();
+        // Stop our private reactor loop and join the thread.
+        m_reactor->end_reactor_event_loop();
         m_impl->wait();              // join the active-object thread
         m_impl->running.store(false);
         m_own_thread = false;
     }
+    if (m_priv_reactor) {
+        delete m_priv_reactor;
+        m_priv_reactor = nullptr;
+    }
+    m_reactor = nullptr;
 }
 
 StatsSample StatsPublisher::sample() {


### PR DESCRIPTION
## Bug
lwm2m-bs / lwm2m-dm (and device-role lwm2m) showed **all-zero** telemetry (`#CPU = 0`, etc.) even though they self-reported `running`.

## Root cause
The lwm2m `udpAdapter` owns the **singleton `ACE_Reactor`** and runs its event loop on its **own thread** (`[UdpSvc]`). The StatsPublisher timer was scheduled from the *main* thread with `run_reactor_thread=false`, expecting the daemon to dispatch it — but a timer owned/dispatched by a different thread than the one that scheduled it never fired here. (httpd works with `false` because the same thread both schedules and pumps.)

## Fix
`StatsPublisher` now runs a **private `ACE_Reactor` on its own `ACE_Task` thread** when `run_reactor_thread=true` — fully self-contained, no dependency on or contention with the daemon's reactor. lwm2m switches to that mode. iot-httpd / ds-server keep `false` (they pump the singleton in-thread). iot-cloudd already used the owned-thread mode.

## Also
- `apps/cloud/INSTALL.md` — clone + `run.sh` install guide for a fresh host (prebuilt-image and build-from-source paths, config, update, troubleshooting).

## Verification
- 22 `Stats*` gtests pass, including the timer lifecycle now on the private reactor.
- `lwm2m`, `ds-server`, `iot-httpd`, `iot-cloudd` all compile/link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)