### PR TITLE
feat(device): containerised device stack for dev/e2e without RPi3B

### DIFF
--- a/apps/device/Dockerfile
+++ b/apps/device/Dockerfile
@@ -1,0 +1,162 @@
+# ============================================================
+# IoT Device image — the full device-side stack for dev / e2e
+# testing WITHOUT a real Raspberry Pi 3B board.
+#
+# Mirrors apps/cloud/Dockerfile: a multi-stage build that compiles
+# the same C++ daemons + the device Angular UI (iot-ui/) into a slim
+# Ubuntu 22.04 runtime image. docker-compose then runs the binaries
+# as separate containers sharing the ds-server socket — exactly the
+# layout that runs on a real board via systemd, just containerised.
+#
+#   Stage 1 (ui-builder) — Angular build of iot-ui/  → dist/iot-ui
+#   Stage 2 (builder)    — ACE/TAO + tinydtls + cmake build of apps/
+#   Stage 3 (runtime)    — slim image: binaries + device UI + config
+#
+# The lwm2m binary is built with -DIOT_ENABLE_MONGO=OFF: the device
+# MongoDB registration mirror isn't needed for container e2e (the
+# same flag the cloud image uses). Drop the flag for a mongo build.
+#
+# Build from the REPO ROOT (the build context must see modules/,
+# apps/, packaging/, iot-ui/):
+#   docker build -t naushada/iot-device:latest -f apps/device/Dockerfile .
+# Or: cd apps/device && ./run.sh build
+# ============================================================
+
+# ============================================================
+# Stage 1: Build the device Angular UI (iot-ui)
+# ============================================================
+FROM docker.io/library/node:18-alpine AS ui-builder
+ENV NG_BUILD_MAX_WORKERS=1
+ENV NODE_OPTIONS=--max_old_space_size=1024
+
+WORKDIR /ui
+COPY iot-ui/package.json iot-ui/package-lock.json ./
+RUN npm ci 2>/dev/null || npm install --no-audit --no-fund
+
+COPY iot-ui/ ./
+# Device UI is served at the web root by iot-httpd (base-href "/"),
+# unlike the cloud UI which lives under /webui/.
+RUN npx ng build --configuration production --progress=false
+
+# ============================================================
+# Stage 2: Build C++ daemons (ds-server, lwm2m, iot-httpd, …)
+# ============================================================
+FROM docker.io/library/ubuntu:22.04 AS builder
+ENV DEBIAN_FRONTEND=noninteractive
+
+RUN apt-get -o Acquire::Check-Date=false update && \
+    apt-get install -y --no-install-recommends \
+    build-essential cmake ninja-build pkg-config autoconf \
+    libssl-dev zlib1g-dev libreadline-dev \
+    liblua5.3-dev lua5.3 wget ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# ACE/TAO 7.0.0 (~60s) — same install prefix apps/CMakeLists.txt expects.
+RUN wget -q https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_0/ACE+TAO-7.0.0.tar.gz \
+    -O /tmp/ace.tar.gz && cd /tmp && tar xzf ace.tar.gz && cd ACE_wrappers && \
+    echo '#include "ace/config-linux.h"' > ace/config.h && \
+    echo 'include $(ACE_ROOT)/include/makeinclude/platform_linux.GNU' > include/makeinclude/platform_macros.GNU && \
+    export ACE_ROOT=/tmp/ACE_wrappers && make -j$(nproc) -C ace && \
+    mkdir -p /usr/local/ACE_TAO-7.0.0/include /usr/local/ACE_TAO-7.0.0/lib && \
+    cp -r ace/ /usr/local/ACE_TAO-7.0.0/include/ && \
+    cp ace/libACE.so.* /usr/local/ACE_TAO-7.0.0/lib/ && \
+    ln -sf libACE.so.7.0.0 /usr/local/ACE_TAO-7.0.0/lib/libACE.so && \
+    ldconfig && echo /usr/local/ACE_TAO-7.0.0/lib > /etc/ld.so.conf.d/ace.conf && \
+    rm -rf /tmp/ACE_wrappers /tmp/ace.tar.gz
+
+COPY modules/    /src/modules/
+COPY apps/       /src/apps/
+COPY packaging/  /src/packaging/
+
+# Drop the Angular build where modules/http-server/CMakeLists.txt looks
+# for it (../../iot-ui/dist/iot-ui). When present at configure time,
+# `make install` stages the SPA to /usr/share/iot/www automatically.
+COPY --from=ui-builder /ui/dist/iot-ui/ /src/iot-ui/dist/iot-ui/
+
+# Build vendored tinydtls → libtinydtls.a (the lwm2m target links it).
+# The repo .gitignore excludes apps/3rdparty/tinydtls/doc/, so its
+# autoconf inputs aren't in the build context; stub them so configure
+# completes (we don't build the docs).
+RUN cd /src/apps/3rdparty/tinydtls && \
+    mkdir -p doc && \
+    [ -f doc/Makefile.in ] || : > doc/Makefile.in && \
+    [ -f doc/Doxyfile.in ] || : > doc/Doxyfile.in && \
+    autoconf && autoheader && ./configure && \
+    make libtinydtls.a -j$(nproc)
+
+# One cmake build of apps/ produces every device binary — apps/CMakeLists
+# add_subdirectory()s data-store, openvpn/client, net/router, wan/wifi,
+# and http-server — then `make install` stages binaries + schemas + env
+# files + config + the SPA into /staging.
+RUN mkdir -p /tmp/bapps && cd /tmp/bapps && \
+    cmake /src/apps \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DACE_ROOT=/usr/local/ACE_TAO-7.0.0 \
+        -DLUA_INCLUDE_DIR=/usr/include/lua5.3 \
+        -DIOT_ENABLE_MONGO=OFF && \
+    make -j$(nproc) && \
+    make install DESTDIR=/staging
+
+# Container deploys treat the image as the unit of upgrade, so rename the
+# object-resource config templates from .lua.example back to .lua — the
+# lwm2m binary's config=/etc/iot/config boots out of the box. Operators
+# override by mounting their own /etc/iot/config tree.
+RUN find /staging/etc/iot/config -name '*.lua.example' \
+        -exec sh -c 'mv "$1" "${1%.example}"' _ {} \;
+
+# Strip the binaries — saves ~20 MB across the set.
+RUN strip /staging/usr/bin/ds-server \
+          /staging/usr/bin/ds-cli \
+          /staging/usr/bin/lwm2m \
+          /staging/usr/bin/iot-httpd \
+          /staging/usr/bin/openvpn-client \
+          /staging/usr/bin/net-router \
+          /staging/usr/bin/wifi-client
+
+# ============================================================
+# Stage 3: Minimal runtime
+# ============================================================
+FROM docker.io/library/ubuntu:22.04 AS runtime
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Runtime libs the binaries link against, plus the userspace tools the
+# device daemons shell out to: openvpn(8) (openvpn-client), nft + ip
+# (net-router), wpa_supplicant + udhcpc (wifi-client).
+RUN apt-get -o Acquire::Check-Date=false update && \
+    apt-get install -y --no-install-recommends \
+    libssl3 zlib1g libreadline8 liblua5.3-0 ca-certificates \
+    openvpn nftables iproute2 wpasupplicant udhcpc wireless-tools \
+    && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /usr/share/man/*
+
+# ACE 7.0.0 shared library.
+COPY --from=builder /usr/local/ACE_TAO-7.0.0/lib/libACE.so* /usr/local/lib/
+RUN ldconfig
+
+# Binaries.
+COPY --from=builder /staging/usr/bin/ds-server      /usr/local/bin/
+COPY --from=builder /staging/usr/bin/ds-cli         /usr/local/bin/
+COPY --from=builder /staging/usr/bin/lwm2m          /usr/local/bin/
+COPY --from=builder /staging/usr/bin/iot-httpd      /usr/local/bin/
+COPY --from=builder /staging/usr/bin/openvpn-client /usr/local/bin/
+COPY --from=builder /staging/usr/bin/net-router     /usr/local/bin/
+COPY --from=builder /staging/usr/bin/wifi-client    /usr/local/bin/
+
+# Config tree: ds-schemas/*.lua, *.env, config/**/*.lua  (all under /etc/iot).
+COPY --from=builder /staging/etc/iot      /etc/iot
+# Device UI (SPA) served by iot-httpd at www-dir=/usr/share/iot/www.
+COPY --from=builder /staging/usr/share/iot /usr/share/iot
+
+# Entrypoint dispatches on IOT_ROLE or forwards a binary invocation.
+COPY packaging/iot-entrypoint.sh /usr/local/bin/iot-entrypoint
+RUN chmod +x /usr/local/bin/iot-entrypoint
+
+# ds-server binds its socket here; /var/lib/iot holds the persisted store.
+RUN mkdir -p /run/iot /var/lib/iot && \
+    chmod 0755 /run/iot && chmod 0755 /var/lib/iot
+
+# 8080 device UI/REST · 5683 DM (server role) · 5684 client local · 5685 BS
+EXPOSE 8080 5683 5684 5685
+
+ENTRYPOINT ["/usr/local/bin/iot-entrypoint"]
+CMD []

--- a/apps/device/README.md
+++ b/apps/device/README.md
@@ -1,0 +1,96 @@
+# apps/device — IoT Device stack (containerised, no RPi3B)
+
+Build and run the **device-side** IoT stack in containers for development
+and end-to-end testing **without a real Raspberry Pi 3B board**. It mirrors
+`apps/cloud/` (Dockerfile + docker-compose.yml + run.sh) but builds the
+device binaries and the device UI (`iot-ui/`) instead of the cloud ones.
+
+The same daemons that run on a board via systemd run here as separate
+containers sharing the ds-server Unix socket:
+
+```
+ds-server ── lwm2m-server (BS 5685 + DM 5683)
+   │             ▲
+   │             │ bootstrap + register (plain CoAP)
+   │         lwm2m-client (local 5684)
+   │
+   └──────── iot-httpd (device REST API + device UI, :8080 → host :8081)
+                 all IPC via /run/iot/data_store.sock
+```
+
+## Build
+
+The image is built locally (not published). Build from this directory —
+the build context is the repo root so it can see `modules/`, `apps/`,
+`packaging/`, and `iot-ui/`:
+
+```bash
+cd apps/device
+./run.sh build        # → naushada/iot-device:latest
+```
+
+Or directly:
+
+```bash
+docker build -t naushada/iot-device:latest -f apps/device/Dockerfile .
+```
+
+The `lwm2m` binary is built with `-DIOT_ENABLE_MONGO=OFF` (the device
+MongoDB registration mirror isn't needed for container e2e — the same
+flag the cloud image uses). Drop the flag for a mongo-enabled build.
+
+## Run
+
+```bash
+./run.sh              # start all services
+./run.sh logs         # tail all logs (or: ./run.sh logs lwm2m-client)
+./run.sh ps           # list services
+./run.sh ds get log.lwm2m.text   # read a ds key via ds-cli
+./run.sh stop         # stop all
+```
+
+By default this is a **self-contained loop**: the local `lwm2m-server`
+plays the LwM2M authority and the `lwm2m-client` bootstraps + registers
+against it over plain CoAP — a working registration cycle with zero
+external dependencies.
+
+| Port | Service |
+|------|---------|
+| 8081 (host) → 8080 | Device UI + REST API |
+
+CoAP ports stay internal to the compose network (not published) so the
+device stack can run **alongside the cloud stack** on the same host
+without port clashes.
+
+## Test against the real cloud
+
+Start the cloud stack (`apps/cloud/run.sh`) — it publishes the Bootstrap
+server on host `5684` and DM on `5683` — then point the device client at
+it:
+
+```bash
+DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh
+```
+
+`host.docker.internal` resolves to the host via the `host-gateway`
+mapping already wired into the client service. (For a DTLS/PSK bootstrap
+seed the client's PSK keys first, e.g. `./run.sh ds set iot.bs.psk.key …`
+— see `apps/cloud/CLAUDE.md` for the PSK provisioning flow.)
+
+## Environment knobs
+
+| Var | Default | Meaning |
+|-----|---------|---------|
+| `DEVICE_IMAGE` | `docker.io/naushada/iot-device:latest` | image tag |
+| `HTTP_PORT` | `8081` | host port for the device UI |
+| `DEVICE_BS_URI` | `coap://lwm2m-server:5685` | client's bootstrap server |
+| `RESET_CONFIG` | `1` | refresh the `dev-etc` config volume on start |
+
+## Relationship to the other device build paths
+
+| Path | Purpose |
+|------|---------|
+| `apps/device/` (this) | **Dev / e2e** — full stack as compose services, no board |
+| `docker/Dockerfile` | Fat dev image (`naushada/iot:latest`) — full toolchain |
+| `packaging/Containerfile` | Slim single-binary runtime image (`IOT_ROLE=…`) |
+| `yocto/build.sh` | Real RPi3B bootable `.wic.bz2` + `.ipk` feed |

--- a/apps/device/docker-compose.yml
+++ b/apps/device/docker-compose.yml
@@ -1,0 +1,120 @@
+# docker-compose.yml — IoT Device stack (dev / e2e, no RPi3B board)
+#
+# Brings up the device-side daemons as separate containers sharing the
+# ds-server Unix socket on the dev-run volume — the same wiring that runs
+# on a real board under systemd. By default it is a SELF-CONTAINED loop:
+# a local lwm2m server (role=server) plays the LwM2M authority and the
+# lwm2m client bootstraps + registers against it over plain CoAP, so
+# `./run.sh` gives a working end-to-end registration cycle with zero
+# external dependencies.
+#
+#   ds-server      → shared data store (IPC backbone)
+#   lwm2m-server   → local Bootstrap (5685) + DM (5683) authority
+#   lwm2m-client   → device client: bootstraps from BS, registers to DM
+#   iot-httpd      → device REST API (/api/v1/*) + device UI (served at /)
+#
+# Point the client at a real cloud instead of the local server by
+# overriding DEVICE_BS_URI (and dropping the local server if you like):
+#   DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh
+# (the cloud compose publishes BS on 5684/DM on 5683 to the host;
+#  host.docker.internal resolves via the host-gateway extra_hosts entry.)
+#
+# Usage:
+#   docker compose up -d
+#   docker compose logs -f lwm2m-client
+#   docker compose down
+#
+#   HTTP_PORT=8081 docker compose up -d   # custom host port for the UI
+
+version: "3.8"
+
+services:
+  # ── Data Store (IPC backbone) ──────────────────────────────────
+  ds-server:
+    image: ${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}
+    container_name: iot-dev-ds
+    command: >
+      ds-server
+      ds-socket=/run/iot/data_store.sock
+      ds-store=/var/lib/iot/data_store.lua
+      ds-schema-dir=/etc/iot/ds-schemas
+    volumes:
+      - dev-run:/run/iot
+      - dev-etc:/etc/iot
+      - dev-lib:/var/lib/iot
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "ds-cli", "--socket=/run/iot/data_store.sock", "get", "log.version"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+
+  # ── Local LwM2M authority (Bootstrap 5685 + DM 5683) ───────────
+  # The device binary in role=server. For self-contained e2e only —
+  # override DEVICE_BS_URI to target a real cloud and this sits idle.
+  lwm2m-server:
+    image: ${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}
+    container_name: iot-dev-lwm2m-server
+    command: >
+      lwm2m
+      role=server
+      local=coap://0.0.0.0:5685
+      config=/etc/iot/config
+      ds-sock=/run/iot/data_store.sock
+    volumes:
+      - dev-run:/run/iot
+      - dev-etc:/etc/iot
+    depends_on:
+      ds-server:
+        condition: service_healthy
+    restart: unless-stopped
+
+  # ── Device LwM2M client ────────────────────────────────────────
+  lwm2m-client:
+    image: ${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}
+    container_name: iot-dev-lwm2m-client
+    command: >
+      lwm2m
+      role=client
+      local=coap://0.0.0.0:5684
+      bs=${DEVICE_BS_URI:-coap://lwm2m-server:5685}
+      config=/etc/iot/config
+      ds-sock=/run/iot/data_store.sock
+    # Lets DEVICE_BS_URI=coaps://host.docker.internal:5684 reach a cloud
+    # stack published on the host (Linux needs the host-gateway mapping).
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    volumes:
+      - dev-run:/run/iot
+      - dev-etc:/etc/iot
+    depends_on:
+      ds-server:
+        condition: service_healthy
+      lwm2m-server:
+        condition: service_started
+    restart: unless-stopped
+
+  # ── HTTP Server (device REST API + device UI) ──────────────────
+  iot-httpd:
+    image: ${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}
+    container_name: iot-dev-httpd
+    command: >
+      iot-httpd
+      ds-socket=/run/iot/data_store.sock
+      http-port=8080
+      www-dir=/usr/share/iot/www
+    ports:
+      - "${HTTP_PORT:-8081}:8080"
+    volumes:
+      - dev-run:/run/iot
+    depends_on:
+      ds-server:
+        condition: service_healthy
+    restart: unless-stopped
+
+# ── Shared volumes ──────────────────────────────────────────────
+volumes:
+  dev-run:    # Unix socket (ds-server ↔ all daemons)
+  dev-etc:    # Schemas, env files, LwM2M object config
+  dev-lib:    # Persisted data store

--- a/apps/device/run.sh
+++ b/apps/device/run.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# run.sh — Run the IoT Device stack (dev / e2e, no RPi3B board).
+#
+# Spawns ds-server, a local lwm2m server, the lwm2m device client, and
+# iot-httpd as separate containers communicating through a shared Unix
+# socket volume — the same daemon split that runs on a real board via
+# systemd. Prefers docker (falls back to podman only if docker is absent).
+#
+# This image is built locally (not published), so the default is to build
+# rather than pull. Build once, then start:
+#   ./run.sh build              # build naushada/iot-device:latest
+#   ./run.sh                    # start all services
+#
+# Usage:
+#   ./run.sh                    # start all services; UI on http://localhost:8081
+#   ./run.sh stop               # stop all services
+#   ./run.sh logs [service]     # tail logs (default: all services)
+#   ./run.sh build              # build the image
+#   ./run.sh nocache            # build without cache
+#   ./run.sh ps                 # list running services
+#   ./run.sh ds get log.text    # run ds-cli inside the ds-server container
+#
+#   HTTP_PORT=9090 ./run.sh                          # custom UI host port
+#   DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh
+#                               # point the client at a real cloud stack
+#                               # (cloud compose publishes BS 5684 / DM 5683)
+#
+# Persistent state (named volumes):
+#   - dev-etc   volume: /etc/iot      (schemas, env files, LwM2M config)
+#   - dev-lib   volume: /var/lib/iot  (persisted data store)
+#   - dev-run   volume: /run/iot      (ds-server socket)
+
+set -euo pipefail
+
+IMAGE="${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}"
+HTTP_PORT="${HTTP_PORT:-8081}"
+DEVICE_BS_URI="${DEVICE_BS_URI:-coap://lwm2m-server:5685}"
+# Reset the dev-etc config volume on start so the latest schema/config
+# from the image is always loaded (set to 0 to preserve manual edits).
+RESET_CONFIG="${RESET_CONFIG:-1}"
+# Compose project name → deterministic volume names (device_dev-etc, …).
+PROJECT="${COMPOSE_PROJECT_NAME:-device}"
+# Image is local-only by default; don't try to pull it.
+PULL="${PULL:-0}"
+
+GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
+log_section() { echo -e "\n${GREEN}=== $1 ===${NC}"; }
+log_info()    { echo -e "${YELLOW} → $1${NC}"; }
+
+detect_runtime() {
+    if command -v docker &>/dev/null; then echo "docker"
+    elif command -v podman &>/dev/null; then echo "podman"
+    else echo "ERROR: docker required (podman also accepted)" >&2; exit 1; fi
+}
+
+CR=$(detect_runtime)
+COMPOSE="$CR compose"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Export env so docker-compose.yml can reference them.
+export DEVICE_IMAGE="$IMAGE"
+export HTTP_PORT DEVICE_BS_URI
+export COMPOSE_PROJECT_NAME="$PROJECT"
+
+case "${1:-start}" in
+    build)
+        log_section "Building $IMAGE"
+        $CR build -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR/../../"
+        log_info "Built — start it with: ./run.sh"
+        ;;
+    nocache|build-nocache)
+        log_section "Building $IMAGE (no cache)"
+        $CR build --no-cache -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR/../../"
+        log_info "Built — start it with: ./run.sh"
+        ;;
+
+    start|up)
+        if [ "$PULL" = "1" ]; then
+            log_info "Pulling $IMAGE..."
+            $CR pull "$IMAGE" || log_info "pull failed — using local image if present"
+        fi
+        if ! $CR image inspect "$IMAGE" >/dev/null 2>&1; then
+            echo "ERROR: image '$IMAGE' not found — build it first: ./run.sh build" >&2
+            exit 1
+        fi
+
+        # Reload schemas/config from the image. dev-etc (/etc/iot) holds
+        # image-provided static config (Lua schemas + LwM2M object config);
+        # persisting it across rebuilds causes stale schemas. Persisted
+        # data (dev-lib) and the socket (dev-run) are untouched.
+        if [ "$RESET_CONFIG" = "1" ]; then
+            log_info "Refreshing config volume ${PROJECT}_dev-etc (set RESET_CONFIG=0 to keep)"
+            $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" down --remove-orphans 2>/dev/null || true
+            $CR volume rm "${PROJECT}_dev-etc" 2>/dev/null || true
+        fi
+
+        log_section "Starting IoT Device stack"
+        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" up -d
+
+        sleep 3
+        echo ""
+        echo -e "  ${GREEN}Device UI:${NC}    http://localhost:$HTTP_PORT"
+        echo -e "  ${GREEN}Bootstrap:${NC}    client → ${DEVICE_BS_URI}"
+        echo ""
+        echo "  ./run.sh logs [service]  — tail logs"
+        echo "  ./run.sh ps              — list services"
+        echo "  ./run.sh ds get log.lwm2m.text  — read a ds key"
+        echo "  ./run.sh stop            — stop all"
+        ;;
+
+    stop|down)
+        log_section "Stopping IoT Device stack"
+        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" down
+        ;;
+
+    logs)
+        shift || true
+        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" logs -f "${@}"
+        ;;
+
+    ps|status)
+        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" ps
+        ;;
+
+    restart)
+        shift || true
+        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" restart "${@}"
+        ;;
+
+    ds)
+        # Forward to ds-cli inside the ds-server container:
+        #   ./run.sh ds get log.lwm2m.text
+        #   ./run.sh ds set iot.endpoint '"urn:dev:test-1"'
+        shift || true
+        $CR exec iot-dev-ds ds-cli --socket=/run/iot/data_store.sock "${@}"
+        ;;
+
+    *)
+        echo "Usage: $0 {start|stop|logs|ps|build|nocache|restart|ds}" >&2
+        exit 1
+        ;;
+esac

--- a/packaging/iot-entrypoint.sh
+++ b/packaging/iot-entrypoint.sh
@@ -29,7 +29,7 @@ set -e
 # If the first arg is one of our binaries, forward verbatim — supports
 # `podman run iot:l11 ds-cli get foo`.
 case "${1:-}" in
-    ds-cli|ds-server|lwm2m|openvpn-client|openvpn|net-router|nft|ip|wifi-client|wpa_supplicant|wpa_cli|udhcpc|dhclient)
+    ds-cli|ds-server|lwm2m|iot-httpd|openvpn-client|openvpn|net-router|nft|ip|wifi-client|wpa_supplicant|wpa_cli|udhcpc|dhclient)
         exec "$@"
         ;;
 esac
@@ -79,7 +79,7 @@ case "${IOT_ROLE:-}" in
         ;;
     "")
         echo "iot-entrypoint: set IOT_ROLE to one of: ds | client | server | ovpn | net | wifi" >&2
-        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m / openvpn-client / openvpn / net-router / wifi-client / wpa_supplicant / wpa_cli / udhcpc / dhclient / nft / ip" >&2
+        echo "                or invoke a binary directly: ds-cli / ds-server / lwm2m / iot-httpd / openvpn-client / openvpn / net-router / wifi-client / wpa_supplicant / wpa_cli / udhcpc / dhclient / nft / ip" >&2
         exit 64
         ;;
     *)


### PR DESCRIPTION
## Summary
Adds `apps/device/` mirroring `apps/cloud/` — a Dockerfile + docker-compose + run.sh that builds the **device-side** stack into a slim runtime image and runs the daemons as compose services sharing the ds-server socket, so the full stack can be exercised **end-to-end without a real Raspberry Pi 3B board**.

- **Self-contained by default**: a local `lwm2m-server` (BS 5685 + DM 5683) is the authority and the `lwm2m-client` bootstraps + registers over plain CoAP — working registration loop, no external deps.
- **Point at a real cloud**: `DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh`.
- `lwm2m` built with `-DIOT_ENABLE_MONGO=OFF` (same as the cloud image). One cmake build of `apps/` stages every binary + schemas + config + the device UI via `make install`.
- CoAP ports stay internal so the device stack runs alongside the cloud stack without port clashes.

Also forwards `iot-httpd` in `packaging/iot-entrypoint.sh`'s binary-passthrough list (was missing → `command: iot-httpd ...` fell through to `IOT_ROLE` dispatch and failed). Also benefits `packaging/Containerfile`.

## Test plan
- `bash -n run.sh`, `sh -n iot-entrypoint.sh` — syntax OK
- `podman compose config` — normalizes cleanly (all 4 services, env interpolation resolves)
- `./run.sh build` — full image compile (in progress at time of opening)

🤖 Generated with [Claude Code](https://claude.com/claude-code)