### PR TITLE
docs: document iot.conn.state connection-status plane

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ in `iot-httpd`, or run the dev server with `./serve.sh` (podman required).
 
 | Section    | Purpose |
 |------------|---------|
-| Dashboard  | Live VPN/WiFi/WAN/LwM2M status cards + service overview |
+| Dashboard  | Live VPN/WiFi/WAN/LwM2M connection-status cards (real-time LwM2M bootstrap → device-management → registered lifecycle) + service overview |
 | VPN        | OpenVPN config form + real-time connection status |
 | WAN        | WiFi config, scan results, interface priority |
 | Routing    | DNAT target + port forwarding rules |

--- a/apps/docs/architecture.md
+++ b/apps/docs/architecture.md
@@ -361,6 +361,15 @@ The lwm2m binary holds a `DsConfig` for its process lifetime:
   - `iot.server.uri` → fills a `Rebind` mailbox + flips
     `pending_reregister` → after Unregistered, reactor swaps the
     ServiceContext peer + auto-Registers to the new server
+- The reactor tick also *publishes* the connection lifecycle to
+  `iot.conn.state` via `DsConfig::set_conn_state` (only on a transition):
+  `bootstrapping → bootstrapped → dm-connecting → dm-connected →
+  registered`, with `failed`/`idle` as the terminal/initial tokens
+  (`*-connecting` = DTLS handshake in flight, `*-connected` = secure
+  channel up + protocol exchange). `iot-httpd` surfaces it on
+  `GET /api/v1/status` as `lwm2m.conn_state` and long-polls it alongside
+  `vpn.state`, so the device-ui dashboard reflects transitions within
+  ~1 RTT.
 - DsConfig is optional: connect failures log once at LM_INFO and
   every accessor returns nullopt → caller's compiled defaults run.
 


### PR DESCRIPTION
Follow-up to #121 — documents the new connection-status plane.

- **README.md** — Dashboard row now notes the real-time LwM2M bootstrap → device-management → registered lifecycle (not just static status cards).
- **apps/docs/architecture.md** — the DsConfig integration section now documents that the reactor tick publishes `iot.conn.state` via `DsConfig::set_conn_state` (only on a transition), and that `iot-httpd` surfaces it on `GET /api/v1/status` as `lwm2m.conn_state` and long-polls it alongside `vpn.state`.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)