### PR TITLE
feat(device): ds-driven client, per-service logs, dashboard dedup, DTLS logs to UI

### DIFF
--- a/apps/3rdparty/tinydtls/dtls_debug.c
+++ b/apps/3rdparty/tinydtls/dtls_debug.c
@@ -214,6 +214,12 @@ dsrv_print_addr(const session_t *addr, char *buf, size_t len) {
 #ifdef HAVE_VPRINTF
 #ifndef WITH_CONTIKI
 /*Macro-ed in dtls_debug.h in order to use the platform's standard debug output*/
+/*SWISTART*/
+static void (*g_dtls_log_sink)(int level, const char *line) = NULL;
+void dtls_set_log_sink(void (*sink)(int level, const char *line)) {
+  g_dtls_log_sink = sink;
+}
+/*SWISTOP*/
 #ifndef __RTOS__
 void
 dsrv_log(log_t level, char *format, ...) {
@@ -236,6 +242,16 @@ dsrv_log(log_t level, char *format, ...) {
   vfprintf(log_fd, format, ap);
   va_end(ap);
   fflush(log_fd);
+
+  /*SWISTART: mirror the formatted line to the host log sink (→ LogBuffer → UI). */
+  if (g_dtls_log_sink) {
+    char line[512];
+    va_start(ap, format);
+    vsnprintf(line, sizeof(line), format, ap);
+    va_end(ap);
+    g_dtls_log_sink((int)level, line);
+  }
+  /*SWISTOP*/
 }
 #endif /*__RTOS__*/
 #else /* WITH_CONTIKI */

--- a/apps/3rdparty/tinydtls/dtls_debug.h
+++ b/apps/3rdparty/tinydtls/dtls_debug.h
@@ -69,6 +69,13 @@ log_t dtls_get_log_level(void);
 /** Sets the log level to the specified value. */
 void dtls_set_log_level(log_t level);
 
+/*SWISTART*/
+/** Optional sink: when set, every dsrv_log() line is also delivered here
+ * (in addition to stderr/stdout) so the host app can route DTLS logs into
+ * its own log buffer / UI. `line` is the formatted message (no timestamp). */
+void dtls_set_log_sink(void (*sink)(int level, const char *line));
+/*SWISTOP*/
+
 /**
  * Writes the given text to \c stdout. The text is output only when \p
  * level is below or equal to the log level that set by

--- a/apps/device/docker-compose.yml
+++ b/apps/device/docker-compose.yml
@@ -58,17 +58,17 @@ services:
     user: "engineer:engineer"
     group_add:
       - iot
-    command: >
-      lwm2m
-      role=client
-      local=coaps://0.0.0.0:5684
-      bs=${DEVICE_BS_URI:-coaps://host.docker.internal:5684}
-      identity=${LWM2M_PSK_ID:-97554878B284CE3B727D8DD06E87659A}
-      secret=${LWM2M_PSK_KEY:-3894beedaa7fe0eae6597dc350a59525}
-      config=/etc/iot/config
-      ds-sock=/run/iot/data_store.sock
-    # host.docker.internal → the host, so the client reaches the cloud stack's
-    # published BS/DM ports (Linux needs the host-gateway mapping).
+    # Fully ds-driven: no CLI args. The binary defaults role=client, binds
+    # coaps://0.0.0.0:5684, reads config from /etc/iot/config, connects to the
+    # default ds socket, and reads the bootstrap URI (iot.bs.uri) + BS PSK
+    # (iot.bs.psk.*) + endpoint (iot.endpoint) from the data-store — all
+    # commissioned via device-ui in commissioning mode. Running as `engineer`
+    # is what lets it read those gid:engineer keys. An unprovisioned device
+    # won't connect (by design): commission it first (./run.sh commission on,
+    # then set serial + bootstrap URI + generate BS PSK in device-ui).
+    command: lwm2m
+    # host.docker.internal → the host, so a bootstrap URI of
+    # coaps://host.docker.internal:5684 reaches the cloud stack's published BS.
     extra_hosts:
       - "host.docker.internal:host-gateway"
     volumes:

--- a/apps/device/run.sh
+++ b/apps/device/run.sh
@@ -150,8 +150,14 @@ case "${1:-start}" in
             off|false|0) val=false ;;
             *) echo "Usage: $0 commission [on|off]" >&2; exit 1 ;;
         esac
-        log_info "Setting iot.dev.mode=$val (ds-cli as engineer in lwm2m-client)"
-        $CR exec iot-dev-lwm2m-client ds-cli --socket=/run/iot/data_store.sock set iot.dev.mode "$val"
+        # Use a one-off container running as the engineer account (not exec in
+        # the client, which crash-loops while unprovisioned). engineer's
+        # gid:engineer satisfies the write_acl on iot.dev.mode; --group-add iot
+        # lets it reach the ds socket (group iot).
+        log_info "Setting iot.dev.mode=$val (one-off engineer container)"
+        $CR run --rm --user engineer:engineer --group-add iot \
+            -v "${PROJECT}_dev-run":/run/iot "$IMAGE" \
+            ds-cli --socket=/run/iot/data_store.sock set iot.dev.mode "$val"
         ;;
 
     *)

--- a/apps/inc/ds_config.hpp
+++ b/apps/inc/ds_config.hpp
@@ -53,6 +53,7 @@ public:
     enum class Key {
         Endpoint,
         ServerUri,
+        BsUri,
         Lifetime,
         // PSK provisioning (tasks E/F/G).
         Serial,
@@ -82,6 +83,7 @@ public:
     /// Thread-safe.
     std::optional<std::string>   endpoint()   const;
     std::optional<std::string>   server_uri() const;
+    std::optional<std::string>   bs_uri()     const;  // iot.bs.uri (commissioned)
     std::optional<std::uint32_t> lifetime()   const;
 
     // PSK provisioning accessors (task E/F/G). All return nullopt when

--- a/apps/src/ds_config.cpp
+++ b/apps/src/ds_config.cpp
@@ -19,6 +19,7 @@ namespace {
 
 constexpr const char* kKeyEndpoint  = "iot.endpoint";
 constexpr const char* kKeyServerUri = "iot.server.uri";
+constexpr const char* kKeyBsUri     = "iot.bs.uri";
 constexpr const char* kKeyLifetime  = "iot.lifetime";
 // PSK provisioning keys (tasks E/F/G).
 constexpr const char* kKeySerial      = "iot.serial";
@@ -38,6 +39,7 @@ struct DsConfig::Impl {
     mutable std::mutex                  mtx;
     std::optional<std::string>          endpoint;
     std::optional<std::string>          server_uri;
+    std::optional<std::string>          bs_uri;
     std::optional<std::uint32_t>        lifetime;
     // PSK provisioning cache (tasks E/F/G).
     std::optional<std::string>          serial;
@@ -55,6 +57,7 @@ struct DsConfig::Impl {
                              const data_store::Value& v) {
         if (key == kKeyEndpoint)   { endpoint = data_store::to_string(v); return Key::Endpoint; }
         if (key == kKeyServerUri)  { server_uri = data_store::to_string(v); return Key::ServerUri; }
+        if (key == kKeyBsUri)      { bs_uri = data_store::to_string(v); return Key::BsUri; }
         if (key == kKeyLifetime)   { lifetime = data_store::to_uint32(v); return Key::Lifetime; }
         if (key == kKeySerial)     { serial = data_store::to_string(v); return Key::Serial; }
         if (key == kKeyBsPskId)    { bs_psk_identity = data_store::to_string(v); return Key::BsPskIdentity; }
@@ -88,7 +91,7 @@ DsConfig::DsConfig(std::string socketPath)
 
     // All keys this reader caches + watches.
     const std::vector<std::string> kKeys = {
-        kKeyEndpoint, kKeyServerUri, kKeyLifetime,
+        kKeyEndpoint, kKeyServerUri, kKeyBsUri, kKeyLifetime,
         kKeySerial, kKeyBsPskId, kKeyBsPskKey,
         kKeyDmPskId, kKeyDmPskKey, kKeyDevMode,
     };
@@ -161,6 +164,12 @@ std::optional<std::string> DsConfig::server_uri() const {
     if (!m_ok) return std::nullopt;
     std::lock_guard<std::mutex> g(m_impl->mtx);
     return m_impl->server_uri;
+}
+
+std::optional<std::string> DsConfig::bs_uri() const {
+    if (!m_ok) return std::nullopt;
+    std::lock_guard<std::mutex> g(m_impl->mtx);
+    return m_impl->bs_uri;
 }
 
 std::optional<std::uint32_t> DsConfig::lifetime() const {

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -12,6 +12,8 @@
 #include <unordered_map>
 
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>   // ACE_OS::sleep
+#include <ace/Time_Value.h>
 
 #include "data_store/log_buffer.hpp"
 #include "data_store/stats_publisher.hpp"
@@ -146,6 +148,16 @@ inline void tx_via(App& app,
 // Captures ACE log output → ds log.lwm2m.*.text for the cloud UI.
 // Key may be overridden at startup for per-instance logs (bs / dm).
 data_store::LogBuffer g_log("lwm2m", "log.lwm2m.text", "log.level.lwm2m");
+
+// tinydtls log sink → ring buffer → ds → UI. tinydtls logs via its own
+// dsrv_log() (fprintf), which bypasses ACE; this C-linkage callback routes
+// each DTLS line into the same LogBuffer so the handshake shows in the UI.
+extern "C" void dtls_set_log_sink(void (*)(int, const char*));
+extern "C" void iot_dtls_log_sink(int /*level*/, const char* line) {
+    std::string s(line ? line : "");
+    while (!s.empty() && (s.back() == '\n' || s.back() == '\r')) s.pop_back();
+    if (!s.empty()) g_log.append("dtls: " + s + "\n");
+}
 
 /// Read the existing security/server-object JSON files under
 /// `apps/config/{securityObject,serverObject}/` and synthesise one
@@ -571,36 +583,34 @@ int main(std::int32_t argc, char *argv[]) {
         }
     }
 
-    UDPAdapter::Role_t role = UDPAdapter::Role_t::SERVER;
-    if(!argValueMap["role"].empty() && (argValueMap["role"] == "server" || argValueMap["role"] == "client")) {
-        role = roleMap[argValueMap["role"]];
-    } else {
+    // Device default is client (it runs client-only and may be launched with
+    // no args, fully ds-driven). The cloud passes role=server explicitly for
+    // the BS/DM instances. Only an explicit, invalid role is an error.
+    UDPAdapter::Role_t role = UDPAdapter::Role_t::CLIENT;
+    if(argValueMap["role"] == "server") {
+        role = UDPAdapter::Role_t::SERVER;
+    } else if(!argValueMap["role"].empty() && argValueMap["role"] != "client") {
         ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%D lwm2m:thread:%t %M %N:%l invalid option for role\n")),
+                          ACE_TEXT("%D lwm2m:thread:%t %M %N:%l invalid role '%C' (use client|server)\n"),
+                          argValueMap["role"].c_str()),
                          -1);
     }
 
     UDPAdapter::Scheme_t scheme;
-    /// Bootstrap Host & Port
+    // Bootstrap host/port are resolved AFTER the ds connection below: for a
+    // client they come from iot.bs.uri (commissioned via device-ui), falling
+    // back to a bs= CLI arg.
     std::string bsHost;
-    std::uint16_t bsPort;
-    if(UDPAdapter::Role_t::CLIENT == role) {
-        if(argValueMap["bs"].empty()) {
-            ACE_ERROR_RETURN((LM_ERROR,
-                              ACE_TEXT("%D lwm2m:thread:%t %M %N:%l bs=value missing from command line\n")),
-                             -1);
-        }
-        parsePeerOption(argValueMap["bs"], scheme, bsHost, bsPort);
-    }
+    std::uint16_t bsPort = 0;
 
     std::string selfHost;
     std::uint16_t selfPort;
-    if(argValueMap["local"].empty()) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%D lwm2m:thread:%t %M %N:%l local=value missing from command line\n")),
-                         -1);
-    }
-    parsePeerOption(argValueMap["local"], scheme, selfHost, selfPort);
+    // Local bind defaults to coaps://0.0.0.0:5684 (DTLS) for a ds-driven
+    // launch with no args; the scheme is taken from here.
+    const std::string localUri = !argValueMap["local"].empty()
+                                     ? argValueMap["local"]
+                                     : std::string("coaps://0.0.0.0:5684");
+    parsePeerOption(localUri, scheme, selfHost, selfPort);
 
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("%D lwm2m:thread:%t %M %N:%l scheme=%d host=%C port=%u\n"),
@@ -613,6 +623,45 @@ int main(std::int32_t argc, char *argv[]) {
     // DTLS adapter. ds-server is optional (absence → CLI/compiled-in
     // fallback). On a Raspberry Pi the serial is auto-filled here.
     iot::DsConfig ds(argValueMap["ds-sock"]);
+
+    // Wire logging BEFORE the provisioning park below so the "awaiting
+    // provisioning" notice + any startup failures reach the UI (ds), not just
+    // stderr. start()/open() are idempotent — the later calls (after the
+    // cloud-instance key setup) just refine the level key.
+    g_log.start();
+    dtls_set_log_sink(&iot_dtls_log_sink);   // DTLS (tinydtls) logs → UI
+    if (auto* cli = ds.client()) { g_log.apply_level(*cli); g_log.open(*cli, 5, 1); }
+
+    // Bootstrap URI + BS PSK (client only): ds-driven from iot.bs.uri /
+    // iot.bs.psk.* (commissioned via device-ui), with bs=/identity=/secret=
+    // CLI fallback. PARK here until commissioned rather than exiting — an
+    // unprovisioned device stays alive (no crash-loop that resets the log
+    // buffer + blocks commissioning) and resumes as soon as the ds watch sees
+    // the values appear. Running as `engineer` is what lets the watch read
+    // the gid:engineer PSK keys.
+    if (UDPAdapter::Role_t::CLIENT == role) {
+        std::string bsUri;
+        bool logged_wait = false;
+        for (;;) {
+            bsUri = ds.bs_uri().value_or(argValueMap["bs"]);
+            auto pid  = ds.bs_psk_identity();
+            auto pkey = ds.bs_psk_key();
+            const bool have_psk =
+                (pid && !pid->empty() && pkey && !pkey->empty()) ||
+                (!argValueMap["identity"].empty() && !argValueMap["secret"].empty());
+            if (!bsUri.empty() && have_psk) break;
+            if (!logged_wait) {
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l awaiting provisioning "
+                                    "(iot.bs.uri + BS PSK via device-ui commissioning)\n")));
+                logged_wait = true;
+            }
+            ACE_OS::sleep(ACE_Time_Value(5, 0));
+        }
+        UDPAdapter::Scheme_t bsScheme;
+        parsePeerOption(bsUri, bsScheme, bsHost, bsPort);
+    }
+
     const bool rpi = iot::is_rpi();
     iot::EndpointResolution epres = iot::resolve_endpoint(
         argValueMap["ep"], ds.serial(), rpi,
@@ -691,12 +740,11 @@ int main(std::int32_t argc, char *argv[]) {
 
     // L9 wiring: instantiate the LwM2M handlers + ObjectStore and bind
     // them to the relevant ServiceContext_t CoAPAdapters. configDir
-    // defaults to "../config" so the existing apps/config/ JSON files
-    // (security, server, device) are picked up when the binary runs
-    // from apps/build/.
+    // defaults to the deployed /etc/iot/config so a ds-driven launch with no
+    // args works; dev builds running from apps/build/ pass config=../config.
     const std::string configDir = !argValueMap["config"].empty()
                                       ? argValueMap["config"]
-                                      : std::string("../config");
+                                      : std::string("/etc/iot/config");
     // Endpoint resolved above (task E) from CLI ep= / data-store serial /
     // RPi auto-detect. When non-RPi and nothing is provisioned yet,
     // epres.ready is false → fall back to the legacy placeholder so the

--- a/iot-ui/src/app/dashboard/dashboard.component.html
+++ b/iot-ui/src/app/dashboard/dashboard.component.html
@@ -58,38 +58,6 @@
       </div>
     </div>
   </div>
-
-  <!-- Service overview table -->
-  <h3 style="margin-top: 32px;">Services</h3>
-  <table class="table" *ngIf="status?.services">
-    <thead>
-      <tr>
-        <th>Service</th>
-        <th>State</th>
-        <th>Enabled</th>
-        <th>Details</th>
-      </tr>
-    </thead>
-    <tbody>
-      <tr *ngFor="let k of serviceKeys()">
-        <td><code>{{ svcLabel(k) }}</code></td>
-        <td>
-          <app-status-badge
-            [label]="svcInfo(k).state || 'unknown'"
-            [state]="svcInfo(k).state || ''">
-          </app-status-badge>
-        </td>
-        <td>
-          <clr-icon [attr.shape]="svcInfo(k).enable ? 'check-circle' : 'times-circle'"
-                    [style.color]="svcInfo(k).enable ? '#2e7d32' : '#c62828'">
-          </clr-icon>
-        </td>
-        <td>
-          <span *ngIf="svcInfo(k).uptime_sec != null">
-            uptime {{ svcInfo(k).uptime_sec }}s
-          </span>
-        </td>
-      </tr>
-    </tbody>
-  </table>
+  <!-- Service status lives on the Services page (mirrors cloud-ui) — the
+       Dashboard shows only connectivity status, no duplicated service table. -->
 </div>

--- a/iot-ui/src/app/dashboard/dashboard.component.ts
+++ b/iot-ui/src/app/dashboard/dashboard.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { HttpsvcService } from '../../common/httpsvc.service';
 import { PubSubService } from '../../common/pubsubsvc.service';
-import { StatusSnapshot, ServiceInfo, ServicesStatus, VpnStatus, WifiStatus, WanStatus } from '../../common/app-globals';
+import { StatusSnapshot } from '../../common/app-globals';
 
 @Component({
   selector: 'app-dashboard',
@@ -72,19 +72,5 @@ export class DashboardComponent implements OnDestroy {
 
   lwm2mState(): string {
     return this.status?.lwm2m?.server_uri ? 'configured' : 'unconfigured';
-  }
-
-  serviceKeys(): string[] {
-    if (!this.status?.services) return [];
-    return Object.keys(this.status.services).sort();
-  }
-
-  svcLabel(key: string): string {
-    return key.replace(/_/g, '.');
-  }
-
-  svcInfo(key: string): ServiceInfo {
-    const svcs = this.status?.services as Record<string, ServiceInfo> | undefined;
-    return svcs?.[key] || {};
   }
 }

--- a/iot-ui/src/app/log-level/log-viewer.component.ts
+++ b/iot-ui/src/app/log-level/log-viewer.component.ts
@@ -2,14 +2,61 @@ import { Component, OnInit, OnDestroy, ViewChild, ElementRef } from '@angular/co
 import { Subscription } from 'rxjs';
 import { HttpClient } from '@angular/common/http';
 import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+import { ToastService } from '../../common/toast.service';
 import { environment } from '../../environments/environment';
 
 @Component({
   selector: 'app-log-viewer',
   template: `
-    <div class="log-viewer">
-      <div class="log-header">
-        <span class="title">Log Output</span>
+    <div class="page">
+      <h3>Logs</h3>
+
+      <!-- Per-service log level (mirrors cloud-ui). "lwm2m" is implicit —
+           client on the device. -->
+      <h4>Log Level</h4>
+      <div class="form-grid">
+        <clr-select-container>
+          <label>All Daemons</label>
+          <select clrSelect [disabled]="!isAdmin"
+                  [ngModel]="logLevel" (ngModelChange)="setLevel('log.level', $event)">
+            <option *ngFor="let l of levels" [value]="l">{{ l }}</option>
+          </select>
+          <clr-control-helper>Global default — used when per-daemon is unset</clr-control-helper>
+        </clr-select-container>
+        <clr-select-container>
+          <label>httpd</label>
+          <select clrSelect [disabled]="!isAdmin"
+                  [ngModel]="logLevelHttpd" (ngModelChange)="setLevel('log.level.httpd', $event)">
+            <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
+          </select>
+        </clr-select-container>
+        <clr-select-container>
+          <label>lwm2m</label>
+          <select clrSelect [disabled]="!isAdmin"
+                  [ngModel]="logLevelLwm2m" (ngModelChange)="setLevel('log.level.lwm2m', $event)">
+            <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
+          </select>
+        </clr-select-container>
+        <clr-select-container>
+          <label>vpn</label>
+          <select clrSelect [disabled]="!isAdmin"
+                  [ngModel]="logLevelVpn" (ngModelChange)="setLevel('log.level.vpn', $event)">
+            <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
+          </select>
+        </clr-select-container>
+        <clr-select-container>
+          <label>dtls</label>
+          <select clrSelect [disabled]="!isAdmin"
+                  [ngModel]="logLevelDtls" (ngModelChange)="setLevel('log.level.dtls', $event)">
+            <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
+          </select>
+        </clr-select-container>
+      </div>
+
+      <!-- Log output -->
+      <h4 style="margin-top:28px;">Output</h4>
+      <div class="log-toolbar">
         <button class="btn btn-sm" (click)="refresh()">Refresh</button>
         <label class="auto-refresh">
           <input type="checkbox" [checked]="autoRefresh" (change)="toggleAuto()" />
@@ -22,17 +69,18 @@ import { environment } from '../../environments/environment';
     </div>
   `,
   styles: [`
-    .log-viewer { padding: 16px; display: flex; flex-direction: column; height: calc(100vh - 160px); }
-    .log-header { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
-    .title { font-size: 15px; font-weight: 600; color: #333; }
-    .btn-sm { background: #1a5276; border: none; color: #333; padding: 3px 10px; border-radius: 3px; cursor: pointer; font-size: 11px; }
+    .page { padding: 16px 24px; display: flex; flex-direction: column; height: calc(100vh - 150px); }
+    h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 12px 0; }
+    h4 { font-size: 13px; font-weight: 600; color: #555; margin: 0 0 10px 0; }
+    .log-toolbar { display: flex; align-items: center; gap: 12px; margin-bottom: 8px; }
+    .btn-sm { background: #1a5276; border: none; color: #fff; padding: 3px 10px; border-radius: 3px; cursor: pointer; font-size: 11px; }
     .btn-sm:hover { opacity: 0.8; }
     .auto-refresh { font-size: 12px; color: #9e9e9e; display: flex; align-items: center; gap: 4px; cursor: pointer; margin-left: auto; }
     .log-textarea {
       flex: 1; width: 100%; background: #0d1117; color: #c9d1d9; border: 1px solid #1a5276;
       border-radius: 4px; padding: 12px; font-family: 'SF Mono', 'Monaco', 'Menlo', monospace;
       font-size: 12px; line-height: 1.5; resize: none; overflow-y: scroll;
-      white-space: pre; tab-size: 2;
+      white-space: pre; tab-size: 2; min-height: 240px;
     }
     .log-textarea:focus { outline: none; border-color: #2e7d32; }
   `]
@@ -41,28 +89,42 @@ export class LogViewerComponent implements OnInit, OnDestroy {
   @ViewChild('ta') ta!: ElementRef<HTMLTextAreaElement>;
   logText = '';
   autoRefresh = true;
+
+  // Per-service levels (device daemons). "" = inherit global.
+  logLevel = 'INFO';
+  logLevelHttpd = '';
+  logLevelLwm2m = '';
+  logLevelVpn = '';
+  logLevelDtls = '';
+  levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR'];
+  daemonLevels: string[] = ['', 'DEBUG', 'INFO', 'WARNING', 'ERROR'];
+  private readonly lvlKeys = ['log.level', 'log.level.httpd', 'log.level.lwm2m',
+                              'log.level.vpn', 'log.level.dtls'];
+
   private active = true;
   private sub = new Subscription();
   private api = environment.apiUrl;
 
-  // Mirrors the cloud-ui log viewer (apps/cloud/ui log-viewer): one raw
-  // text fetch of the merged /api/v1/log, plus a long-poll on log.version
-  // (every daemon bumps it on flush) to drive live updates. The long-poll
-  // loop re-subscribes in both next and error, so a transient failure
-  // (e.g. a 401 after the session expires) never tears the stream down.
-  constructor(private http: HttpClient, private httpSvc: HttpsvcService) {}
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpClient, private httpSvc: HttpsvcService,
+              private session: SessionService, private toast: ToastService) {}
 
   ngOnInit(): void {
+    this.reloadLevels();
     this.refresh();
     this.pollLog();
   }
 
+  // Long-poll log.version (every daemon bumps it on flush); on each tick
+  // refresh the output and the levels. Re-subscribes on error so a transient
+  // 401 doesn't tear the stream down.
   private pollLog(): void {
     if (!this.active) return;
     this.sub.add(
       this.httpSvc.dbGetLongPoll('log.version', 30).subscribe({
         next: () => {
-          if (this.autoRefresh) this.fetchAndShow();
+          if (this.autoRefresh) { this.fetchAndShow(); this.reloadLevels(); }
           this.pollLog();
         },
         error: () => { if (this.active) setTimeout(() => this.pollLog(), 2000); }
@@ -70,20 +132,49 @@ export class LogViewerComponent implements OnInit, OnDestroy {
     );
   }
 
-  refresh(): void { this.fetchAndShow(); }
-
-  toggleAuto(): void { this.autoRefresh = !this.autoRefresh; }
-
-  private fetchAndShow(): void {
-    this.fetchLog().subscribe({
-      next: (text) => { this.logText = text; this.scrollBottom(); }
+  setLevel(key: string, level: string): void {
+    this.httpSvc.dbSet([{ key, value: level }]).subscribe({
+      next: (r) => {
+        if (r.ok) {
+          if (key === 'log.level') this.logLevel = level;
+          else if (key === 'log.level.httpd') this.logLevelHttpd = level;
+          else if (key === 'log.level.lwm2m') this.logLevelLwm2m = level;
+          else if (key === 'log.level.vpn') this.logLevelVpn = level;
+          else if (key === 'log.level.dtls') this.logLevelDtls = level;
+          this.toast.success(key + ' set to ' + (level || 'inherited'));
+        } else { this.toast.error(r.err || 'Failed to set log level'); }
+      },
+      error: () => this.toast.error('Failed to set log level')
     });
   }
 
-  private fetchLog() {
-    return this.http.get(`${this.api}/api/v1/log`, {
-      responseType: 'text', withCredentials: true
+  private pickLevel(v: unknown): string {
+    const s = (v as string || '').toUpperCase();
+    return this.daemonLevels.includes(s) ? s : '';
+  }
+
+  private reloadLevels(): void {
+    this.httpSvc.dbGet(this.lvlKeys).subscribe({
+      next: (r) => {
+        if (r.ok && r.data) {
+          const d = r.data as Record<string, unknown>;
+          const g = (d['log.level'] as string || 'INFO').toUpperCase();
+          if (this.levels.includes(g)) this.logLevel = g;
+          this.logLevelHttpd = this.pickLevel(d['log.level.httpd']);
+          this.logLevelLwm2m = this.pickLevel(d['log.level.lwm2m']);
+          this.logLevelVpn = this.pickLevel(d['log.level.vpn']);
+          this.logLevelDtls = this.pickLevel(d['log.level.dtls']);
+        }
+      }
     });
+  }
+
+  refresh(): void { this.fetchAndShow(); }
+  toggleAuto(): void { this.autoRefresh = !this.autoRefresh; }
+
+  private fetchAndShow(): void {
+    this.http.get(`${this.api}/api/v1/log`, { responseType: 'text', withCredentials: true })
+      .subscribe({ next: (text) => { this.logText = text; this.scrollBottom(); } });
   }
 
   private scrollBottom(): void {

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
@@ -1,44 +1,37 @@
 <div class="page">
-  <h3>{{ mode === 'security' ? 'LwM2M Security (Bootstrap)' : 'LwM2M Server' }}</h3>
+  <h3>{{ mode === 'security' ? 'LwM2M Security (Bootstrap)' : 'LwM2M Server (Device Management)' }}</h3>
 
   <form [formGroup]="serverForm" (ngSubmit)="save()" *ngIf="!loading">
 
-    <!-- ── Server tab: registration / Server Object fields ───────── -->
-    <div class="form-grid" *ngIf="mode === 'server'">
-      <clr-input-container>
-        <label>Server URI</label>
-        <input clrInput [disabled]="!isAdmin" formControlName="server_uri" placeholder="coaps://lwm2m.example.com:5684" />
-      </clr-input-container>
-      <clr-input-container>
-        <label>Endpoint Name</label>
-        <input clrInput [disabled]="!isAdmin" formControlName="endpoint" placeholder="urn:dev:client-1" />
-      </clr-input-container>
-      <clr-select-container>
-        <label>Binding Mode</label>
-        <select clrSelect [disabled]="!isAdmin" formControlName="binding">
-          <option value="U">U — UDP</option>
-          <option value="S">S — SMS</option>
-          <option value="US">US — UDP+SMS</option>
-          <option value="UQ">UQ — UDP+Queue</option>
-        </select>
-      </clr-select-container>
-      <clr-input-container>
-        <label>Lifetime (s)</label>
-        <input clrInput [disabled]="!isAdmin" type="number" formControlName="lifetime" min="0" max="2592000" />
-      </clr-input-container>
+    <!-- ── Server tab: DM config is PROVISIONED BY THE BOOTSTRAP SERVER ──
+         The device receives the Server Object (DM URI, lifetime, binding)
+         during the /bs exchange. These are read-only status here. -->
+    <div *ngIf="mode === 'server'">
+      <div class="info-card" style="margin-bottom:16px;">
+        These values are pushed by the bootstrap server during commissioning
+        and are read-only. Configure the bootstrap server + PSK on the
+        <strong>Security</strong> tab.
+      </div>
+      <div class="form-grid">
+        <clr-input-container>
+          <label>DM Server URI</label>
+          <input clrInput readonly formControlName="server_uri" />
+        </clr-input-container>
+        <clr-input-container>
+          <label>Binding Mode</label>
+          <input clrInput readonly formControlName="binding" />
+        </clr-input-container>
+        <clr-input-container>
+          <label>Lifetime (s)</label>
+          <input clrInput readonly type="number" formControlName="lifetime" />
+        </clr-input-container>
+      </div>
     </div>
 
-    <clr-checkbox-container style="margin-top:16px;" *ngIf="mode === 'server'">
-      <clr-checkbox-wrapper>
-        <input type="checkbox" clrCheckbox [disabled]="!isAdmin" formControlName="observable" />
-        <label>Observable</label>
-      </clr-checkbox-wrapper>
-    </clr-checkbox-container>
-
-    <!-- ── Security tab: serial (Security Object identity) ───────── -->
-    <!-- iot.serial is write_acl=gid:engineer; the data-store only accepts
-         a write from device-ui while commissioning mode (iot.dev.mode) is
-         on. So the field is read-only unless devMode (or RPi auto-fill). -->
+    <!-- ── Security tab: commissioned values (serial + bootstrap URI) ──
+         iot.serial / iot.bs.uri are write_acl=gid:engineer; the data-store
+         only accepts a device-ui write while commissioning mode
+         (iot.dev.mode) is on, so they are read-only otherwise. -->
     <div class="form-grid" *ngIf="mode === 'security'">
       <clr-input-container>
         <label>Serial Number</label>
@@ -47,20 +40,28 @@
                [disabled]="!isAdmin"
                placeholder="enter device serial number" />
         <clr-control-helper *ngIf="serialAutoDetected">
-          Auto-detected (Raspberry Pi) — read-only
+          Auto-detected (Raspberry Pi) — read-only. Used as endpoint + BS PSK identity.
         </clr-control-helper>
         <clr-control-helper *ngIf="!serialAutoDetected && devMode">
-          Not a Raspberry Pi — enter the serial printed on the device
+          Printed on the device. Used as endpoint + BS PSK identity.
         </clr-control-helper>
         <clr-control-helper *ngIf="!serialAutoDetected && !devMode">
           Enable commissioning mode (iot.dev.mode) to set the serial
         </clr-control-helper>
       </clr-input-container>
+      <clr-input-container>
+        <label>Bootstrap Server URI</label>
+        <input clrInput formControlName="bs_uri"
+               [readonly]="!devMode" [disabled]="!isAdmin"
+               placeholder="coaps://cloud.example.com:5684" />
+        <clr-control-helper *ngIf="devMode">Where the device bootstraps from</clr-control-helper>
+        <clr-control-helper *ngIf="!devMode">Enable commissioning mode to set the bootstrap URI</clr-control-helper>
+      </clr-input-container>
     </div>
 
-    <!-- Save: server fields always; serial only when commissioning + editable -->
+    <!-- Save only on the Security tab (Server tab is read-only status). -->
     <div style="margin-top:24px;"
-         *ngIf="isAdmin && (mode === 'server' || (devMode && !serialAutoDetected))">
+         *ngIf="isAdmin && mode === 'security' && devMode">
       <button type="submit" class="btn btn-primary" [disabled]="saving">
         {{ saving ? 'Saving…' : 'Save' }}
       </button>
@@ -68,11 +69,9 @@
     </div>
   </form>
 
-  <!-- PSK provisioning (task H): on the Security tab. Generate a 32-byte BS
-       PSK, show it once so the engineer can copy serial + PSK into cloud-ui.
-       The value is stored write-only; it is never read back. Generation
-       requires commissioning mode (iot.dev.mode) so the data-store bypasses
-       the PSK ACLs and httpd can write it. -->
+  <!-- PSK provisioning: on the Security tab. Generate a 32-byte BS PSK,
+       show it once so the engineer can copy serial + PSK into cloud-ui.
+       Stored write-only; never read back. Requires commissioning mode. -->
   <div class="card" style="margin-top:32px;"
        *ngIf="!loading && mode === 'security' && isAdmin">
     <div class="card-header">Bootstrap PSK (commissioning)</div>

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -29,19 +29,18 @@ export class Lwm2mConfigComponent implements OnInit {
   constructor(private http: HttpsvcService, fb: FormBuilder, private session: SessionService, private toast: ToastService) {
     this.serverForm = fb.group({
       serial:     [''],
-      server_uri: ['coaps://'],
-      endpoint:   ['urn:dev:client-1'],
+      bs_uri:     ['coaps://'],
+      // Bootstrap-provided (read-only on the Server tab).
+      server_uri: [''],
       binding:    ['U'],
       lifetime:   [86400],
-      observable: [true],
     });
   }
 
   ngOnInit(): void {
     this.http.dbGet([
-      'iot.serial', 'iot.dev.mode',
-      'iot.server.uri', 'iot.endpoint', 'iot.binding',
-      'iot.lifetime', 'iot.observable'
+      'iot.serial', 'iot.dev.mode', 'iot.bs.uri',
+      'iot.server.uri', 'iot.binding', 'iot.lifetime'
     ]).subscribe({
       next: (r) => {
         if (r.ok && r.data) {
@@ -53,11 +52,11 @@ export class Lwm2mConfigComponent implements OnInit {
           this.devMode = d['iot.dev.mode'] === true;
           this.serverForm.patchValue({
             serial:     serial,
-            server_uri: d['iot.server.uri'] || 'coaps://',
-            endpoint:   d['iot.endpoint']   || 'urn:dev:client-1',
+            bs_uri:     d['iot.bs.uri']    || 'coaps://',
+            // DM config below is pushed by the bootstrap server — read-only.
+            server_uri: d['iot.server.uri'] || '(set by bootstrap)',
             binding:    d['iot.binding']    || 'U',
             lifetime:   d['iot.lifetime']   || 86400,
-            observable: d['iot.observable'] ?? true,
           });
         }
         this.loading = false;
@@ -66,29 +65,20 @@ export class Lwm2mConfigComponent implements OnInit {
     });
   }
 
+  // Only the Security (commissioning) tab saves — the Server tab is
+  // read-only DM status pushed by the bootstrap server. Writes the
+  // serial + bootstrap URI (gid:engineer, allowed in commissioning mode).
   save(): void {
     this.saving = true; this.msg = '';
     const v = this.serverForm.value;
-    let pairs: { key: string; value: unknown }[];
-    if (this.mode === 'security') {
-      // Security tab owns the serial. Only push it when the installer
-      // entered it (non-RPi); on RPi the client owns iot.serial read-only.
-      pairs = (!this.serialAutoDetected && v.serial)
-        ? [{ key: 'iot.serial', value: v.serial }]
-        : [];
-      if (pairs.length === 0) { this.saving = false; return; }
-    } else {
-      // Server tab owns the registration (Server Object) fields.
-      pairs = [
-        { key: 'iot.server.uri', value: v.server_uri },
-        { key: 'iot.endpoint',   value: v.endpoint },
-        { key: 'iot.binding',    value: v.binding },
-        { key: 'iot.lifetime',   value: v.lifetime },
-        { key: 'iot.observable', value: v.observable },
-      ];
+    const pairs: { key: string; value: unknown }[] = [
+      { key: 'iot.bs.uri', value: v.bs_uri },
+    ];
+    if (!this.serialAutoDetected && v.serial) {
+      pairs.push({ key: 'iot.serial', value: v.serial });
     }
     this.http.dbSet(pairs).subscribe({
-      next: (r) => { this.saving = false; if(r.ok) this.toast.success('LwM2M config saved'); else this.toast.error(r.err||'Save failed'); },
+      next: (r) => { this.saving = false; if(r.ok) this.toast.success('Commissioning saved'); else this.toast.error(r.err||'Save failed'); },
       error: () => { this.saving = false; this.toast.error('Save failed'); }
     });
   }

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -63,7 +63,6 @@
       <span class="access-badge" [class.viewer]="!isAdmin">{{ isAdmin ? 'Admin' : 'Viewer' }}</span>
 
       <div class="live-spacer"></div>
-      <app-log-level></app-log-level>
       <button class="refresh-btn" (click)="refreshStatus()" title="Refresh">
         <clr-icon shape="sync"></clr-icon>
       </button>

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -33,6 +33,13 @@ return {
         access  = "Admin",
       type    = "string",
     },
+    -- Bootstrap server URI the client connects to (e.g.
+    -- coaps://cloud.example.com:5684). ds-driven: the client reads this
+    -- (falling back to a bs= CLI arg) and re-bootstraps when it changes.
+    ["iot.bs.uri"]     = {
+        access  = "Admin",
+      type    = "string",
+    },
     ["iot.binding"]    = {
         access  = "Admin",
       type    = "string",
@@ -128,6 +135,12 @@ return {
       default = "",
     },
     ["log.level.httpd"] = {
+        access  = "Admin",
+      type    = "string",
+      default = "",
+    },
+    -- Device-side lwm2m client level (cloud servers use .bs/.dm below).
+    ["log.level.lwm2m"] = {
         access  = "Admin",
       type    = "string",
       default = "",

--- a/modules/data-store/src/log_buffer.cpp
+++ b/modules/data-store/src/log_buffer.cpp
@@ -231,13 +231,21 @@ void LogBuffer::apply_level(Client& ds) {
             }
         }
     }
-    unsigned long mask = LM_INFO;
+    // Cumulative: a level enables itself AND everything more severe, so e.g.
+    // INFO still shows WARNING/ERROR and DEBUG shows INFO. The old mapping
+    // enabled only the single level, hiding higher-severity lines (and hiding
+    // INFO when set to DEBUG).
+    const unsigned long kErr  = LM_ERROR | LM_CRITICAL | LM_ALERT | LM_EMERGENCY;
+    const unsigned long kWarn = LM_WARNING | kErr;
+    const unsigned long kInfo = LM_INFO | LM_NOTICE | kWarn;
+    const unsigned long kDbg  = LM_TRACE | LM_DEBUG | kInfo;
+    unsigned long mask = kInfo;   // default: INFO and above
     if (!lvl_str.empty()) {
         for (auto& c : lvl_str) c = static_cast<char>(std::toupper(c));
-        if (lvl_str == "DEBUG")       mask = LM_DEBUG;
-        else if (lvl_str == "INFO")   mask = LM_INFO;
-        else if (lvl_str == "WARNING") mask = LM_WARNING;
-        else if (lvl_str == "ERROR")  mask = LM_ERROR | LM_CRITICAL;
+        if (lvl_str == "DEBUG")        mask = kDbg;
+        else if (lvl_str == "INFO")    mask = kInfo;
+        else if (lvl_str == "WARNING") mask = kWarn;
+        else if (lvl_str == "ERROR")   mask = kErr;
     }
     s_active_mask = mask;   // remembered for attach_current_thread()
     ACE_Log_Msg::instance()->priority_mask(

--- a/modules/data-store/src/server/worker.cpp
+++ b/modules/data-store/src/server/worker.cpp
@@ -273,10 +273,14 @@ void Worker::handle_process_request(WorkMsg* msg) {
                                              *err));
                         return;
                     }
-                    // L17c — per-key ACL check.
+                    // L17c — per-key ACL check. PSK provisioning (task C):
+                    // dev-mode bypasses write_acl too (not just read_acl), so
+                    // device-ui/httpd can write the serial + BS PSK + carrier
+                    // during commissioning. Without this, "Generate BS PSK"
+                    // and serial save are denied even with dev.mode on.
                     auto acl_err = m_schema->check_write_acl(
                         k, s->peer_uid(), s->peer_gid());
-                    if (acl_err) {
+                    if (acl_err && !dev_mode_on()) {
                         s->send(encode_error(op, h.reqID,
                                              proto::Status::SchemaRejected,
                                              *acl_err));

--- a/packaging/etc-iot/lwm2m-client.env
+++ b/packaging/etc-iot/lwm2m-client.env
@@ -1,15 +1,19 @@
 # EnvironmentFile for iot-lwm2m-client.service.
 #
-# Edit LWM2M_ARGS to point at your bootstrap server. The values below
-# match the smoke harness defaults — they boot but will sit in
-# AwaitingRegisterAck if no peer answers on bs=.
+# The device client is fully data-store-driven — no CLI args needed. The
+# binary defaults role=client, binds coaps://0.0.0.0:5684, reads
+# /etc/iot/config, connects to the default ds socket, and reads its
+# provisioning from the data-store (commissioned via device-ui):
+#   iot.bs.uri           — bootstrap server URI (required to connect)
+#   iot.bs.psk.identity  — bootstrap PSK identity (= serial)
+#   iot.bs.psk.key       — bootstrap PSK secret
+#   iot.endpoint         — endpoint name
+# Everything else (DM server URI, DM PSK, lifetime, binding) is provisioned
+# by the bootstrap server during the /bs exchange and lands in the store,
+# where the client picks it up live (watch). All keys are gid:engineer; the
+# unit runs User=engineer so the client can read them.
 #
-# Hot-reloadable via ds-cli (preferred):
-#   iot.endpoint    — endpoint name (overrides the compiled-in default)
-#   iot.lifetime    — registration lifetime (uint32 seconds)
-#   iot.server.uri  — DM server URI (live re-bind via Deregister-then-
-#                     Register; plain CoAP only, CoAPs logs a warning)
-#
-# See /etc/iot/ds-schemas/iot.lua for type + range constraints.
+# Override LWM2M_ARGS only for dev (e.g. config=../config when running from a
+# build tree, or bs=/identity=/secret= as a fallback when the store is empty).
 
-LWM2M_ARGS="role=client local=coap://0.0.0.0:5684 bs=coap://127.0.0.1:5683 config=/etc/iot/config ds-sock=/run/iot/data_store.sock"
+LWM2M_ARGS=""


### PR DESCRIPTION
Builds on #106. Items 1–3 + the ds-driven client model, all verified end-to-end (commission → bootstrap) except the DTLS handshake itself (see Known issue).

## What's in
**ds-store (`worker.cpp`, `log_buffer.cpp`)**
- dev-mode now bypasses **write_acl** (not just read) → device-ui can write serial/BS PSK in commissioning mode (fixes "Generate BS PSK" being denied).
- Log-level mask is **cumulative** (INFO shows WARNING/ERROR; DEBUG shows INFO) — was single-level.

**lwm2m client (`main.cpp`, `ds_config`, tinydtls)**
- **ds-driven, no CLI args**: defaults role=client, binds `coaps://0.0.0.0:5684`, config `/etc/iot/config`, reads `bs` from new `iot.bs.uri` (CLI fallback) + watches it.
- **Parks until provisioned** (iot.bs.uri + BS PSK) instead of crash-looping; resumes via the watch.
- Logging wired **before** the park so "awaiting provisioning" reaches the UI.
- **DTLS logs to UI**: tinydtls `dtls_set_log_sink()` hook → `LogBuffer` (tagged `dtls:`).

**device-ui**
- **Logs**: per-service level selectors (global, httpd, lwm2m, vpn, dtls); removed redundant strip widget.
- **Dashboard**: dropped the duplicated service table (status only on Services, like cloud-ui).
- **LwM2M**: Server tab = read-only DM status (bootstrap-provided); Security tab commissions serial + bootstrap URI + BS PSK.

**device stack / Yocto**
- compose command is just `lwm2m`; `run.sh commission [on|off]` (one-off engineer container); `lwm2m-client.env` → `LWM2M_ARGS=""`.

## Verified (rebuilt images, live stacks)
- Client launches with no args, **parks** ("awaiting provisioning" in UI), no crash-loop.
- `commission on` + set serial/endpoint/bs.uri/BS-PSK all return **ok** (dev-mode write bypass).
- Client **unparks** via the watch and initiates DTLS.
- **`dtls:` handshake lines now appear in the UI** (both client and BS have the sink).

## Known issue (follow-up)
- **DTLS handshake doesn't complete**: client sends `client_hello`, the BS (confirmed listening on `0.0.0.0:5684`) never receives it, and the client errors at `dtls_adapter.cpp:231` (`Error in establishes Channel`) — identical via gateway and direct same-network IP, so it's a **client-side DTLS-handshake bug**, not just networking. Needs focused investigation.
- The cumulative-mask fix is committed but rebuild-pending (added after the last image build).

Next: PSK redesign (`identity = SHA-256(endpoint)`, 256-bit) + the DTLS-handshake fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)