### PR TITLE
fix(openvpn-client): subscribe to mgmt state so vpn.state reaches connected

### DIFF
--- a/modules/openvpn/client/src/supervisor.cpp
+++ b/modules/openvpn/client/src/supervisor.cpp
@@ -174,6 +174,24 @@ bool Supervisor::serve_one_session(const std::string& iface) {
         return false;
     }
 
+    // Subscribe to real-time state notifications. Real openvpn keeps the
+    // management interface silent after the `>INFO:` banner until a client
+    // asks for them; `state on` makes it emit the CURRENT state immediately
+    // (covers the case where openvpn reached CONNECTED before we attached)
+    // AND every subsequent transition as a `>STATE:` event the Lifecycle
+    // consumes. Without this, vpn.state never advances past "connecting"
+    // against real openvpn — the L12/L14 fake openvpn masked the gap by
+    // pushing STATE/PUSH_REPLY lines unsolicited.
+    {
+        static const char kStateOn[] = "state on\r\n";
+        if (stream.send_n(kStateOn, sizeof(kStateOn) - 1) < 0) {
+            ACE_ERROR((LM_WARNING,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l mgmt 'state on' send "
+                                "failed errno=%d; vpn.state may stall\n"),
+                       errno));
+        }
+    }
+
     Lifecycle::Sinks sinks;
     sinks.set_state            = [this](const std::string& s) { m_ds.set_state(s); };
     sinks.set_assigned_ip      = [this](const std::string& s) { m_ds.set_assigned_ip(s); };


### PR DESCRIPTION
## Problem

The `openvpn-client` daemon connects to openvpn(8)'s management interface but **only ever reads from it** — `serve_one_session` never sends a subscription command. Real openvpn keeps the management interface silent after the initial `>INFO:` banner until a client subscribes, so `Lifecycle` (which advances on `>STATE:` / `>PUSH_REPLY:` async events) never sees `CONNECTED`.

Result against a **real** tunnel: the tunnel comes fully up (TLS verified, `PUSH_REPLY` received, tun configured, traffic flows), but the daemon's published `vpn.state` stays `"connecting"` and `vpn.assigned.ip` stays null.

This was masked by the L12/L14 smokes because the fake openvpn writes `>STATE:`/`>PUSH_REPLY:` lines **unsolicited** — it only surfaces under a real device↔cloud tunnel.

## Fix

Send `state on\r\n` to the management stream right after `connect_mgmt()` succeeds. `state on` makes openvpn emit the **current** state immediately (covering the race where openvpn reaches `CONNECTED` before the daemon attaches) plus every subsequent transition.

## Verification (real tunnel)

Stood up `iot-cloudd`'s openvpn server ↔ `openvpn-client` in two podman containers with a fresh PKI (the cloud image's CA key is purged at build, so an ad-hoc CA was used for both ends).

| | before | after |
|---|---|---|
| `vpn.state` | `connecting` (stuck) | `connected` |
| `vpn.assigned.ip` | `(null)` | `10.9.0.2` |
| mgmt | silent after banner | `CMD 'state on'` → `>STATE:...,CONNECTED,SUCCESS,10.9.0.2,...` |
| tunnel ICMP | 0% loss | 0% loss |

## Out of scope (follow-up)

`vpn.assigned.gateway/netmask/dns` remain null against real openvpn: those come from the `PushReply` branch, but real openvpn does **not** emit `>PUSH_REPLY:` as a management async event — only the `>STATE:` line (which carries just the tun IP). Populating them needs `log on` + parsing `>LOG:` "PUSH: Received control message" lines, a larger change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)