### PR TITLE
feat(lwm2m): DM server confirms cert delivery via Object 2048 status read

### DIFF
--- a/apps/inc/coap_adapter.hpp
+++ b/apps/inc/coap_adapter.hpp
@@ -7,6 +7,7 @@
 #include <unordered_map>
 #include <algorithm>
 #include <fstream>
+#include <functional>
 
 #include <ace/Log_Msg.h>
 
@@ -360,6 +361,18 @@ class CoAPAdapter {
             return m_regClient;
         }
 
+        /// Server-side response sink. A DM server sends its own GET/Read
+        /// requests (e.g. the cert-status poll /2048/0/4); the device's
+        /// 2.xx response would otherwise be dropped. When set, processRequest
+        /// routes any response-class inbound (code class >= 2) to this handler
+        /// for the server role instead of dispatching it as a request. The
+        /// caller correlates by token (CoAPMessage.tokens) and reads the value
+        /// from CoAPMessage.payload. nullptr → responses dropped (prior
+        /// behaviour).
+        void dmResponseHandler(std::function<void(const CoAPMessage&)> h) {
+            m_dmRspHandler = std::move(h);
+        }
+
         std::vector<std::string> handleLwM2MObjects(const CoAPAdapter::CoAPMessage& message, std::string uri, std::uint32_t oid,
                                                     std::uint32_t oiid, std::uint32_t rid, std::uint32_t riid);
 
@@ -369,6 +382,7 @@ class CoAPAdapter {
         std::shared_ptr<lwm2m::DmClient>              m_dmClient;
         std::shared_ptr<lwm2m::bootstrap::Client>     m_bsClient;
         std::shared_ptr<lwm2m::RegistrationClient>    m_regClient;
+        std::function<void(const CoAPMessage&)>       m_dmRspHandler;
 
         std::unordered_map<std::uint32_t, std::string> OptionNumber;
         std::unordered_map<std::uint32_t, std::string> ContentFormat;

--- a/apps/src/coap_adapter.cpp
+++ b/apps/src/coap_adapter.cpp
@@ -1049,6 +1049,17 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
     std::string rsp;
     auto ret = parseRequest(in, coapmessage);
 
+    // Server-side response sink. A DM server originates GET/Reads (the cert-
+    // status poll /2048/0/4); the device's reply carries a response-class
+    // code (class >= 2: 2.xx/4.xx/5.xx) while requests are class 0
+    // (GET/PUT/POST/DELETE). Route responses to the handler and never
+    // dispatch them as requests. Covers ACK-piggybacked and separate
+    // responses alike.
+    if (!isAmIClient && (coapmessage.coapheader.code >> 5) != 0) {
+        if (m_dmRspHandler) m_dmRspHandler(coapmessage);
+        return 0;
+    }
+
     // L9 / FUP-2 — Acknowledgement-typed frames are responses to one of
     // *our* outbound CON requests (Register, Update, Deregister, …).
     // Forward them to the RegistrationClient FSM if one is attached so
@@ -1266,6 +1277,14 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
     ACE_DEBUG((LM_DEBUG,
                ACE_TEXT("%D lwm2m:thread:%t %M %N:%l processRequest with session cf.length: %d\n"),
                static_cast<int>(cf.length())));
+
+    // Server-side response sink (DTLS path). Same as the no-session overload:
+    // a response-class code (>= class 2) is the device's reply to one of our
+    // server-initiated Reads (cert-status poll), not a request to dispatch.
+    if (!isAmIClient && (coapmessage.coapheader.code >> 5) != 0) {
+        if (m_dmRspHandler) m_dmRspHandler(coapmessage);
+        return 0;
+    }
 
     // L9 / FUP-2 — Acknowledgement short-circuit + dispatch to
     // RegistrationClient FSM. Same shape as the no-DTLS overload above.

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -138,6 +138,19 @@ namespace {
 std::atomic<std::uint16_t> g_next_msgid{0x1000};
 inline std::uint16_t next_msgid() { return ++g_next_msgid; }
 
+/// Stable 64-bit FNV-1a → lowercase 16-hex. MUST match
+/// lwm2m::objects (lwm2m_object_cert.cpp) so the DM server can compute the
+/// fingerprint of the family it pushes and compare it against the device's
+/// Object-2048 RID 4 "Applied" value to confirm delivery.
+inline std::string fnv1a_hex(const std::string& s) {
+    std::uint64_t h = 1469598103934665603ull;
+    for (unsigned char c : s) { h ^= c; h *= 1099511628211ull; }
+    char buf[17];
+    std::snprintf(buf, sizeof(buf), "%016llx",
+                  static_cast<unsigned long long>(h));
+    return std::string(buf);
+}
+
 /// Convenience tx wrapper — UDPAdapter::tx takes non-const lvalue refs
 /// for historical reasons, so callers need locals.
 inline void tx_via(App& app,
@@ -409,16 +422,39 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
     auto last_poll = std::make_shared<Clock::time_point>(Clock::now());
     std::weak_ptr<App> wapp_srv = app;
 
-    // Phase 3 — VPN cert delivery. Per-endpoint push state: {hash of the
-    // pushed cert family, attempts}. Push on first registration + on cert
-    // change, with a small bounded re-push for loss tolerance (v1 has no CoAP
-    // ACK matching — see follow-up).
+    // VPN cert delivery over Object 2048, with device-confirmed stop.
+    //   reportedFp : endpoint → fingerprint the device last reported applied
+    //                (Object 2048 RID 4), filled by the response handler below
+    //   epId/idEp  : endpoint ↔ small id stashed in the status-Read token so
+    //                the response can be attributed back to its endpoint
+    // Each tick the DM server READs /2048/0/4 and pushes the family only while
+    // the device's reported fingerprint != the family we want — i.e. until the
+    // device confirms it applied THIS cert. No blind re-push cap: delivery
+    // recovers from loss and self-limits once confirmed.
     auto* dsCertPush = ds.client();
-    auto certPushed = std::make_shared<
-        std::unordered_map<std::string, std::pair<std::size_t, int>>>();
+    auto reportedFp = std::make_shared<std::unordered_map<std::string, std::string>>();
+    auto epId       = std::make_shared<std::unordered_map<std::string, std::uint16_t>>();
+    auto idEp       = std::make_shared<std::unordered_map<std::uint16_t, std::string>>();
+    auto nextId     = std::make_shared<std::uint16_t>(1);
+
+    // Consume the device's response to our status Read: token = {0x05, idHi,
+    // idLo}, payload = the applied fingerprint. Map the id back to its
+    // endpoint and record what the device reports.
+    for (auto& [type, ctx] : services) {
+        if (type != ::UDPAdapter::ServiceType_t::DeviceMgmtServer) continue;
+        ctx->coapAdapter()->dmResponseHandler(
+            [reportedFp, idEp](const CoAPAdapter::CoAPMessage& m) {
+                if (m.tokens.size() < 3 || m.tokens[0] != 0x05) return;
+                std::uint16_t id = (static_cast<std::uint16_t>(m.tokens[1]) << 8)
+                                 | static_cast<std::uint16_t>(m.tokens[2]);
+                auto it = idEp->find(id);
+                if (it != idEp->end()) (*reportedFp)[it->second] = m.payload;
+            });
+    }
 
     app->udpAdapter()->on_tick_server([registry, wapp_srv, last_poll,
-                                       publish_regs, dsCertPush, certPushed]() {
+                                       publish_regs, dsCertPush,
+                                       reportedFp, epId, idEp, nextId]() {
         // Local constexpr inside the lambda body — gcc 11 wouldn't let
         // us reference an outer-scope constexpr without an explicit
         // capture even though it's a constant expression.
@@ -487,28 +523,50 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                     /*accept*/ -1);
                 ctx->send_async(req, reg.peerHost, reg.peerPort);
 
-                // Phase 3: push the VPN cert family over Object 2048 on first
-                // registration + on cert change; bounded re-push for loss
-                // tolerance. The device stages each WRITE and the Apply EXECUTE
+                // VPN cert delivery over Object 2048 with device-confirmed
+                // stop. Poll the device's applied fingerprint (RID 4) with a
+                // per-endpoint token so the response handler can attribute the
+                // reply; push the family only while the device hasn't confirmed
+                // THIS cert. The device stages each WRITE and the Apply EXECUTE
                 // materialises the family; its cert sidecar reloads openvpn.
                 std::string ca, cert, key;
                 if (vpn_family(reg.endpoint, ca, cert, key)) {
-                    const std::size_t h = std::hash<std::string>{}(ca + cert + key);
-                    auto& st = (*certPushed)[reg.endpoint];
-                    if (st.first != h) st = {h, 0};       // new/changed → reset
-                    constexpr int kMaxCertPush = 3;
-                    if (st.second < kMaxCertPush) {
+                    std::uint16_t id;
+                    auto idit = epId->find(reg.endpoint);
+                    if (idit == epId->end()) {
+                        id = (*nextId)++;
+                        (*epId)[reg.endpoint] = id;
+                        (*idEp)[id] = reg.endpoint;
+                    } else {
+                        id = idit->second;
+                    }
+
+                    // Status poll: Read /2048/0/4 (token carries the id).
+                    std::string stok;
+                    stok.push_back(static_cast<char>(0x05));
+                    stok.push_back(static_cast<char>((id >> 8) & 0xFF));
+                    stok.push_back(static_cast<char>(id & 0xFF));
+                    ctx->send_async(::lwm2m::dmsrv::build_read(
+                                        next_msgid(), stok, 2048, 0, 4, -1),
+                                    reg.peerHost, reg.peerPort);
+
+                    const std::string want = fnv1a_hex(ca + cert + key);
+                    auto rf = reportedFp->find(reg.endpoint);
+                    const bool confirmed =
+                        (rf != reportedFp->end() && rf->second == want);
+                    if (!confirmed) {
                         std::string ctok{static_cast<char>(0x04)};
                         const std::uint16_t m0 = next_msgid();
                         next_msgid(); next_msgid(); next_msgid();  // reserve 4 ids
                         for (auto& fr : ::lwm2m::dmsrv::build_cert_push(
                                  m0, ctok, ca, cert, key))
                             ctx->send_async(fr, reg.peerHost, reg.peerPort);
-                        ++st.second;
                         ACE_DEBUG((LM_INFO,
                             ACE_TEXT("%D lwm2m:thread:%t %M %N:%l pushed VPN cert "
-                                     "family to %C (attempt %d/%d) peer=%C:%u\n"),
-                            reg.endpoint.c_str(), st.second, kMaxCertPush,
+                                     "to %C (want=%C reported=%C) peer=%C:%u\n"),
+                            reg.endpoint.c_str(), want.c_str(),
+                            (rf != reportedFp->end() ? rf->second.c_str()
+                                                     : "<none>"),
                             reg.peerHost.c_str(),
                             static_cast<unsigned>(reg.peerPort)));
                     }

--- a/apps/test/dm_test.cpp
+++ b/apps/test/dm_test.cpp
@@ -412,3 +412,54 @@ TEST(CertPush, server_push_materializes_family_on_device) {
         std::remove((certDir + f).c_str());
     std::remove(certDir.c_str());
 }
+
+// Server-side confirmation: after the device applies a family, the DM server
+// READs /2048/0/4 (status) and must CONSUME the device's 2.05 response — the
+// payload (applied fingerprint) routed to the dmResponseHandler, the token
+// (endpoint id) preserved, and NOT dispatched as a request.
+TEST(CertConfirm, server_consumes_status_read_response) {
+    char tmpl[] = "/tmp/iot-confirm-XXXXXX";
+    char* dir = ::mkdtemp(tmpl);
+    if (!dir) GTEST_SKIP() << "no writable scratch dir";
+    const std::string certDir(dir);
+
+    auto store = std::make_shared<ObjectStore>();
+    ::lwm2m::objects::install_cert(*store, certDir);
+    store->find(2048, 0, 1)->write("CA");
+    store->find(2048, 1, 1)->write("CERT");
+    store->find(2048, 2, 1)->write("KEY");
+    ASSERT_EQ(0, store->find(2048, 0, 3)->execute(""));
+    const std::string fp = store->find(2048, 0, 4)->read();
+    ASSERT_FALSE(fp.empty());
+
+    // Device answers the server's status Read.
+    DmClient dm(store);
+    CoAPAdapter devCoap;
+    std::string tok;                       // {0x05, idHi=0x00, idLo=0x07}
+    tok.push_back(static_cast<char>(0x05));
+    tok.push_back(static_cast<char>(0x00));
+    tok.push_back(static_cast<char>(0x07));
+    auto rd = dmsrv::build_read(0x321, tok, 2048, 0, 4, /*accept*/ -1);
+    CoAPAdapter::CoAPMessage parsed; devCoap.parseRequest(rd, parsed);
+    auto out = dm.handle(parsed, devCoap);
+    ASSERT_EQ(DmOutcome::Read, out.kind);
+
+    // Server consumes the response via the handler (not the request path).
+    CoAPAdapter srv;
+    std::string gotPayload; std::vector<std::uint8_t> gotTok;
+    srv.dmResponseHandler([&](const CoAPAdapter::CoAPMessage& m) {
+        gotPayload = m.payload; gotTok = m.tokens;
+    });
+    std::vector<std::string> sout;
+    srv.processRequest(/*isAmIClient*/ false, out.response, sout);
+
+    EXPECT_EQ(fp, gotPayload);              // device's applied fingerprint
+    ASSERT_GE(gotTok.size(), 3u);
+    EXPECT_EQ(0x05, gotTok[0]);             // our status-token marker
+    EXPECT_EQ(0x07, gotTok[2]);             // endpoint id echoed back
+    EXPECT_TRUE(sout.empty());             // consumed, not dispatched as request
+
+    for (auto* f : {"/ca.crt", "/client.crt", "/client.key"})
+        std::remove((certDir + f).c_str());
+    std::remove(certDir.c_str());
+}


### PR DESCRIPTION
## Why

Completes the cert-push reliability work (#117). The DM server now **READs the device's applied fingerprint and stops pushing once the device confirms it applied THIS cert** — replacing the blind bounded re-push. Delivery now both **recovers from loss** (keeps pushing until confirmed) and **self-limits** (stops on confirmation), and re-pushes automatically when the cert is re-minted.

## The blocker

Server-initiated request *responses* were dropped — `processRequest`'s ACK branch only handled the client role (`isAmIClient`). The device's `2.05` reply to a server Read went nowhere.

## What

- **`CoAPAdapter`** — a `dmResponseHandler` setter + a branch in **both** `processRequest` variants (plain + DTLS): for the server role, any **response-class** inbound (code class ≥ 2, i.e. 2.xx/4.xx/5.xx) is routed to the handler instead of being dispatched as a request. Requests are class 0 (GET/PUT/POST/DELETE), so existing Register/Update/DM dispatch is untouched.
- **DM tick (`main.cpp`)** — each tick `READ /2048/0/4` with a token `{0x05, idHi, idLo}` encoding a per-endpoint id; the handler maps the id back to the endpoint and records the device's reported fingerprint. The family is pushed only while `reported != fnv1a(ca+cert+key)` — the **same stable FNV-1a** the device's RID 4 reports. Correlation is by token, so **no peer-address plumbing** is needed (works over plain + DTLS).

## Tests

- **`CertConfirm.server_consumes_status_read_response`** — device applies a family → server `READ /2048/0/4` → the device's `2.05` response is consumed by the handler (payload = fingerprint, endpoint-id token preserved, **not** dispatched).
- **Full `lwm2m_test` suite: 185/185 green** — no regression in request handling. The `lwm2m` binary builds with the wiring.

Verified in-process (build + unit/loopback); the live DTLS round-trip isn't exercised in this CI.

## Closes the loop

cloud mints (runtime CA) → DM server pushes Object 2048 → device materializes (atomic) → device reports applied fingerprint → **server reads it and stops pushing**. The provisioning chain is now loss-tolerant end to end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)