### PR TITLE
refactor(log): drive LogBuffer flush from its own ACE reactor timer

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -184,6 +184,10 @@ int main(int argc, char** argv) {
                             "open failed\n")));
     }
 
+    // Flush logs to ds every 10s via LogBuffer's own ACE reactor timer
+    // (same pattern as StatsPublisher) instead of from the loop below.
+    g_log.open(ds, 10, 200);
+
     // ── Main loop ─────────────────────────────────────────────────
     // Block on recv_event() up to sync_interval seconds.  A provision
     // or deprovision request from iot-httpd wakes us immediately; a
@@ -240,7 +244,6 @@ int main(int argc, char** argv) {
                 ds.set("cloud.vpn.port.next",
                        data_store::Value{static_cast<std::uint32_t>(proxy_port_start)});
                 g_log.apply_level(ds);
-                g_log.flush(ds, 200);
             }
         }
     }
@@ -265,9 +268,8 @@ int main(int argc, char** argv) {
                        rs.err.c_str()));
         }
     }
-    g_log.flush(ds);
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("%D cloudd:thread:%t %M %N:%l stopped\n")));
-    g_log.flush(ds);
+    g_log.close();   // stop flush timer + final flush (ds still alive)
     return 0;
 }

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -692,16 +692,10 @@ int main(std::int32_t argc, char *argv[]) {
     }
 
 
-    // Background thread that flushes the log ring-buffer every 10 s.
-    // The lwm2m binary blocks on ACE_Reactor::run_reactor_event_loop()
-    // and has no periodic timeout — the thread ensures logs reach ds.
-    std::atomic<bool> log_flush_stop{false};
-    std::thread log_flush_thread([&ds, &log_flush_stop]() {
-        while (!log_flush_stop.load(std::memory_order_acquire)) {
-            std::this_thread::sleep_for(std::chrono::seconds(10));
-            if (auto* cli = ds.client()) g_log.flush(*cli, 200);
-        }
-    });
+    // Flush the log ring-buffer every 10s via LogBuffer's own ACE reactor
+    // timer (private reactor on its own thread — same pattern as
+    // StatsPublisher). Replaces the old std::thread flusher.
+    if (auto* cli = ds.client()) g_log.open(*cli, 10, 200);
 
     std::unique_ptr<data_store::ServiceGate> svc_gate;
     std::unique_ptr<data_store::DepWatch>    dep_watch;
@@ -959,10 +953,8 @@ int main(std::int32_t argc, char *argv[]) {
         }
     }
 
-    // Flush remaining log lines before exit.
-    if (auto* cli = ds.client()) g_log.flush(*cli);
-    log_flush_stop.store(true, std::memory_order_release);
-    if (log_flush_thread.joinable()) log_flush_thread.join();
+    // Stop the log-flush timer + final flush (ds still alive).
+    g_log.close();
 
     // L16/D5b cleanup — wake the watcher thread + join.
     svc_stop.store(true, std::memory_order_release);

--- a/modules/data-store/inc/data_store/log_buffer.hpp
+++ b/modules/data-store/inc/data_store/log_buffer.hpp
@@ -69,6 +69,19 @@ public:
     /// Safe to call as often as you like — cheap no-op most of the time.
     void flush(Client& ds, std::size_t min_bytes = 0);
 
+    /// Drive flush() automatically on a dedicated ACE reactor timer — same
+    /// pattern as StatsPublisher (a private ACE_Reactor run on its own
+    /// ACE_Task thread). Call once, after start(), instead of flushing from
+    /// the daemon's own loop / a std::thread. `ds` must outlive close().
+    /// @param interval_sec  flush cadence (default 10s).
+    /// @param min_bytes     only write when this many new bytes accrued.
+    int  open(Client& ds, int interval_sec = 10, std::size_t min_bytes = 0);
+
+    /// Cancel the timer, do a final flush, end the loop and join the thread.
+    /// Idempotent; also called by the destructor (but call it explicitly
+    /// while `ds` is still alive — e.g. before main() returns).
+    void close();
+
     /// Change the data-store log-text key for subsequent flushes
     /// (useful when the same binary runs in different roles).
     void set_log_key(const std::string& key);

--- a/modules/data-store/src/log_buffer.cpp
+++ b/modules/data-store/src/log_buffer.cpp
@@ -2,10 +2,18 @@
 #include "data_store/client.hpp"
 #include "data_store/value.hpp"
 
+#include <ace/Event_Handler.h>
 #include <ace/Log_Msg.h>
 #include <ace/Log_Record.h>
 #include <ace/Log_Msg_Callback.h>
+#include <ace/OS_NS_Thread.h>
+#include <ace/Reactor.h>
+#include <ace/Synch_Traits.h>
+#include <ace/Task.h>
+#include <ace/Time_Value.h>
 
+#include <atomic>
+#include <cerrno>
 #include <ctime>
 #include <deque>
 #include <mutex>
@@ -43,6 +51,34 @@ struct LogBuffer::Impl {
     };
 
     Callback cb{this};
+
+    // ── Periodic flush timer (same pattern as StatsPublisher) ────────
+    // A private ACE_Reactor run on its own ACE_Task thread fires every
+    // interval and flushes the ring buffer to ds — so daemons don't flush
+    // from their own loop / a std::thread.
+    LogBuffer*    owner = nullptr;          // back-ref for flush()
+    Client*       ds    = nullptr;          // flush target (set in open())
+    std::size_t   min_bytes = 0;
+    ACE_Reactor*  reactor = nullptr;        // private, owned while running
+    long          timer_id = -1;
+
+    struct Pump : ACE_Task<ACE_MT_SYNCH> {
+        ACE_Reactor* reactor = nullptr;
+        std::atomic<bool> running{false};
+        int svc() override {
+            reactor->owner(ACE_OS::thr_self());
+            reactor->run_reactor_event_loop();
+            return 0;
+        }
+    } pump;
+
+    struct Tick : ACE_Event_Handler {
+        Impl* impl = nullptr;
+        int handle_timeout(const ACE_Time_Value&, const void*) override {
+            if (impl->owner && impl->ds) impl->owner->flush(*impl->ds, impl->min_bytes);
+            return 0;
+        }
+    } tick;
 };
 
 LogBuffer::LogBuffer(const std::string& daemon, const std::string& log_key,
@@ -67,7 +103,56 @@ void LogBuffer::start() {
     lm->msg_callback(&m_impl->cb);
 }
 
+int LogBuffer::open(Client& ds, int interval_sec, std::size_t min_bytes) {
+    if (!m_impl || m_impl->timer_id != -1) return 0;   // already open
+    if (interval_sec < 1) interval_sec = 1;
+
+    m_impl->owner     = this;
+    m_impl->ds        = &ds;
+    m_impl->min_bytes = min_bytes;
+    m_impl->tick.impl = m_impl.get();
+    m_impl->reactor   = new ACE_Reactor();
+
+    ACE_Time_Value iv(interval_sec);
+    long id = m_impl->reactor->schedule_timer(&m_impl->tick, nullptr, iv, iv);
+    if (id == -1) {
+        delete m_impl->reactor; m_impl->reactor = nullptr; m_impl->ds = nullptr;
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("%D %M %N:%l log flush schedule_timer failed "
+                                   "for %C\n"), m_impl->daemon.c_str()),
+                         -1);
+    }
+    m_impl->timer_id = id;
+
+    m_impl->pump.reactor = m_impl->reactor;
+    m_impl->pump.running.store(true);
+    if (m_impl->pump.activate(THR_NEW_LWP | THR_JOINABLE, 1) == -1) {
+        m_impl->reactor->cancel_timer(&m_impl->tick);
+        m_impl->timer_id = -1;
+        m_impl->pump.running.store(false);
+        delete m_impl->reactor; m_impl->reactor = nullptr; m_impl->ds = nullptr;
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("%D %M %N:%l log flush activate failed for "
+                                   "%C errno=%d\n"), m_impl->daemon.c_str(), errno),
+                         -1);
+    }
+    return 0;
+}
+
+void LogBuffer::close() {
+    if (!m_impl || m_impl->timer_id == -1) return;
+    m_impl->reactor->cancel_timer(&m_impl->tick);
+    m_impl->timer_id = -1;
+    m_impl->reactor->end_reactor_event_loop();
+    m_impl->pump.wait();                       // join the flush thread
+    m_impl->pump.running.store(false);
+    if (m_impl->ds) flush(*m_impl->ds, 0);     // final flush while ds alive
+    delete m_impl->reactor; m_impl->reactor = nullptr;
+    m_impl->ds = nullptr;
+}
+
 LogBuffer::~LogBuffer() {
+    close();
     if (m_impl) ACE_Log_Msg::instance()->msg_callback(nullptr);
 }
 

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -268,6 +268,9 @@ int main(int argc, char** argv) {
 
     // Push startup logs immediately so the cloud UI can tail them.
     g_log.flush(ds);
+    // Periodic log flush via LogBuffer's own ACE reactor timer (same
+    // pattern as StatsPublisher) instead of flushing from the loop below.
+    g_log.open(ds, 10, 200);
 
     // ── Resource telemetry (L22) ──────────────────────────────────
     // Publish this container's CPU/mem/fd/threads every 10s. iot-httpd
@@ -399,7 +402,6 @@ int main(int argc, char** argv) {
                 // (stateless — no cache to invalidate).
 
                 g_log.apply_level(ds);
-                g_log.flush(ds, 200);
             }
             DsHttpCfg cur = read_ds_http_cfg(ds);
             bool tlsDirty = false, listenDirty = false;
@@ -436,6 +438,7 @@ int main(int argc, char** argv) {
                        rs.err.c_str()));
         }
     }
+    g_log.close();   // stop flush timer + final flush (ds still alive)
     // Join the workers before tearing down the reactor/sessions so no
     // in-flight handler is left holding a session that's about to vanish.
     pool.stop();


### PR DESCRIPTION
Applies the same pattern we just validated for `StatsPublisher` to logging.

## Change
`LogBuffer` gains `open(ds, interval=10, min_bytes=0)` / `close()` that run a **private `ACE_Reactor` on a dedicated `ACE_Task` thread** and flush the ring buffer on a timer. Daemons stop flushing from their own loops / a raw `std::thread`.

- **log_buffer**: private reactor + `ACE_Task` pump + `ACE_Event_Handler` tick → `flush(ds, min_bytes)`. `close()` does a final flush (while `ds` is alive) then joins; the destructor calls `close()`.
- **lwm2m**: removed the `std::thread` log flusher → `g_log.open(*cli, 10, 200)`; `g_log.close()` at shutdown.
- **iot-cloudd / iot-httpd**: removed the in-loop `g_log.flush()` → `g_log.open()` after startup, `g_log.close()` at shutdown. `apply_level()` stays on the `log.level` watch path for hot-reload.

## Why
Consistency (ACE everywhere — no stray `std::thread`), and the same robustness the StatsPublisher private-reactor change gave us: the flush timer never depends on which thread owns the daemon's reactor.

## Verification
- `ds-tests` builds; **22 `Stats*` gtests pass**.
- `iot-httpd`, `iot-cloudd`, `lwm2m`, `datastore_client` all compile/link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)