### PR TITLE
refactor(ui): Debug mode shows only the ds key (no value box)

### DIFF
--- a/apps/cloud/ui/src/common/ds-hint.component.ts
+++ b/apps/cloud/ui/src/common/ds-hint.component.ts
@@ -1,68 +1,19 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { HttpsvcService } from './httpsvc.service';
-import { SessionService } from './session.service';
+import { Component, Input } from '@angular/core';
 
 /// Debug aid rendered just below a form input (inside a clr-control-helper):
-/// shows the data-store KEY that fills the field and an editable RAW value box
-/// bound straight to that key. Lets an Admin building their own app see the
-/// exact ds key/value behind every field and poke it directly.
-///
-/// Self-contained — it fetches and writes the raw value itself via
-/// /api/v1/db, so wiring a field is just:
-///   <clr-control-helper *dsDebug>
-///     <app-ds-hint key="cloud.vpn.subnet"></app-ds-hint>
-///   </clr-control-helper>
-/// Only instantiated while Debug mode is on (see DsDebugDirective), so it
-/// costs nothing when off. Mirrors the services-list `.svc-key` styling.
+/// shows the data-store KEY that fills the field, so an Admin building their
+/// own app can see the exact ds key behind every field. The field's current
+/// value already shows in the Clarity input above, so no extra value box is
+/// needed. Only instantiated while Debug mode is on (see DsDebugDirective),
+/// so it costs nothing when off. Mirrors the services-list `.svc-key` styling.
 @Component({
   selector: 'app-ds-hint',
-  template: `
-    <code class="ds-key" [title]="key">{{ key }}</code>
-    <input class="ds-raw" [value]="raw" [disabled]="!isAdmin"
-           [title]="'Raw value of ' + key"
-           (change)="save($any($event.target).value)" />
-    <span class="ds-msg" *ngIf="msg">{{ msg }}</span>
-  `,
+  template: `<code class="ds-key" [title]="key">{{ key }}</code>`,
   styles: [`
     :host { display: block; margin-top: 2px; }
     .ds-key { display: block; font-size: 11px; color: #9e9e9e; font-family: monospace; }
-    .ds-raw {
-      display: block; width: 100%; box-sizing: border-box; margin-top: 2px;
-      font-size: 11px; font-family: monospace; padding: 2px 6px;
-      border: 1px solid #c9c9c9; border-radius: 3px; background: #fafafa; color: #333;
-    }
-    .ds-raw:disabled { opacity: .6; cursor: not-allowed; }
-    .ds-msg { font-size: 10px; color: #66bb6a; margin-left: 2px; }
   `]
 })
-export class DsHintComponent implements OnInit {
+export class DsHintComponent {
   @Input() key = '';
-  raw = '';
-  msg = '';
-
-  get isAdmin(): boolean { return this.session.isAdmin; }
-
-  constructor(private http: HttpsvcService, private session: SessionService) {}
-
-  ngOnInit(): void {
-    if (!this.key) return;
-    this.http.dbGet([this.key]).subscribe({
-      next: (r) => {
-        const v = r.ok && r.data ? r.data[this.key] : undefined;
-        this.raw = (v === undefined || v === null) ? '' : String(v);
-      }
-    });
-  }
-
-  save(value: string): void {
-    if (!this.isAdmin || !this.key) return;
-    this.http.dbSet([{ key: this.key, value }]).subscribe({
-      next: (r) => {
-        this.raw = value;
-        this.msg = r.ok ? 'saved' : (r.err || 'error');
-        if (r.ok) setTimeout(() => { this.msg = ''; }, 1500);
-      },
-      error: () => { this.msg = 'error'; }
-    });
-  }
 }

--- a/apps/cloud/ui/src/styles.scss
+++ b/apps/cloud/ui/src/styles.scss
@@ -259,8 +259,6 @@ body.dark-theme {
   .clr-input, .clr-select { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
   .btn-sm { background: #2a2a4a; color: #bdbdbd; border-color: #3a3a5a; }
   .nav-logout { border-color: #2a2a4a; }
-  // Debug mode ds-hint (app-ds-hint) — keep the raw box readable on dark.
-  app-ds-hint .ds-raw { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
 }
 
 // ── Responsive ────────────────────────────────────────────────────

--- a/iot-ui/src/common/ds-hint.component.ts
+++ b/iot-ui/src/common/ds-hint.component.ts
@@ -1,68 +1,19 @@
-import { Component, Input, OnInit } from '@angular/core';
-import { HttpsvcService } from './httpsvc.service';
-import { SessionService } from './session.service';
+import { Component, Input } from '@angular/core';
 
 /// Debug aid rendered just below a form input (inside a clr-control-helper):
-/// shows the data-store KEY that fills the field and an editable RAW value box
-/// bound straight to that key. Lets an Admin building their own app see the
-/// exact ds key/value behind every field and poke it directly.
-///
-/// Self-contained — it fetches and writes the raw value itself via
-/// /api/v1/db, so wiring a field is just:
-///   <clr-control-helper *dsDebug>
-///     <app-ds-hint key="vpn.remote.host"></app-ds-hint>
-///   </clr-control-helper>
-/// Only instantiated while Debug mode is on (see DsDebugDirective), so it
-/// costs nothing when off. Mirrors the services-list `.svc-key` styling.
+/// shows the data-store KEY that fills the field, so an Admin building their
+/// own app can see the exact ds key behind every field. The field's current
+/// value already shows in the Clarity input above, so no extra value box is
+/// needed. Only instantiated while Debug mode is on (see DsDebugDirective),
+/// so it costs nothing when off. Mirrors the services-list `.svc-key` styling.
 @Component({
   selector: 'app-ds-hint',
-  template: `
-    <code class="ds-key" [title]="key">{{ key }}</code>
-    <input class="ds-raw" [value]="raw" [disabled]="!isAdmin"
-           [title]="'Raw value of ' + key"
-           (change)="save($any($event.target).value)" />
-    <span class="ds-msg" *ngIf="msg">{{ msg }}</span>
-  `,
+  template: `<code class="ds-key" [title]="key">{{ key }}</code>`,
   styles: [`
     :host { display: block; margin-top: 2px; }
     .ds-key { display: block; font-size: 11px; color: #9e9e9e; font-family: monospace; }
-    .ds-raw {
-      display: block; width: 100%; box-sizing: border-box; margin-top: 2px;
-      font-size: 11px; font-family: monospace; padding: 2px 6px;
-      border: 1px solid #c9c9c9; border-radius: 3px; background: #fafafa; color: #333;
-    }
-    .ds-raw:disabled { opacity: .6; cursor: not-allowed; }
-    .ds-msg { font-size: 10px; color: #66bb6a; margin-left: 2px; }
   `]
 })
-export class DsHintComponent implements OnInit {
+export class DsHintComponent {
   @Input() key = '';
-  raw = '';
-  msg = '';
-
-  get isAdmin(): boolean { return this.session.isAdmin; }
-
-  constructor(private http: HttpsvcService, private session: SessionService) {}
-
-  ngOnInit(): void {
-    if (!this.key) return;
-    this.http.dbGet([this.key]).subscribe({
-      next: (r) => {
-        const v = r.ok && r.data ? r.data[this.key] : undefined;
-        this.raw = (v === undefined || v === null) ? '' : String(v);
-      }
-    });
-  }
-
-  save(value: string): void {
-    if (!this.isAdmin || !this.key) return;
-    this.http.dbSet([{ key: this.key, value }]).subscribe({
-      next: (r) => {
-        this.raw = value;
-        this.msg = r.ok ? 'saved' : (r.err || 'error');
-        if (r.ok) setTimeout(() => { this.msg = ''; }, 1500);
-      },
-      error: () => { this.msg = 'error'; }
-    });
-  }
 }

--- a/iot-ui/src/styles.scss
+++ b/iot-ui/src/styles.scss
@@ -232,8 +232,6 @@ body.dark-theme {
   .clr-input, .clr-select { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
   .btn-sm { background: #2a2a4a; color: #bdbdbd; border-color: #3a3a5a; }
   .nav-logout { border-color: #2a2a4a; }
-  // Debug mode ds-hint (app-ds-hint) — keep the raw box readable on dark.
-  app-ds-hint .ds-raw { background: #16213e; color: #e0e0e0; border-color: #2a2a4a; }
 }
 
 // ── Responsive ────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Simplifies Debug mode: the per-field hint now shows **only the data-store key** below the Clarity input. The editable raw value box is removed — the field's current value already appears in the Clarity input above, so it was redundant.

`DsHintComponent` is now purely presentational (`<code class="ds-key">{{ key }}</code>`); dropped the self-fetch/write-back logic, the `HttpsvcService`/`SessionService` deps, and the now-unused dark-mode `.ds-raw` override.

## Scope
Applies to **every field across both UIs (device + cloud)** automatically — all hints render through the single shared `DsHintComponent` per UI, so no per-page changes were needed. The `*dsDebug` directive and per-field wiring are unchanged.

## Verification
Both Angular apps build clean (`ng build`, Angular 14) in podman — exit 0, only the pre-existing unrelated `wifi-scan` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)