### PR TITLE
fix(cloud): copy VPN PKI into runtime image (openvpn was crash-looping)

### DIFF
--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -134,6 +134,11 @@ COPY --from=builder /tmp/blwm2m/lwm2m /usr/local/bin/
 # by iot-httpd depending on www-dir.
 COPY --from=ui-builder /ui/dist/cloud-ui /usr/share/iot/cloud-www/webui/
 
+# VPN server PKI (ca.crt + server.crt/key) generated in the builder stage.
+# Without this the runtime image has no /etc/iot/vpn and openvpn(8) fails
+# to start (--ca/--cert/--key: No such file or directory).
+COPY --from=builder /etc/iot/vpn /etc/iot/vpn
+
 # Schemas (device + cloud — same ds-server loads both)
 COPY modules/data-store/schemas/iot.lua /etc/iot/ds-schemas/
 COPY modules/data-store/schemas/services.lua /etc/iot/ds-schemas/

--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -121,6 +121,9 @@ case "${1:-start}" in
             log_info "Refreshing config volume ${PROJECT}_iot-etc (set RESET_CONFIG=0 to keep)"
             $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" down --remove-orphans 2>/dev/null || true
             $CR volume rm "${PROJECT}_iot-etc" 2>/dev/null || true
+            # iot-vpn holds the image-provided server PKI (ca/server certs);
+            # repopulate it from the (possibly rebuilt) image too.
+            $CR volume rm "${PROJECT}_iot-vpn" 2>/dev/null || true
         fi
 
         log_section "Starting IoT Cloud"


### PR DESCRIPTION
openvpn(8) crash-looped: `--ca/--cert/--key: No such file or directory`. The Dockerfile generates the server PKI in the **builder** stage but the **runtime** stage never copied `/etc/iot/vpn`, so the image (and the `iot-vpn` volume) had no certs.

- **Dockerfile**: `COPY --from=builder /etc/iot/vpn /etc/iot/vpn`.
- **run.sh**: also reset `${PROJECT}_iot-vpn` on start so the stale/empty volume repopulates from the rebuilt image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)