### PR TITLE
Close the bootstrap → DM registration e2e (DTLS wiring, per-peer sessions, 128-bit DM PSK)

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -351,8 +351,13 @@ int main(int argc, char** argv) {
                         ds_str(ds, "cloud.provision.bs.psk", "");
                     if (!bs_psk.empty()) {
                         try {
+                            // 128-bit (16-byte) DM PSK. tinydtls'
+                            // TLS_PSK_WITH_AES_128_CCM_8 key buffer is 16 bytes,
+                            // so a 32-byte PSK overflows it ("PSK exceeds caller
+                            // buffer") and the DM handshake fails. Matches the
+                            // 128-bit BS PSK.
                             const std::string dm_psk =
-                                server::lwm2m::generate_psk_hex();
+                                server::lwm2m::generate_psk_hex(16);
                             const std::string cur =
                                 ds_str(ds, "cloud.endpoint.credentials", "[]");
                             const std::string next =

--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -145,6 +145,13 @@ class DTLSAdapter {
         std::int32_t rx(std::int32_t fd);
         std::int32_t tx(std::string& in);
         std::int32_t tx(std::string& in, std::string peerIP, std::uint16_t peerPort);
+        /// Send to the dedicated client-outbound peer session (the last
+        /// connect() target), NOT m_session — which dtlsReadCb overwrites
+        /// with whichever peer last sent us a packet. A client that talks to
+        /// two servers (Bootstrap, then DM) must keep sending Register/Update
+        /// to the DM even while stray Bootstrap retransmits arrive, so its
+        /// own requests use this fixed peer session.
+        std::int32_t tx_peer(std::string& in);
         void connect(const std::string& ip, const std::uint16_t& port);
 
         /**
@@ -293,12 +300,27 @@ class DTLSAdapter {
         }
 
         std::string identity() {
+            // Once more than one credential is installed (e.g. the BS
+            // identity at startup + the DM identity after bootstrap), the
+            // map order is non-deterministic, so the active identity pins
+            // which one the client presents for the current peer. Empty =
+            // fall back to the first (single-credential) entry.
+            if(!m_activeIdentity.empty()) {
+                return(m_activeIdentity);
+            }
             if(isClient() && !device_credentials.empty()) {
                 for(auto ent: device_credentials) {
                     return(ent.first);
                 }
             }
             return(std::string());
+        }
+
+        /// Pin the PSK identity the client presents on the next handshake.
+        /// Used to switch from the BS identity to the bootstrap-delivered DM
+        /// identity before reconnecting to the DM server.
+        void active_identity(const std::string& id) {
+            m_activeIdentity = id;
         }
 
         auto& clients() {
@@ -312,10 +334,12 @@ class DTLSAdapter {
         std::int32_t dtlsFd;
         std::shared_ptr<CoAPAdapter> m_coapAdapter;
         session_t m_session;
+        session_t m_peerSession{};   ///< fixed client-outbound peer (connect target)
         std::string m_data;
         std::vector<std::string> m_responses;
         bool m_isClient;
         std::string m_clientState;
+        std::string m_activeIdentity;
         std::vector<ClientDetails> m_clients;
 };
 

--- a/apps/src/coap_adapter.cpp
+++ b/apps/src/coap_adapter.cpp
@@ -1057,6 +1057,17 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
     // the ACK back to whoever sent it and trigger an exception trace
     // in Leshan.
     if (!RequestType[coapmessage.coapheader.type].compare("Acknowledgement")) {
+        // A 2.04 ACK to our POST /bs is the Bootstrap server's response, not
+        // a Register/Update ACK. While the bootstrap client is awaiting it,
+        // route the ACK there so its FSM advances to WaitForBSWrites — else
+        // the later Bootstrap-Finish is rejected and bootstrap stalls.
+        if (isAmIClient && m_bsClient &&
+            m_bsClient->state() ==
+                ::lwm2m::bootstrap::ClientState::AwaitingBSAck) {
+            auto rsp = m_bsClient->handle_bs_traffic(coapmessage, *this);
+            if (!rsp.empty()) out.push_back(std::move(rsp));
+            return static_cast<std::int32_t>(out.size());
+        }
         if (isAmIClient && m_regClient) {
             m_regClient->on_response(coapmessage, *this);
         }
@@ -1084,8 +1095,16 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
         }
     }
 
+    // While bootstrapping, inbound /{oid}/{iid} frames are Bootstrap-Writes,
+    // not DM Writes — let the bootstrap client (below) claim them instead of
+    // the DM Write handler, which would otherwise answer 2.01 and swallow the
+    // Security/Server objects.
+    const bool bootstrapping = isAmIClient && m_bsClient &&
+        (m_bsClient->state() == ::lwm2m::bootstrap::ClientState::AwaitingBSAck ||
+         m_bsClient->state() == ::lwm2m::bootstrap::ClientState::WaitForBSWrites);
+
     // L5 hot path: client-side DM dispatcher (no DTLS variant).
-    if (isAmIClient && m_dmClient) {
+    if (isAmIClient && m_dmClient && !bootstrapping) {
         auto dmOut = m_dmClient->handle(coapmessage, *this);
         if (dmOut.kind != ::lwm2m::DmOutcome::None) {
             if (!dmOut.response.empty()) out.push_back(std::move(dmOut.response));
@@ -1251,6 +1270,17 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
     // L9 / FUP-2 — Acknowledgement short-circuit + dispatch to
     // RegistrationClient FSM. Same shape as the no-DTLS overload above.
     if (!RequestType[coapmessage.coapheader.type].compare("Acknowledgement")) {
+        // A 2.04 ACK to our POST /bs is the Bootstrap server's response, not
+        // a Register/Update ACK. While the bootstrap client is awaiting it,
+        // route the ACK there so its FSM advances to WaitForBSWrites — else
+        // the later Bootstrap-Finish is rejected and bootstrap stalls.
+        if (isAmIClient && m_bsClient &&
+            m_bsClient->state() ==
+                ::lwm2m::bootstrap::ClientState::AwaitingBSAck) {
+            auto rsp = m_bsClient->handle_bs_traffic(coapmessage, *this);
+            if (!rsp.empty()) out.push_back(std::move(rsp));
+            return static_cast<std::int32_t>(out.size());
+        }
         if (isAmIClient && m_regClient) {
             m_regClient->on_response(coapmessage, *this);
         }
@@ -1280,10 +1310,18 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
         }
     }
 
+    // While bootstrapping, inbound /{oid}/{iid} frames are Bootstrap-Writes,
+    // not DM Writes — let the bootstrap client (below) claim them instead of
+    // the DM Write handler, which would otherwise answer 2.01 and swallow the
+    // Security/Server objects.
+    const bool bootstrapping = isAmIClient && m_bsClient &&
+        (m_bsClient->state() == ::lwm2m::bootstrap::ClientState::AwaitingBSAck ||
+         m_bsClient->state() == ::lwm2m::bootstrap::ClientState::WaitForBSWrites);
+
     // L5 hot path: client-side DM dispatcher. Handles /{oid}[/...] coming
     // from the registered LwM2M Server. Returns kind==None when the URI
     // isn't a numeric DM path.
-    if (isAmIClient && m_dmClient) {
+    if (isAmIClient && m_dmClient && !bootstrapping) {
         auto dmOut = m_dmClient->handle(coapmessage, *this);
         if (dmOut.kind != ::lwm2m::DmOutcome::None) {
             if (!dmOut.response.empty()) out.push_back(std::move(dmOut.response));

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -217,6 +217,10 @@ DTLSAdapter::~DTLSAdapter() {
 
 void DTLSAdapter::connect(const std::string& ip, const std::uint16_t& port) {
     session(ip, port);
+    // Pin the connect target as the client's outbound peer. m_session is
+    // overwritten on every inbound packet (dtlsReadCb), so client-initiated
+    // requests (Register/Update) must use this stable copy instead.
+    m_peerSession = m_session;
     isClient(true);
 
     auto ret = dtls_connect(dtls_ctx(), &m_session);
@@ -261,9 +265,16 @@ std::int32_t DTLSAdapter::rx(std::int32_t fd) {
             
             if(!ret) {
                 dtls_debug("Message is deciphered successfully\n");
+                // Reply to the peer this datagram CAME FROM (the captured
+                // `session`), not m_session. Handling the message may have
+                // switched m_session to a different peer — e.g. a
+                // Bootstrap-Finish triggers the client to connect() to the DM
+                // mid-handling — and replying to m_session would then leak the
+                // Bootstrap ACK onto the freshly-opened DM session.
                 for(auto rsp: responses()) {
                     dtls_debug("Sending response to peer\n");
-                    tx(rsp);
+                    dtls_write(dtls_ctx(), &session,
+                               (std::uint8_t *)&rsp.at(0), rsp.size());
                 }
             }
             return(ret);
@@ -281,6 +292,14 @@ std::int32_t DTLSAdapter::tx(std::string& in) {
     std::int32_t ret = -1;
     ret = dtls_write(dtls_ctx(), &m_session, (std::uint8_t *)&in.at(0), in.size());
     return(ret);
+}
+
+std::int32_t DTLSAdapter::tx_peer(std::string& in) {
+    // Client-initiated send to the pinned connect target (m_peerSession),
+    // immune to m_session being overwritten by inbound packets from another
+    // peer (e.g. lingering Bootstrap retransmits after switching to the DM).
+    return dtls_write(dtls_ctx(), &m_peerSession,
+                      (std::uint8_t *)&in.at(0), in.size());
 }
 
 std::int32_t DTLSAdapter::tx(std::string& in, std::string peerIP, std::uint16_t peerPort) {

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -477,6 +477,12 @@ struct ClientPlumbing {
     std::shared_ptr<Rebind>                          rebind;
 };
 
+/// Client bootstrap progress. The client sends POST /bs first; once the
+/// Bootstrap-Server delivers + the client commits the DM account, on_done
+/// switches the DTLS peer/identity to the DM and the tick registers there.
+/// Skipped is the plain-DM / no-BS fallback (or a bootstrap timeout).
+enum class BootPhase { NotStarted, InProgress, Done, Skipped };
+
 ClientPlumbing wire_client(std::shared_ptr<App>& app,
                            const std::string& endpoint,
                            const std::string& configDir,
@@ -506,14 +512,12 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
 
     ::lwm2m::ClientConfig cfg;
     cfg.endpoint     = endpoint;
-    auto dsLifetime  = ds.lifetime();
-    cfg.lifetime     = dsLifetime.value_or(86400);
-    if (dsLifetime) {
-        ACE_DEBUG((LM_INFO,
-                   ACE_TEXT("%D lwm2m:thread:%t %M %N:%l Registration lifetime from "
-                            "data-store: %u\n"),
-                   static_cast<unsigned>(cfg.lifetime)));
-    }
+    // The authoritative registration lifetime is delivered by the Bootstrap
+    // server in the Server Object (RID 1) — which the BS reads from
+    // cloud.dm.lifetime. The client does NOT read its own data-store for it;
+    // this is only the pre-bootstrap default (used if bootstrap is skipped).
+    // on_done applies the bootstrap-delivered value below.
+    cfg.lifetime     = 86400;
     cfg.binding      = "U";
     cfg.lwm2mVersion = "1.1";
     plumb.reg = std::make_shared<::lwm2m::RegistrationClient>(cfg, *plumb.store);
@@ -529,21 +533,29 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
         ctx->coapAdapter()->registrationClient(plumb.reg);
     }
 
-    // L9 stub 1 — Register POST after bootstrap commit. Runs on the
-    // reactor thread (handle_bs_traffic invoked it); the tx itself
-    // queues via send_async + notify so we don't recurse into the I/O
-    // path inside the callback.
+    // Bootstrap progress, shared between on_done (writer) and the reactor
+    // tick (reader/driver). Both run on the reactor thread, so no lock.
+    auto bootPhase    = std::make_shared<BootPhase>(BootPhase::NotStarted);
+    auto bootDeadline =
+        std::make_shared<std::chrono::steady_clock::time_point>();
+
+    // After the Bootstrap commit, switch the LwM2MClient peer + DTLS identity
+    // to the DM and (re)connect; the tick sends Register once the DM
+    // handshake completes. Runs on the reactor thread (apply_commit invoked
+    // it); we only mutate state + kick the handshake, no recursion into tx.
     std::weak_ptr<App>                          wapp_bs = app;
     std::weak_ptr<::lwm2m::RegistrationClient>  wreg_bs = plumb.reg;
-    plumb.bs->on_done([wapp_bs, wreg_bs, &ds]
+    plumb.bs->on_done([wapp_bs, wreg_bs, &ds, dtls, bootPhase]
                       (const ::lwm2m::bootstrap::StagingBuffer& committed) {
-        // Task F — persist the bootstrap-delivered DM credentials to the
-        // data-store (write-only). The DM security instance is the
-        // non-bootstrap PSK entry; its secretKey is raw bytes, so we hex-
-        // encode to match how PSK keys are stored + consumed elsewhere.
+        // Pull the bootstrap-delivered DM account (the non-BS PSK instance):
+        // server URI (RID 0) + identity (RID 3). Persist its key (RID 5) to
+        // the data-store (write-only) for visibility.
+        std::string dmUri, dmIdentity;
         for (const auto& s : committed.security) {
             if (s.isBootstrapServer || s.securityMode != 0 /*PSK*/) continue;
             if (s.identity.empty() || s.secretKey.empty()) continue;
+            dmUri      = s.serverUri;
+            dmIdentity = s.identity;
             const std::string key_hex = iot::hex_encode(
                 reinterpret_cast<const unsigned char*>(s.secretKey.data()),
                 s.secretKey.size());
@@ -556,14 +568,49 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
             break;
         }
         auto a = wapp_bs.lock();
-        auto r = wreg_bs.lock();
-        if (!a || !r) return;
+        if (!a) return;
+        UDPAdapter::Scheme_t sc{};
+        std::string   dmHost;
+        std::uint16_t dmPort = 0;
+        if (!dmUri.empty()) parsePeerOption(dmUri, sc, dmHost, dmPort);
+        if (dmHost.empty() || dmPort == 0) {
+            ACE_ERROR((LM_WARNING,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l bootstrap commit but "
+                                "no usable DM URI — falling back to direct "
+                                "Register\n")));
+            *bootPhase = BootPhase::Skipped;
+            return;
+        }
+        // Point the LwM2MClient peer at the DM, pin the DM PSK identity, and
+        // force a fresh DTLS handshake against the DM.
+        for (auto& [type, ctx] : a->udpAdapter()->services()) {
+            if (type != ::UDPAdapter::ServiceType_t::LwM2MClient) continue;
+            ctx->peerHost(dmHost);
+            ctx->peerPort(dmPort);
+        }
+        if (dtls) {
+            dtls->active_identity(dmIdentity);
+            dtls->clientState("");            // drop the BS session state
+            dtls->connect(dmHost, dmPort);    // start the DM handshake now
+        }
+        // Apply the bootstrap-delivered registration lifetime (Server Object
+        // RID 1) — the client uses this, sourced by the BS from
+        // cloud.dm.lifetime, rather than its own data-store.
+        if (auto r = wreg_bs.lock(); r && !committed.server.empty()) {
+            const std::uint32_t lt = committed.server.front().lifetime;
+            r->set_lifetime(lt);
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l applied bootstrap "
+                                "lifetime=%u (Server Object RID 1)\n"),
+                       static_cast<unsigned>(lt)));
+        }
+        *bootPhase = BootPhase::Done;
         ACE_DEBUG((LM_INFO,
                    ACE_TEXT("%D lwm2m:thread:%t %M %N:%l bootstrap commit done; "
-                            "sending Register\n")));
-        auto payload = r->build_register_request(next_msgid(),
-                                                 std::string{static_cast<char>(0x01)});
-        tx_via(*a, payload, ::UDPAdapter::ServiceType_t::LwM2MClient);
+                            "switching to DM %C:%u (identity=%C) — Register on "
+                            "next connected tick\n"),
+                   dmHost.c_str(), static_cast<unsigned>(dmPort),
+                   dmIdentity.c_str()));
     });
 
     // FUP-DS-11 — DM server URI rebind mailbox. Listener thread fills
@@ -585,7 +632,8 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     auto reboot_after =
         std::make_shared<std::chrono::steady_clock::time_point>();
     app->udpAdapter()->on_tick_client([wreg, wdm, wapp, rebind, wbs,
-                                       reboot_after]() {
+                                       reboot_after, bootPhase, bootDeadline,
+                                       dtls]() {
         auto reg = wreg.lock();
         auto dm  = wdm.lock();
         auto a   = wapp.lock();
@@ -615,26 +663,62 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
             }
         }
 
-        // L9 fallback (Leshan interop) — if we never went through
-        // Bootstrap (e.g. the server is a plain LwM2M DM server with no
-        // BS account for us), fire the initial Register on the first
-        // tick after startup. Also the second leg of FUP-DS-10/11:
-        // after a triggered Deregister completes, state returns to
-        // Unregistered and this branch sends a fresh Register with
-        // the new endpoint (via RegistrationClient::endpoint()) and/or
-        // to the freshly-swapped peer above.
+        // Bootstrap-first startup. While Unregistered we:
+        //   1. send POST /bs once (NotStarted → InProgress);
+        //   2. wait for on_done to commit + switch us to the DM (→ Done),
+        //      or time out and fall back to direct Register (→ Skipped);
+        //   3. Register once ready — for Done that means the DM DTLS
+        //      handshake (kicked in on_done) has completed.
+        // The branch fires every tick while Unregistered, so step 3 retries
+        // until the handshake is up; after a later Deregister it re-registers
+        // without re-bootstrapping (bootPhase stays Done).
         if (reg->state() == ::lwm2m::RegistrationState::Unregistered &&
             !reg->is_disabled()) {
-            ACE_DEBUG((LM_INFO,
-                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l no bootstrap; "
-                                "sending Register directly\n")));
-            auto payload = reg->build_register_request(
-                next_msgid(),
-                std::string{static_cast<char>(0x10)});
-            tx_via(*a, payload, svc);
-            // Endpoint change is naturally satisfied by this Register;
-            // clear the flag so we don't double-act on it later.
-            reg->clear_pending_reregister();
+            auto bs = wbs.lock();
+            // True once the DTLS session to the *current* peer is up — the BS
+            // while NotStarted, the DM once on_done switched us over. Gating
+            // both the single-shot /bs and Register on it avoids sending into
+            // a half-open handshake (the frame would be dropped, not retried).
+            const bool dtlsReady = !dtls || dtls->clientState() == "connected";
+
+            if (*bootPhase == BootPhase::NotStarted) {
+                if (!bs) {
+                    *bootPhase = BootPhase::Skipped;        // plain-DM / no BS
+                } else if (dtlsReady) {
+                    ACE_DEBUG((LM_INFO,
+                               ACE_TEXT("%D lwm2m:thread:%t %M %N:%l initiating "
+                                        "bootstrap: POST /bs\n")));
+                    auto payload = bs->build_bs_request(
+                        next_msgid(), std::string{static_cast<char>(0x40)});
+                    tx_via(*a, payload, svc);
+                    *bootPhase    = BootPhase::InProgress;
+                    *bootDeadline = now + std::chrono::seconds(15);
+                }
+                // else: wait for the BS handshake, retry next tick.
+            } else if (*bootPhase == BootPhase::InProgress &&
+                       now >= *bootDeadline) {
+                ACE_ERROR((LM_WARNING,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l bootstrap did "
+                                    "not complete in time — registering "
+                                    "directly\n")));
+                *bootPhase = BootPhase::Skipped;
+            }
+
+            // Register when ready: bootstrap committed + the DM DTLS session
+            // is up, or bootstrap skipped (peer connected at startup).
+            if ((*bootPhase == BootPhase::Done && dtlsReady) ||
+                *bootPhase == BootPhase::Skipped) {
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l sending "
+                                    "Register\n")));
+                auto payload = reg->build_register_request(
+                    next_msgid(),
+                    std::string{static_cast<char>(0x10)});
+                tx_via(*a, payload, svc);
+                // Endpoint change is naturally satisfied by this Register;
+                // clear the flag so we don't double-act on it later.
+                reg->clear_pending_reregister();
+            }
         }
 
         // FUP-DS-10 — endpoint hot-reload kicks the re-register cycle.

--- a/apps/src/udp_adapter.cpp
+++ b/apps/src/udp_adapter.cpp
@@ -26,6 +26,13 @@ ServiceContext_t::ServiceContext_t(Scheme_t scheme,
         // callbacks ::sendto/::recvfrom on it directly. The fd is filled
         // in inside open() once the socket is actually bound.
         m_dtlsAdapter = std::make_shared<DTLSAdapter>(ACE_INVALID_HANDLE, DTLS_LOG_DEBUG);
+        // Share THIS context's CoAPAdapter with the DTLS read path. The
+        // DTLSAdapter's dtlsReadCb dispatches deciphered datagrams via its
+        // own coapAdapter(); without this it would use a private, unwired
+        // CoAPAdapter and every LwM2M handler attached here (bsServer /
+        // regServer / dmClient / bsClient / regClient) would be invisible
+        // over coaps, silently falling through to the legacy path.
+        m_dtlsAdapter->coapAdapter() = m_coapAdapter;
     }
 }
 
@@ -166,7 +173,10 @@ void ServiceContext_t::drain_tx_queue() {
                 m_dtlsAdapter->connect(host, port);
             }
             if (m_dtlsAdapter->clientState() == "connected") {
-                m_dtlsAdapter->tx(frame.payload);
+                // tx_peer (not tx) so our request goes to the pinned connect
+                // target, even if an inbound packet from another peer just
+                // overwrote m_session (Bootstrap retransmit vs the DM).
+                m_dtlsAdapter->tx_peer(frame.payload);
             } else {
                 ACE_DEBUG((LM_DEBUG,
                            ACE_TEXT("%D [UdpSvc:%t] %M %N:%l DTLS not connected, dropping tx\n")));


### PR DESCRIPTION
Makes the full device↔cloud LwM2M flow work end-to-end over DTLS:
**bootstrap → DM credential delivery → DM handshake → registration → online state.**
Verified live in the podman device↔cloud stack — the endpoint shows
`registered:true, state:"online"` in `cloud.endpoints`, with a single clean
bootstrap→DM switch (no churn).

### Bugs fixed (all latent — the bootstrap path was never exercised over DTLS)

1. **`fix(dtls)` — CoAPAdapter not wired into the DTLS path.** The DTLSAdapter
   dispatched deciphered datagrams through its *own* unconfigured CoAPAdapter,
   so no LwM2M handler (bsServer/regServer/dmClient/bsClient/regClient) was
   reachable over coaps; everything fell through to the legacy path. Plus
   per-peer session routing: `tx_peer()`/`m_peerSession` (client requests go to
   the pinned connect target), rx replies to the captured inbound session (no
   Bootstrap-ACK leak onto the DM session), and `active_identity()` so the
   client presents the DM PSK identity to the DM.
2. **`fix(coap)` — bootstrap traffic mis-routed.** The `/bs` `2.04` ACK went to
   the RegistrationClient (bootstrap client stuck in `AwaitingBSAck`), and the
   Bootstrap-Write PUTs were stolen by the DM Write dispatcher. Route both to
   the bootstrap client during the bootstrap window.
3. **`feat(lwm2m-client)` — bootstrap-first startup.** Client now sends `/bs`,
   commits, switches peer+identity to the DM, and registers there. Registration
   lifetime comes from the bootstrap Server Object (RID 1), not the data-store.
4. **`fix(cloud)` — 128-bit DM PSK.** 256-bit PSK overflowed tinydtls' 16-byte
   AES-128-CCM key buffer → DM handshake failed.

### Verification
All changed TUs pass `-fsyntax-only -Wall -Wextra`; both images rebuilt and the
full e2e exercised live (bootstrap commit, DM handshake `Handshake complete`,
Register, `cloud.endpoints` → online).

🤖 Generated with [Claude Code](https://claude.com/claude-code)