### PR TITLE
docs(yocto): update SD-card flashing + host image-location instructions

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -147,13 +147,18 @@ needs only podman or docker; no Yocto SDK, no host Yocto install. The
 build runs entirely in the container and the artifacts are copied back
 to the host.
 
-Two artifacts come out per machine:
+Two artifacts come out per machine, copied back to the host under
+`yocto/build/<machine>/`:
 
-- **`iot-image-*.wic.bz2`** — a flashable SD-card image. The default
-  `MACHINE` is `raspberrypi3-64` (Pi 3B, 64-bit). It bundles the full
-  gateway stack (`packagegroup-iot-full`), all kernel modules, the Pi's
-  onboard Wi-Fi/Bluetooth firmware, an SSH server, and `opkg`.
-- **`.ipk` feed** — the same per-daemon packages, for pushing app
+- **`images/<machine>/iot-image-<machine>.rootfs-<timestamp>.wic.bz2`** — a
+  flashable SD-card image. The default `MACHINE` is `raspberrypi3-64`
+  (Pi 3B, 64-bit), so the Pi image lands at
+  `yocto/build/raspberrypi3-64/images/raspberrypi3-64/`. A stable
+  `iot-image-<machine>.rootfs.wic.bz2` symlink in the same directory always
+  points at the latest build. It bundles the full gateway stack
+  (`packagegroup-iot-full`), all kernel modules, the Pi's onboard
+  Wi-Fi/Bluetooth firmware, an SSH server, and `opkg`.
+- **`ipk/` feed** — the same per-daemon packages, for pushing app
   updates to an already-running target over ssh.
 
 > First boot needs a physical SD-card flash — a Pi can't be
@@ -191,18 +196,23 @@ build-steps walkthrough.
 
 ### 2. Flash the SD card
 
-Find the SD device first (`/dev/sdX` on Linux, `/dev/diskN` on macOS),
-then write it. `bmaptool` is fast and verified; plain `dd` also works:
+Find the SD device first — `lsblk` on Linux (`/dev/sdX`), `diskutil list`
+on macOS (`/dev/diskN`; unmount with `diskutil unmountDisk` first). Write
+the **whole disk**, not a partition. Decompress on the fly and write with
+`dd`:
 
 ```sh
-IMG=yocto/build/raspberrypi3-64/images/raspberrypi3-64/iot-image-*.wic.bz2
+IMG=yocto/build/raspberrypi3-64/images/raspberrypi3-64/iot-image-raspberrypi3-64.rootfs.wic.bz2
 
-# Verified write (recommended — needs bmaptool, picks up the .bmap automatically)
-bmaptool copy $IMG /dev/sdX
-
-# Or plain dd
 bzcat $IMG | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
+# macOS: target the raw node /dev/rdiskN instead of /dev/diskN — much faster.
 ```
+
+> The build does **not** emit a `.bmap` file: `bmaptool` needs the FIEMAP
+> ioctl / `SEEK_HOLE`, which the macOS-podman build filesystem doesn't
+> support, so `wic.bmap` is omitted from `IMAGE_FSTYPES`. If you build on a
+> Linux host and want `bmaptool copy`'s faster verified writes, add
+> `"wic.bmap"` back to `IMAGE_FSTYPES` in `meta-iot/recipes-iot/images/iot-image.bb`.
 
 ### 3. Boot + ssh in
 

--- a/README.md
+++ b/README.md
@@ -181,13 +181,17 @@ clones poky + meta-openembedded + meta-raspberrypi at Scarthgap
 in `yocto/build/<machine>/`:
 
 - `images/<machine>/iot-image-*.wic.bz2` — flashable SD-card image
-  (full gateway stack + kernel modules + Pi Wi-Fi/BT firmware + sshd + opkg)
+  (full gateway stack + kernel modules + Pi Wi-Fi/BT firmware + sshd + opkg).
+  A stable `iot-image-<machine>.rootfs.wic.bz2` symlink alongside it always
+  points at the newest build.
 - `ipk/` — the `.ipk` feed for `opkg install` over ssh
 
-Flash, boot, ssh in, then push app updates over ssh:
+Flash (find the SD device with `lsblk` / `diskutil list` first — write the
+whole disk, not a partition), boot, ssh in, then push app updates over ssh:
 
 ```sh
-bmaptool copy yocto/build/raspberrypi3-64/images/raspberrypi3-64/iot-image-*.wic.bz2 /dev/sdX
+bzcat yocto/build/raspberrypi3-64/images/raspberrypi3-64/iot-image-*.wic.bz2 \
+  | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress   # macOS: /dev/rdiskN
 ssh root@<pi-ip>                                   # sshd baked in (debug-tweaks)
 scp yocto/build/raspberrypi3-64/ipk/*/iot-*.ipk root@<pi-ip>:/tmp/   # later updates
 ssh root@<pi-ip> 'opkg install /tmp/iot-*.ipk'

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -211,11 +211,10 @@ print_summary() {
         cat <<EOF
 
   ── Flash the SD card (Raspberry Pi 3B) ──────────────────────────────
-    # Find the SD device first (e.g. /dev/sdX on Linux, /dev/diskN on macOS).
-    # Fast + verified (recommended, needs bmaptool):
-    bmaptool copy "$rpi_img" /dev/sdX
-    # Or plain dd:
+    # Find the SD device first: lsblk (Linux, /dev/sdX) or
+    # diskutil list (macOS, /dev/diskN). Write the whole disk, not a partition.
     bzcat "$rpi_img" | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
+    # macOS: target the raw node /dev/rdiskN instead of /dev/diskN — much faster.
 
   ── First boot + ssh in ──────────────────────────────────────────────
     # The image runs sshd with debug-tweaks (empty root password).

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -26,9 +26,13 @@ meta-openembedded + meta-raspberrypi, all at Scarthgap 5.0 LTS), runs
 `bitbake` inside it, and copies the artifacts back to the host. The **first**
 run compiles the whole distribution (toolchain, glibc, ACE, kernel…) — hours.
 
-**2. Collect the output** — per machine, under `yocto/build/<machine>/`:
+**2. Collect the output** — copied back to the host per machine, under
+`yocto/build/<machine>/`:
 
-- `images/<machine>/iot-image-*.wic.bz2` — flashable SD-card image
+- `images/<machine>/iot-image-<machine>.rootfs-<timestamp>.wic.bz2` —
+  flashable SD-card image. A stable `iot-image-<machine>.rootfs.wic.bz2`
+  symlink in the same directory always points at the latest build, e.g.
+  `yocto/build/raspberrypi3-64/images/raspberrypi3-64/iot-image-raspberrypi3-64.rootfs.wic.bz2`
 - `ipk/` — the `.ipk` feed for `opkg install` over ssh
 
 The persistent `iot-yocto-sstate` / `iot-yocto-downloads` volumes make
@@ -118,8 +122,12 @@ mirrors and wires `SSTATE_MIRRORS` / `own-mirrors`.
 ### Deploy to a Raspberry Pi 3B
 
 ```sh
-# 1. Flash the SD card (verified write; or use dd — see build.sh summary)
-bmaptool copy yocto/build/raspberrypi3-64/images/raspberrypi3-64/iot-image-*.wic.bz2 /dev/sdX
+# 1. Flash the SD card. Find the device first: lsblk (Linux) or
+#    `diskutil list` (macOS) — write to the whole disk, not a partition.
+#    Decompress on the fly and write with dd:
+bzcat yocto/build/raspberrypi3-64/images/raspberrypi3-64/iot-image-*.wic.bz2 \
+  | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
+#    (Linux: /dev/sdX. macOS: /dev/rdiskN — the raw node is much faster.)
 
 # 2. Boot the Pi, then ssh in (image runs sshd; debug-tweaks → empty root pw)
 ssh root@<pi-ip>


### PR DESCRIPTION
## Summary
Doc follow-up to #98 (which dropped `wic.bmap` from `IMAGE_FSTYPES`). The build no longer emits a `.bmap`, so `bmaptool` is no longer the default flash path. Updated all flashing docs and clarified where the Pi image lands on the host.

### Flashing
- Switch the primary instructions from `bmaptool copy` → `bzcat | dd` across `README.md`, `DEPLOY.md`, `yocto/meta-iot/README.md`, and the `build.sh` post-build summary.
- Note device discovery (`lsblk` / `diskutil list`) and the macOS `/dev/rdiskN` raw-node speedup.
- `DEPLOY.md` keeps a short note on why there's no `.bmap` and how to re-enable `bmaptool` on a Linux host.

### Host image location
Document the exact path and the convenience symlink:
```
yocto/build/<machine>/images/<machine>/iot-image-<machine>.rootfs-<timestamp>.wic.bz2
yocto/build/<machine>/images/<machine>/iot-image-<machine>.rootfs.wic.bz2   # -> latest
```

Docs-only; no recipe/build behavior change. `bash -n yocto/build.sh` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)