### PR TITLE
ci(cloud): multi-arch image (amd64+arm64) + arch-aware run.sh pull

### DIFF
--- a/.github/workflows/cloud-image.yml
+++ b/.github/workflows/cloud-image.yml
@@ -19,6 +19,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up QEMU   # enables cross-building the arm64 image on the amd64 runner
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -43,6 +46,7 @@ jobs:
         with:
           context: .
           file: apps/cloud/Dockerfile
+          platforms: linux/amd64,linux/arm64
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}

--- a/apps/cloud/INSTALL.md
+++ b/apps/cloud/INSTALL.md
@@ -73,8 +73,8 @@ docker pull docker.io/naushada/iot-cloud:latest
 ## 3B. Install — build the image locally
 
 ```bash
-./run.sh build      # builds docker.io/naushada/iot-cloud:latest from source
-./run.sh            # start the stack
+./run.sh build         # builds docker.io/naushada/iot-cloud:latest for the host arch
+PULL=0 ./run.sh        # start using the local build (don't re-pull)
 ```
 
 `./run.sh nocache` forces a clean rebuild. The build compiles ACE, the C++
@@ -111,6 +111,8 @@ Override on the command line — they pass through to `docker-compose.yml`:
 | `PROXY_START` / `PROXY_END` | `5001` / `6000` | Device-UI reverse-proxy port pool |
 | `HTTP_WORKERS` | `4` | iot-httpd handler threads |
 | `CLOUD_IMAGE` | `docker.io/naushada/iot-cloud:latest` | Image to run |
+| `PULL` | `1` | Pull the image on start. `0` = use a local `./run.sh build` as-is |
+| `PLATFORM` | auto (`uname -m`) | Image arch to pull. The published image is multi-arch (`linux/amd64` + `linux/arm64`), so the host arch is selected automatically; override e.g. `linux/amd64` |
 | `RESET_CONFIG` | `1` | Reload schema/config from the image on each start (see §7). `0` keeps manual `/etc/iot` edits |
 
 Example:

--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -5,8 +5,12 @@
 # communicating through a shared Unix socket volume. Prefers docker
 # (falls back to podman only if docker is absent).
 #
-# On start it refreshes the iot-etc config volume from the image so
-# schema/config changes always take effect (RESET_CONFIG=0 to keep it).
+# On start it pulls the image for the host's architecture (the published
+# image is a multi-arch manifest: linux/amd64 + linux/arm64) and refreshes
+# the iot-etc config volume so schema/config changes always take effect.
+#   PULL=0          use a local ./run.sh build instead of pulling
+#   PLATFORM=...    override the auto-detected arch (e.g. linux/amd64)
+#   RESET_CONFIG=0  keep manual /etc/iot edits across restarts
 #
 # Usage:
 #   ./run.sh                    # start all services on http://localhost:8080
@@ -41,6 +45,16 @@ HTTP_WORKERS="${HTTP_WORKERS:-4}"
 RESET_CONFIG="${RESET_CONFIG:-1}"
 # Compose project name → deterministic volume names (cloud_iot-etc, …).
 PROJECT="${COMPOSE_PROJECT_NAME:-cloud}"
+# Detect host arch so we pull the matching image from the multi-arch
+# manifest (override with PLATFORM=linux/amd64). PULL=1 fetches the
+# published image on start; PULL=0 uses a local ./run.sh build as-is.
+case "$(uname -m)" in
+    x86_64|amd64)  HOST_PLATFORM="linux/amd64" ;;
+    aarch64|arm64) HOST_PLATFORM="linux/arm64" ;;
+    *)             HOST_PLATFORM="" ;;
+esac
+PLATFORM="${PLATFORM:-$HOST_PLATFORM}"
+PULL="${PULL:-1}"
 
 RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 log_section() { echo -e "\n${GREEN}=== $1 ===${NC}"; }
@@ -65,21 +79,29 @@ export COMPOSE_PROJECT_NAME="$PROJECT"
 
 case "${1:-start}" in
     build)
-        log_section "Building $IMAGE"
+        log_section "Building $IMAGE (${PLATFORM:-host} arch)"
         $CR build -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" \
             "$SCRIPT_DIR/../../"
+        log_info "Built locally — start it without re-pulling: PULL=0 ./run.sh"
         ;;
     nocache|build-nocache)
-        log_section "Building $IMAGE (no cache)"
+        log_section "Building $IMAGE (no cache, ${PLATFORM:-host} arch)"
         $CR build --no-cache -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" \
             "$SCRIPT_DIR/../../"
+        log_info "Built locally — start it without re-pulling: PULL=0 ./run.sh"
         ;;
 
     start|up)
-        # Pull if not present (image inspect works on both docker + podman)
-        if ! $CR image inspect "$IMAGE" >/dev/null 2>&1; then
-            log_info "Pulling $IMAGE..."
-            $CR pull "$IMAGE"
+        # Fetch the image for this host's architecture. The published image
+        # is a multi-arch manifest, so the pull selects the matching arch.
+        # PULL=0 skips this to use a locally-built image (./run.sh build).
+        if [ "$PULL" = "1" ] || ! $CR image inspect "$IMAGE" >/dev/null 2>&1; then
+            log_info "Pulling $IMAGE (${PLATFORM:-host} arch)..."
+            if [ -n "$PLATFORM" ]; then
+                $CR pull --platform "$PLATFORM" "$IMAGE" || log_info "pull failed — using local image if present"
+            else
+                $CR pull "$IMAGE" || log_info "pull failed — using local image if present"
+            fi
         fi
 
         # Stop old single-container if running (migration from v1)


### PR DESCRIPTION
Fixes two issues found while deploying on Apple Silicon:

1. **CI published amd64-only** — arm64 hosts couldn't pull `:latest` (`no image found in image index for architecture "arm64"`).
2. **`run.sh` never fetched updates** — it only pulled when the image was missing, so hosts kept running a stale local build.

## Changes
- **`.github/workflows/cloud-image.yml`**: add `docker/setup-qemu-action` + `platforms: linux/amd64,linux/arm64` on the build-push step → publishes a **multi-arch manifest**.
- **`apps/cloud/run.sh`**: detect host arch (`uname -m`) and pull the matching image on start. `PULL=1` (default) fetches the published image; `PULL=0` uses a local `./run.sh build`; `PLATFORM=…` overrides.
- **`INSTALL.md`**: document `PULL` / `PLATFORM` and the local-build path.

## Notes
- arm64 is cross-built via QEMU on the amd64 runner — correct but slower on the first run (gha cache speeds up subsequent builds). If build time becomes a problem we can switch to native arm64 runners with a manifest-merge matrix.
- With the multi-arch manifest, `docker/podman pull` auto-selects the host arch; `run.sh` also passes `--platform` explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)