### PR TITLE
docs(device-ui): fix stale iot.dev_mode comment to dotted iot.dev.mode

### DIFF
--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -14,7 +14,7 @@ export class Lwm2mConfigComponent implements OnInit {
   loading = true; saving = false; msg = '';
 
   // PSK provisioning (task H).
-  devMode = false;             // iot.dev_mode — gates PSK generation/reveal
+  devMode = false;             // iot.dev.mode — gates PSK generation/reveal
   serialAutoDetected = false;  // true when iot.serial was already populated (RPi)
   generatedPsk = '';           // last generated BS PSK (hex), shown once to copy
   generatingPsk = false;


### PR DESCRIPTION
Comment-only follow-up to #101. Renames a stale `// iot.dev_mode` comment in `lwm2m-config.component.ts` to the dotted `iot.dev.mode`; the actual key reference was already correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)