### PR TITLE
fix(yocto): unbreak iot-image build (ACE staging + missing <functional>)

### DIFF
--- a/apps/src/lwm2m_object_3_device.cpp
+++ b/apps/src/lwm2m_object_3_device.cpp
@@ -2,6 +2,7 @@
 
 #include <ctime>
 #include <fstream>
+#include <functional>
 #include <iostream>
 #include <sstream>
 #include <unordered_map>

--- a/modules/data-store/src/server/schema.cpp
+++ b/modules/data-store/src/server/schema.cpp
@@ -5,6 +5,7 @@
 #include <cstdio>
 #include <cstring>
 #include <dirent.h>
+#include <functional>
 #include <grp.h>
 #include <limits>
 #include <memory>

--- a/yocto/meta-iot/recipes-support/ace-tao/ace-tao_7.0.0.bb
+++ b/yocto/meta-iot/recipes-support/ace-tao/ace-tao_7.0.0.bb
@@ -78,22 +78,22 @@ do_compile() {
 # directly from the build tree instead. (do_compile builds libs into
 # ${S}/lib and ACE's headers live under ${S}/ace.)
 do_install() {
-    # Use `cp -dR` (preserve symlinks, recurse) NOT `cp -a`: -a also
-    # preserves the build user's uid/gid (1000), which under pseudo records
-    # non-root ownership and makes do_package fail with "getpwuid(): uid not
-    # found: 1000 ... host contamination". -dR creates the copies as the
-    # pseudo-root user, so they're root-owned to begin with.
     install -d ${D}${libdir}
-    # Versioned shared libs + their .so / .so.MAJOR symlinks.
-    cp -dR ${S}/lib/libACE.so*     ${D}${libdir}/
-    cp -dR ${S}/lib/libACE_SSL.so* ${D}${libdir}/
-    # Ensure the .so symlink exists — some ACE builds don't create it
-    if [ ! -e ${D}${libdir}/libACE.so ]; then
-        ln -sf libACE.so.7.0.0 ${D}${libdir}/libACE.so
-    fi
-    if [ ! -e ${D}${libdir}/libACE_SSL.so ]; then
-        ln -sf libACE_SSL.so.7.0.0 ${D}${libdir}/libACE_SSL.so
-    fi
+    # ACE builds the real shared objects under ${S}/ace (and ace/SSL) and
+    # leaves only symlinks in ${S}/lib (e.g. libACE.so.7.0.0 -> ../ace/
+    # libACE.so.7.0.0). A plain `cp -dR` copies those symlinks verbatim, so
+    # once staged into a downstream recipe-sysroot they dangle (../ace/ does
+    # not exist there) and the iot build fails:
+    #   "libACE.so ... missing and no known rule to make it".
+    # Copy the REAL objects instead — readlink -f dereferences the lib/
+    # symlink to the actual file under ace/ — and `install` writes them as the
+    # pseudo-root user (avoids the uid-1000 host-contamination that `cp -a`
+    # would cause). Then recreate the .so dev symlink ourselves. The ELF
+    # SONAME is libACE.so.7.0.0, so no .so.MAJOR intermediate is needed.
+    install -m 0755 "$(readlink -f ${S}/lib/libACE.so.7.0.0)"     ${D}${libdir}/libACE.so.7.0.0
+    install -m 0755 "$(readlink -f ${S}/lib/libACE_SSL.so.7.0.0)" ${D}${libdir}/libACE_SSL.so.7.0.0
+    ln -sf libACE.so.7.0.0     ${D}${libdir}/libACE.so
+    ln -sf libACE_SSL.so.7.0.0 ${D}${libdir}/libACE_SSL.so
 
     # Public headers: the ace/ tree (*.h, *.inl, and the template *.cpp
     # files that headers #include), minus build artifacts. ACE_SSL headers


### PR DESCRIPTION
## Summary
Three fixes so `yocto/build.sh` (bitbake `iot-image`, gcc 13.4 / Scarthgap) builds the device image end to end. Without these the build fails at `iot-git do_compile`.

### 1. `ace-tao` recipe — dangling `libACE.so` in sysroot
ACE builds the real shared objects under `ACE_wrappers/ace` (and `ace/SSL`) and leaves only **symlinks** in `lib/` (`libACE.so.7.0.0 -> ../ace/libACE.so.7.0.0`). The old `cp -dR` copied those symlinks verbatim, so once staged into the downstream iot `recipe-sysroot` they dangled (`../ace/` doesn't exist there):

```
ninja: error: '.../recipe-sysroot/usr/lib/libACE.so', needed by 'lwm2m',
       missing and no known rule to make it
```

It also left the **runtime** package shipping a dangling symlink instead of the real `.so`. Fix: copy the dereferenced objects (`readlink -f`) and recreate the `.so` dev symlink. ELF SONAME is `libACE.so.7.0.0`, so no `.so.MAJOR` intermediate is needed (matches the existing FILES split).

### 2. Missing `#include <functional>`
`modules/data-store/src/server/schema.cpp` and `apps/src/lwm2m_object_3_device.cpp` use `std::function` but relied on a transitive include that gcc 13.4 no longer provides:

```
schema.cpp:275: error: 'function' is not a member of 'std'
```

## Test
`cd yocto && ./build.sh` (raspberrypi3-64 / iot-image) — verified the ACE link error and both `std::function` errors are resolved; rebuild in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)