### PR TITLE
fix(ui): show — for unmeasured services (openvpn-server)

### DIFF
--- a/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
+++ b/apps/cloud/ui/src/app/services/services-list/services-list.component.ts
@@ -42,11 +42,11 @@ interface SvcRow {
             <app-status-badge [label]="s.state||'unknown'"
               [state]="s.state||''"></app-status-badge>
           </clr-dg-cell>
-          <clr-dg-cell class="num">{{ fmtCpu(s.cpu_permille) }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ s.cpu_count ?? '—' }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ fmtKb(s.mem_kb) }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ s.fd_count ?? '—' }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ s.threads ?? '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? fmtCpu(s.cpu_permille) : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? s.cpu_count : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? fmtKb(s.mem_kb) : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? s.fd_count : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? s.threads : '—' }}</clr-dg-cell>
           <clr-dg-cell>
             <clr-checkbox-wrapper *ngIf="gateable(s)">
               <input type="checkbox" clrCheckbox
@@ -111,6 +111,11 @@ export class ServicesListComponent implements OnInit, OnDestroy {
 
   /// Services that can be enabled/disabled + restarted (have an enable key).
   gateable(s: SvcRow): boolean { return !!s.enable_key; }
+
+  /// A live StatsPublisher always reports >=1 core, so cpu_count==0 means
+  /// the service isn't separately measured (e.g. openvpn-server, which is
+  /// managed by iot-cloudd and has no process of its own) — show "—".
+  hasStats(s: SvcRow): boolean { return (s.cpu_count ?? 0) > 0; }
 
   /// ds key prefix for a service's L22 telemetry keys.
   private statsPrefix(s: SvcRow): string {

--- a/iot-ui/src/app/services/services-list/services-list.component.ts
+++ b/iot-ui/src/app/services/services-list/services-list.component.ts
@@ -28,11 +28,11 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
         <clr-dg-row *clrDgItems="let s of services">
           <clr-dg-cell><code>{{ s.label }}</code></clr-dg-cell>
           <clr-dg-cell><app-status-badge [label]="s.info.state||'unknown'" [state]="s.info.state||''"></app-status-badge></clr-dg-cell>
-          <clr-dg-cell class="num">{{ fmtCpu(s.info.cpu_permille) }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ s.info.cpu_count ?? '—' }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ fmtKb(s.info.mem_kb) }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ s.info.fd_count ?? '—' }}</clr-dg-cell>
-          <clr-dg-cell class="num">{{ s.info.threads ?? '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? fmtCpu(s.info.cpu_permille) : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? s.info.cpu_count : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? fmtKb(s.info.mem_kb) : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? s.info.fd_count : '—' }}</clr-dg-cell>
+          <clr-dg-cell class="num">{{ hasStats(s) ? s.info.threads : '—' }}</clr-dg-cell>
           <clr-dg-cell>
             <input type="checkbox" [checked]="s.info.enable" [disabled]="!isAdmin" (change)="toggleEnable(s)" />
           </clr-dg-cell>
@@ -72,6 +72,10 @@ export class ServicesListComponent implements OnInit, OnDestroy {
     get isAdmin(): boolean { return this.session.isAdmin; }
 
   constructor(private http: HttpsvcService, private session: SessionService) {}
+
+  /// cpu_count==0 ⇒ no live StatsPublisher for this service (not separately
+  /// measured) → show "—" rather than misleading zeros.
+  hasStats(s: SvcRow): boolean { return ((s.info.cpu_count as number) ?? 0) > 0; }
 
   fmtCpu(permille?: number): string {
     if (permille == null) return '—';


### PR DESCRIPTION
`openvpn-server` is a logical service managed by iot-cloudd with no process of its own, so its `services.cloud.openvpn.server.*` metric keys stay at the schema default `0`. The Services table showed `0.0% / 0 KB / 0 / 0`, which looks broken.

A live StatsPublisher always reports `#CPU >= 1`, so `cpu_count == 0` reliably means "not separately measured". Both Services pages now render `—` across the metric columns in that case (cloud + device).

(Once iot-cloudd actually spawns + measures openvpn, those cells will show real values automatically.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)