### PR TITLE
feat(device-ui): real-time LwM2M + VPN connection status

### DIFF
--- a/apps/inc/ds_config.hpp
+++ b/apps/inc/ds_config.hpp
@@ -104,6 +104,11 @@ public:
     /// Bootstrap delivered DM credentials → iot.dm.psk.identity / .key.
     bool set_dm_credentials(const std::string& identity,
                             const std::string& key_hex);
+    /// Publish the LwM2M connection lifecycle token to iot.conn.state so
+    /// the device-ui can render real-time progress. One of: idle /
+    /// bootstrapping / bootstrapped / dm-connecting / dm-connected /
+    /// registered / failed. No-op when !connected().
+    bool set_conn_state(const std::string& state);
 
     /// Register a per-key change listener. The callback fires on the
     /// data_store::Client's listener thread — keep it short, don't

--- a/apps/src/ds_config.cpp
+++ b/apps/src/ds_config.cpp
@@ -28,6 +28,8 @@ constexpr const char* kKeyBsPskKey    = "iot.bs.psk.key";
 constexpr const char* kKeyDmPskId     = "iot.dm.psk.identity";
 constexpr const char* kKeyDmPskKey    = "iot.dm.psk.key";
 constexpr const char* kKeyDevMode     = "iot.dev.mode";
+// LwM2M connection lifecycle published to the device-ui (write-only here).
+constexpr const char* kKeyConnState   = "iot.conn.state";
 
 } // namespace
 
@@ -244,6 +246,16 @@ bool DsConfig::set_dm_credentials(const std::string& identity,
         m_impl->dm_psk_identity = identity;
         m_impl->dm_psk_key = key_hex;
     }
+    return s.ok;
+}
+
+bool DsConfig::set_conn_state(const std::string& state) {
+    if (!m_ok || !m_impl) return false;
+    // iot.conn.state is published, never read back into the cache — the
+    // client is the sole writer, so there's nothing to mirror locally.
+    auto s = m_impl->client.set({
+        {kKeyConnState, data_store::Value{state}},
+    });
     return s.ok;
 }
 

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -624,6 +624,32 @@ struct ClientPlumbing {
 /// Skipped is the plain-DM / no-BS fallback (or a bootstrap timeout).
 enum class BootPhase { NotStarted, InProgress, Done, Skipped };
 
+/// Derive the device-ui connection-lifecycle token from the live FSM
+/// signals. Published to iot.conn.state each tick (only when it changes).
+/// The progression mirrors what the operator sees on the dashboard:
+///   bootstrapping → bootstrapped → dm-connecting → dm-connected → registered
+/// "*-connecting" means a DTLS handshake is in flight; "*-connected" means
+/// the secure channel is up and the protocol exchange (BS writes / Register)
+/// is underway. `dtlsReady` is true when the session to the current peer is
+/// established (or there is no DTLS at all, i.e. plain CoAP).
+static const char* compute_conn_state(BootPhase bp,
+                                      ::lwm2m::RegistrationState rs,
+                                      bool dtlsReady, bool disabled) {
+    using RS = ::lwm2m::RegistrationState;
+    if (rs == RS::Registered || rs == RS::AwaitingUpdateAck) return "registered";
+    if (rs == RS::Failed)                                    return "failed";
+    if (disabled && rs == RS::Unregistered)                  return "idle";
+    switch (bp) {
+        case BootPhase::NotStarted:
+        case BootPhase::InProgress:
+            return dtlsReady ? "bootstrapped" : "bootstrapping";
+        case BootPhase::Done:
+        case BootPhase::Skipped:
+            return dtlsReady ? "dm-connected" : "dm-connecting";
+    }
+    return "idle";
+}
+
 /// Single-quote a string for safe inclusion in a /bin/sh command.
 static std::string ota_shquote(const std::string& s) {
     std::string out = "'";
@@ -836,9 +862,13 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     // bootstrap. Shared across ticks; default-constructed = epoch.
     auto reboot_after =
         std::make_shared<std::chrono::steady_clock::time_point>();
+    // Last connection-lifecycle token published to iot.conn.state. The tick
+    // runs at 1 Hz; we only re-publish on a transition so the device-ui
+    // long-poll fires on real changes, not every second.
+    auto lastConn = std::make_shared<std::string>();
     app->udpAdapter()->on_tick_client([wreg, wdm, wapp, rebind, wbs,
                                        reboot_after, bootPhase, bootDeadline,
-                                       dtls]() {
+                                       dtls, &ds, lastConn]() {
         auto reg = wreg.lock();
         auto dm  = wdm.lock();
         auto a   = wapp.lock();
@@ -846,6 +876,17 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
 
         const auto svc = ::UDPAdapter::ServiceType_t::LwM2MClient;
         const auto now = std::chrono::steady_clock::now();
+
+        // Publish the connection lifecycle for the device-ui (only on change).
+        {
+            const bool dtlsUp = !dtls || dtls->clientState() == "connected";
+            const char* cs = compute_conn_state(*bootPhase, reg->state(),
+                                                dtlsUp, reg->is_disabled());
+            if (*lastConn != cs) {
+                *lastConn = cs;
+                ds.set_conn_state(cs);
+            }
+        }
 
         // FUP-DS-11 — if a rebind is queued and we're between
         // registrations, swap the LwM2MClient peer FIRST so the next

--- a/iot-ui/src/app/dashboard/dashboard.component.html
+++ b/iot-ui/src/app/dashboard/dashboard.component.html
@@ -7,7 +7,7 @@
     <div class="clr-col-lg-3 clr-col-md-6 clr-col-12">
       <div class="card status-card" [ngClass]="vpnClass()">
         <clr-icon shape="network-globe" size="36"></clr-icon>
-        <div class="card-value">{{ status?.vpn?.state || '—' | uppercase }}</div>
+        <div class="card-value">{{ vpnLabel() }}</div>
         <div class="card-label">OpenVPN Client</div>
         <div class="card-detail" *ngIf="status?.vpn?.ip">
           {{ status?.vpn?.ip }}
@@ -48,10 +48,13 @@
 
     <!-- LwM2M card -->
     <div class="clr-col-lg-3 clr-col-md-6 clr-col-12">
-      <div class="card status-card" [ngClass]="cardClass(lwm2mState(), ['configured'])">
+      <div class="card status-card" [ngClass]="lwm2mClass()">
         <clr-icon shape="devices" size="36"></clr-icon>
-        <div class="card-value">{{ status?.lwm2m?.server_uri || '—' }}</div>
-        <div class="card-label">LwM2M Server</div>
+        <div class="card-value">{{ lwm2mLabel() }}</div>
+        <div class="card-label">LwM2M Connection</div>
+        <div class="card-detail" *ngIf="status?.lwm2m?.server_uri">
+          {{ status?.lwm2m?.server_uri }}
+        </div>
         <div class="card-detail" *ngIf="status?.lwm2m?.endpoint">
           EP: {{ status?.lwm2m?.endpoint }}
         </div>

--- a/iot-ui/src/app/dashboard/dashboard.component.ts
+++ b/iot-ui/src/app/dashboard/dashboard.component.ts
@@ -59,9 +59,6 @@ export class DashboardComponent implements OnDestroy {
     return upStates.includes(state.toLowerCase()) ? 'connected' : 'disconnected';
   }
 
-  vpnClass(): string {
-    return this.cardClass(this.status?.vpn?.state, ['connected']);
-  }
   wifiClass(): string {
     return this.cardClass(this.status?.wifi?.state, ['connected']);
   }
@@ -70,7 +67,38 @@ export class DashboardComponent implements OnDestroy {
     return a && a.length > 0 ? 'connected' : 'disconnected';
   }
 
-  lwm2mState(): string {
-    return this.status?.lwm2m?.server_uri ? 'configured' : 'unconfigured';
+  // ── VPN connection (reuses vpn.state; professional 3-state label) ──
+  vpnLabel(): string {
+    const s = (this.status?.vpn?.state || '').toLowerCase();
+    if (s === 'connected') return 'Connected';
+    if (!s || s === 'disconnected' || s === 'exited') return 'Disconnected';
+    return 'Connecting';   // resolving / auth / wait / connecting
+  }
+  vpnClass(): string {
+    const s = (this.status?.vpn?.state || '').toLowerCase();
+    if (s === 'connected') return 'connected';
+    if (!s || s === 'disconnected' || s === 'exited') return 'disconnected';
+    return 'starting';
+  }
+
+  // ── LwM2M connection lifecycle (iot.conn.state) ───────────────────
+  private readonly lwm2mLabels: Record<string, string> = {
+    'idle':          'Disconnected',
+    'bootstrapping': 'Bootstrap: Connecting',
+    'bootstrapped':  'Bootstrap: Connected',
+    'dm-connecting': 'Device Management: Connecting',
+    'dm-connected':  'Device Management: Connected',
+    'registered':    'LwM2M Connected',
+    'failed':        'Connection Failed',
+  };
+  lwm2mLabel(): string {
+    return this.lwm2mLabels[this.status?.lwm2m?.conn_state || 'idle']
+        || 'Disconnected';
+  }
+  lwm2mClass(): string {
+    const s = this.status?.lwm2m?.conn_state;
+    if (s === 'registered') return 'connected';
+    if (!s || s === 'idle' || s === 'failed') return 'disconnected';
+    return 'starting';   // bootstrapping / bootstrapped / dm-* in progress
   }
 }

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -13,6 +13,10 @@ export interface StatusSnapshot {
 export interface Lwm2mStatus {
   server_uri?: string;
   endpoint?: string;
+  // Connection lifecycle token published by the client on iot.conn.state:
+  // idle / bootstrapping / bootstrapped / dm-connecting / dm-connected /
+  // registered / failed. The dashboard maps these to professional labels.
+  conn_state?: string;
 }
 
 export interface VpnStatus {

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -117,6 +117,23 @@ return {
         read_acl  = {"gid:engineer"},
     },
 
+    -- ── LwM2M connection lifecycle (client → device-ui) ──────────────
+    -- The lwm2m client publishes its live connection progress here so the
+    -- device-ui can show real-time status. Single string, read-only to the
+    -- UI. Machine tokens (the UI maps these to professional labels):
+    --   idle           - not started / no link               ("Disconnected")
+    --   bootstrapping  - establishing secure channel to BS    ("Bootstrap: Connecting")
+    --   bootstrapped   - BS channel up; exchanging /bs writes  ("Bootstrap: Connected")
+    --   dm-connecting  - establishing secure channel to DM     ("Device Management: Connecting")
+    --   dm-connected   - DM channel up; Register in flight     ("Device Management: Connected")
+    --   registered     - registered with DM                    ("LwM2M Connected")
+    --   failed         - registration rejected / link failed   ("Connection Failed")
+    ["iot.conn.state"] = {
+        access  = "Viewer",
+        type    = "string",
+        default = "idle",
+    },
+
     -- ── OTA software update (mirrors LwM2M Object 5 onto ds) ──────────
     -- Self-update trigger: device-ui (or the Object-5 RID2 apply) sets the
     -- .ipk URL here; the lwm2m client watches it and runs iot-ota-apply.

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -409,8 +409,10 @@ void install_handlers(Router& router,
                 if (timeout > 60) timeout = 60;  // cap at 1 min
             }
 
-            // Long-poll path: watch vpn.state (most dynamic key) and
-            // return full status on change or timeout
+            // Long-poll path: watch the two most dynamic status keys —
+            // vpn.state (VPN lifecycle) and iot.conn.state (LwM2M
+            // bootstrap → DM → registered lifecycle) — and return the full
+            // status snapshot on either change or timeout.
             if (timeout > 0) {
                 using LpState = struct {
                     std::mutex                 m;
@@ -418,27 +420,32 @@ void install_handlers(Router& router,
                     bool                       fired = false;
                 };
                 auto st = std::make_shared<LpState>();
-                data_store::Client::WatchHandle wh =
+                auto notify = [st](const data_store::Client::Event& /*e*/) {
+                    std::lock_guard<std::mutex> lk(st->m);
+                    st->fired = true;
+                    st->cv.notify_one();
+                };
+                data_store::Client::WatchHandle wh_vpn =
                     data_store::Client::kInvalidHandle;
-                auto ws = ds->watch("vpn.state",
-                    [st](const data_store::Client::Event& /*e*/) {
-                        std::lock_guard<std::mutex> lk(st->m);
-                        st->fired = true;
-                        st->cv.notify_one();
-                    }, &wh);
+                data_store::Client::WatchHandle wh_conn =
+                    data_store::Client::kInvalidHandle;
+                auto ws = ds->watch("vpn.state", notify, &wh_vpn);
+                ds->watch("iot.conn.state", notify, &wh_conn);
                 if (ws.ok) {
                     std::unique_lock<std::mutex> lk(st->m);
                     st->cv.wait_for(lk, std::chrono::seconds(timeout),
                                     [&] { return st->fired; });
-                    if (wh != data_store::Client::kInvalidHandle)
-                        ds->unwatch(wh);
                 }
+                if (wh_vpn != data_store::Client::kInvalidHandle)
+                    ds->unwatch(wh_vpn);
+                if (wh_conn != data_store::Client::kInvalidHandle)
+                    ds->unwatch(wh_conn);
                 // Fall through to build the full status snapshot
             }
             std::vector<data_store::Client::GetResult> got;
             auto rs = ds->get({
                 // LwM2M
-                "iot.server.uri", "iot.endpoint",
+                "iot.server.uri", "iot.endpoint", "iot.conn.state",
                 // VPN
                 "vpn.state", "vpn.assigned.ip", "vpn.assigned.gateway",
                 "vpn.assigned.netmask", "vpn.assigned.dns", "vpn.pid",
@@ -516,6 +523,7 @@ void install_handlers(Router& router,
 
                 if (k == "iot.server.uri")        lwm2m["server_uri"] = sv();
                 else if (k == "iot.endpoint")     lwm2m["endpoint"] = sv();
+                else if (k == "iot.conn.state")   lwm2m["conn_state"] = sv();
 
                 else if (k == "vpn.state")             vpn["state"] = sv();
                 else if (k == "vpn.assigned.ip")       vpn["ip"] = sv();


### PR DESCRIPTION
## What & why

The device-ui previously *inferred* LwM2M connectivity from the presence of `iot.server.uri` ("configured" vs "unconfigured"), so it never showed the actual bootstrap → registration progress. This adds a real status plane.

A **single** new ds key `iot.conn.state` (string, Viewer, default `idle`) is published by the lwm2m client; VPN **reuses** the existing `vpn.state` (no new key) per the ds-key-reuse convention — both are relabelled to a consistent, professional vocabulary in the UI.

## LwM2M lifecycle

The client publishes its real FSM state from the 1 Hz reactor tick (only on a transition, so the long-poll fires on real changes):

| `iot.conn.state` | dashboard label |
|---|---|
| `idle` | Disconnected |
| `bootstrapping` | Bootstrap: Connecting |
| `bootstrapped` | Bootstrap: Connected |
| `dm-connecting` | Device Management: Connecting |
| `dm-connected` | Device Management: Connected |
| `registered` | **LwM2M Connected** |
| `failed` | Connection Failed |

Semantics: `*-connecting` = DTLS handshake in flight; `*-connected` = secure channel up, protocol exchange (BS writes / Register) underway.

## VPN

`vpn.state` mapped to the same vocabulary — Connected / Connecting (resolving·auth·wait·connecting) / Disconnected (disconnected·exited·none). Card colour: green = up, yellow = in-progress, red = down.

## Endpoint

`GET /api/v1/status` now returns `lwm2m.conn_state`, and its long-poll watches **both** `vpn.state` and `iot.conn.state` so LwM2M transitions reach the dashboard within ~1 RTT.

## Files
- `modules/data-store/schemas/iot.lua` — new `iot.conn.state` key
- `apps/inc/ds_config.hpp` / `apps/src/ds_config.cpp` — `DsConfig::set_conn_state()` writer
- `apps/src/main.cpp` — `compute_conn_state()` + publish from the reactor tick
- `modules/http-server/src/handler.cpp` — status JSON + dual-key long-poll
- `iot-ui/src/common/app-globals.ts` — `conn_state?` on `Lwm2mStatus`
- `iot-ui/src/app/dashboard/dashboard.component.{ts,html}` — labels/colours + cards

## Verification
- Angular production build: ✅ (AOT template check clean)
- Full C++ device image build via podman (all daemons incl. `lwm2m`, `iot-httpd`): ✅ exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)