### PR TITLE
feat(lwm2m): harden cert provisioning — atomic family commit + applied status

### DIFF
--- a/apps/inc/lwm2m_object_cert.hpp
+++ b/apps/inc/lwm2m_object_cert.hpp
@@ -31,11 +31,20 @@
  *   RID 2  Hash               String  W    lowercase hex SHA-256 of RID 1
  *   RID 3  Apply              ----    E    commit staged artifacts + reload
  *                                          (present on instance 0 only)
+ *   RID 4  Applied            String  R    fingerprint of the last committed
+ *                                          family, "" if none (instance 0 only)
  *
  * Write semantics: WRITEs to RID 1/2 stage the bytes in memory. EXECUTE on
- * /2048/0/3 atomically commits every staged artifact via store_artifact()
- * then calls apply(). Staging-then-commit avoids a half-written cert family
- * if the push is interrupted between WRITEs.
+ * /2048/0/3 commits the staged family via store_artifact() then calls
+ * apply(). With `require_complete` (the default), Apply commits ONLY when all
+ * three artifacts (ca+cert+key) are staged — an interrupted push leaves the
+ * partial set staged (not written to disk) and a later Apply, once the
+ * missing artifact arrives, commits the whole family. This makes the
+ * server's re-push loss-tolerant and never half-provisions openvpn.
+ *
+ * After a successful commit, RID 4 reports a stable fingerprint (FNV-1a over
+ * the committed PEM bytes) of the applied family, so a server can READ it to
+ * confirm delivery + detect a re-mint without re-pushing blindly.
  *
  * Note: this carries the private key down the wire (under DTLS). A
  * device-generated keypair + CSR-up enrolment is the stronger model and a
@@ -75,10 +84,13 @@ struct CertHooks {
 /// Install OID 2048 (instances 0/1/2) into `store`. `certDir` is the
 /// directory the default store_artifact writes the cert family into
 /// (e.g. "/etc/iot/vpn"); ignored when a store_artifact hook is supplied.
-/// Returns 0 on success.
+/// `require_complete` (default true): Apply commits only when ca+cert+key are
+/// all staged — set false to commit whatever is staged (e.g. for tests that
+/// exercise a single artifact). Returns 0 on success.
 int install_cert(ObjectStore& store,
                  const std::string& certDir,
-                 CertHooks hooks = {});
+                 CertHooks hooks = {},
+                 bool require_complete = true);
 
 }} // namespace lwm2m::objects
 

--- a/apps/src/lwm2m_object_cert.cpp
+++ b/apps/src/lwm2m_object_cert.cpp
@@ -1,6 +1,8 @@
 #include "lwm2m_object_cert.hpp"
 
 #include <cerrno>
+#include <cstdint>
+#include <cstdio>
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <unistd.h>
@@ -86,15 +88,33 @@ int default_store(const std::string& certDir,
     return 0;
 }
 
+/// Artifact types that make a complete VPN credential family, in the order
+/// the fingerprint concatenates them.
+const char* const kFamilyTypes[3] = {"ca", "cert", "key"};
+
+/// Stable 64-bit FNV-1a over `s`, lowercase 16-hex. Deterministic across
+/// processes (unlike std::hash) so a server can compute the same fingerprint
+/// of the family it pushed and compare against RID 4.
+std::string fnv1a_hex(const std::string& s) {
+    std::uint64_t h = 1469598103934665603ull;
+    for (unsigned char c : s) { h ^= c; h *= 1099511628211ull; }
+    char buf[17];
+    std::snprintf(buf, sizeof(buf), "%016llx",
+                  static_cast<unsigned long long>(h));
+    return std::string(buf);
+}
+
 /// Build one credential instance. RID 0 reports the fixed type; RID 1 stages
-/// the PEM; RID 2 stages the hash. The Apply trigger (RID 3) lives only on
-/// the instance flagged `withApply`.
+/// the PEM; RID 2 stages the hash. The Apply trigger (RID 3) + the Applied
+/// fingerprint (RID 4) live only on the instance flagged `withApply`.
 ObjectInstance make_instance(std::uint32_t iid,
                              const std::string& type,
                              std::shared_ptr<Staging> staging,
                              bool withApply,
                              const std::string& certDir,
-                             std::shared_ptr<CertHooks> hooks) {
+                             std::shared_ptr<CertHooks> hooks,
+                             bool require_complete,
+                             std::shared_ptr<std::string> applied) {
     ObjectInstance inst;
     inst.iid = iid;
 
@@ -137,8 +157,27 @@ ObjectInstance make_instance(std::uint32_t iid,
         Resource r;
         r.rid = 3; r.name = "Apply";
         r.type = ResourceType::None; r.ops = Operations::E;
-        r.execute = [staging, certDir, hooks](const std::string& /*args*/) -> int {
+        r.execute = [staging, certDir, hooks, require_complete, applied]
+                    (const std::string& /*args*/) -> int {
+            // Completeness gate: don't half-provision. If we require a full
+            // family, hold the commit until ca+cert+key are all staged. The
+            // partial set stays staged so a later Apply (after the missing
+            // WRITE is re-pushed) commits the whole family — making the
+            // server's re-push loss-tolerant.
+            if (require_complete) {
+                for (auto* t : kFamilyTypes) {
+                    auto it = staging->find(t);
+                    if (it == staging->end() || !it->second.present) {
+                        ACE_DEBUG((LM_INFO,
+                            ACE_TEXT("%D [cert-obj] %M %N:%l apply deferred: '%C' "
+                                     "not staged yet; retaining partial family\n"),
+                            t));
+                        return -1;   // not applied (server will re-push)
+                    }
+                }
+            }
             int committed = 0;
+            std::string fpInput;     // FNV-1a input: PEMs in ca,cert,key order
             for (auto& [type, s] : *staging) {
                 if (!s.present) continue;
                 if (hooks->verify && !s.hash.empty()) {
@@ -152,6 +191,7 @@ ObjectInstance make_instance(std::uint32_t iid,
                        ? hooks->store_artifact(type, s.pem)
                        : default_store(certDir, type, s.pem);
                 if (rc != 0) return -1;
+                fpInput += s.pem;    // map is sorted → ca, cert, key
                 ++committed;
             }
             if (committed == 0) {
@@ -160,13 +200,24 @@ ObjectInstance make_instance(std::uint32_t iid,
             }
             // Clear staging so a later partial push can't re-commit stale bytes.
             staging->clear();
+            if (applied) *applied = fnv1a_hex(fpInput);
             int rc = hooks->apply ? hooks->apply() : 0;
             ACE_DEBUG((LM_INFO,
-                ACE_TEXT("%D [cert-obj] %M %N:%l applied %d artifact(s), reload rc=%d\n"),
-                committed, rc));
+                ACE_TEXT("%D [cert-obj] %M %N:%l applied %d artifact(s) fp=%C, "
+                         "reload rc=%d\n"),
+                committed, applied ? applied->c_str() : "", rc));
             return rc;
         };
         inst.resources[3] = std::move(r);
+
+        // RID 4 — Applied: stable fingerprint of the last committed family
+        // (empty until the first successful Apply). A server READs this to
+        // confirm delivery + detect a re-mint.
+        Resource st;
+        st.rid = 4; st.name = "Applied";
+        st.type = ResourceType::String; st.ops = Operations::R;
+        st.read = [applied]() { return applied ? *applied : std::string(); };
+        inst.resources[4] = std::move(st);
     }
     return inst;
 }
@@ -175,9 +226,11 @@ ObjectInstance make_instance(std::uint32_t iid,
 
 int install_cert(ObjectStore& store,
                  const std::string& certDir,
-                 CertHooks hooks) {
+                 CertHooks hooks,
+                 bool require_complete) {
     auto staging = std::make_shared<Staging>();
     auto hooksp  = std::make_shared<CertHooks>(std::move(hooks));
+    auto applied = std::make_shared<std::string>();   // RID 4 fingerprint
 
     ObjectDescriptor desc;
     desc.oid              = kCertObjectOid;
@@ -186,11 +239,12 @@ int install_cert(ObjectStore& store,
     desc.multipleInstance = true;
     desc.mandatory        = false;
 
-    // Apply trigger lives on instance 0 (the CA instance) so the server has
-    // a single, well-known commit point: EXECUTE /2048/0/3.
-    desc.instances[0] = make_instance(0, "ca",   staging, /*withApply*/true,  certDir, hooksp);
-    desc.instances[1] = make_instance(1, "cert", staging, /*withApply*/false, certDir, hooksp);
-    desc.instances[2] = make_instance(2, "key",  staging, /*withApply*/false, certDir, hooksp);
+    // Apply trigger + Applied status live on instance 0 (the CA instance) so
+    // the server has a single, well-known commit point: EXECUTE /2048/0/3,
+    // READ /2048/0/4.
+    desc.instances[0] = make_instance(0, "ca",   staging, /*withApply*/true,  certDir, hooksp, require_complete, applied);
+    desc.instances[1] = make_instance(1, "cert", staging, /*withApply*/false, certDir, hooksp, require_complete, applied);
+    desc.instances[2] = make_instance(2, "key",  staging, /*withApply*/false, certDir, hooksp, require_complete, applied);
 
     store.add_object(std::move(desc));
     return 0;

--- a/apps/test/objects_test.cpp
+++ b/apps/test/objects_test.cpp
@@ -324,7 +324,9 @@ TEST(CertObject, apply_invokes_reload_hook_and_runs_verify) {
                    const std::string&) { ++verified; return hash == "good" ? 0 : -1; };
 
     ObjectStore store;
-    objects::install_cert(store, "/unused", std::move(h));
+    // require_complete=false so the single-artifact apply commits (this test
+    // exercises the hook + verify path, not the family-completeness gate).
+    objects::install_cert(store, "/unused", std::move(h), /*require_complete*/false);
 
     store.find(2048, 1, 1)->write("cert-bytes");
     store.find(2048, 1, 2)->write("good");          // hash → verify runs, passes
@@ -337,4 +339,55 @@ TEST(CertObject, apply_invokes_reload_hook_and_runs_verify) {
     store.find(2048, 2, 2)->write("bad");
     EXPECT_NE(0, store.find(2048, 0, 3)->execute(""));
     EXPECT_EQ(1, applied);                            // unchanged
+}
+
+TEST(CertObject, apply_deferred_until_family_complete_then_self_heals) {
+    char tmpl[64];
+    char* dir = make_temp_dir(tmpl, sizeof(tmpl));
+    if (!dir) GTEST_SKIP() << "no writable scratch dir";
+    std::string certDir(dir);
+
+    ObjectStore store;
+    objects::install_cert(store, certDir);   // require_complete = true (default)
+
+    // First push lost the key WRITE: only ca + cert staged.
+    store.find(2048, 0, 1)->write("CA");
+    store.find(2048, 1, 1)->write("CERT");
+    EXPECT_NE(0, store.find(2048, 0, 3)->execute(""));   // deferred, not applied
+    struct stat st;
+    EXPECT_NE(0, ::stat((certDir + "/ca.crt").c_str(), &st));   // nothing written
+    EXPECT_EQ("", store.find(2048, 0, 4)->read());             // Applied still empty
+
+    // Re-push fills the missing key; the retained ca+cert + new key now apply.
+    store.find(2048, 2, 1)->write("KEY");
+    EXPECT_EQ(0, store.find(2048, 0, 3)->execute(""));
+    EXPECT_EQ("CA",   slurp(certDir + "/ca.crt"));
+    EXPECT_EQ("CERT", slurp(certDir + "/client.crt"));
+    EXPECT_EQ("KEY",  slurp(certDir + "/client.key"));
+
+    // RID 4 now reports a stable 16-hex fingerprint of the committed family.
+    const std::string fp = store.find(2048, 0, 4)->read();
+    EXPECT_EQ(16u, fp.size());
+    EXPECT_NE("", fp);
+
+    for (auto* f : {"/ca.crt", "/client.crt", "/client.key"})
+        std::remove((certDir + f).c_str());
+    std::remove(certDir.c_str());
+}
+
+TEST(CertObject, applied_fingerprint_is_deterministic_for_same_family) {
+    objects::CertHooks h;
+    h.store_artifact = [](const std::string&, const std::string&) { return 0; };
+    auto fp_of = [&](const std::string& ca, const std::string& c,
+                     const std::string& k) {
+        ObjectStore store;
+        objects::install_cert(store, "/unused", h);
+        store.find(2048, 0, 1)->write(ca);
+        store.find(2048, 1, 1)->write(c);
+        store.find(2048, 2, 1)->write(k);
+        EXPECT_EQ(0, store.find(2048, 0, 3)->execute(""));
+        return store.find(2048, 0, 4)->read();
+    };
+    EXPECT_EQ(fp_of("A", "B", "C"), fp_of("A", "B", "C"));   // stable
+    EXPECT_NE(fp_of("A", "B", "C"), fp_of("A", "B", "X"));   // sensitive to key
 }


### PR DESCRIPTION
## Why

Reliability hardening for the Phase-3 server→device cert push (#116). v1 committed **whatever was staged** when Apply fired, so a lost WRITE before the EXECUTE could **half-provision openvpn** — e.g. cert+CA written but the key missing → a silent misconfiguration that fails the tunnel.

## What (device side — correctness-critical, fully verifiable)

- **Atomic completeness.** With `require_complete` (the new default), Apply commits **only when all three artifacts (ca+cert+key) are staged**. A partial push leaves the set staged (nothing written to disk) and returns *deferred*; a later Apply — once the missing WRITE is re-pushed — commits the whole family. This makes the server's bounded re-push **loss-tolerant** and guarantees openvpn is never half-provisioned. `require_complete=false` keeps the old commit-whatever behaviour for single-artifact tests.
- **RID 4 "Applied".** A readable, stable **FNV-1a fingerprint** of the last committed family ("" until first Apply). Deterministic across processes (unlike `std::hash`), so a server can `READ /2048/0/4` to confirm delivery + detect a re-mint instead of re-pushing blindly; device-ui can surface provisioning status.

## Tests (all green)

- `apply_deferred_until_family_complete_then_self_heals` — a push that loses the key WRITE defers (writes nothing), then **self-heals** to a full commit when the key is re-pushed.
- `applied_fingerprint_is_deterministic_for_same_family` — RID 4 is stable + sensitive to the cert bytes.
- Existing `CertObject` + `CertPush` suites still pass (the full push stages all three).

## Follow-up (server-side confirmation — separate PR)

Have the DM tick `READ /2048/0/4` and stop pushing once the device's fingerprint matches the pushed family. That requires the CoAP adapter to **consume the response to a server-initiated GET** — today server-side responses are dropped (`coap_adapter.cpp` returns at the ACK branch for `isAmIClient=false`). It's additive (~a pending-read map keyed by peer→endpoint + one branch in `processRequest` + a callback) but touches the core wire path, so it's best landed on its own with DTLS wire testing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)