### PR TITLE
fix(device): UI fixes, client-only stack + engineer account, reactor-thread logging

### DIFF
--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -20,15 +20,16 @@ interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered
       <div class="card" *ngIf="isAdmin" style="margin-bottom:20px;">
         <div class="card-header">Provision a device</div>
         <div class="card-block">
-          <div class="prov-grid">
-            <clr-input-container>
+          <div class="form-grid">
+            <clr-input-container style="grid-column: span 2;">
               <label>Serial Number</label>
-              <input clrInput [(ngModel)]="provSerial" placeholder="device serial (from device-ui)" />
+              <input clrInput [(ngModel)]="provSerial" style="width:100%;"
+                     placeholder="device serial (from device-ui)" />
             </clr-input-container>
-            <clr-input-container>
+            <clr-input-container style="grid-column: span 2;">
               <label>Bootstrap PSK (64 hex)</label>
-              <input clrInput [(ngModel)]="provBsPsk" placeholder="paste BS PSK from device-ui"
-                     style="width:30rem;font-family:monospace;" />
+              <input clrInput [(ngModel)]="provBsPsk" style="width:100%;font-family:monospace;"
+                     placeholder="paste BS PSK from device-ui" />
             </clr-input-container>
           </div>
           <button class="btn btn-primary" [disabled]="provisioning" (click)="provision()">

--- a/apps/device/Dockerfile
+++ b/apps/device/Dockerfile
@@ -129,6 +129,18 @@ RUN apt-get -o Acquire::Check-Date=false update && \
     openvpn nftables iproute2 wpasupplicant udhcpc wireless-tools \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /usr/share/man/*
 
+# PSK-provisioning accounts — mirror packaging/systemd/iot-sysusers.conf so
+# the container matches the SD-card/systemd deployment:
+#   * `engineer` runs the LwM2M client; its ds connection carries
+#     gid:engineer, matching the read/write ACLs on the PSK keys.
+#   * `iot` is the ds-socket access group (ds-server chgrp's its 0660 socket
+#     to it; `engineer` is a member so it can connect).
+# httpd stays root and relies on iot.dev.mode for commissioning writes.
+RUN groupadd --system iot && \
+    groupadd --system engineer && \
+    useradd --system --no-create-home --shell /usr/sbin/nologin --gid engineer engineer && \
+    usermod -aG iot engineer
+
 # ACE 7.0.0 shared library.
 COPY --from=builder /usr/local/ACE_TAO-7.0.0/lib/libACE.so* /usr/local/lib/
 RUN ldconfig

--- a/apps/device/docker-compose.yml
+++ b/apps/device/docker-compose.yml
@@ -2,22 +2,18 @@
 #
 # Brings up the device-side daemons as separate containers sharing the
 # ds-server Unix socket on the dev-run volume — the same wiring that runs
-# on a real board under systemd. By default it is a SELF-CONTAINED loop:
-# a local lwm2m server (role=server) plays the LwM2M authority and the
-# lwm2m client bootstraps + registers against it over plain CoAP, so
-# `./run.sh` gives a working end-to-end registration cycle with zero
-# external dependencies.
+# on a real board under systemd. The device is CLIENT-ONLY: it registers
+# against a cloud (apps/cloud) LwM2M Bootstrap/DM server. It never runs an
+# LwM2M server itself (that role belongs to the cloud).
 #
-#   ds-server      → shared data store (IPC backbone)
-#   lwm2m-server   → local Bootstrap (5685) + DM (5683) authority
-#   lwm2m-client   → device client: bootstraps from BS, registers to DM
-#   iot-httpd      → device REST API (/api/v1/*) + device UI (served at /)
+#   ds-server     → shared data store (IPC backbone)
+#   lwm2m-client  → device client: bootstraps from the cloud BS, registers to DM
+#   iot-httpd     → device REST API (/api/v1/*) + device UI (served at /)
 #
-# Point the client at a real cloud instead of the local server by
-# overriding DEVICE_BS_URI (and dropping the local server if you like):
+# Point the client at your cloud Bootstrap server with DEVICE_BS_URI (the
+# cloud compose publishes BS on 5684/DM on 5683 to the host;
+# host.docker.internal resolves via the host-gateway extra_hosts entry):
 #   DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh
-# (the cloud compose publishes BS on 5684/DM on 5683 to the host;
-#  host.docker.internal resolves via the host-gateway extra_hosts entry.)
 #
 # Usage:
 #   docker compose up -d
@@ -38,6 +34,7 @@ services:
       ds-socket=/run/iot/data_store.sock
       ds-store=/var/lib/iot/data_store.lua
       ds-schema-dir=/etc/iot/ds-schemas
+      ds-socket-group=iot
     volumes:
       - dev-run:/run/iot
       - dev-etc:/etc/iot
@@ -50,39 +47,28 @@ services:
       retries: 3
       start_period: 5s
 
-  # ── Local LwM2M authority (Bootstrap 5685 + DM 5683) ───────────
-  # The device binary in role=server. For self-contained e2e only —
-  # override DEVICE_BS_URI to target a real cloud and this sits idle.
-  lwm2m-server:
-    image: ${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}
-    container_name: iot-dev-lwm2m-server
-    command: >
-      lwm2m
-      role=server
-      local=coap://0.0.0.0:5685
-      config=/etc/iot/config
-      ds-sock=/run/iot/data_store.sock
-    volumes:
-      - dev-run:/run/iot
-      - dev-etc:/etc/iot
-    depends_on:
-      ds-server:
-        condition: service_healthy
-    restart: unless-stopped
-
-  # ── Device LwM2M client ────────────────────────────────────────
+  # ── Device LwM2M client (registers against the cloud BS/DM) ────
+  # Runs as `engineer` (primary group engineer, supplementary iot) — same
+  # as iot-lwm2m-client.service on the SD-card/systemd build. gid:engineer
+  # lets it read/write the PSK keys; supplementary `iot` lets it reach the
+  # ds socket (group iot, ds-socket-group=iot on ds-server).
   lwm2m-client:
     image: ${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}
     container_name: iot-dev-lwm2m-client
+    user: "engineer:engineer"
+    group_add:
+      - iot
     command: >
       lwm2m
       role=client
-      local=coap://0.0.0.0:5684
-      bs=${DEVICE_BS_URI:-coap://lwm2m-server:5685}
+      local=coaps://0.0.0.0:5684
+      bs=${DEVICE_BS_URI:-coaps://host.docker.internal:5684}
+      identity=${LWM2M_PSK_ID:-97554878B284CE3B727D8DD06E87659A}
+      secret=${LWM2M_PSK_KEY:-3894beedaa7fe0eae6597dc350a59525}
       config=/etc/iot/config
       ds-sock=/run/iot/data_store.sock
-    # Lets DEVICE_BS_URI=coaps://host.docker.internal:5684 reach a cloud
-    # stack published on the host (Linux needs the host-gateway mapping).
+    # host.docker.internal → the host, so the client reaches the cloud stack's
+    # published BS/DM ports (Linux needs the host-gateway mapping).
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:
@@ -91,8 +77,6 @@ services:
     depends_on:
       ds-server:
         condition: service_healthy
-      lwm2m-server:
-        condition: service_started
     restart: unless-stopped
 
   # ── HTTP Server (device REST API + device UI) ──────────────────
@@ -103,6 +87,7 @@ services:
       iot-httpd
       ds-socket=/run/iot/data_store.sock
       http-port=8080
+      http-workers=${HTTP_WORKERS:-4}
       www-dir=/usr/share/iot/www
     ports:
       - "${HTTP_PORT:-8081}:8080"

--- a/apps/device/run.sh
+++ b/apps/device/run.sh
@@ -34,7 +34,7 @@ set -euo pipefail
 
 IMAGE="${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}"
 HTTP_PORT="${HTTP_PORT:-8081}"
-DEVICE_BS_URI="${DEVICE_BS_URI:-coap://lwm2m-server:5685}"
+DEVICE_BS_URI="${DEVICE_BS_URI:-coaps://host.docker.internal:5684}"
 # Reset the dev-etc config volume on start so the latest schema/config
 # from the image is always loaded (set to 0 to preserve manual edits).
 RESET_CONFIG="${RESET_CONFIG:-1}"
@@ -115,7 +115,7 @@ case "${1:-start}" in
 
     logs)
         shift || true
-        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" logs -f "${@}"
+        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" logs -f ${@+"${@}"}
         ;;
 
     ps|status)
@@ -128,15 +128,34 @@ case "${1:-start}" in
         ;;
 
     ds)
-        # Forward to ds-cli inside the ds-server container:
+        # Forward to ds-cli inside the ds-server container (runs as root):
         #   ./run.sh ds get log.lwm2m.text
         #   ./run.sh ds set iot.endpoint '"urn:dev:test-1"'
+        # NOTE: root cannot write gid:engineer keys (serial/PSK/dev.mode) —
+        # use `./run.sh commission` for those.
         shift || true
         $CR exec iot-dev-ds ds-cli --socket=/run/iot/data_store.sock "${@}"
         ;;
 
+    commission)
+        # Enter/leave commissioning mode by setting iot.dev.mode. This key is
+        # write_acl=gid:engineer, so we run ds-cli inside the lwm2m-client
+        # container, which runs as the `engineer` account — root (the `ds`
+        # command / ds-cli on the host) is denied. While on, ds-server
+        # bypasses the PSK ACLs so device-ui can write the serial + BS PSK.
+        #   ./run.sh commission on    # enable, then set serial/PSK in device-ui
+        #   ./run.sh commission off   # lock down after provisioning
+        case "${2:-on}" in
+            on|true|1)  val=true ;;
+            off|false|0) val=false ;;
+            *) echo "Usage: $0 commission [on|off]" >&2; exit 1 ;;
+        esac
+        log_info "Setting iot.dev.mode=$val (ds-cli as engineer in lwm2m-client)"
+        $CR exec iot-dev-lwm2m-client ds-cli --socket=/run/iot/data_store.sock set iot.dev.mode "$val"
+        ;;
+
     *)
-        echo "Usage: $0 {start|stop|logs|ps|build|nocache|restart|ds}" >&2
+        echo "Usage: $0 {start|stop|logs|ps|build|nocache|restart|ds|commission}" >&2
         exit 1
         ;;
 esac

--- a/apps/src/coap_adapter.cpp
+++ b/apps/src/coap_adapter.cpp
@@ -1025,10 +1025,14 @@ std::vector<std::string> CoAPAdapter::handleLwM2MObjects(const CoAPAdapter::CoAP
                                ACE_TEXT("%D lwm2m:thread:%t %M %N:%l %C\n"),
                                std::string(ent.m_ridvalue.begin(), ent.m_ridvalue.end()).c_str()));
                 } else {
+                    std::string hex; char b[4];
                     for(const auto& elm: ent.m_ridvalue) {
-                        printf("%0.2X ", (std::uint8_t)elm);
+                        snprintf(b, sizeof(b), "%02X ", (std::uint8_t)elm);
+                        hex += b;
                     }
-                    printf("\n");
+                    ACE_DEBUG((LM_DEBUG,
+                               ACE_TEXT("%D lwm2m:thread:%t %M %N:%l ridvalue(hex): %C\n"),
+                               hex.c_str()));
                 }
             }
 
@@ -1214,10 +1218,16 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
                                        static_cast<unsigned>(ent.m_ridlength),
                                        static_cast<int>(ent.m_ridvalue.size())));
         
-                            for(const auto& elm: ent.m_ridvalue) {
-                                printf("%0.2X ", (std::uint8_t)elm);
+                            {
+                                std::string hex; char b[4];
+                                for(const auto& elm: ent.m_ridvalue) {
+                                    snprintf(b, sizeof(b), "%02X ", (std::uint8_t)elm);
+                                    hex += b;
+                                }
+                                ACE_DEBUG((LM_DEBUG,
+                                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l ridvalue(hex): %C\n"),
+                                           hex.c_str()));
                             }
-                            printf("\n");
                         }
                     }
                 }
@@ -1396,10 +1406,16 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
                                        static_cast<unsigned>(ent.m_ridlength),
                                        static_cast<int>(ent.m_ridvalue.size())));
         
-                            for(const auto& elm: ent.m_ridvalue) {
-                                printf("%0.2X ", (std::uint8_t)elm);
+                            {
+                                std::string hex; char b[4];
+                                for(const auto& elm: ent.m_ridvalue) {
+                                    snprintf(b, sizeof(b), "%02X ", (std::uint8_t)elm);
+                                    hex += b;
+                                }
+                                ACE_DEBUG((LM_DEBUG,
+                                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l ridvalue(hex): %C\n"),
+                                           hex.c_str()));
                             }
-                            printf("\n");
                         }
                     }
                 }
@@ -1443,7 +1459,8 @@ void CoAPAdapter::dumpCoAPMessage(const CoAPMessage& coapmessage) {
     if(it != coapmessage.uripath.end()) {
         auto ent = *it;
         auto blk1 = static_cast<std::uint8_t>(ent.optionvalue.at(0));
-        printf("Block1 Length: %0.2X\n", blk1);
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D lwm2m:thread:%t %M %N:%l Block1 Length: %02X\n"), blk1));
         auto szx = blk1 & 0b111;
         auto m = (blk1 >> 3) & 0b1;
         auto num = (blk1 >> 4) & 0b1111;

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -772,10 +772,11 @@ int main(std::int32_t argc, char *argv[]) {
     }
 
 
-    // Flush the log ring-buffer every 10s via LogBuffer's own ACE reactor
+    // Flush the log ring-buffer every 5s via LogBuffer's own ACE reactor
     // timer (private reactor on its own thread — same pattern as
-    // StatsPublisher). Replaces the old std::thread flusher.
-    if (auto* cli = ds.client()) g_log.open(*cli, 10, 200);
+    // StatsPublisher). min_bytes=1 so even a low-traffic daemon's lines
+    // actually reach ds (200 suppressed small buffers → empty Logs page).
+    if (auto* cli = ds.client()) g_log.open(*cli, 5, 1);
 
     std::unique_ptr<data_store::ServiceGate> svc_gate;
     std::unique_ptr<data_store::DepWatch>    dep_watch;

--- a/apps/src/udp_adapter.cpp
+++ b/apps/src/udp_adapter.cpp
@@ -2,6 +2,7 @@
 #define __udp_adapter_cpp__
 
 #include "udp_adapter.hpp"
+#include "data_store/log_buffer.hpp"   // LogBuffer::attach_current_thread
 
 #include <ace/Log_Msg.h>
 #include <ace/Reactor.h>
@@ -371,6 +372,12 @@ int UDPAdapter::svc() {
     // this svc() path (see UDPAdapter::start) so the owner() call is
     // unconditional.
     ACE_Reactor::instance()->owner(ACE_Thread::self());
+
+    // ACE_Log_Msg is per-thread: this reactor runs on its own svc() thread,
+    // so without re-attaching the LogBuffer sink here, every CoAP/UDP/DTLS
+    // log line emitted on this thread would bypass the ring buffer and never
+    // reach log.lwm2m.text. Attach the (main-thread-registered) callback.
+    data_store::LogBuffer::attach_current_thread();
 
     ACE_Time_Value to(1, 0);
     while (!m_stop.load()) {

--- a/iot-ui/src/app/log-level/log-viewer.component.ts
+++ b/iot-ui/src/app/log-level/log-viewer.component.ts
@@ -1,7 +1,7 @@
 import { Component, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/core';
-import { Subscription, interval } from 'rxjs';
-import { switchMap } from 'rxjs/operators';
+import { Subscription } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
+import { HttpsvcService } from '../../common/httpsvc.service';
 import { environment } from '../../environments/environment';
 
 @Component({
@@ -13,7 +13,7 @@ import { environment } from '../../environments/environment';
         <button class="btn btn-sm" (click)="refresh()">Refresh</button>
         <label class="auto-refresh">
           <input type="checkbox" [checked]="autoRefresh" (change)="toggleAuto()" />
-          auto (3s)
+          auto
         </label>
       </div>
       <textarea #ta class="log-textarea" readonly
@@ -41,27 +41,44 @@ export class LogViewerComponent implements OnInit, OnDestroy {
   @ViewChild('ta') ta!: ElementRef<HTMLTextAreaElement>;
   logText = '';
   autoRefresh = true;
+  private active = true;
   private sub = new Subscription();
   private api = environment.apiUrl;
 
-  constructor(private http: HttpClient) {}
+  // Mirrors the cloud-ui log viewer (apps/cloud/ui log-viewer): one raw
+  // text fetch of the merged /api/v1/log, plus a long-poll on log.version
+  // (every daemon bumps it on flush) to drive live updates. The long-poll
+  // loop re-subscribes in both next and error, so a transient failure
+  // (e.g. a 401 after the session expires) never tears the stream down.
+  constructor(private http: HttpClient, private httpSvc: HttpsvcService) {}
 
   ngOnInit(): void {
     this.refresh();
+    this.pollLog();
+  }
+
+  private pollLog(): void {
+    if (!this.active) return;
     this.sub.add(
-      interval(3000).pipe(switchMap(() => this.fetchLog())).subscribe({
-        next: (text) => { if (this.autoRefresh) { this.logText = text; this.scrollBottom(); } }
+      this.httpSvc.dbGetLongPoll('log.version', 30).subscribe({
+        next: () => {
+          if (this.autoRefresh) this.fetchAndShow();
+          this.pollLog();
+        },
+        error: () => { if (this.active) setTimeout(() => this.pollLog(), 2000); }
       })
     );
   }
 
-  refresh(): void {
+  refresh(): void { this.fetchAndShow(); }
+
+  toggleAuto(): void { this.autoRefresh = !this.autoRefresh; }
+
+  private fetchAndShow(): void {
     this.fetchLog().subscribe({
       next: (text) => { this.logText = text; this.scrollBottom(); }
     });
   }
-
-  toggleAuto(): void { this.autoRefresh = !this.autoRefresh; }
 
   private fetchLog() {
     return this.http.get(`${this.api}/api/v1/log`, {
@@ -76,5 +93,5 @@ export class LogViewerComponent implements OnInit, OnDestroy {
     }, 50);
   }
 
-  ngOnDestroy(): void { this.sub.unsubscribe(); }
+  ngOnDestroy(): void { this.active = false; this.sub.unsubscribe(); }
 }

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
@@ -1,21 +1,10 @@
 <div class="page">
-  <h3>LwM2M Endpoint Configuration</h3>
+  <h3>{{ mode === 'security' ? 'LwM2M Security (Bootstrap)' : 'LwM2M Server' }}</h3>
 
   <form [formGroup]="serverForm" (ngSubmit)="save()" *ngIf="!loading">
-    <div class="form-grid">
-      <clr-input-container>
-        <label>Serial Number</label>
-        <input clrInput formControlName="serial"
-               [readonly]="serialAutoDetected"
-               [disabled]="!isAdmin"
-               placeholder="enter device serial number" />
-        <clr-control-helper *ngIf="serialAutoDetected">
-          Auto-detected (Raspberry Pi) — read-only
-        </clr-control-helper>
-        <clr-control-helper *ngIf="!serialAutoDetected">
-          Not a Raspberry Pi — enter the serial printed on the device
-        </clr-control-helper>
-      </clr-input-container>
+
+    <!-- ── Server tab: registration / Server Object fields ───────── -->
+    <div class="form-grid" *ngIf="mode === 'server'">
       <clr-input-container>
         <label>Server URI</label>
         <input clrInput [disabled]="!isAdmin" formControlName="server_uri" placeholder="coaps://lwm2m.example.com:5684" />
@@ -39,14 +28,39 @@
       </clr-input-container>
     </div>
 
-    <clr-checkbox-container style="margin-top:16px;">
+    <clr-checkbox-container style="margin-top:16px;" *ngIf="mode === 'server'">
       <clr-checkbox-wrapper>
         <input type="checkbox" clrCheckbox [disabled]="!isAdmin" formControlName="observable" />
         <label>Observable</label>
       </clr-checkbox-wrapper>
     </clr-checkbox-container>
 
-    <div style="margin-top:24px;" *ngIf="isAdmin">
+    <!-- ── Security tab: serial (Security Object identity) ───────── -->
+    <!-- iot.serial is write_acl=gid:engineer; the data-store only accepts
+         a write from device-ui while commissioning mode (iot.dev.mode) is
+         on. So the field is read-only unless devMode (or RPi auto-fill). -->
+    <div class="form-grid" *ngIf="mode === 'security'">
+      <clr-input-container>
+        <label>Serial Number</label>
+        <input clrInput formControlName="serial"
+               [readonly]="serialAutoDetected || !devMode"
+               [disabled]="!isAdmin"
+               placeholder="enter device serial number" />
+        <clr-control-helper *ngIf="serialAutoDetected">
+          Auto-detected (Raspberry Pi) — read-only
+        </clr-control-helper>
+        <clr-control-helper *ngIf="!serialAutoDetected && devMode">
+          Not a Raspberry Pi — enter the serial printed on the device
+        </clr-control-helper>
+        <clr-control-helper *ngIf="!serialAutoDetected && !devMode">
+          Enable commissioning mode (iot.dev.mode) to set the serial
+        </clr-control-helper>
+      </clr-input-container>
+    </div>
+
+    <!-- Save: server fields always; serial only when commissioning + editable -->
+    <div style="margin-top:24px;"
+         *ngIf="isAdmin && (mode === 'server' || (devMode && !serialAutoDetected))">
       <button type="submit" class="btn btn-primary" [disabled]="saving">
         {{ saving ? 'Saving…' : 'Save' }}
       </button>
@@ -54,10 +68,13 @@
     </div>
   </form>
 
-  <!-- PSK provisioning (task H): dev-mode only. Generate a 32-byte BS PSK,
-       show it once so the engineer can copy serial + PSK into cloud-ui. The
-       value is stored write-only; it is never read back from the store. -->
-  <div class="card" style="margin-top:32px;" *ngIf="!loading && devMode && isAdmin">
+  <!-- PSK provisioning (task H): on the Security tab. Generate a 32-byte BS
+       PSK, show it once so the engineer can copy serial + PSK into cloud-ui.
+       The value is stored write-only; it is never read back. Generation
+       requires commissioning mode (iot.dev.mode) so the data-store bypasses
+       the PSK ACLs and httpd can write it. -->
+  <div class="card" style="margin-top:32px;"
+       *ngIf="!loading && mode === 'security' && isAdmin">
     <div class="card-header">Bootstrap PSK (commissioning)</div>
     <div class="card-block">
       <p class="card-text">
@@ -67,9 +84,13 @@
         only once.
       </p>
       <button type="button" class="btn btn-outline"
-              [disabled]="generatingPsk" (click)="generateBsPsk()">
+              [disabled]="generatingPsk || !devMode" (click)="generateBsPsk()">
         {{ generatingPsk ? 'Generating…' : 'Generate BS PSK' }}
       </button>
+      <p *ngIf="!devMode" class="hint" style="margin-top:8px;">
+        Enable commissioning mode (<code>iot.dev.mode</code>) to generate and
+        store the BS PSK.
+      </p>
       <clr-input-container *ngIf="generatedPsk" style="margin-top:12px;">
         <label>Generated BS PSK (copy now)</label>
         <input clrInput readonly [value]="generatedPsk" style="width:34rem;font-family:monospace;" />

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, Input, OnInit } from '@angular/core';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
@@ -10,6 +10,11 @@ import { ToastService } from '../../../common/toast.service';
   styleUrls: ['./lwm2m-config.component.scss']
 })
 export class Lwm2mConfigComponent implements OnInit {
+  // Which tab is rendering this component: 'server' shows the registration
+  // fields (Server Object), 'security' shows serial + Bootstrap PSK
+  // (Security Object). Same form-group backs both; we just show a subset.
+  @Input() mode: 'server' | 'security' = 'server';
+
   serverForm: FormGroup;
   loading = true; saving = false; msg = '';
 
@@ -64,17 +69,23 @@ export class Lwm2mConfigComponent implements OnInit {
   save(): void {
     this.saving = true; this.msg = '';
     const v = this.serverForm.value;
-    const pairs: { key: string; value: unknown }[] = [
-      { key: 'iot.server.uri', value: v.server_uri },
-      { key: 'iot.endpoint',   value: v.endpoint },
-      { key: 'iot.binding',    value: v.binding },
-      { key: 'iot.lifetime',   value: v.lifetime },
-      { key: 'iot.observable', value: v.observable },
-    ];
-    // Only push the serial when the installer entered it (non-RPi). On RPi
-    // the client owns iot.serial and the field is read-only.
-    if (!this.serialAutoDetected && v.serial) {
-      pairs.push({ key: 'iot.serial', value: v.serial });
+    let pairs: { key: string; value: unknown }[];
+    if (this.mode === 'security') {
+      // Security tab owns the serial. Only push it when the installer
+      // entered it (non-RPi); on RPi the client owns iot.serial read-only.
+      pairs = (!this.serialAutoDetected && v.serial)
+        ? [{ key: 'iot.serial', value: v.serial }]
+        : [];
+      if (pairs.length === 0) { this.saving = false; return; }
+    } else {
+      // Server tab owns the registration (Server Object) fields.
+      pairs = [
+        { key: 'iot.server.uri', value: v.server_uri },
+        { key: 'iot.endpoint',   value: v.endpoint },
+        { key: 'iot.binding',    value: v.binding },
+        { key: 'iot.lifetime',   value: v.lifetime },
+        { key: 'iot.observable', value: v.observable },
+      ];
     }
     this.http.dbSet(pairs).subscribe({
       next: (r) => { this.saving = false; if(r.ok) this.toast.success('LwM2M config saved'); else this.toast.error(r.err||'Save failed'); },

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -94,7 +94,7 @@
 
       <!-- LwM2M -->
       <ng-container *ngIf="selectedMenu==='lwm2m'">
-        <app-lwm2m-config *ngIf="!selectedSubNav || selectedSubNav==='server' || selectedSubNav==='security'"></app-lwm2m-config>
+        <app-lwm2m-config [mode]="selectedSubNav==='security' ? 'security' : 'server'"></app-lwm2m-config>
       </ng-container>
 
       <!-- Services -->

--- a/iot-ui/src/app/services/services-list/services-list.component.ts
+++ b/iot-ui/src/app/services/services-list/services-list.component.ts
@@ -4,7 +4,7 @@ import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { StatusSnapshot, ServiceInfo } from '../../../common/app-globals';
 
-interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: boolean; msg: string; }
+interface SvcRow { key: string; name: string; label: string; info: ServiceInfo; restarting: boolean; msg: string; }
 
 @Component({
   selector: 'app-services-list',
@@ -26,7 +26,10 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
 
         <clr-dg-row *clrDgItems="let s of services">
-          <clr-dg-cell><code>{{ s.label }}</code></clr-dg-cell>
+          <clr-dg-cell>
+            <span class="svc-name">{{ s.name }}</span>
+            <code class="svc-key" [title]="s.label + '.state'">{{ s.label }}</code>
+          </clr-dg-cell>
           <clr-dg-cell><app-status-badge [label]="s.info.state||'unknown'" [state]="s.info.state||''"></app-status-badge></clr-dg-cell>
           <clr-dg-cell class="num">{{ hasStats(s) ? fmtCpu(s.info.cpu_permille) : '—' }}</clr-dg-cell>
           <clr-dg-cell class="num">{{ hasStats(s) ? s.info.cpu_count : '—' }}</clr-dg-cell>
@@ -53,6 +56,8 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
   `,
   styles: [`
     .page { padding: 24px; } h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 20px 0; }
+    .svc-name { display: block; font-weight: 600; }
+    .svc-key { display: block; font-size: 11px; color: #9e9e9e; }
     .num { text-align: left; font-variant-numeric: tabular-nums; }
     .btn-sm:disabled { opacity: 0.5; cursor: not-allowed; }
     .hint { font-size: 12px; color: #757575; margin-top: 16px; }
@@ -60,12 +65,11 @@ interface SvcRow { key: string; label: string; info: ServiceInfo; restarting: bo
 })
 export class ServicesListComponent implements OnInit, OnDestroy {
   services: SvcRow[] = [
-    { key: 'ds', label: 'services.ds', info: {}, restarting: false, msg: '' },
-    { key: 'net_router',      label: 'services.net.router',     info: {}, restarting: false, msg: '' },
-    { key: 'openvpn_client',  label: 'services.openvpn.client', info: {}, restarting: false, msg: '' },
-    { key: 'lwm2m_client',    label: 'services.lwm2m.client',   info: {}, restarting: false, msg: '' },
-    { key: 'lwm2m_server',    label: 'services.lwm2m.server',   info: {}, restarting: false, msg: '' },
-    { key: 'wifi_client',     label: 'services.wifi.client',    info: {}, restarting: false, msg: '' },
+    { key: 'ds',             name: 'Data Store',     label: 'services.ds',             info: {}, restarting: false, msg: '' },
+    { key: 'net_router',     name: 'Network Router', label: 'services.net.router',     info: {}, restarting: false, msg: '' },
+    { key: 'openvpn_client', name: 'OpenVPN Client', label: 'services.openvpn.client', info: {}, restarting: false, msg: '' },
+    { key: 'lwm2m_client',   name: 'LwM2M Client',   label: 'services.lwm2m.client',   info: {}, restarting: false, msg: '' },
+    { key: 'wifi_client',    name: 'Wi-Fi Client',   label: 'services.wifi.client',    info: {}, restarting: false, msg: '' },
   ];
   private sub = new Subscription();
 
@@ -140,7 +144,6 @@ export class ServicesListComponent implements OnInit, OnDestroy {
       net_router: 'services.net.router.enable',
       openvpn_client: 'services.openvpn.client.enable',
       lwm2m_client: 'services.lwm2m.client.enable',
-      lwm2m_server: 'services.lwm2m.server.enable',
       wifi_client: 'services.wifi.client.enable',
     };
     return m[k] || '';

--- a/modules/data-store/inc/data_store/log_buffer.hpp
+++ b/modules/data-store/inc/data_store/log_buffer.hpp
@@ -54,6 +54,15 @@ public:
     /// after ACE is initialised — NOT during static initialisation.
     void start();
 
+    /// Attach the (already-started) log callback to the CALLING thread.
+    /// ACE_Log_Msg is thread-specific: a thread that runs its own reactor
+    /// (e.g. the LwM2M UDP/CoAP svc() thread) does NOT inherit the callback
+    /// registered by start() on the main thread, so its ACE_DEBUG/ACE_ERROR
+    /// output bypasses the ring buffer and never reaches log.*.text. Such a
+    /// thread must call this once at entry. No-op if start() hasn't run.
+    /// Process-wide: targets the most recently start()ed LogBuffer.
+    static void attach_current_thread();
+
     /// Unregister the callback. Flush one last time before destroying.
     ~LogBuffer();
 

--- a/modules/data-store/src/log_buffer.cpp
+++ b/modules/data-store/src/log_buffer.cpp
@@ -21,6 +21,16 @@
 
 namespace data_store {
 
+// Most recently start()ed callback + the level mask computed by the last
+// apply_level(). Used by attach_current_thread() so a worker thread running
+// its own reactor can route its ACE log output into the same ring buffer AND
+// honour the configured log level — ACE_Log_Msg is per-thread, so a spawned
+// reactor thread inherits neither. One LogBuffer per process in practice.
+namespace {
+    ACE_Log_Msg_Callback* s_active_cb   = nullptr;
+    unsigned long         s_active_mask = LM_INFO;
+}
+
 struct LogBuffer::Impl {
     std::mutex              mtx;
     std::deque<std::string> buf;
@@ -101,6 +111,18 @@ void LogBuffer::start() {
     auto* lm = ACE_Log_Msg::instance();
     lm->set_flags(lm->flags() | ACE_Log_Msg::MSG_CALLBACK);
     lm->msg_callback(&m_impl->cb);
+    s_active_cb = &m_impl->cb;   // so worker threads can attach the same sink
+}
+
+void LogBuffer::attach_current_thread() {
+    if (!s_active_cb) return;
+    auto* lm = ACE_Log_Msg::instance();
+    lm->set_flags(lm->flags() | ACE_Log_Msg::MSG_CALLBACK);
+    lm->msg_callback(s_active_cb);
+    // Also pin this thread's level to the configured mask — a freshly
+    // spawned reactor thread otherwise defaults to "all levels", leaking
+    // DEBUG noise that the INFO default is meant to suppress.
+    lm->priority_mask(static_cast<int>(s_active_mask), ACE_Log_Msg::THREAD);
 }
 
 int LogBuffer::open(Client& ds, int interval_sec, std::size_t min_bytes) {
@@ -217,6 +239,7 @@ void LogBuffer::apply_level(Client& ds) {
         else if (lvl_str == "WARNING") mask = LM_WARNING;
         else if (lvl_str == "ERROR")  mask = LM_ERROR | LM_CRITICAL;
     }
+    s_active_mask = mask;   // remembered for attach_current_thread()
     ACE_Log_Msg::instance()->priority_mask(
         static_cast<int>(mask), ACE_Log_Msg::PROCESS);
 }


### PR DESCRIPTION
Batch of device-stack + UI + logging fixes found during end-to-end testing (device ↔ cloud, no RPi3B).

## UI (no new ds keys)
- **device-ui LwM2M**: split into **Server** (registration) and **Security** (serial + BS PSK) tabs via a `mode` input — the two nav items no longer render the same form, and the serial/PSK UI is now reachable.
- **device-ui Services**: friendly daemon names (LwM2M Client, Network Router, …) with the ds key as subtitle; removed the LwM2M Server row (device is client-only).
- **device-ui Logs**: replicate the cloud-ui pattern (long-poll `log.version`, error→re-poll) so a transient 401 no longer blanks the page.
- **device-ui Security**: serial field gated behind commissioning mode (`iot.dev.mode`) with a clear hint (it's `write_acl=engineer`).
- **cloud-ui Endpoints**: provisioning form uses the 4-column `.form-grid`; the two fields span the row so they're not cramped.

## Device stack (mirrors SD-card/systemd model)
- **client-only**: removed the `lwm2m-server` service; client registers against the cloud BS/DM.
- **`iot-httpd` `http-workers=4`**: a long-poll no longer blocks every other request (~30s page stalls).
- **engineer account**: image creates `iot`+`engineer` (per `iot-sysusers.conf`); `lwm2m-client` runs as `engineer:engineer`+`group_add iot`, `ds-server` `ds-socket-group=iot`. httpd stays root.
- **`run.sh commission [on|off]`**: toggles `iot.dev.mode` via ds-cli as the engineer account (root is ACL-denied).

## Logging (shared LogBuffer; cloud-safe)
- The lwm2m reactor runs on its own `svc()` thread; ACE_Log_Msg is per-thread, so it inherited neither the LogBuffer callback nor the level. `attach_current_thread()` now sets **both** on the reactor thread → `log.lwm2m.text` populates and honors the per-daemon level.
- Lower the lwm2m flush threshold (5s / `min_bytes=1`) so low-traffic daemons flush.
- Convert `coap_adapter.cpp` hot-path `printf` hex-dumps to level-gated `ACE_DEBUG`.
- Additive: only the lwm2m binary calls `attach_current_thread`; `iot-cloudd`/`iot-httpd` unaffected.

## Verification
- Both images rebuilt green (device + cloud).
- Device `log.lwm2m.text` now captures reactor-thread lines (`[UdpSvc:7] …`); cloud `log.text`/`log.cloudd.text` still populate (no regression).
- `./run.sh commission on` sets `iot.dev.mode=true` as engineer; client runs as `uid=engineer gid=engineer groups=engineer,iot`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)