### PR TITLE
feat(cloud): operator-tunable openvpn server config (cloud.vpn.*) + UI

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -56,6 +56,15 @@ std::string ds_str(data_store::Client& ds, const std::string& key,
     return dflt;
 }
 
+// Read an integer ds key with a fallback default.
+int ds_int(data_store::Client& ds, const std::string& key, int dflt) {
+    std::vector<data_store::Client::GetResult> got;
+    auto s = ds.get({key}, got);
+    if (s.ok && !got.empty() && got[0].has_value)
+        if (auto v = data_store::to_int32(got[0].value)) return *v;
+    return dflt;
+}
+
 // Sync endpoint registry to cloud.endpoints JSON in the data store.
 void sync_endpoints_to_ds(data_store::Client& ds,
                            server::lwm2m::EndpointRegistry& reg) {
@@ -169,13 +178,24 @@ int main(int argc, char** argv) {
     ovpn_cfg.ca_path   = ds_str(ds, "cloud.vpn.ca.crt",     "/etc/iot/vpn/ca/ca.crt");
     ovpn_cfg.cert_path = ds_str(ds, "cloud.vpn.server.crt", "/etc/iot/vpn/server.crt");
     ovpn_cfg.key_path  = ds_str(ds, "cloud.vpn.server.key", "/etc/iot/vpn/server.key");
-    {
-        std::vector<data_store::Client::GetResult> got;
-        if (ds.get({"cloud.vpn.listen.port"}, got).ok && !got.empty() &&
-            got[0].has_value)
-            if (auto p = data_store::to_int32(got[0].value); p && *p > 0)
-                ovpn_cfg.port = static_cast<std::uint16_t>(*p);
-    }
+    ovpn_cfg.cipher    = ds_str(ds, "cloud.vpn.cipher",     "AES-256-GCM");
+    ovpn_cfg.dev       = ds_str(ds, "cloud.vpn.dev",        "tun");
+    ovpn_cfg.port      = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.listen.port", 1194));
+    ovpn_cfg.mgmt_port = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.mgmt.port", 7506));
+    ovpn_cfg.verb      = ds_int(ds, "cloud.vpn.verb", 3);
+    // Seed the effective config back to ds so every cloud.vpn.* key exists
+    // with its default (visible in the cloud UI / ds-cli).
+    ds.set({
+        {"cloud.vpn.proto",       data_store::Value{ovpn_cfg.proto}},
+        {"cloud.vpn.cipher",      data_store::Value{ovpn_cfg.cipher}},
+        {"cloud.vpn.dev",         data_store::Value{ovpn_cfg.dev}},
+        {"cloud.vpn.ca.crt",      data_store::Value{ovpn_cfg.ca_path}},
+        {"cloud.vpn.server.crt",  data_store::Value{ovpn_cfg.cert_path}},
+        {"cloud.vpn.server.key",  data_store::Value{ovpn_cfg.key_path}},
+        {"cloud.vpn.listen.port", data_store::Value{static_cast<std::int32_t>(ovpn_cfg.port)}},
+        {"cloud.vpn.mgmt.port",   data_store::Value{static_cast<std::int32_t>(ovpn_cfg.mgmt_port)}},
+        {"cloud.vpn.verb",        data_store::Value{static_cast<std::int32_t>(ovpn_cfg.verb)}},
+    });
     server::openvpn::OpenVpnServer ovpn(ovpn_cfg);
 
     // Bring openvpn to the operator-desired state and publish it. Runs on

--- a/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.html
+++ b/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.html
@@ -17,6 +17,48 @@
       </clr-input-container>
 
       <clr-input-container>
+        <label>Listen Port</label>
+        <input clrInput [disabled]="!isAdmin" type="number"
+               formControlName="listen_port" min="1" max="65535" />
+        <clr-control-helper>OpenVPN server UDP/TCP listen port (default 1194)</clr-control-helper>
+      </clr-input-container>
+
+      <clr-select-container>
+        <label>Protocol</label>
+        <select clrSelect [disabled]="!isAdmin" formControlName="proto">
+          <option value="udp">udp</option>
+          <option value="tcp">tcp</option>
+        </select>
+      </clr-select-container>
+
+      <clr-select-container>
+        <label>Device</label>
+        <select clrSelect [disabled]="!isAdmin" formControlName="dev">
+          <option value="tun">tun</option>
+          <option value="tap">tap</option>
+        </select>
+      </clr-select-container>
+
+      <clr-input-container>
+        <label>Cipher</label>
+        <input clrInput [disabled]="!isAdmin" formControlName="cipher"
+               placeholder="AES-256-GCM" />
+      </clr-input-container>
+
+      <clr-input-container>
+        <label>Management Port</label>
+        <input clrInput [disabled]="!isAdmin" type="number"
+               formControlName="mgmt_port" min="1" max="65535" />
+        <clr-control-helper>openvpn(8) management socket on 127.0.0.1</clr-control-helper>
+      </clr-input-container>
+
+      <clr-input-container>
+        <label>Log Verbosity</label>
+        <input clrInput [disabled]="!isAdmin" type="number"
+               formControlName="verb" min="0" max="11" />
+      </clr-input-container>
+
+      <clr-input-container>
         <label>CA Certificate</label>
         <input clrInput [disabled]="!isAdmin" formControlName="ca_crt"
                placeholder="/etc/iot/vpn/ca/ca.crt" />

--- a/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.ts
+++ b/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.ts
@@ -22,8 +22,14 @@ export class VpnConfigComponent implements OnInit {
     private toast: ToastService
   ) {
     this.form = fb.group({
-      subnet:     ['10.9.0.0/24'],
-      port_next:  [5001],
+      subnet:      ['10.9.0.0/24'],
+      port_next:   [5001],
+      listen_port: [1194],
+      proto:       ['udp'],
+      cipher:      ['AES-256-GCM'],
+      dev:         ['tun'],
+      mgmt_port:   [7506],
+      verb:        [3],
       ca_crt:     ['/etc/iot/vpn/ca/ca.crt'],
       ca_key:     ['/run/secrets/iot-ca-key/ca.key'],
       server_crt: ['/etc/iot/vpn/server.crt'],
@@ -34,6 +40,8 @@ export class VpnConfigComponent implements OnInit {
   ngOnInit(): void {
     this.http.dbGet([
       'cloud.vpn.subnet', 'cloud.vpn.port.next',
+      'cloud.vpn.listen.port', 'cloud.vpn.proto', 'cloud.vpn.cipher',
+      'cloud.vpn.dev', 'cloud.vpn.mgmt.port', 'cloud.vpn.verb',
       'cloud.vpn.ca.crt', 'cloud.vpn.ca.key',
       'cloud.vpn.server.crt', 'cloud.vpn.server.key'
     ]).subscribe({
@@ -41,8 +49,14 @@ export class VpnConfigComponent implements OnInit {
         if (r.ok && r.data) {
           const d = r.data as Record<string, unknown>;
           this.form.patchValue({
-            subnet:     d['cloud.vpn.subnet']      || '10.9.0.0/24',
-            port_next:  d['cloud.vpn.port.next']   || 5001,
+            subnet:      d['cloud.vpn.subnet']      || '10.9.0.0/24',
+            port_next:   d['cloud.vpn.port.next']   || 5001,
+            listen_port: d['cloud.vpn.listen.port'] || 1194,
+            proto:       d['cloud.vpn.proto']       || 'udp',
+            cipher:      d['cloud.vpn.cipher']      || 'AES-256-GCM',
+            dev:         d['cloud.vpn.dev']         || 'tun',
+            mgmt_port:   d['cloud.vpn.mgmt.port']   || 7506,
+            verb:        d['cloud.vpn.verb']        ?? 3,
             ca_crt:     d['cloud.vpn.ca.crt']      || '/etc/iot/vpn/ca/ca.crt',
             ca_key:     d['cloud.vpn.ca.key']      || '/run/secrets/iot-ca-key/ca.key',
             server_crt: d['cloud.vpn.server.crt']  || '/etc/iot/vpn/server.crt',
@@ -61,6 +75,12 @@ export class VpnConfigComponent implements OnInit {
     this.http.dbSet([
       { key: 'cloud.vpn.subnet',      value: v.subnet },
       { key: 'cloud.vpn.port.next',   value: v.port_next },
+      { key: 'cloud.vpn.listen.port', value: v.listen_port },
+      { key: 'cloud.vpn.proto',       value: v.proto },
+      { key: 'cloud.vpn.cipher',      value: v.cipher },
+      { key: 'cloud.vpn.dev',         value: v.dev },
+      { key: 'cloud.vpn.mgmt.port',   value: v.mgmt_port },
+      { key: 'cloud.vpn.verb',        value: v.verb },
       { key: 'cloud.vpn.ca.crt',      value: v.ca_crt },
       { key: 'cloud.vpn.ca.key',      value: v.ca_key },
       { key: 'cloud.vpn.server.crt',  value: v.server_crt },

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -158,6 +158,26 @@ return {
       type    = "string",
       default = "udp",          -- "udp" | "tcp"
     },
+    ["cloud.vpn.cipher"] = {
+      type    = "string",
+      default = "AES-256-GCM",
+    },
+    ["cloud.vpn.dev"] = {
+      type    = "string",
+      default = "tun",          -- "tun" | "tap"
+    },
+    ["cloud.vpn.mgmt.port"] = {
+      type    = "integer",
+      default = 7506,
+      min     = 1,
+      max     = 65535,
+    },
+    ["cloud.vpn.verb"] = {
+      type    = "integer",
+      default = 3,
+      min     = 0,
+      max     = 11,
+    },
 
     -- Next available proxy port (bump-counter).
     ["cloud.vpn.port.next"] = {


### PR DESCRIPTION
Adds the remaining openvpn server knobs as data-store keys and surfaces them in the cloud UI.

- **schema**: `cloud.vpn.{cipher,dev,mgmt.port,verb}` (listen.port/proto added earlier).
- **cloudd**: reads them into `OpenVpnServerConfig`, and **seeds all cloud.vpn.* server keys back to ds** at startup so they exist with defaults (visible in UI / ds-cli).
- **cloud UI vpn-config**: Listen Port, Protocol, Device, Cipher, Management Port, Log Verbosity fields.

`build_server_config` stays a pure POD renderer — the data store is the source of truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)