### PR TITLE
feat(ui): Debug mode — reveal ds key + editable raw value per form field

### DIFF
--- a/apps/cloud/ui/src/app/app.module.ts
+++ b/apps/cloud/ui/src/app/app.module.ts
@@ -37,6 +37,8 @@ import { SoftwareUpdateComponent } from './software-update/software-update.compo
 
 import { SsoAuthInterceptor } from '../common/sso-auth.interceptor';
 import { SessionService, initSession } from '../common/session.service';
+import { DsHintComponent } from '../common/ds-hint.component';
+import { DsDebugDirective } from '../common/ds-debug.directive';
 
 @NgModule({
   declarations: [
@@ -48,6 +50,7 @@ import { SessionService, initSession } from '../common/session.service';
     Lwm2mSubmenuComponent, Lwm2mConfigComponent, BsConfigComponent,
     ServicesSubmenuComponent, ServicesListComponent, HttpConfigComponent,
     UsersComponent, SoftwareUpdateComponent,
+    DsHintComponent, DsDebugDirective,
   ],
   imports: [
     BrowserModule, AppRoutingModule, BrowserAnimationsModule,

--- a/apps/cloud/ui/src/app/http-config/http-config.component.ts
+++ b/apps/cloud/ui/src/app/http-config/http-config.component.ts
@@ -24,11 +24,13 @@ import { DataStoreService } from '../../common/datastore.service';
             <label>IP</label>
             <input clrInput [disabled]="!isAdmin" formControlName="ip"
                    placeholder="0.0.0.0" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.listen.ip"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-input-container>
             <label>Port</label>
             <input clrInput [disabled]="!isAdmin" type="number"
                    formControlName="port" min="1" max="65535" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.listen.port"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-select-container>
             <label>Scheme</label>
@@ -36,12 +38,14 @@ import { DataStoreService } from '../../common/datastore.service';
               <option value="http">HTTP</option>
               <option value="https">HTTPS</option>
             </select>
+            <clr-control-helper *dsDebug><app-ds-hint key="http.listen.scheme"></app-ds-hint></clr-control-helper>
           </clr-select-container>
           <clr-input-container>
             <label>Worker Threads</label>
             <input clrInput [disabled]="!isAdmin" type="number"
                    formControlName="workers" min="0" max="64" />
             <clr-control-helper>0 = inline. Requires restart to change.</clr-control-helper>
+            <clr-control-helper *dsDebug><app-ds-hint key="http.workers"></app-ds-hint></clr-control-helper>
           </clr-input-container>
         </div>
 
@@ -51,16 +55,19 @@ import { DataStoreService } from '../../common/datastore.service';
             <label>Certificate (PEM)</label>
             <input clrInput [disabled]="!isAdmin" formControlName="cert"
                    placeholder="/etc/iot/certs/server.crt" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.tls.cert"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-input-container>
             <label>Private Key (PEM)</label>
             <input clrInput [disabled]="!isAdmin" formControlName="key"
                    placeholder="/etc/iot/certs/server.key" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.tls.key"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-input-container>
             <label>CA Bundle (PEM) <span class="hint">(optional — enables mTLS)</span></label>
             <input clrInput [disabled]="!isAdmin" formControlName="ca"
                    placeholder="/etc/iot/certs/ca.crt" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.tls.ca"></app-ds-hint></clr-control-helper>
           </clr-input-container>
         </div>
 

--- a/apps/cloud/ui/src/app/log-level/log-viewer.component.ts
+++ b/apps/cloud/ui/src/app/log-level/log-viewer.component.ts
@@ -23,6 +23,7 @@ import { environment } from '../../environments/environment';
             <option *ngFor="let l of levels" [value]="l">{{ l }}</option>
           </select>
           <clr-control-helper>Global default — used when per-daemon is unset</clr-control-helper>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>iot-cloudd</label>
@@ -30,6 +31,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelCloudd" (ngModelChange)="setLevel('log.level.cloudd', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.cloudd"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>iot-httpd</label>
@@ -37,6 +39,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelHttpd" (ngModelChange)="setLevel('log.level.httpd', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.httpd"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>lwm2m-bs</label>
@@ -44,6 +47,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelLwm2mBs" (ngModelChange)="setLevel('log.level.lwm2m.bs', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.lwm2m.bs"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>lwm2m-dm</label>
@@ -51,6 +55,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelLwm2mDm" (ngModelChange)="setLevel('log.level.lwm2m.dm', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.lwm2m.dm"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>VPN Server</label>
@@ -58,6 +63,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelVpn" (ngModelChange)="setLevel('log.level.vpn', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.vpn"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>DTLS</label>
@@ -65,6 +71,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelDtls" (ngModelChange)="setLevel('log.level.dtls', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.dtls"></app-ds-hint></clr-control-helper>
         </clr-select-container>
       </div>
 

--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
@@ -11,12 +11,14 @@
         <label>Endpoint <span class="hint">(BS server identity)</span></label>
         <input clrInput [disabled]="!isAdmin" formControlName="endpoint"
                placeholder="urn:dev:gateway-" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.endpoint"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
         <label>BS URI <span class="hint">(Bootstrap endpoint)</span></label>
         <input clrInput [disabled]="!isAdmin" formControlName="bs_uri"
                placeholder="coaps://0.0.0.0:5684" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.uri"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-select-container>
@@ -25,6 +27,7 @@
           <option value="PSK">PSK — Pre-Shared Key</option>
           <option value="None">None — No DTLS (dev only)</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.security.mode"></app-ds-hint></clr-control-helper>
       </clr-select-container>
 
       <ng-container *ngIf="bsForm.value.security_mode === 'PSK'">
@@ -32,11 +35,13 @@
           <label>PSK Identity (RID 3)</label>
           <input clrInput [disabled]="!isAdmin" formControlName="psk_id"
                  placeholder="iot-client" />
+          <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.psk.id"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>PSK Key — RID 5 <span class="hint">(hex secret)</span></label>
           <input clrInput [disabled]="!isAdmin" formControlName="psk_key"
                  placeholder="0102030405060708090a0b0c0d0e0f10" />
+          <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.psk.key"></app-ds-hint></clr-control-helper>
         </clr-input-container>
       </ng-container>
 
@@ -44,6 +49,7 @@
         <label>DM URI — RID 0 <span class="hint">(pushed to device)</span></label>
         <input clrInput [disabled]="!isAdmin" formControlName="dm_uri"
                placeholder="coaps://cloud:5683" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.uri"></app-ds-hint></clr-control-helper>
       </clr-input-container>
     </div>
 

--- a/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
+++ b/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
@@ -8,6 +8,7 @@
         <input clrInput [disabled]="!isAdmin" formControlName="dm_uri"
                placeholder="coaps://cloud.example.com:5683" />
         <clr-control-helper>Devices register here after bootstrapping</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.uri"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
@@ -15,6 +16,7 @@
         <input clrInput [disabled]="!isAdmin" type="number" formControlName="lifetime"
                min="0" max="2592000" />
         <clr-control-helper>Registration lifetime pushed to devices at bootstrap</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.lifetime"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-select-container>
@@ -26,6 +28,7 @@
           <option value="UQ">UQ — UDP+Queue</option>
         </select>
         <clr-control-helper>Pushed in Server Object (OID 1) at bootstrap</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.binding"></app-ds-hint></clr-control-helper>
       </clr-select-container>
 
       <clr-input-container>
@@ -33,6 +36,7 @@
         <input clrInput [disabled]="!isAdmin" formControlName="dm_psk_id"
                placeholder="iot-dm-client" />
         <clr-control-helper>Device identity for post-bootstrap DM communication</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.psk.id"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
@@ -40,6 +44,7 @@
         <input clrInput [disabled]="!isAdmin" formControlName="dm_psk_key"
                placeholder="hex-encoded PSK" />
         <clr-control-helper>Separate from BS PSK — used after bootstrap</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.psk.key"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
@@ -47,6 +52,7 @@
         <input clrInput [disabled]="!isAdmin" formControlName="lwm2m_version"
                placeholder="1.1" />
         <clr-control-helper>Default version for provisioned devices</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.lwm2m.version"></app-ds-hint></clr-control-helper>
       </clr-input-container>
     </div>
 

--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -11,6 +11,10 @@
     <a class="nav-item" (click)="theme.toggle()" title="Toggle theme">
       <clr-icon [attr.shape]="theme.dark ? 'sun' : 'moon'"></clr-icon><span>{{theme.dark ? 'Light' : 'Dark'}}</span>
     </a>
+    <a class="nav-item" [class.active]="debug.on" (click)="debug.toggle()"
+       title="Show the data-store key + editable raw value under each form field">
+      <clr-icon [attr.shape]="debug.on ? 'eye-hide' : 'eye'"></clr-icon><span>{{debug.on ? 'Debug Off' : 'Debug'}}</span>
+    </a>
     <a class="nav-item nav-logout" (click)="onLogout()"><clr-icon shape="logout"></clr-icon><span>Sign out</span></a>
   </nav>
   <div class="main-area">

--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -3,6 +3,7 @@ import { Router } from '@angular/router';
 import { HttpsvcService } from '../../common/httpsvc.service';
 import { SessionService } from '../../common/session.service';
 import { ThemeService } from '../../common/theme.service';
+import { DebugService } from '../../common/debug.service';
 import { DataStoreService } from '../../common/datastore.service';
 
 @Component({
@@ -31,7 +32,8 @@ export class MainComponent implements OnInit {
 
   constructor(private http: HttpsvcService, private session: SessionService,
               private router: Router, public theme: ThemeService,
-              private ds: DataStoreService) { this.theme.init(); }
+              public debug: DebugService,
+              private ds: DataStoreService) { this.theme.init(); this.debug.init(); }
 
   ngOnInit(): void {
     // Authenticated shell: warm the shared data-store cache once so every

--- a/apps/cloud/ui/src/app/routing/port-forward/port-forward.component.ts
+++ b/apps/cloud/ui/src/app/routing/port-forward/port-forward.component.ts
@@ -17,10 +17,12 @@ import { DataStoreService } from '../../../common/datastore.service';
           <clr-input-container>
             <label>Target IP <span class="hint">(LwM2M client)</span></label>
             <input clrInput [disabled]="!isAdmin" [(ngModel)]="targetIp" placeholder="192.168.1.100" />
+            <clr-control-helper *dsDebug><app-ds-hint key="net.lwm2m.target.ip"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-input-container>
             <label>Target Port</label>
             <input clrInput type="number" [disabled]="!isAdmin" [(ngModel)]="targetPort" />
+            <clr-control-helper *dsDebug><app-ds-hint key="net.lwm2m.target.port"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <div class="btn-cell" *ngIf="isAdmin">
             <button class="btn btn-primary" (click)="saveDnat()" [disabled]="savingDnat">
@@ -38,6 +40,7 @@ import { DataStoreService } from '../../../common/datastore.service';
             <label>Port List</label>
             <input clrInput [disabled]="!isAdmin" [(ngModel)]="forwardPorts" placeholder="80,443,5684" />
             <clr-control-helper>Comma-separated, DNAT'd to {{ targetIp || 'target IP' }}:{{ targetPort }}</clr-control-helper>
+            <clr-control-helper *dsDebug><app-ds-hint key="net.forward.ports"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <div class="btn-cell" *ngIf="isAdmin">
             <button class="btn btn-primary" (click)="savePorts()" [disabled]="savingPorts">

--- a/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.html
+++ b/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.html
@@ -8,12 +8,14 @@
         <input clrInput [disabled]="!isAdmin" formControlName="subnet"
                placeholder="10.9.0.0/24" />
         <clr-control-helper>Device tunnel IPs are allocated from this subnet</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.subnet"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
         <label>Proxy Port Start</label>
         <input clrInput [disabled]="!isAdmin" type="number"
                formControlName="port_next" min="5001" max="6000" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.port.next"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
@@ -21,6 +23,7 @@
         <input clrInput [disabled]="!isAdmin" type="number"
                formControlName="listen_port" min="1" max="65535" />
         <clr-control-helper>OpenVPN server UDP/TCP listen port (default 1194)</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.listen.port"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-select-container>
@@ -29,6 +32,7 @@
           <option value="udp">udp</option>
           <option value="tcp">tcp</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.proto"></app-ds-hint></clr-control-helper>
       </clr-select-container>
 
       <clr-select-container>
@@ -37,12 +41,14 @@
           <option value="tun">tun</option>
           <option value="tap">tap</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.dev"></app-ds-hint></clr-control-helper>
       </clr-select-container>
 
       <clr-input-container>
         <label>Cipher</label>
         <input clrInput [disabled]="!isAdmin" formControlName="cipher"
                placeholder="AES-256-GCM" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.cipher"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
@@ -50,18 +56,21 @@
         <input clrInput [disabled]="!isAdmin" type="number"
                formControlName="mgmt_port" min="1" max="65535" />
         <clr-control-helper>openvpn(8) management socket on 127.0.0.1</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.mgmt.port"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
         <label>Log Verbosity</label>
         <input clrInput [disabled]="!isAdmin" type="number"
                formControlName="verb" min="0" max="11" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.verb"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
         <label>CA Certificate</label>
         <input clrInput [disabled]="!isAdmin" formControlName="ca_crt"
                placeholder="/etc/iot/vpn/ca/ca.crt" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.ca.crt"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
@@ -69,18 +78,21 @@
         <input clrInput [disabled]="!isAdmin" formControlName="ca_key"
                placeholder="/run/secrets/iot-ca-key/ca.key" />
         <clr-control-helper>Mounted from secret volume at runtime</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.ca.key"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
         <label>Server Certificate</label>
         <input clrInput [disabled]="!isAdmin" formControlName="server_crt"
                placeholder="/etc/iot/vpn/server.crt" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.server.crt"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
         <label>Server Private Key</label>
         <input clrInput [disabled]="!isAdmin" formControlName="server_key"
                placeholder="/etc/iot/vpn/server.key" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.server.key"></app-ds-hint></clr-control-helper>
       </clr-input-container>
     </div>
 

--- a/apps/cloud/ui/src/app/wan/iface-priority/iface-priority.component.ts
+++ b/apps/cloud/ui/src/app/wan/iface-priority/iface-priority.component.ts
@@ -15,22 +15,27 @@ import { DataStoreService } from '../../../common/datastore.service';
         <clr-input-container>
           <label>Priority List</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="priority" placeholder="eth,wifi,cellular" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.priority"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Ethernet Interface</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="ethName" placeholder="eth0" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.eth.name"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>WiFi Interface</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="wifiName" placeholder="wlan0" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.wifi.name"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Cellular Interface</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="cellName" placeholder="wwan0" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.cellular.name"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Poll Interval (s)</label>
           <input clrInput [disabled]="!isAdmin" type="number" [(ngModel)]="pollInterval" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.poll.interval.sec"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <div>
           <label class="clr-control-label">Active Interface</label>

--- a/apps/cloud/ui/src/app/wan/wifi-config/wifi-config.component.html
+++ b/apps/cloud/ui/src/app/wan/wifi-config/wifi-config.component.html
@@ -6,28 +6,34 @@
       <clr-input-container>
         <label>Interface</label>
         <input clrInput [disabled]="!isAdmin" formControlName="iface" placeholder="wlan0" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.iface"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>wpa_supplicant Path</label>
         <input clrInput [disabled]="!isAdmin" formControlName="wpa_path" placeholder="/usr/sbin/wpa_supplicant" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.wpa.path"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Control Directory</label>
         <input clrInput [disabled]="!isAdmin" formControlName="ctrl_dir" placeholder="/run/wpa_supplicant" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.ctrl.dir"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-select-container>
         <label>DHCP Client</label>
         <select clrSelect [disabled]="!isAdmin" formControlName="dhcp_client">
           <option value="auto">auto</option><option value="udhcpc">udhcpc</option><option value="dhclient">dhclient</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.dhcp.client"></app-ds-hint></clr-control-helper>
       </clr-select-container>
       <clr-input-container>
         <label>Scan Interval (s)</label>
         <input clrInput [disabled]="!isAdmin" type="number" formControlName="scan_interval" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.scan.interval.sec"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Max Scan Results</label>
         <input clrInput [disabled]="!isAdmin" type="number" formControlName="scan_max_results" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.scan.max.results"></app-ds-hint></clr-control-helper>
       </clr-input-container>
     </div>
 

--- a/apps/cloud/ui/src/common/debug.service.ts
+++ b/apps/cloud/ui/src/common/debug.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+
+/// UI "Debug" mode — a developer aid that, when on, reveals beneath every
+/// config form input the data-store key that backs it plus an editable raw
+/// value box, so an Admin building their own app can see and poke the
+/// underlying ds key/value. Mirrors ThemeService exactly: per-browser,
+/// client-side only, persisted to localStorage under `iot-debug`.
+@Injectable({ providedIn: 'root' })
+export class DebugService {
+  private _on = false;
+
+  get on(): boolean { return this._on; }
+
+  init(): void {
+    this._on = localStorage.getItem('iot-debug') === 'on';
+  }
+
+  toggle(): void {
+    this._on = !this._on;
+    localStorage.setItem('iot-debug', this._on ? 'on' : 'off');
+  }
+}

--- a/apps/cloud/ui/src/common/ds-debug.directive.ts
+++ b/apps/cloud/ui/src/common/ds-debug.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, DoCheck, TemplateRef, ViewContainerRef } from '@angular/core';
+import { DebugService } from './debug.service';
+
+/// Structural directive: renders its content only while Debug mode is on —
+/// like `*ngIf="debug.on"` but without every host component needing to inject
+/// DebugService. Re-evaluated each change-detection tick (toggling Debug in
+/// the sidebar triggers CD), so the hints appear/disappear instantly.
+///
+/// Used on a `<clr-control-helper>` so the hint slots into Clarity's
+/// below-the-input helper region and the 4-column .form-grid stays aligned.
+@Directive({ selector: '[dsDebug]' })
+export class DsDebugDirective implements DoCheck {
+  private shown = false;
+
+  constructor(private tpl: TemplateRef<unknown>,
+              private vcr: ViewContainerRef,
+              private debug: DebugService) {}
+
+  ngDoCheck(): void {
+    if (this.debug.on && !this.shown) {
+      this.vcr.createEmbeddedView(this.tpl);
+      this.shown = true;
+    } else if (!this.debug.on && this.shown) {
+      this.vcr.clear();
+      this.shown = false;
+    }
+  }
+}

--- a/apps/cloud/ui/src/common/ds-hint.component.ts
+++ b/apps/cloud/ui/src/common/ds-hint.component.ts
@@ -1,0 +1,68 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { HttpsvcService } from './httpsvc.service';
+import { SessionService } from './session.service';
+
+/// Debug aid rendered just below a form input (inside a clr-control-helper):
+/// shows the data-store KEY that fills the field and an editable RAW value box
+/// bound straight to that key. Lets an Admin building their own app see the
+/// exact ds key/value behind every field and poke it directly.
+///
+/// Self-contained — it fetches and writes the raw value itself via
+/// /api/v1/db, so wiring a field is just:
+///   <clr-control-helper *dsDebug>
+///     <app-ds-hint key="cloud.vpn.subnet"></app-ds-hint>
+///   </clr-control-helper>
+/// Only instantiated while Debug mode is on (see DsDebugDirective), so it
+/// costs nothing when off. Mirrors the services-list `.svc-key` styling.
+@Component({
+  selector: 'app-ds-hint',
+  template: `
+    <code class="ds-key" [title]="key">{{ key }}</code>
+    <input class="ds-raw" [value]="raw" [disabled]="!isAdmin"
+           [title]="'Raw value of ' + key"
+           (change)="save($any($event.target).value)" />
+    <span class="ds-msg" *ngIf="msg">{{ msg }}</span>
+  `,
+  styles: [`
+    :host { display: block; margin-top: 2px; }
+    .ds-key { display: block; font-size: 11px; color: #9e9e9e; font-family: monospace; }
+    .ds-raw {
+      display: block; width: 100%; box-sizing: border-box; margin-top: 2px;
+      font-size: 11px; font-family: monospace; padding: 2px 6px;
+      border: 1px solid #c9c9c9; border-radius: 3px; background: #fafafa; color: #333;
+    }
+    .ds-raw:disabled { opacity: .6; cursor: not-allowed; }
+    .ds-msg { font-size: 10px; color: #66bb6a; margin-left: 2px; }
+  `]
+})
+export class DsHintComponent implements OnInit {
+  @Input() key = '';
+  raw = '';
+  msg = '';
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpsvcService, private session: SessionService) {}
+
+  ngOnInit(): void {
+    if (!this.key) return;
+    this.http.dbGet([this.key]).subscribe({
+      next: (r) => {
+        const v = r.ok && r.data ? r.data[this.key] : undefined;
+        this.raw = (v === undefined || v === null) ? '' : String(v);
+      }
+    });
+  }
+
+  save(value: string): void {
+    if (!this.isAdmin || !this.key) return;
+    this.http.dbSet([{ key: this.key, value }]).subscribe({
+      next: (r) => {
+        this.raw = value;
+        this.msg = r.ok ? 'saved' : (r.err || 'error');
+        if (r.ok) setTimeout(() => { this.msg = ''; }, 1500);
+      },
+      error: () => { this.msg = 'error'; }
+    });
+  }
+}

--- a/apps/cloud/ui/src/styles.scss
+++ b/apps/cloud/ui/src/styles.scss
@@ -259,6 +259,8 @@ body.dark-theme {
   .clr-input, .clr-select { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
   .btn-sm { background: #2a2a4a; color: #bdbdbd; border-color: #3a3a5a; }
   .nav-logout { border-color: #2a2a4a; }
+  // Debug mode ds-hint (app-ds-hint) — keep the raw box readable on dark.
+  app-ds-hint .ds-raw { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
 }
 
 // ── Responsive ────────────────────────────────────────────────────

--- a/iot-ui/src/app/app.module.ts
+++ b/iot-ui/src/app/app.module.ts
@@ -37,6 +37,8 @@ import { SoftwareUpdateComponent } from './software-update/software-update.compo
 
 import { SsoAuthInterceptor } from '../common/sso-auth.interceptor';
 import { SessionService, initSession } from '../common/session.service';
+import { DsHintComponent } from '../common/ds-hint.component';
+import { DsDebugDirective } from '../common/ds-debug.directive';
 
 @NgModule({
   declarations: [
@@ -52,6 +54,7 @@ import { SessionService, initSession } from '../common/session.service';
     ServicesSubmenuComponent, ServicesListComponent,
     LogLevelComponent, LogViewerComponent, ToastComponent,
     UsersComponent, SoftwareUpdateComponent,
+    DsHintComponent, DsDebugDirective,
   ],
   imports: [
     BrowserModule,

--- a/iot-ui/src/app/log-level/log-viewer.component.ts
+++ b/iot-ui/src/app/log-level/log-viewer.component.ts
@@ -24,6 +24,7 @@ import { environment } from '../../environments/environment';
             <option *ngFor="let l of levels" [value]="l">{{ l }}</option>
           </select>
           <clr-control-helper>Global default — used when per-daemon is unset</clr-control-helper>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>httpd</label>
@@ -31,6 +32,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelHttpd" (ngModelChange)="setLevel('log.level.httpd', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.httpd"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>lwm2m</label>
@@ -38,6 +40,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelLwm2m" (ngModelChange)="setLevel('log.level.lwm2m', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.lwm2m"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>vpn</label>
@@ -45,6 +48,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelVpn" (ngModelChange)="setLevel('log.level.vpn', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.vpn"></app-ds-hint></clr-control-helper>
         </clr-select-container>
         <clr-select-container>
           <label>dtls</label>
@@ -52,6 +56,7 @@ import { environment } from '../../environments/environment';
                   [ngModel]="logLevelDtls" (ngModelChange)="setLevel('log.level.dtls', $event)">
             <option *ngFor="let l of daemonLevels" [value]="l">{{ l }}</option>
           </select>
+          <clr-control-helper *dsDebug><app-ds-hint key="log.level.dtls"></app-ds-hint></clr-control-helper>
         </clr-select-container>
       </div>
 

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
@@ -16,14 +16,17 @@
         <clr-input-container>
           <label>DM Server URI</label>
           <input clrInput readonly formControlName="server_uri" />
+          <clr-control-helper *dsDebug><app-ds-hint key="iot.server.uri"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Binding Mode</label>
           <input clrInput readonly formControlName="binding" />
+          <clr-control-helper *dsDebug><app-ds-hint key="iot.binding"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Lifetime (s)</label>
           <input clrInput readonly type="number" formControlName="lifetime" />
+          <clr-control-helper *dsDebug><app-ds-hint key="iot.lifetime"></app-ds-hint></clr-control-helper>
         </clr-input-container>
       </div>
     </div>
@@ -48,6 +51,7 @@
         <clr-control-helper *ngIf="!serialAutoDetected && !devMode">
           Enable commissioning mode (iot.dev.mode) to set the serial
         </clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="iot.serial"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Bootstrap Server URI</label>
@@ -56,6 +60,7 @@
                placeholder="coaps://cloud.example.com:5684" />
         <clr-control-helper *ngIf="devMode">Where the device bootstraps from</clr-control-helper>
         <clr-control-helper *ngIf="!devMode">Enable commissioning mode to set the bootstrap URI</clr-control-helper>
+        <clr-control-helper *dsDebug><app-ds-hint key="iot.bs.uri"></app-ds-hint></clr-control-helper>
       </clr-input-container>
     </div>
 

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -40,6 +40,12 @@
       <span>{{ theme.dark ? 'Light' : 'Dark' }}</span>
     </a>
 
+    <a class="nav-item" [class.active]="debug.on" (click)="debug.toggle()"
+       title="Show the data-store key + editable raw value under each form field">
+      <clr-icon [attr.shape]="debug.on ? 'eye-hide' : 'eye'"></clr-icon>
+      <span>{{ debug.on ? 'Debug Off' : 'Debug' }}</span>
+    </a>
+
     <a class="nav-item nav-logout" (click)="onLogout()">
       <clr-icon shape="logout"></clr-icon>
       <span>Sign out</span>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -4,6 +4,7 @@ import { HttpsvcService } from '../../common/httpsvc.service';
 import { SessionService } from '../../common/session.service';
 import { PubSubService } from '../../common/pubsubsvc.service';
 import { ThemeService } from '../../common/theme.service';
+import { DebugService } from '../../common/debug.service';
 import { DataStoreService } from '../../common/datastore.service';
 import { StatusSnapshot } from '../../common/app-globals';
 
@@ -50,9 +51,11 @@ export class MainComponent {
     private router: Router,
     private pubsub: PubSubService,
     public theme: ThemeService,
+    public debug: DebugService,
     private ds: DataStoreService
   ) {
     this.theme.init();
+    this.debug.init();
   }
 
   ngOnInit(): void {

--- a/iot-ui/src/app/routing/port-forward/port-forward.component.ts
+++ b/iot-ui/src/app/routing/port-forward/port-forward.component.ts
@@ -17,10 +17,12 @@ import { DataStoreService } from '../../../common/datastore.service';
           <clr-input-container>
             <label>Target IP <span class="hint">(LwM2M client)</span></label>
             <input clrInput [disabled]="!isAdmin" [(ngModel)]="targetIp" placeholder="192.168.1.100" />
+            <clr-control-helper *dsDebug><app-ds-hint key="net.lwm2m.target.ip"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-input-container>
             <label>Target Port</label>
             <input clrInput type="number" [disabled]="!isAdmin" [(ngModel)]="targetPort" />
+            <clr-control-helper *dsDebug><app-ds-hint key="net.lwm2m.target.port"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <div class="btn-cell" *ngIf="isAdmin">
             <button class="btn btn-primary" (click)="saveDnat()" [disabled]="savingDnat">
@@ -38,6 +40,7 @@ import { DataStoreService } from '../../../common/datastore.service';
             <label>Port List</label>
             <input clrInput [disabled]="!isAdmin" [(ngModel)]="forwardPorts" placeholder="80,443,5684" />
             <clr-control-helper>Comma-separated, DNAT'd to {{ targetIp || 'target IP' }}:{{ targetPort }}</clr-control-helper>
+            <clr-control-helper *dsDebug><app-ds-hint key="net.forward.ports"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <div class="btn-cell" *ngIf="isAdmin">
             <button class="btn btn-primary" (click)="savePorts()" [disabled]="savingPorts">

--- a/iot-ui/src/app/vpn/vpn-config/vpn-config.component.html
+++ b/iot-ui/src/app/vpn/vpn-config/vpn-config.component.html
@@ -6,16 +6,19 @@
       <clr-input-container>
         <label>Remote Host</label>
         <input clrInput [disabled]="!isAdmin" formControlName="remote_host" placeholder="vpn.example.com" />
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.remote.host"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Port</label>
         <input clrInput [disabled]="!isAdmin" type="number" formControlName="remote_port" min="1" max="65535" />
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.remote.port"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-select-container>
         <label>Protocol</label>
         <select clrSelect [disabled]="!isAdmin" formControlName="remote_proto">
           <option value="udp">UDP</option><option value="tcp">TCP</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.remote.proto"></app-ds-hint></clr-control-helper>
       </clr-select-container>
       <clr-select-container>
         <label>Cipher</label>
@@ -24,28 +27,34 @@
           <option value="AES-128-GCM">AES-128-GCM</option>
           <option value="CHACHA20-POLY1305">CHACHA20-POLY1305</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.cipher"></app-ds-hint></clr-control-helper>
       </clr-select-container>
       <clr-select-container>
         <label>Device Type</label>
         <select clrSelect [disabled]="!isAdmin" formControlName="dev">
           <option value="tun">TUN (L3)</option><option value="tap">TAP (L2)</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.dev"></app-ds-hint></clr-control-helper>
       </clr-select-container>
       <clr-input-container>
         <label>Management Port</label>
         <input clrInput [disabled]="!isAdmin" type="number" formControlName="mgmt_port" min="1024" max="65535" />
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.mgmt.port"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Client Certificate Path</label>
         <input clrInput [disabled]="!isAdmin" formControlName="cert_path" placeholder="/etc/iot/certs/client.crt" />
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.cert.path"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Private Key Path</label>
         <input clrInput [disabled]="!isAdmin" formControlName="key_path" placeholder="/etc/iot/certs/client.key" />
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.key.path"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>CA Certificate Path</label>
         <input clrInput [disabled]="!isAdmin" formControlName="ca_path" placeholder="/etc/iot/certs/ca.crt" />
+        <clr-control-helper *dsDebug><app-ds-hint key="vpn.ca.path"></app-ds-hint></clr-control-helper>
       </clr-input-container>
     </div>
 

--- a/iot-ui/src/app/wan/iface-priority/iface-priority.component.ts
+++ b/iot-ui/src/app/wan/iface-priority/iface-priority.component.ts
@@ -15,22 +15,27 @@ import { DataStoreService } from '../../../common/datastore.service';
         <clr-input-container>
           <label>Priority List</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="priority" placeholder="eth,wifi,cellular" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.priority"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Ethernet Interface</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="ethName" placeholder="eth0" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.eth.name"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>WiFi Interface</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="wifiName" placeholder="wlan0" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.wifi.name"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Cellular Interface</label>
           <input clrInput [disabled]="!isAdmin" [(ngModel)]="cellName" placeholder="wwan0" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.iface.cellular.name"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Poll Interval (s)</label>
           <input clrInput [disabled]="!isAdmin" type="number" [(ngModel)]="pollInterval" />
+          <clr-control-helper *dsDebug><app-ds-hint key="net.poll.interval.sec"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <div>
           <label class="clr-control-label">Active Interface</label>

--- a/iot-ui/src/app/wan/wifi-config/wifi-config.component.html
+++ b/iot-ui/src/app/wan/wifi-config/wifi-config.component.html
@@ -6,28 +6,34 @@
       <clr-input-container>
         <label>Interface</label>
         <input clrInput [disabled]="!isAdmin" formControlName="iface" placeholder="wlan0" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.iface"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>wpa_supplicant Path</label>
         <input clrInput [disabled]="!isAdmin" formControlName="wpa_path" placeholder="/usr/sbin/wpa_supplicant" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.wpa.path"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Control Directory</label>
         <input clrInput [disabled]="!isAdmin" formControlName="ctrl_dir" placeholder="/run/wpa_supplicant" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.ctrl.dir"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-select-container>
         <label>DHCP Client</label>
         <select clrSelect [disabled]="!isAdmin" formControlName="dhcp_client">
           <option value="auto">auto</option><option value="udhcpc">udhcpc</option><option value="dhclient">dhclient</option>
         </select>
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.dhcp.client"></app-ds-hint></clr-control-helper>
       </clr-select-container>
       <clr-input-container>
         <label>Scan Interval (s)</label>
         <input clrInput [disabled]="!isAdmin" type="number" formControlName="scan_interval" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.scan.interval.sec"></app-ds-hint></clr-control-helper>
       </clr-input-container>
       <clr-input-container>
         <label>Max Scan Results</label>
         <input clrInput [disabled]="!isAdmin" type="number" formControlName="scan_max_results" />
+        <clr-control-helper *dsDebug><app-ds-hint key="wifi.scan.max.results"></app-ds-hint></clr-control-helper>
       </clr-input-container>
     </div>
 

--- a/iot-ui/src/common/debug.service.ts
+++ b/iot-ui/src/common/debug.service.ts
@@ -1,0 +1,22 @@
+import { Injectable } from '@angular/core';
+
+/// UI "Debug" mode — a developer aid that, when on, reveals beneath every
+/// config form input the data-store key that backs it plus an editable raw
+/// value box, so an Admin building their own app can see and poke the
+/// underlying ds key/value. Mirrors ThemeService exactly: per-browser,
+/// client-side only, persisted to localStorage under `iot-debug`.
+@Injectable({ providedIn: 'root' })
+export class DebugService {
+  private _on = false;
+
+  get on(): boolean { return this._on; }
+
+  init(): void {
+    this._on = localStorage.getItem('iot-debug') === 'on';
+  }
+
+  toggle(): void {
+    this._on = !this._on;
+    localStorage.setItem('iot-debug', this._on ? 'on' : 'off');
+  }
+}

--- a/iot-ui/src/common/ds-debug.directive.ts
+++ b/iot-ui/src/common/ds-debug.directive.ts
@@ -1,0 +1,28 @@
+import { Directive, DoCheck, TemplateRef, ViewContainerRef } from '@angular/core';
+import { DebugService } from './debug.service';
+
+/// Structural directive: renders its content only while Debug mode is on —
+/// like `*ngIf="debug.on"` but without every host component needing to inject
+/// DebugService. Re-evaluated each change-detection tick (toggling Debug in
+/// the sidebar triggers CD), so the hints appear/disappear instantly.
+///
+/// Used on a `<clr-control-helper>` so the hint slots into Clarity's
+/// below-the-input helper region and the 4-column .form-grid stays aligned.
+@Directive({ selector: '[dsDebug]' })
+export class DsDebugDirective implements DoCheck {
+  private shown = false;
+
+  constructor(private tpl: TemplateRef<unknown>,
+              private vcr: ViewContainerRef,
+              private debug: DebugService) {}
+
+  ngDoCheck(): void {
+    if (this.debug.on && !this.shown) {
+      this.vcr.createEmbeddedView(this.tpl);
+      this.shown = true;
+    } else if (!this.debug.on && this.shown) {
+      this.vcr.clear();
+      this.shown = false;
+    }
+  }
+}

--- a/iot-ui/src/common/ds-hint.component.ts
+++ b/iot-ui/src/common/ds-hint.component.ts
@@ -1,0 +1,68 @@
+import { Component, Input, OnInit } from '@angular/core';
+import { HttpsvcService } from './httpsvc.service';
+import { SessionService } from './session.service';
+
+/// Debug aid rendered just below a form input (inside a clr-control-helper):
+/// shows the data-store KEY that fills the field and an editable RAW value box
+/// bound straight to that key. Lets an Admin building their own app see the
+/// exact ds key/value behind every field and poke it directly.
+///
+/// Self-contained — it fetches and writes the raw value itself via
+/// /api/v1/db, so wiring a field is just:
+///   <clr-control-helper *dsDebug>
+///     <app-ds-hint key="vpn.remote.host"></app-ds-hint>
+///   </clr-control-helper>
+/// Only instantiated while Debug mode is on (see DsDebugDirective), so it
+/// costs nothing when off. Mirrors the services-list `.svc-key` styling.
+@Component({
+  selector: 'app-ds-hint',
+  template: `
+    <code class="ds-key" [title]="key">{{ key }}</code>
+    <input class="ds-raw" [value]="raw" [disabled]="!isAdmin"
+           [title]="'Raw value of ' + key"
+           (change)="save($any($event.target).value)" />
+    <span class="ds-msg" *ngIf="msg">{{ msg }}</span>
+  `,
+  styles: [`
+    :host { display: block; margin-top: 2px; }
+    .ds-key { display: block; font-size: 11px; color: #9e9e9e; font-family: monospace; }
+    .ds-raw {
+      display: block; width: 100%; box-sizing: border-box; margin-top: 2px;
+      font-size: 11px; font-family: monospace; padding: 2px 6px;
+      border: 1px solid #c9c9c9; border-radius: 3px; background: #fafafa; color: #333;
+    }
+    .ds-raw:disabled { opacity: .6; cursor: not-allowed; }
+    .ds-msg { font-size: 10px; color: #66bb6a; margin-left: 2px; }
+  `]
+})
+export class DsHintComponent implements OnInit {
+  @Input() key = '';
+  raw = '';
+  msg = '';
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpsvcService, private session: SessionService) {}
+
+  ngOnInit(): void {
+    if (!this.key) return;
+    this.http.dbGet([this.key]).subscribe({
+      next: (r) => {
+        const v = r.ok && r.data ? r.data[this.key] : undefined;
+        this.raw = (v === undefined || v === null) ? '' : String(v);
+      }
+    });
+  }
+
+  save(value: string): void {
+    if (!this.isAdmin || !this.key) return;
+    this.http.dbSet([{ key: this.key, value }]).subscribe({
+      next: (r) => {
+        this.raw = value;
+        this.msg = r.ok ? 'saved' : (r.err || 'error');
+        if (r.ok) setTimeout(() => { this.msg = ''; }, 1500);
+      },
+      error: () => { this.msg = 'error'; }
+    });
+  }
+}

--- a/iot-ui/src/styles.scss
+++ b/iot-ui/src/styles.scss
@@ -232,6 +232,8 @@ body.dark-theme {
   .clr-input, .clr-select { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
   .btn-sm { background: #2a2a4a; color: #bdbdbd; border-color: #3a3a5a; }
   .nav-logout { border-color: #2a2a4a; }
+  // Debug mode ds-hint (app-ds-hint) — keep the raw box readable on dark.
+  app-ds-hint .ds-raw { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
 }
 
 // ── Responsive ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Adds a sidebar **Debug** toggle (next to **Dark**) to both the device-ui (`iot-ui`) and cloud-ui (`apps/cloud/ui`). When on, every config form input shows — just below it — the **data-store key** that fills the field plus an **editable raw value box** bound straight to that key, so an admin building their own app can discover and poke the ds key/value behind any field.

## How it works (mirrors `ThemeService` / services-list `.svc-key`)
- **`DebugService`** — per-browser flag, persisted to `localStorage['iot-debug']`.
- **`DsDebugDirective` (`*dsDebug`)** — renders content only while Debug is on, no per-component injection; placed on `<clr-control-helper>` so it slots into Clarity's below-input region and keeps the 4-column `.form-grid` aligned (Project Rule 5).
- **`DsHintComponent` (`<app-ds-hint key="...">`)** — self-fetches/writes the raw value via `/api/v1/db`, admin-gated; dark-mode styling included.

Wiring a field is a one-liner an admin can copy:
```html
<clr-control-helper *dsDebug><app-ds-hint key="vpn.remote.host"></app-ds-hint></clr-control-helper>
```

## Coverage
Wired into every single-ds-key input across both UIs (VPN, WiFi, LwM2M incl. readonly Server-tab keys, Bootstrap, HTTP, Port-forward, Iface-priority, Log levels).

**Intentionally excluded:** array/datagrid editors that don't map to a single key — WiFi Saved Networks, cloud custom firewall rules, per-endpoint provision JSON — and the `http.auth.enabled` checkbox container.

## Verification
Both Angular apps build clean (`ng build`, Angular 14) in podman — exit 0, only one pre-existing unrelated `wifi-scan` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)