### PR TITLE
fix(dtls): complete device↔cloud DTLS-PSK handshake (#2)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Docker/podman build-context excludes. Unlike .gitignore (which the daemon
+# never reads), this keeps host build artifacts out of the COPY'd context so
+# they can't shadow an in-image rebuild — and shrinks the context.
+
+# VCS / tooling
+.git
+.gitignore
+
+# tinydtls is rebuilt inside the image (Dockerfile `make libtinydtls.a`).
+# A stale host-built archive/objects COPY'd in makes `make` skip the rebuild,
+# silently linking outdated DTLS code. Never ship them into the context.
+apps/3rdparty/tinydtls/libtinydtls.a
+apps/3rdparty/tinydtls/*.o
+apps/3rdparty/tinydtls/aes/*.o
+apps/3rdparty/tinydtls/ecc/*.o
+apps/3rdparty/tinydtls/sha2/*.o
+
+# Generic compiled artifacts — all binaries are built in-image.
+**/*.a
+**/*.o
+
+# Heavy/regenerated trees (the UI is built in the ui-builder stage).
+**/node_modules/
+**/dist/
+**/build/

--- a/apps/3rdparty/tinydtls/crypto.h
+++ b/apps/3rdparty/tinydtls/crypto.h
@@ -75,8 +75,10 @@ typedef struct {
 } dtls_handshake_parameters_ecdsa_t;
 
 /* This is the maximal supported length of the psk client identity and psk
- * server identity hint */
-#define DTLS_PSK_MAX_CLIENT_IDENTITY_LEN   32
+ * server identity hint. Raised from the upstream default of 32 so our BS PSK
+ * identity = sha256(endpoint) rendered as 64 hex chars fits (with headroom);
+ * the DTLS wire format allows identities up to 2^16-1 bytes. */
+#define DTLS_PSK_MAX_CLIENT_IDENTITY_LEN   128
 
 /* This is the maximal supported length of the pre-shared key. */
 #define DTLS_PSK_MAX_KEY_LEN DTLS_KEY_LENGTH

--- a/apps/3rdparty/tinydtls/crypto.h
+++ b/apps/3rdparty/tinydtls/crypto.h
@@ -75,10 +75,8 @@ typedef struct {
 } dtls_handshake_parameters_ecdsa_t;
 
 /* This is the maximal supported length of the psk client identity and psk
- * server identity hint. Raised from the upstream default of 32 so our BS PSK
- * identity = sha256(endpoint) rendered as 64 hex chars fits (with headroom);
- * the DTLS wire format allows identities up to 2^16-1 bytes. */
-#define DTLS_PSK_MAX_CLIENT_IDENTITY_LEN   128
+ * server identity hint */
+#define DTLS_PSK_MAX_CLIENT_IDENTITY_LEN   32
 
 /* This is the maximal supported length of the pre-shared key. */
 #define DTLS_PSK_MAX_KEY_LEN DTLS_KEY_LENGTH

--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -167,9 +167,9 @@ COPY apps/config/ /etc/iot/config/
 
 RUN mkdir -p /var/run/iot /var/lib/iot
 
-# CoAP/DTLS (5683 DM, 5684 BS) and OpenVPN (1194) are UDP — make it explicit
-# (EXPOSE defaults to TCP). 8080 is the HTTP API (TCP).
-EXPOSE 8080 5683/udp 5684/udp 1194/udp
+# CoAP/DTLS (5683 DM, 5684 BS) are UDP — make it explicit (EXPOSE defaults to
+# TCP). 8080 HTTP API and 1194 OpenVPN are TCP.
+EXPOSE 8080 5683/udp 5684/udp 1194
 
 # Default: start ds-server then iot-httpd (single-container mode).
 # docker-compose overrides CMD per service.

--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -167,7 +167,9 @@ COPY apps/config/ /etc/iot/config/
 
 RUN mkdir -p /var/run/iot /var/lib/iot
 
-EXPOSE 8080 5683 5684 1194
+# CoAP/DTLS (5683 DM, 5684 BS) and OpenVPN (1194) are UDP — make it explicit
+# (EXPOSE defaults to TCP). 8080 is the HTTP API (TCP).
+EXPOSE 8080 5683/udp 5684/udp 1194/udp
 
 # Default: start ds-server then iot-httpd (single-container mode).
 # docker-compose overrides CMD per service.

--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -82,6 +82,7 @@ RUN cd /src/apps/3rdparty/tinydtls && \
     [ -f doc/Makefile.in ] || : > doc/Makefile.in && \
     [ -f doc/Doxyfile.in ] || : > doc/Doxyfile.in && \
     autoconf && autoheader && ./configure && \
+    rm -f libtinydtls.a *.o aes/*.o ecc/*.o sha2/*.o && \
     make libtinydtls.a -j$(nproc)
 
 # Build LwM2M binary (reused in server role for BS + DM).

--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -57,7 +57,7 @@ services:
     devices:
       - /dev/net/tun        # openvpn(8) server spawned by iot-cloudd
     ports:
-      - "1194:1194/udp"     # OpenVPN server
+      - "1194:1194/tcp"     # OpenVPN server (TCP)
     depends_on:
       ds-server:
         condition: service_healthy

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -175,7 +175,7 @@ int main(int argc, char** argv) {
     // ── OpenVPN server — spawn + supervise (config from cloud.vpn.*) ──
     server::openvpn::OpenVpnServerConfig ovpn_cfg;
     ovpn_cfg.subnet    = ds_str(ds, "cloud.vpn.subnet",     "10.9.0.0/24");
-    ovpn_cfg.proto     = ds_str(ds, "cloud.vpn.proto",      "udp");
+    ovpn_cfg.proto     = ds_str(ds, "cloud.vpn.proto",      "tcp-server");
     ovpn_cfg.ca_path   = ds_str(ds, "cloud.vpn.ca.crt",     "/etc/iot/vpn/ca/ca.crt");
     ovpn_cfg.cert_path = ds_str(ds, "cloud.vpn.server.crt", "/etc/iot/vpn/server.crt");
     ovpn_cfg.key_path  = ds_str(ds, "cloud.vpn.server.key", "/etc/iot/vpn/server.key");

--- a/apps/device/Dockerfile
+++ b/apps/device/Dockerfile
@@ -82,6 +82,7 @@ RUN cd /src/apps/3rdparty/tinydtls && \
     [ -f doc/Makefile.in ] || : > doc/Makefile.in && \
     [ -f doc/Doxyfile.in ] || : > doc/Doxyfile.in && \
     autoconf && autoheader && ./configure && \
+    rm -f libtinydtls.a *.o aes/*.o ecc/*.o sha2/*.o && \
     make libtinydtls.a -j$(nproc)
 
 # One cmake build of apps/ produces every device binary — apps/CMakeLists

--- a/apps/device/Dockerfile
+++ b/apps/device/Dockerfile
@@ -168,7 +168,8 @@ RUN mkdir -p /run/iot /var/lib/iot && \
     chmod 0755 /run/iot && chmod 0755 /var/lib/iot
 
 # 8080 device UI/REST · 5683 DM (server role) · 5684 client local · 5685 BS
-EXPOSE 8080 5683 5684 5685
+# CoAP/DTLS ports are UDP (EXPOSE defaults to TCP); 8080 is the HTTP UI/API (TCP).
+EXPOSE 8080 5683/udp 5684/udp 5685/udp
 
 ENTRYPOINT ["/usr/local/bin/iot-entrypoint"]
 CMD []

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -766,7 +766,9 @@ int main(std::int32_t argc, char *argv[]) {
                 if (is_bs) {
                     const std::string serial = e.value("serial", std::string());
                     key = e.value("bs.psk.key", std::string());
-                    if (!serial.empty()) ident = iot::sha256_hex(serial);
+                    // 128-bit identity (first 32 hex chars), matching the
+                    // device's iot::sha256_hex(endpoint).substr(0,32).
+                    if (!serial.empty()) ident = iot::sha256_hex(serial).substr(0, 32);
                 } else {
                     ident = e.value("dm.psk.id", std::string());
                     key   = e.value("dm.psk.key", std::string());

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -901,32 +901,40 @@ int main(std::int32_t argc, char *argv[]) {
                        lwm2m_instance.c_str()));
         }
 
-        const std::string svc_name =
-            (UDPAdapter::CLIENT == role) ? "lwm2m.client" : "lwm2m.server";
-        svc_gate = std::make_unique<data_store::ServiceGate>(*cli, svc_name);
-        dep_watch = std::make_unique<data_store::DepWatch>(
-            *cli, std::vector<std::string>{"net.router"});
+        // The net.router dependency + service-enable gate is a DEVICE concern
+        // (the gateway's routing must be up first). The cloud BS/DM
+        // (lwm2m-instance set) are always-on, docker-compose-managed, and have
+        // no net-router — so skip the gate entirely. Otherwise they park on
+        // net.router forever and their reactor never reads the DTLS socket
+        // (so no client can ever bootstrap/register).
+        if (lwm2m_instance.empty()) {
+            const std::string svc_name =
+                (UDPAdapter::CLIENT == role) ? "lwm2m.client" : "lwm2m.server";
+            svc_gate = std::make_unique<data_store::ServiceGate>(*cli, svc_name);
+            dep_watch = std::make_unique<data_store::DepWatch>(
+                *cli, std::vector<std::string>{"net.router"});
 
-        // L17a/D4 — dep check before svc check (dep_down > disabled).
-        if (!dep_watch->healthy()) {
-            ACE_DEBUG((LM_INFO,
-                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l dep %C unhealthy "
-                                "at startup; parking\n"),
-                       dep_watch->unhealthy_dep().c_str()));
-            svc_gate->publish_state("disabled");
-            dep_watch->wait();
-        }
+            // L17a/D4 — dep check before svc check (dep_down > disabled).
+            if (!dep_watch->healthy()) {
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l dep %C unhealthy "
+                                    "at startup; parking\n"),
+                           dep_watch->unhealthy_dep().c_str()));
+                svc_gate->publish_state("disabled");
+                dep_watch->wait();
+            }
 
-        if (!svc_gate->enabled()) {
-            ACE_DEBUG((LM_INFO,
-                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l services.%C.enable=false "
-                                "at startup; parking until re-enabled\n"),
-                       svc_name.c_str()));
-            svc_gate->publish_state("disabled");
-            auto v = svc_gate->wait();
-            if (!v.has_value()) return 0;   // shutdown
+            if (!svc_gate->enabled()) {
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l services.%C.enable=false "
+                                    "at startup; parking until re-enabled\n"),
+                           svc_name.c_str()));
+                svc_gate->publish_state("disabled");
+                auto v = svc_gate->wait();
+                if (!v.has_value()) return 0;   // shutdown
+            }
+            svc_gate->publish_state("running");
         }
-        svc_gate->publish_state("running");
     }
 
     ClientPlumbing clientPlumbing;

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -691,7 +691,9 @@ int main(std::int32_t argc, char *argv[]) {
             // device and the cloud BS compute identity = sha256(endpoint), so
             // it is never stored/commissioned. Only the secret (iot.bs.psk.key)
             // is commissioned, with secret= CLI as a dev fallback.
-            identity = iot::sha256_hex(endpoint);
+            // 128-bit identity (first 32 hex chars of sha256) — same size as
+            // the 128-bit BS PSK, and fits tinydtls' 32-byte identity buffer.
+            identity = iot::sha256_hex(endpoint).substr(0, 32);
             if (dsKey && !dsKey->empty())            secret = *dsKey;
             else if (!argValueMap["secret"].empty()) secret = argValueMap["secret"];
             else {

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -84,14 +84,15 @@ export class Lwm2mConfigComponent implements OnInit {
   }
 
   /**
-   * Generate a 32-byte BS PSK in the browser (never leaves the device
-   * un-encrypted), show it once for the engineer to copy into cloud-ui,
-   * and store it write-only. Only available in dev-mode (commissioning),
-   * where the data-store bypasses the PSK ACLs so httpd can write it.
+   * Generate a 16-byte (128-bit) BS PSK in the browser (never leaves the
+   * device un-encrypted), show it once for the engineer to copy into cloud-ui,
+   * and store it write-only. 128-bit matches tinydtls' AES-128-CCM PSK key
+   * length and the 128-bit derived identity. Only available in dev-mode
+   * (commissioning), where the data-store bypasses the PSK ACLs.
    */
   generateBsPsk(): void {
     if (!this.devMode || !this.isAdmin) return;
-    const bytes = new Uint8Array(32);
+    const bytes = new Uint8Array(16);
     crypto.getRandomValues(bytes);
     const hex = Array.from(bytes, b => b.toString(16).padStart(2, '0')).join('');
     this.generatedPsk = hex;

--- a/modules/openvpn/client/schemas/vpn.lua
+++ b/modules/openvpn/client/schemas/vpn.lua
@@ -3,7 +3,7 @@
 -- Read keys (operator configures via ds-cli):
 --   vpn.remote.host   - server hostname or IP (required)
 --   vpn.remote.port   - server port            (default 1194, 1..65535)
---   vpn.remote.proto  - "udp" or "tcp"         (default "udp")
+--   vpn.remote.proto  - "tcp-client" or "udp"  (default "tcp-client")
 --   vpn.cert.path     - client X.509 cert      (required, absolute path)
 --   vpn.key.path      - client X.509 priv key  (required, absolute path)
 --   vpn.ca.path       - server CA              (required, absolute path)
@@ -44,7 +44,7 @@ return {
         access  = "Admin", type = "integer", default = 1194,
                              min = 1, max = 65535 },
     ["vpn.remote.proto"] = {
-        access  = "Admin", type = "string",  default = "udp" },
+        access  = "Admin", type = "string",  default = "tcp-client" },
 
     ["vpn.cert.path"]    = {
         access  = "Admin", type = "string"  },

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -196,7 +196,7 @@ return {
     },
     ["cloud.vpn.proto"] = {
       type    = "string",
-      default = "udp",          -- "udp" | "tcp"
+      default = "tcp-server",   -- "tcp-server" | "udp"
     },
     ["cloud.vpn.cipher"] = {
       type    = "string",

--- a/modules/server/lwm2m/src/cloud_credentials.cpp
+++ b/modules/server/lwm2m/src/cloud_credentials.cpp
@@ -121,8 +121,10 @@ std::vector<CredPair> credentials_for_instance(const std::string& array_json,
             // BS DTLS identity = sha256(endpoint); endpoint == serial here.
             // The device derives the same, so it is never sent in the clear
             // as the readable serial.
+            // 128-bit identity: first 32 hex chars of sha256(serial),
+            // matching the device's iot::sha256_hex(endpoint).substr(0,32).
             if (!serial.empty() && !key.empty())
-                out.push_back({sha256_hex(serial), key});
+                out.push_back({sha256_hex(serial).substr(0, 32), key});
         } else {
             const std::string id  = e.value("dm.psk.id", "");
             const std::string key = e.value("dm.psk.key", "");


### PR DESCRIPTION
Resolves the #2 DTLS transport bug: the device↔cloud BS DTLS-PSK handshake now completes end-to-end and encrypted CoAP/LwM2M application data flows with the per-device PSK.

## Root causes fixed
1. **Build meta-bug (the big one):** an untracked host-built `apps/3rdparty/tinydtls/libtinydtls.a` was COPY'd into the build context; `make libtinydtls.a` saw it up-to-date and skipped rebuilding, so every tinydtls source change silently linked stale code. Fixed: `rm` artifacts before `make` in both Dockerfiles + add `.dockerignore` (Docker never reads `.gitignore`).
2. **Cloud BS/DM parked on `net.router`** — a device-only dependency that doesn't run on the cloud, so the server reactor never read the DTLS socket. Skip the dep/service gate for cloud `lwm2m-instance` servers.
3. **PSK sizing:** a 256-bit PSK can't fit tinydtls' AES-128-CCM key-block (`DTLS_PSK_MAX_KEY_LEN=16`, pre-master overflows `MAX_KEYBLOCK_LENGTH`). Both BS identity and PSK are now **128-bit** (identity = first 32 hex chars of sha256; PSK = 16 bytes).
4. **Identity mismatch:** `register_endpoint_creds` (the real BS loader) registered the full 64-char `sha256(serial)` vs the client's 32-char truncation → "PSK for unknown identity". Truncate both.

Also: OpenVPN switched to TCP (server `tcp-server` / client `tcp-client`, compose + EXPOSE).

## Verified
Handshake reaches `finished` both ways; `encrypt using TLS_PSK_WITH_AES_128_CCM_8`; client decrypts the BS's 2.04 application data. BS logs `registered 1 per-endpoint BS PSK`.

## Follow-ups
- 256-bit PSK (bump key-block buffers, carefully).
- LwM2M bootstrap-vs-register flow (client currently registers directly instead of `/bs` Bootstrap-Request → DM).
- DTLS-logs-to-UI sink (now compiles), BS cred live-refresh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)