### PR TITLE
feat: server-initiated DTLS cert push — live e2e transport fixes + VPN-connected gate

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -24,6 +24,9 @@
 #include "data_store/value.hpp"
 
 #include <ace/Log_Msg.h>
+#include <ace/INET_Addr.h>
+#include <ace/SOCK_Connector.h>
+#include <ace/SOCK_Stream.h>
 
 #include "data_store/log_buffer.hpp"
 #include "data_store/stats_publisher.hpp"
@@ -31,6 +34,7 @@
 #include <atomic>
 #include <cstdint>
 #include <csignal>
+#include <set>
 #include <thread>
 #include <unordered_map>
 
@@ -130,6 +134,47 @@ bool reconcile_registrations(data_store::Client& ds,
         }
     }
     return changed;
+}
+
+// Poll the openvpn server's management interface (127.0.0.1:mgmt_port) for
+// connected clients and return their device serials. The minted client CN is
+// rpi<serial>@cloud.local, so a connected client's CN appears in the `status`
+// output; we scan for that pattern and extract the serial. Best-effort —
+// returns empty on any connect/IO failure (e.g. openvpn not up yet).
+std::vector<std::string> poll_vpn_connected(std::uint16_t mgmt_port) {
+    std::vector<std::string> out;
+    ACE_INET_Addr addr(mgmt_port, "127.0.0.1");
+    ACE_SOCK_Connector conn;
+    ACE_SOCK_Stream stream;
+    ACE_Time_Value to(1, 0);
+    if (conn.connect(stream, addr, &to) != 0) return out;
+    const char cmd[] = "status\n";
+    stream.send_n(cmd, sizeof(cmd) - 1);
+    std::string resp;
+    char buf[2048];
+    for (;;) {
+        ACE_Time_Value rto(1, 0);
+        ssize_t n = stream.recv(buf, sizeof(buf), &rto);
+        if (n <= 0) break;
+        resp.append(buf, static_cast<std::size_t>(n));
+        if (resp.find("\nEND") != std::string::npos || resp.size() > 65536) break;
+    }
+    stream.close();
+
+    const std::string suffix = "@cloud.local";
+    std::set<std::string> seen;
+    for (std::size_t pos = 0; (pos = resp.find("rpi", pos)) != std::string::npos; ) {
+        std::size_t at = resp.find(suffix, pos);
+        if (at == std::string::npos) break;
+        std::string serial = resp.substr(pos + 3, at - (pos + 3));
+        pos = at + suffix.size();
+        if (!serial.empty() &&
+            serial.find_first_of(",\n\r ") == std::string::npos &&
+            seen.insert(serial).second) {
+            out.push_back(std::move(serial));
+        }
+    }
+    return out;
 }
 
 } // namespace
@@ -473,6 +518,17 @@ int main(int argc, char** argv) {
         } else {
             // recv_event timed out — periodic housekeeping
             supervise_ovpn();   // restart on crash / honor enable flips
+
+            // Publish which devices have a live VPN tunnel (from the openvpn
+            // management interface). lwm2m-dm reads this and stops pushing the
+            // cert once the device's tunnel is up — the end-goal "done" signal,
+            // and it needs no server→device request.
+            {
+                nlohmann::json arr = nlohmann::json::array();
+                for (auto& s : poll_vpn_connected(ovpn_cfg.mgmt_port)) arr.push_back(s);
+                ds.set("cloud.vpn.connected", data_store::Value{arr.dump()});
+            }
+
             if (++sync_tick >= 3) {
                 sync_tick = 0;
                 // Safety-net reconcile in case a watch notification was missed.

--- a/apps/device/Dockerfile
+++ b/apps/device/Dockerfile
@@ -168,6 +168,12 @@ RUN chmod +x /usr/local/bin/iot-entrypoint
 RUN mkdir -p /run/iot /var/lib/iot && \
     chmod 0755 /run/iot && chmod 0755 /var/lib/iot
 
+# VPN cert family (ca.crt/client.crt/client.key) is written here by the
+# lwm2m client (LwM2M Object 2048) and read by openvpn-client. The client
+# runs as `engineer`, so make the dir engineer-writable; a fresh
+# dev-vpn-certs volume mounted at this path inherits the ownership.
+RUN mkdir -p /etc/iot/vpn && chown engineer:iot /etc/iot/vpn && chmod 0775 /etc/iot/vpn
+
 # 8080 device UI/REST · 5683 DM (server role) · 5684 client local · 5685 BS
 # CoAP/DTLS ports are UDP (EXPOSE defaults to TCP); 8080 is the HTTP UI/API (TCP).
 EXPOSE 8080 5683/udp 5684/udp 5685/udp

--- a/apps/device/docker-compose.yml
+++ b/apps/device/docker-compose.yml
@@ -74,6 +74,10 @@ services:
     volumes:
       - dev-run:/run/iot
       - dev-etc:/etc/iot
+      # The lwm2m client materialises the cloud-pushed cert family (LwM2M
+      # Object 2048) into this shared volume, which openvpn-client reads and
+      # cert-watcher watches. Mounted rw here, ro on openvpn-client.
+      - dev-vpn-certs:/etc/iot/vpn
     depends_on:
       ds-server:
         condition: service_healthy

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -303,20 +303,23 @@ std::int32_t DTLSAdapter::tx_peer(std::string& in) {
 }
 
 std::int32_t DTLSAdapter::tx(std::string& in, std::string peerIP, std::uint16_t peerPort) {
-    std::int32_t ret = -1;
-    struct sockaddr_in addr;
-
-    addr.sin_addr.s_addr = inet_addr(peerIP.c_str());
-    addr.sin_family = AF_INET;
-    addr.sin_port = htons(peerPort);
-    ::memset(addr.sin_zero, 0, sizeof(addr.sin_zero));
-
+    // Build the peer session EXACTLY as session() / the inbound rx path do:
+    // zero the whole struct first (so ifindex — which dtls_session_equals
+    // compares — is 0, not garbage) and fill addr.sin + size =
+    // sizeof(sockaddr_in). Without the memset the stale ifindex makes
+    // dtls_write fail to match the established inbound peer and instead kick
+    // off a NEW handshake — so a server-initiated send (cert push, liveness
+    // poll) never reaches the already-connected device.
     session_t peersession;
-    peersession.addr.sa = *((struct  sockaddr *)&addr);
-    peersession.size = sizeof(peersession.addr.sa);
-    
-    ret = dtls_write(dtls_ctx(), &peersession, (std::uint8_t *)&in.at(0), in.size());
-    return(ret);
+    ::memset(&peersession, 0, sizeof(peersession));
+    peersession.addr.sin.sin_family      = AF_INET;
+    peersession.addr.sin.sin_addr.s_addr = inet_addr(peerIP.c_str());
+    peersession.addr.sin.sin_port        = htons(peerPort);
+    ::memset(peersession.addr.sin.sin_zero, 0, sizeof(peersession.addr.sin.sin_zero));
+    peersession.size = sizeof(struct sockaddr_in);
+
+    return dtls_write(dtls_ctx(), &peersession,
+                      (std::uint8_t *)&in.at(0), in.size());
 }
 
 

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -10,6 +10,7 @@
 #include <fstream>
 #include <functional>
 #include <memory>
+#include <set>
 #include <sstream>
 #include <unordered_map>
 
@@ -137,19 +138,6 @@ namespace {
 /// wrapping after ~64K outgoing messages is well within spec.
 std::atomic<std::uint16_t> g_next_msgid{0x1000};
 inline std::uint16_t next_msgid() { return ++g_next_msgid; }
-
-/// Stable 64-bit FNV-1a → lowercase 16-hex. MUST match
-/// lwm2m::objects (lwm2m_object_cert.cpp) so the DM server can compute the
-/// fingerprint of the family it pushes and compare it against the device's
-/// Object-2048 RID 4 "Applied" value to confirm delivery.
-inline std::string fnv1a_hex(const std::string& s) {
-    std::uint64_t h = 1469598103934665603ull;
-    for (unsigned char c : s) { h ^= c; h *= 1099511628211ull; }
-    char buf[17];
-    std::snprintf(buf, sizeof(buf), "%016llx",
-                  static_cast<unsigned long long>(h));
-    return std::string(buf);
-}
 
 /// Convenience tx wrapper — UDPAdapter::tx takes non-const lvalue refs
 /// for historical reasons, so callers need locals.
@@ -422,43 +410,17 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
     auto last_poll = std::make_shared<Clock::time_point>(Clock::now());
     std::weak_ptr<App> wapp_srv = app;
 
-    // VPN cert delivery over Object 2048, with device-confirmed stop.
-    //   reportedFp : endpoint → fingerprint the device last reported applied
-    //                (Object 2048 RID 4), filled by the response handler below
-    //   epId/idEp  : endpoint ↔ small id stashed in the status-Read token so
-    //                the response can be attributed back to its endpoint
-    // Each tick the DM server READs /2048/0/4 and pushes the family only while
-    // the device's reported fingerprint != the family we want — i.e. until the
-    // device confirms it applied THIS cert. No blind re-push cap: delivery
-    // recovers from loss and self-limits once confirmed.
+    // VPN cert delivery over Object 2048, with a VPN-connected stop signal.
+    // Each tick the DM server pushes the cert family to a registered device
+    // until its VPN tunnel comes up — observed cloud-side via
+    // cloud.vpn.connected (iot-cloudd reads the openvpn management interface).
+    // The tunnel-up state is the real "done": it needs no server→device read
+    // and proves the cert is not just applied but working. Re-mint drops the
+    // tunnel, which resumes the push.
     auto* dsCertPush = ds.client();
-    auto reportedFp = std::make_shared<std::unordered_map<std::string, std::string>>();
-    auto epId       = std::make_shared<std::unordered_map<std::string, std::uint16_t>>();
-    auto idEp       = std::make_shared<std::unordered_map<std::uint16_t, std::string>>();
-    auto nextId     = std::make_shared<std::uint16_t>(1);
-
-    // Consume the device's response to our status Read: token = {0x05, idHi,
-    // idLo}, payload = the applied fingerprint. Map the id back to its
-    // endpoint and record what the device reports.
-    for (auto& [type, ctx] : services) {
-        // The DM instance's listening context is typed BootstrapServer (the
-        // server-role default in App), while its DeviceMgmtServer context
-        // loses the bind race on the shared 5683 — so accept any server
-        // context, not strictly DeviceMgmtServer. (Client contexts are skipped.)
-        if (type == ::UDPAdapter::ServiceType_t::LwM2MClient) continue;
-        ctx->coapAdapter()->dmResponseHandler(
-            [reportedFp, idEp](const CoAPAdapter::CoAPMessage& m) {
-                if (m.tokens.size() < 3 || m.tokens[0] != 0x05) return;
-                std::uint16_t id = (static_cast<std::uint16_t>(m.tokens[1]) << 8)
-                                 | static_cast<std::uint16_t>(m.tokens[2]);
-                auto it = idEp->find(id);
-                if (it != idEp->end()) (*reportedFp)[it->second] = m.payload;
-            });
-    }
 
     app->udpAdapter()->on_tick_server([registry, wapp_srv, last_poll,
-                                       publish_regs, dsCertPush,
-                                       reportedFp, epId, idEp, nextId]() {
+                                       publish_regs, dsCertPush]() {
         // Local constexpr inside the lambda body — gcc 11 wouldn't let
         // us reference an outer-scope constexpr without an explicit
         // capture even though it's a constant expression.
@@ -509,6 +471,24 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
             return false;
         };
 
+        // Devices whose VPN tunnel is already up (iot-cloudd publishes this
+        // from the openvpn management interface) — the stop signal for the push.
+        std::set<std::string> connected;
+        if (dsCertPush) {
+            std::vector<data_store::Client::GetResult> got;
+            if (dsCertPush->get({std::string("cloud.vpn.connected")}, got).ok
+                && !got.empty() && got[0].has_value) {
+                if (auto s = data_store::to_string(got[0].value)) {
+                    try {
+                        auto arr = nlohmann::json::parse(*s);
+                        if (arr.is_array())
+                            for (const auto& e : arr)
+                                if (e.is_string()) connected.insert(e.get<std::string>());
+                    } catch (const std::exception&) {}
+                }
+            }
+        }
+
         // Walk services to find the DeviceMgmtServer ServiceContext;
         // its send_async takes an explicit peer so one outbound socket
         // serves every registered client.
@@ -527,53 +507,25 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                     /*accept*/ -1);
                 ctx->send_async(req, reg.peerHost, reg.peerPort);
 
-                // VPN cert delivery over Object 2048 with device-confirmed
-                // stop. Poll the device's applied fingerprint (RID 4) with a
-                // per-endpoint token so the response handler can attribute the
-                // reply; push the family only while the device hasn't confirmed
-                // THIS cert. The device stages each WRITE and the Apply EXECUTE
-                // materialises the family; its cert sidecar reloads openvpn.
+                // Push the VPN cert family over Object 2048 until the device's
+                // tunnel is up. The device stages each WRITE and the Apply
+                // EXECUTE materialises the family; its cert sidecar reloads
+                // openvpn. Once cloud.vpn.connected reports this endpoint, the
+                // cert is applied AND working, so we stop pushing.
+                if (connected.count(reg.endpoint)) continue;   // tunnel up → done
                 std::string ca, cert, key;
                 if (vpn_family(reg.endpoint, ca, cert, key)) {
-                    std::uint16_t id;
-                    auto idit = epId->find(reg.endpoint);
-                    if (idit == epId->end()) {
-                        id = (*nextId)++;
-                        (*epId)[reg.endpoint] = id;
-                        (*idEp)[id] = reg.endpoint;
-                    } else {
-                        id = idit->second;
-                    }
-
-                    // Status poll: Read /2048/0/4 (token carries the id).
-                    std::string stok;
-                    stok.push_back(static_cast<char>(0x05));
-                    stok.push_back(static_cast<char>((id >> 8) & 0xFF));
-                    stok.push_back(static_cast<char>(id & 0xFF));
-                    ctx->send_async(::lwm2m::dmsrv::build_read(
-                                        next_msgid(), stok, 2048, 0, 4, -1),
-                                    reg.peerHost, reg.peerPort);
-
-                    const std::string want = fnv1a_hex(ca + cert + key);
-                    auto rf = reportedFp->find(reg.endpoint);
-                    const bool confirmed =
-                        (rf != reportedFp->end() && rf->second == want);
-                    if (!confirmed) {
-                        std::string ctok{static_cast<char>(0x04)};
-                        const std::uint16_t m0 = next_msgid();
-                        next_msgid(); next_msgid(); next_msgid();  // reserve 4 ids
-                        for (auto& fr : ::lwm2m::dmsrv::build_cert_push(
-                                 m0, ctok, ca, cert, key))
-                            ctx->send_async(fr, reg.peerHost, reg.peerPort);
-                        ACE_DEBUG((LM_INFO,
-                            ACE_TEXT("%D lwm2m:thread:%t %M %N:%l pushed VPN cert "
-                                     "to %C (want=%C reported=%C) peer=%C:%u\n"),
-                            reg.endpoint.c_str(), want.c_str(),
-                            (rf != reportedFp->end() ? rf->second.c_str()
-                                                     : "<none>"),
-                            reg.peerHost.c_str(),
-                            static_cast<unsigned>(reg.peerPort)));
-                    }
+                    std::string ctok{static_cast<char>(0x04)};
+                    const std::uint16_t m0 = next_msgid();
+                    next_msgid(); next_msgid(); next_msgid();   // reserve 4 ids
+                    for (auto& fr : ::lwm2m::dmsrv::build_cert_push(
+                             m0, ctok, ca, cert, key))
+                        ctx->send_async(fr, reg.peerHost, reg.peerPort);
+                    ACE_DEBUG((LM_INFO,
+                        ACE_TEXT("%D lwm2m:thread:%t %M %N:%l pushed VPN cert to "
+                                 "%C (tunnel not up yet) peer=%C:%u\n"),
+                        reg.endpoint.c_str(), reg.peerHost.c_str(),
+                        static_cast<unsigned>(reg.peerPort)));
                 }
             }
         }

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -441,7 +441,11 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
     // idLo}, payload = the applied fingerprint. Map the id back to its
     // endpoint and record what the device reports.
     for (auto& [type, ctx] : services) {
-        if (type != ::UDPAdapter::ServiceType_t::DeviceMgmtServer) continue;
+        // The DM instance's listening context is typed BootstrapServer (the
+        // server-role default in App), while its DeviceMgmtServer context
+        // loses the bind race on the shared 5683 — so accept any server
+        // context, not strictly DeviceMgmtServer. (Client contexts are skipped.)
+        if (type == ::UDPAdapter::ServiceType_t::LwM2MClient) continue;
         ctx->coapAdapter()->dmResponseHandler(
             [reportedFp, idEp](const CoAPAdapter::CoAPMessage& m) {
                 if (m.tokens.size() < 3 || m.tokens[0] != 0x05) return;
@@ -509,7 +513,7 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
         // its send_async takes an explicit peer so one outbound socket
         // serves every registered client.
         for (auto& kv : a->udpAdapter()->services()) {
-            if (kv.first != ::UDPAdapter::ServiceType_t::DeviceMgmtServer) continue;
+            if (kv.first == ::UDPAdapter::ServiceType_t::LwM2MClient) continue;
             auto& ctx = kv.second;
             for (const auto& reg_kv : registry->all()) {
                 const auto& reg = reg_kv.second;

--- a/apps/src/udp_adapter.cpp
+++ b/apps/src/udp_adapter.cpp
@@ -169,17 +169,25 @@ void ServiceContext_t::drain_tx_queue() {
         }
 
         if (m_scheme == Scheme_t::CoAPs && m_dtlsAdapter) {
-            if (m_dtlsAdapter->clientState() != "connected") {
-                m_dtlsAdapter->connect(host, port);
-            }
-            if (m_dtlsAdapter->clientState() == "connected") {
+            if (frame.haveExplicitPeer) {
+                // Server-initiated send to a specific registered peer (the DM
+                // liveness Read + the Object-2048 cert push). There is no
+                // client-side connect here — encrypt with that peer's existing
+                // inbound tinydtls session via dtls_write to its address.
+                m_dtlsAdapter->tx(frame.payload, host, port);
+            } else if (m_dtlsAdapter->clientState() == "connected") {
                 // tx_peer (not tx) so our request goes to the pinned connect
                 // target, even if an inbound packet from another peer just
                 // overwrote m_session (Bootstrap retransmit vs the DM).
                 m_dtlsAdapter->tx_peer(frame.payload);
             } else {
-                ACE_DEBUG((LM_DEBUG,
-                           ACE_TEXT("%D [UdpSvc:%t] %M %N:%l DTLS not connected, dropping tx\n")));
+                m_dtlsAdapter->connect(host, port);
+                if (m_dtlsAdapter->clientState() == "connected") {
+                    m_dtlsAdapter->tx_peer(frame.payload);
+                } else {
+                    ACE_DEBUG((LM_DEBUG,
+                               ACE_TEXT("%D [UdpSvc:%t] %M %N:%l DTLS not connected, dropping tx\n")));
+                }
             }
         } else {
             ACE_INET_Addr to(port, host.c_str());

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -198,6 +198,14 @@ return {
       default = "10.9.0.0/24",
     },
 
+    -- JSON array of device serials with a live VPN tunnel right now, written
+    -- by iot-cloudd from the openvpn management interface. lwm2m-dm reads it to
+    -- stop pushing the cert once the device's tunnel is up.
+    ["cloud.vpn.connected"] = {
+      type    = "string",
+      default = "[]",
+    },
+
     -- OpenVPN server listen socket (iot-cloudd spawns openvpn(8) here).
     ["cloud.vpn.listen.port"] = {
       type    = "integer",


### PR DESCRIPTION
Bringing up the **live** device↔cloud cert push surfaced and fixed several real bugs in the LwM2M stack's server-initiated-over-DTLS path (which had never actually worked). Verified against a running podman stack with real PSK-DTLS.

## (a) Server-initiated DTLS sends (`fix(lwm2m): enable server-initiated DTLS sends`)
- `drain_tx_queue` only sent over DTLS as a *client* (connect + tx_peer); a server-initiated send to an explicit peer tried to DTLS-connect *to the device* and dropped the frame. Route explicit-peer sends through `tx(peer)`.
- The DM's listening context is typed `BootstrapServer` (server-role default) while its `DeviceMgmtServer` context loses the bind race on 5683 (`errno:98`). The tick's `== DeviceMgmtServer` filter missed the bound context → accept any server context.

## (c) DTLS peer-session match (`fix(dtls): server-initiated tx must match the established peer session`)
`DTLSAdapter::tx(in, peerIP, peerPort)` built `session_t` **without memset** → garbage `ifindex`, so `dtls_write` never matched the device's established inbound peer and kicked off a **new handshake** (endless `client_hello`/`hello_verify` loop). Build the session like `session()` does (memset + `addr.sin` + `sizeof(sockaddr_in)`). **After this the push lands** — the device's Object-2048 EXECUTE reaches its cert handler with zero handshake churn.

## (b) VPN-connected stop signal (`feat(lwm2m): gate cert push on VPN-connected`)
Replace the fragile server→device `READ /2048/0/4` confirmation with the *better* signal: iot-cloudd polls the openvpn management interface and publishes `cloud.vpn.connected`; the DM tick pushes only while the device's tunnel is **not** up. Tunnel-up proves the cert is applied *and working*, needs no server→device read, and re-mint (tunnel drop) resumes the push.

## perms (`fix(device): make the VPN cert dir engineer-writable`)
The lwm2m client runs as `engineer` but `/etc/iot/vpn` was root-owned, and it wrote to `dev-etc` while openvpn-client reads `dev-vpn-certs`. Make the dir engineer-writable and mount `dev-vpn-certs` into the lwm2m client so the cert lands where the tunnel daemon reads it.

## Live e2e status
✅ runtime CA + per-device mint · ✅ bootstrap + DM register over DTLS · ✅ server→device DTLS push now **delivers** (EXECUTE reaches the device) · ✅ VPN-connected gate.

**Known remaining constraint (separate follow-up):** the cert PEM payloads (~1.4–1.9 KB each) exceed a single DTLS/UDP frame, so the large WRITEs don't arrive (only the small EXECUTE/Read frames do). Fix is CoAP block-wise (RFC 7959) transfer or EC-sized certs.

Regression: full `lwm2m_test` 185/185; `lwm2m` + `iot-cloudd` build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)