### PR TITLE
feat(cloud): runtime VPN CA + per-device client cert minting (Phase 2)

### DIFF
--- a/apps/cloud/server/CMakeLists.txt
+++ b/apps/cloud/server/CMakeLists.txt
@@ -28,7 +28,8 @@ add_executable(iot-cloudd
     ../../../modules/server/lwm2m/src/bootstrap.cpp
     ../../../modules/server/lwm2m/src/cloud_credentials.cpp
     ../../../modules/server/openvpn/src/vpn_registry.cpp
-    ../../../modules/server/openvpn/src/openvpn_server.cpp)
+    ../../../modules/server/openvpn/src/openvpn_server.cpp
+    ../../../modules/server/openvpn/src/cert_authority.cpp)
 
 if(DEFINED DATASTORE_LIB)
     set(DS_LINK_LIB ${DATASTORE_LIB})

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -16,6 +16,7 @@
 #include "endpoint_registry.hpp"
 #include "vpn_registry.hpp"
 #include "openvpn_server.hpp"
+#include "cert_authority.hpp"
 #include "bootstrap.hpp"
 #include "cloud_credentials.hpp"
 
@@ -255,6 +256,29 @@ int main(int argc, char** argv) {
         {"cloud.vpn.mgmt.port",   data_store::Value{static_cast<std::int32_t>(ovpn_cfg.mgmt_port)}},
         {"cloud.vpn.verb",        data_store::Value{static_cast<std::int32_t>(ovpn_cfg.verb)}},
     });
+    // ── Runtime VPN PKI (Phase 2) ─────────────────────────────────
+    // The cloud image generates a CA + server cert at build time but PURGES
+    // the CA key, so the shipped image can't sign new client certs. Generate
+    // and persist a runtime CA (+ a server cert signed by it) before openvpn
+    // starts; the same CA signs the per-device client certs minted at
+    // provision time, so the server trusts them.
+    server::openvpn::CaPaths capaths;
+    capaths.ca_crt  = ovpn_cfg.ca_path;
+    capaths.srv_crt = ovpn_cfg.cert_path;
+    capaths.srv_key = ovpn_cfg.key_path;
+    {
+        auto slash = ovpn_cfg.ca_path.find_last_of('/');
+        capaths.ca_key = (slash == std::string::npos)
+                       ? std::string("ca.key")
+                       : ovpn_cfg.ca_path.substr(0, slash + 1) + "ca.key";
+    }
+    server::openvpn::CertAuthority cert_ca(capaths);
+    if (!cert_ca.ensure()) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l runtime CA ensure() "
+                            "failed — per-device client certs won't be mintable\n")));
+    }
+
     server::openvpn::OpenVpnServer ovpn(ovpn_cfg);
 
     // Bring openvpn to the operator-desired state and publish it. Runs on
@@ -377,6 +401,35 @@ int main(int argc, char** argv) {
                                        ACE_TEXT("%D cloudd:thread:%t %M %N:%l credential "
                                                 "provisioning for %C failed: %C\n"),
                                        ep->c_str(), e.what()));
+                        }
+                    }
+
+                    // Mint a per-device VPN client cert (Phase 2) signed by
+                    // the runtime CA and stash it in the credential record for
+                    // LwM2M Object-2048 delivery (Phase 3). CN = the cloud
+                    // formatted identity, for traceability.
+                    if (cert_ca.have_ca()) {
+                        const std::string cn =
+                            server::lwm2m::format_identity(*ep);
+                        if (auto mc = cert_ca.mint_client(cn)) {
+                            try {
+                                const std::string cur =
+                                    ds_str(ds, "cloud.endpoint.credentials", "[]");
+                                const std::string next =
+                                    server::lwm2m::upsert_vpn_cert(
+                                        cur, *ep, mc->client_crt, mc->client_key);
+                                ds.set("cloud.endpoint.credentials",
+                                       data_store::Value{next});
+                                ACE_DEBUG((LM_INFO,
+                                           ACE_TEXT("%D cloudd:thread:%t %M %N:%l "
+                                                    "minted+stored VPN client cert "
+                                                    "for %C\n"), ep->c_str()));
+                            } catch (const std::exception& e) {
+                                ACE_ERROR((LM_ERROR,
+                                           ACE_TEXT("%D cloudd:thread:%t %M %N:%l "
+                                                    "store VPN cert for %C failed: "
+                                                    "%C\n"), ep->c_str(), e.what()));
+                            }
                         }
                     }
 

--- a/modules/server/lwm2m/inc/cloud_credentials.hpp
+++ b/modules/server/lwm2m/inc/cloud_credentials.hpp
@@ -48,6 +48,17 @@ std::string upsert_credential(const std::string& array_json,
 std::string remove_credential(const std::string& array_json,
                               const std::string& serial);
 
+/// Merge a minted VPN client credential (PEM) into the record for `serial`,
+/// adding/updating the "vpn.client.cert" + "vpn.client.key" fields. Creates a
+/// minimal record (serial + identity) if none exists yet. Phase-3 delivery
+/// reads these and pushes them to the device over LwM2M Object 2048; the
+/// BS/DM PSK loaders ignore the extra fields. Returns the updated array.
+/// Throws std::runtime_error if `array_json` is not a JSON array.
+std::string upsert_vpn_cert(const std::string& array_json,
+                            const std::string& serial,
+                            const std::string& client_cert_pem,
+                            const std::string& client_key_pem);
+
 /// Task N — turn the credential array into the (identity → key) pairs a
 /// server instance must register with its DTLS adapter:
 ///   * BS server (is_bs=true): identity = RAW serial (what the device puts

--- a/modules/server/lwm2m/src/cloud_credentials.cpp
+++ b/modules/server/lwm2m/src/cloud_credentials.cpp
@@ -98,6 +98,30 @@ std::string upsert_credential(const std::string& array_json,
     return arr.dump();
 }
 
+std::string upsert_vpn_cert(const std::string& array_json,
+                            const std::string& serial,
+                            const std::string& client_cert_pem,
+                            const std::string& client_key_pem) {
+    json arr = parse_array(array_json);
+    for (auto& e : arr) {
+        if (e.is_object() && e.value("serial", "") == serial) {
+            e["vpn.client.cert"] = client_cert_pem;
+            e["vpn.client.key"]  = client_key_pem;
+            return arr.dump();
+        }
+    }
+    // No PSK record yet (cert minted before/without PSK provisioning) — create
+    // a minimal record so the cert isn't lost.
+    json rec = {
+        {"serial",          serial},
+        {"identity",        format_identity(serial)},
+        {"vpn.client.cert", client_cert_pem},
+        {"vpn.client.key",  client_key_pem},
+    };
+    arr.push_back(rec);
+    return arr.dump();
+}
+
 std::string remove_credential(const std::string& array_json,
                               const std::string& serial) {
     json arr = parse_array(array_json);

--- a/modules/server/openvpn/CMakeLists.txt
+++ b/modules/server/openvpn/CMakeLists.txt
@@ -14,10 +14,12 @@ include_directories(${OVPN_SERVER_DIR}/inc ${ACE_ROOT}/include)
 
 add_library(server_openvpn STATIC
     src/vpn_registry.cpp
-    src/openvpn_server.cpp)
+    src/openvpn_server.cpp
+    src/cert_authority.cpp)
 
 target_include_directories(server_openvpn PUBLIC inc ${ACE_ROOT}/include)
-target_link_libraries(server_openvpn PUBLIC pthread)
+target_link_directories(server_openvpn PUBLIC ${ACE_ROOT}/lib)
+target_link_libraries(server_openvpn PUBLIC ACE pthread)
 
 option(BUILD_SERVER_OPENVPN_TESTS "Build server/openvpn gtest suite" OFF)
 if(BUILD_SERVER_OPENVPN_TESTS)
@@ -45,4 +47,16 @@ if(BUILD_SERVER_OPENVPN_TESTS)
     target_link_libraries(openvpn-server-tests
         GTest::gtest_main GTest::gtest ACE pthread)
     add_test(NAME openvpn-server-tests COMMAND openvpn-server-tests)
+
+    # CertAuthority: sanitize_cn is pure; ensure()/mint_client() shell out to
+    # openssl and SKIP at runtime if the CLI is absent.
+    add_executable(cert-authority-tests
+        test/cert_authority_test.cpp
+        src/cert_authority.cpp)
+    target_include_directories(cert-authority-tests
+        PRIVATE ${OVPN_SERVER_DIR}/inc ${ACE_ROOT}/include)
+    target_link_directories(cert-authority-tests PRIVATE ${ACE_ROOT}/lib)
+    target_link_libraries(cert-authority-tests
+        GTest::gtest_main GTest::gtest ACE pthread)
+    add_test(NAME cert-authority-tests COMMAND cert-authority-tests)
 endif()

--- a/modules/server/openvpn/inc/cert_authority.hpp
+++ b/modules/server/openvpn/inc/cert_authority.hpp
@@ -1,0 +1,78 @@
+#ifndef __server_openvpn_cert_authority_hpp__
+#define __server_openvpn_cert_authority_hpp__
+
+/// Runtime VPN PKI for iot-cloudd (Phase 2 of the cert-provisioning work).
+///
+/// The cloud image generates a CA + server cert at BUILD time but PURGES the
+/// CA private key, so the shipped image can verify clients but cannot sign
+/// new ones. This component moves the CA to RUNTIME: on first boot it
+/// generates a CA keypair (persisted in the iot-vpn volume) and regenerates
+/// the openvpn server cert signed by it, so the server trusts every client
+/// cert this CA later mints. Per-device client certs are minted at
+/// provision time and delivered to the device over LwM2M Object 2048.
+///
+/// Implementation shells out to the `openssl(1)` CLI (present in the cloud
+/// runtime image) — the same commands the Dockerfile uses to bootstrap the
+/// build-time PKI, so the trust chain is identical.
+
+#include <optional>
+#include <string>
+
+namespace server {
+namespace openvpn {
+
+/// Filesystem locations for the CA + server material. Defaults match the
+/// cloud image layout (and cloud.vpn.* ds defaults). ca_key lives next to
+/// ca_crt under the persistent iot-vpn volume so it survives restarts.
+struct CaPaths {
+    std::string ca_key    = "/etc/iot/vpn/ca/ca.key";
+    std::string ca_crt    = "/etc/iot/vpn/ca/ca.crt";
+    std::string srv_key   = "/etc/iot/vpn/server.key";
+    std::string srv_crt   = "/etc/iot/vpn/server.crt";
+    std::string ca_subj   = "/O=IoT Cloud/CN=iot-cloud-ca";
+    std::string srv_subj  = "/O=IoT Cloud/CN=cloud-vpn";
+    int         days      = 3650;
+};
+
+/// A freshly minted client credential family. ca_crt is included so the
+/// device gets the full trust set in one push.
+struct MintedCert {
+    std::string client_crt;   ///< PEM
+    std::string client_key;   ///< PEM
+    std::string ca_crt;       ///< PEM (the signing CA)
+};
+
+class CertAuthority {
+public:
+    explicit CertAuthority(CaPaths paths = {},
+                           std::string openssl = "/usr/bin/openssl");
+
+    /// Ensure a usable CA exists. If `ca_key` is absent, generate a fresh CA
+    /// AND regenerate the server cert/key signed by it (so the openvpn server
+    /// trusts certs this CA mints). Idempotent: if `ca_key` already exists,
+    /// returns true without touching anything. MUST be called before the
+    /// openvpn server starts. Returns false on any openssl/IO failure.
+    bool ensure();
+
+    /// True once a CA private key is present (after a successful ensure()).
+    bool have_ca() const;
+
+    /// Mint a client cert + key signed by the CA, CN = sanitized `cn`.
+    /// Returns std::nullopt on failure (no CA, openssl error, IO error).
+    std::optional<MintedCert> mint_client(const std::string& cn);
+
+    /// CN sanitiser exposed for tests: keep [A-Za-z0-9._@-], map the rest to
+    /// '_', cap at 64 chars, never empty.
+    static std::string sanitize_cn(const std::string& cn);
+
+private:
+    bool run_openssl(const std::string& args) const;  // args appended to the binary
+
+    CaPaths     m_p;
+    std::string m_openssl;
+};
+
+} // namespace openvpn
+} // namespace server
+
+#endif /* __server_openvpn_cert_authority_hpp__ */

--- a/modules/server/openvpn/src/cert_authority.cpp
+++ b/modules/server/openvpn/src/cert_authority.cpp
@@ -1,0 +1,182 @@
+#include "cert_authority.hpp"
+
+#include <cerrno>
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+
+namespace server {
+namespace openvpn {
+
+namespace {
+
+bool file_exists(const std::string& p) {
+    struct stat st;
+    return ::stat(p.c_str(), &st) == 0;
+}
+
+std::string dirname_of(const std::string& p) {
+    auto slash = p.find_last_of('/');
+    return slash == std::string::npos ? std::string(".") : p.substr(0, slash);
+}
+
+bool slurp(const std::string& path, std::string& out) {
+    std::ifstream ifs(path, std::ios::binary);
+    if (!ifs.is_open()) return false;
+    std::ostringstream ss;
+    ss << ifs.rdbuf();
+    out = ss.str();
+    return true;
+}
+
+} // namespace
+
+CertAuthority::CertAuthority(CaPaths paths, std::string openssl)
+    : m_p(std::move(paths)), m_openssl(std::move(openssl)) {}
+
+std::string CertAuthority::sanitize_cn(const std::string& cn) {
+    std::string out;
+    out.reserve(cn.size());
+    for (char c : cn) {
+        const bool ok = (c >= 'A' && c <= 'Z') || (c >= 'a' && c <= 'z') ||
+                        (c >= '0' && c <= '9') ||
+                        c == '.' || c == '_' || c == '@' || c == '-';
+        out.push_back(ok ? c : '_');
+        if (out.size() >= 64) break;
+    }
+    if (out.empty()) out = "device";
+    return out;
+}
+
+bool CertAuthority::run_openssl(const std::string& args) const {
+    // Single point where we invoke the CLI. Subjects are fixed strings and
+    // the only externally-influenced value (the CN) is sanitised to a shell-
+    // safe charset by sanitize_cn() before it ever reaches here, then wrapped
+    // in single quotes by the caller — so there is no metacharacter that can
+    // escape the quoted -subj argument.
+    std::string cmd = m_openssl + " " + args + " >/dev/null 2>&1";
+    int rc = std::system(cmd.c_str());
+    if (rc != 0) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l openssl failed rc=%d: %C\n"),
+                   rc, args.c_str()));
+        return false;
+    }
+    return true;
+}
+
+bool CertAuthority::have_ca() const {
+    return file_exists(m_p.ca_key) && file_exists(m_p.ca_crt);
+}
+
+bool CertAuthority::ensure() {
+    if (file_exists(m_p.ca_key)) {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l CA key present (%C); "
+                            "runtime CA already initialised\n"),
+                   m_p.ca_key.c_str()));
+        return true;
+    }
+
+    // Make sure the CA dir exists (the iot-vpn volume ships /etc/iot/vpn/ca
+    // with ca.crt, but be defensive on a clean volume).
+    ::mkdir(dirname_of(m_p.ca_key).c_str(), 0755);
+
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D cloudd:thread:%t %M %N:%l no CA key — generating a "
+                        "runtime CA + server cert (build-time CA key was purged)\n")));
+
+    const std::string days = std::to_string(m_p.days);
+
+    // 1) CA keypair + self-signed cert.
+    if (!run_openssl("genrsa -out '" + m_p.ca_key + "' 4096")) return false;
+    ::chmod(m_p.ca_key.c_str(), 0600);
+    if (!run_openssl("req -new -x509 -days " + days +
+                     " -key '" + m_p.ca_key + "' -out '" + m_p.ca_crt +
+                     "' -subj '" + m_p.ca_subj + "'")) return false;
+
+    // 2) Server keypair + cert signed by the new CA (replaces the build-time
+    //    server cert, which was signed by the purged build CA).
+    const std::string csr = dirname_of(m_p.srv_crt) + "/server.csr";
+    const std::string srl = dirname_of(m_p.ca_crt)  + "/ca.srl";
+    if (!run_openssl("genrsa -out '" + m_p.srv_key + "' 2048")) return false;
+    ::chmod(m_p.srv_key.c_str(), 0600);
+    if (!run_openssl("req -new -key '" + m_p.srv_key + "' -out '" + csr +
+                     "' -subj '" + m_p.srv_subj + "'")) return false;
+    if (!run_openssl("x509 -req -days " + days + " -in '" + csr +
+                     "' -CA '" + m_p.ca_crt + "' -CAkey '" + m_p.ca_key +
+                     "' -CAcreateserial -out '" + m_p.srv_crt + "'")) return false;
+    ::unlink(csr.c_str());
+    (void)srl;
+
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D cloudd:thread:%t %M %N:%l runtime CA + server cert "
+                        "generated (ca=%C server=%C)\n"),
+               m_p.ca_crt.c_str(), m_p.srv_crt.c_str()));
+    return true;
+}
+
+std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn) {
+    if (!have_ca()) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l mint_client(%C): no CA "
+                            "available (call ensure() first)\n"),
+                   cn.c_str()));
+        return std::nullopt;
+    }
+    const std::string safe = sanitize_cn(cn);
+
+    // Work in a private temp dir so concurrent/repeated mints don't collide
+    // and nothing leaks into the persistent volume.
+    char tmpl[] = "/tmp/iot-mint-XXXXXX";
+    char* dir = ::mkdtemp(tmpl);
+    if (!dir) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l mint_client: mkdtemp "
+                            "failed errno=%d\n"), errno));
+        return std::nullopt;
+    }
+    const std::string d   = dir;
+    const std::string key = d + "/client.key";
+    const std::string csr = d + "/client.csr";
+    const std::string crt = d + "/client.crt";
+
+    bool ok =
+        run_openssl("genrsa -out '" + key + "' 2048") &&
+        run_openssl("req -new -key '" + key + "' -out '" + csr +
+                    "' -subj '/O=IoT Cloud/CN=" + safe + "'") &&
+        run_openssl("x509 -req -days " + std::to_string(m_p.days) + " -in '" + csr +
+                    "' -CA '" + m_p.ca_crt + "' -CAkey '" + m_p.ca_key +
+                    "' -CAcreateserial -out '" + crt + "'");
+
+    MintedCert out;
+    if (ok) {
+        ok = slurp(crt, out.client_crt) &&
+             slurp(key, out.client_key) &&
+             slurp(m_p.ca_crt, out.ca_crt);
+    }
+
+    // Best-effort cleanup of the temp material.
+    ::unlink(key.c_str()); ::unlink(csr.c_str()); ::unlink(crt.c_str());
+    ::rmdir(d.c_str());
+
+    if (!ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l mint_client(%C) failed\n"),
+                   safe.c_str()));
+        return std::nullopt;
+    }
+    ACE_DEBUG((LM_INFO,
+               ACE_TEXT("%D cloudd:thread:%t %M %N:%l minted client cert CN=%C "
+                        "(%d bytes)\n"),
+               safe.c_str(), static_cast<int>(out.client_crt.size())));
+    return out;
+}
+
+} // namespace openvpn
+} // namespace server

--- a/modules/server/openvpn/test/cert_authority_test.cpp
+++ b/modules/server/openvpn/test/cert_authority_test.cpp
@@ -1,0 +1,116 @@
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <fstream>
+#include <sstream>
+#include <string>
+#include <sys/stat.h>
+
+#include "cert_authority.hpp"
+
+using server::openvpn::CaPaths;
+using server::openvpn::CertAuthority;
+
+namespace {
+
+bool have_openssl() { return std::system("/usr/bin/openssl version >/dev/null 2>&1") == 0; }
+
+bool exists(const std::string& p) { struct stat st; return ::stat(p.c_str(), &st) == 0; }
+
+std::string slurp(const std::string& p) {
+    std::ifstream ifs(p, std::ios::binary);
+    std::ostringstream ss; ss << ifs.rdbuf(); return ss.str();
+}
+
+// A throwaway working dir; SKIP if no writable scratch.
+std::string scratch() {
+    char tmpl[] = "/tmp/iot-ca-test-XXXXXX";
+    char* d = ::mkdtemp(tmpl);
+    return d ? std::string(d) : std::string();
+}
+
+CaPaths paths_under(const std::string& dir) {
+    CaPaths p;
+    ::mkdir((dir + "/ca").c_str(), 0755);
+    p.ca_key  = dir + "/ca/ca.key";
+    p.ca_crt  = dir + "/ca/ca.crt";
+    p.srv_key = dir + "/server.key";
+    p.srv_crt = dir + "/server.crt";
+    return p;
+}
+
+} // namespace
+
+/* ─────────────────────────── sanitize_cn (pure) ───────────────────────── */
+
+TEST(CertAuthority, sanitize_cn_keeps_safe_charset_and_maps_rest) {
+    EXPECT_EQ("rpi100000abcd@cloud.local",
+              CertAuthority::sanitize_cn("rpi100000abcd@cloud.local"));
+    // shell metacharacters are neutralised
+    EXPECT_EQ("a_b_c_rm_-rf", CertAuthority::sanitize_cn("a b/c;rm -rf"));
+    EXPECT_EQ("x__y", CertAuthority::sanitize_cn("x'`y"));
+    // never empty
+    EXPECT_EQ("device", CertAuthority::sanitize_cn(""));
+    // capped at 64
+    EXPECT_LE(CertAuthority::sanitize_cn(std::string(200, 'a')).size(), 64u);
+}
+
+/* ─────────────────────── ensure + mint (needs openssl) ────────────────── */
+
+TEST(CertAuthority, ensure_generates_ca_and_server_then_is_idempotent) {
+    if (!have_openssl()) GTEST_SKIP() << "openssl CLI not available";
+    const std::string dir = scratch();
+    if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";
+    CaPaths p = paths_under(dir);
+
+    CertAuthority ca(p);
+    EXPECT_FALSE(ca.have_ca());
+    ASSERT_TRUE(ca.ensure());
+    EXPECT_TRUE(ca.have_ca());
+    EXPECT_TRUE(exists(p.ca_key));
+    EXPECT_TRUE(exists(p.ca_crt));
+    EXPECT_TRUE(exists(p.srv_crt));
+    EXPECT_TRUE(exists(p.srv_key));
+
+    // CA key + server key must be private (0600).
+    struct stat st;
+    ASSERT_EQ(0, ::stat(p.ca_key.c_str(), &st));  EXPECT_EQ(0600, st.st_mode & 0777);
+    ASSERT_EQ(0, ::stat(p.srv_key.c_str(), &st)); EXPECT_EQ(0600, st.st_mode & 0777);
+
+    // Idempotent: a second ensure() leaves the CA key byte-identical.
+    const std::string ca_before = slurp(p.ca_key);
+    ASSERT_TRUE(ca.ensure());
+    EXPECT_EQ(ca_before, slurp(p.ca_key));
+}
+
+TEST(CertAuthority, mint_client_returns_family_that_chains_to_ca) {
+    if (!have_openssl()) GTEST_SKIP() << "openssl CLI not available";
+    const std::string dir = scratch();
+    if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";
+    CaPaths p = paths_under(dir);
+
+    CertAuthority ca(p);
+    ASSERT_TRUE(ca.ensure());
+
+    auto mc = ca.mint_client("rpi100000abcd@cloud.local");
+    ASSERT_TRUE(mc.has_value());
+    EXPECT_NE(std::string::npos, mc->client_crt.find("BEGIN CERTIFICATE"));
+    EXPECT_NE(std::string::npos, mc->client_key.find("PRIVATE KEY"));
+    EXPECT_EQ(slurp(p.ca_crt), mc->ca_crt);
+
+    // The minted client cert AND the server cert both verify against the CA.
+    const std::string crt = dir + "/client.crt";
+    std::ofstream(crt, std::ios::binary) << mc->client_crt;
+    EXPECT_EQ(0, std::system(("/usr/bin/openssl verify -CAfile '" + p.ca_crt +
+                              "' '" + crt + "' >/dev/null 2>&1").c_str()));
+    EXPECT_EQ(0, std::system(("/usr/bin/openssl verify -CAfile '" + p.ca_crt +
+                              "' '" + p.srv_crt + "' >/dev/null 2>&1").c_str()));
+}
+
+TEST(CertAuthority, mint_without_ca_fails) {
+    const std::string dir = scratch();
+    if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";
+    CaPaths p = paths_under(dir);
+    CertAuthority ca(p);                 // ensure() not called
+    EXPECT_FALSE(ca.mint_client("x").has_value());
+}


### PR DESCRIPTION
## Why

The cloud image generates a CA + server cert at build time but **purges the CA private key** (`apps/cloud/Dockerfile:43`), so the shipped image can verify clients yet cannot sign new ones — the blocker for per-device VPN provisioning. This moves the CA to **runtime**, closing the gap that forced an ad-hoc CA in earlier tunnel tests.

## What

**`CertAuthority`** (`modules/server/openvpn`) — shells out to `openssl(1)` (present in the cloud image; same commands as the Dockerfile, so the trust chain is identical):
- **`ensure()`** — if the CA key is absent, generate a CA **and** regenerate the openvpn server cert signed by it, so the server trusts every client cert this CA later mints. Idempotent; CA/server keys written `0600`; persisted under `/etc/iot/vpn` (the `iot-vpn` volume) so it survives restarts.
- **`mint_client(cn)`** — sign a per-device client cert+key, returning the family incl. the CA. CN is sanitised to a shell-safe charset (`sanitize_cn`).

**iot-cloudd wiring** — calls `ensure()` before starting openvpn, and on `cloud.provision.request` mints a client cert and stores it in the per-endpoint `cloud.endpoint.credentials` record (new `upsert_vpn_cert` helper; BS/DM PSK loaders ignore the extra fields) for Phase-3 delivery over LwM2M Object 2048.

## Tests (`cert_authority_test.cpp`, gtest — all pass)

- `sanitize_cn` neutralises shell metacharacters, caps length, never empty.
- `ensure()` creates a CA + server with `0600` keys and is byte-idempotent on a second call.
- **`mint_client()` returns a family whose client cert AND the server cert both `openssl verify` against the runtime CA** — the property that makes the openvpn server trust minted client certs.
- mint without a CA fails.

Verified end-to-end at the crypto layer: `openssl verify` OK for both server and minted client against the generated CA (built + ran in the cloud builder image).

## Follow-up (Phase 3)

The server→device WRITE/EXECUTE transport that pushes the stored cert to the device's Object 2048 (`build_write`/`build_execute` exist but aren't wired to send to a registered client yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)