### PR TITLE
docs: document UI Debug mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ One binary, `lwm2m`, plays either role:
 | L17d | Rate-limit + chaos coverage — set-rate throttling, random gate-flip harness | ✅ |
 | L18 | HTTP REST API server (`iot-httpd`) — AF_UNIX data-store bridge, worker pool, TLS/mTLS, hot-reload | ✅ |
 | L19 | Auth module — SHA-256 session cookies, role-based access control (Admin/Viewer), log ring buffer, keep-alive + idle timeout | ✅ |
-| L20 | **IoT Manager UI** — Angular 14 SPA with Clarity Design System, collapsible sidebar, long-poll real-time updates, dark/light theme | ✅ |
+| L20 | **IoT Manager UI** — Angular 14 SPA with Clarity Design System, collapsible sidebar, long-poll real-time updates, dark/light theme, Debug mode (reveals the data-store key + editable raw value under each form field) | ✅ |
 
 All six binding decisions (D1–D6) are recorded in
 [`apps/docs/lwm2m-rdd.md`](apps/docs/lwm2m-rdd.md#11-decisions-log) and

--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -90,6 +90,34 @@ Dashboard  Endpoints  VPN  HTTP  WAN  Routing  LwM2M              Services  Logs
 | Services | services.cloud.* (polled every 5s) |
 | Logs | log.level + GET /api/v1/log |
 
+### Debug mode (developer aid)
+
+A global **Debug** toggle sits at the bottom of the sidebar next to
+**Dark** (in both cloud-ui and iot-ui). Like the theme toggle it is a
+`providedIn:'root'` `DebugService` persisted per-browser in
+`localStorage['iot-debug']` — no backend state.
+
+When on, every config form input shows — just below it — the data-store
+key that fills the field plus an **editable raw value box** bound straight
+to that key, so an operator building their own app can discover and poke
+the ds key/value behind any field. Implementation (in each UI's
+`src/common/`):
+
+- `debug.service.ts` — the on/off flag.
+- `ds-debug.directive.ts` — `*dsDebug`, a structural directive that renders
+  its content only while Debug is on (placed on `<clr-control-helper>` so
+  the hint slots into Clarity's below-input region and keeps the 4-column
+  `.form-grid` aligned).
+- `ds-hint.component.ts` — `<app-ds-hint key="cloud.vpn.subnet">`, which
+  self-reads/writes the raw value via `/api/v1/db`, admin-gated.
+
+Wire a new field with one line — no component changes needed:
+```html
+<clr-control-helper *dsDebug><app-ds-hint key="cloud.vpn.subnet"></app-ds-hint></clr-control-helper>
+```
+Array/datagrid editors (no single key) and checkbox containers are not
+wired.
+
 ## API patterns
 
 All config pages use the same REST surface.  The UI always calls the

--- a/log/L21/cloud-ui-design.md
+++ b/log/L21/cloud-ui-design.md
@@ -152,12 +152,23 @@ Calls `POST /api/v1/cloud/provision` with `{"endpoint":"..."}`.
 │              │
 │              │
 │ ☀ Dark       │
+│ ◎ Debug      │
 │ ← Sign out   │
 └──────────────┘
 ```
 
 Same collapsible tree structure as iot-ui — but only 4 menu items,
 no children needed (simpler than device UI).
+
+**Dark** and **Debug** are global toggles pinned to the bottom of the
+sidebar (both in iot-ui and cloud-ui), each a `providedIn:'root'` service
+persisted per-browser in `localStorage` (`iot-theme` / `iot-debug`).
+With **Debug** on, every config form input renders — just below it, in a
+Clarity `<clr-control-helper>` so the 4-column `.form-grid` stays aligned —
+the data-store key that fills the field plus an editable raw value box
+bound straight to that key (`<app-ds-hint key="...">`, gated to admins,
+reads/writes via `/api/v1/db`). The `*dsDebug` structural directive shows
+the hint only while Debug is on, so it costs nothing when off.
 
 ## API Endpoints (already built in TDD #7)
 


### PR DESCRIPTION
Documents the new sidebar **Debug** toggle (shipped in #123) alongside **Dark**:

- `README.md` — L20 feature line now mentions Debug mode.
- `log/L21/cloud-ui-design.md` — sidebar mockup gains a `◎ Debug` entry plus a note on how Dark/Debug work (`localStorage`-persisted root services; `*dsDebug` + `<app-ds-hint>`).
- `apps/cloud/CLAUDE.md` — new "Debug mode" subsection under Cloud UI Nav, with the one-line wiring snippet.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)