### PR TITLE
feat(cloud-ui): derive + lock BS/DM PSK Identity from endpoint

### DIFF
--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
@@ -101,8 +101,9 @@
 
       <clr-input-container>
         <label>PSK Identity — RID 3</label>
-        <input clrInput [disabled]="!isAdmin" formControlName="sec_identity"
-               placeholder="iot-client" />
+        <input clrInput [disabled]="true" formControlName="sec_identity"
+               placeholder="rpi&lt;endpoint&gt;&#64;cloud.local" />
+        <clr-control-helper>Auto-derived from Endpoint Name — not editable</clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>
@@ -120,8 +121,9 @@
       <!-- DM PSK (post-bootstrap, separate from BS PSK above) -->
       <clr-input-container>
         <label>DM PSK Identity <span class="hint">(per-device)</span></label>
-        <input clrInput [disabled]="!isAdmin" formControlName="dm_psk_id"
-               placeholder="iot-dm-client" />
+        <input clrInput [disabled]="true" formControlName="dm_psk_id"
+               placeholder="rpi&lt;endpoint&gt;&#64;cloud.local" />
+        <clr-control-helper>Auto-derived from Endpoint Name — not editable</clr-control-helper>
       </clr-input-container>
 
       <clr-input-container>

--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
@@ -83,6 +83,26 @@ export class BsConfigComponent implements OnInit {
       },
       error: () => { this.loading = false; }
     });
+
+    // BS/DM PSK Identity are never free-text: the cloud always derives the
+    // identity from the endpoint as rpi<endpoint>@cloud.local (mirrors
+    // server::lwm2m::format_identity). Keep them in lock-step with the
+    // Endpoint Name field; the template renders them read-only so the
+    // installer cannot enter a mismatching value.
+    this.syncIdentities(this.provForm.value.endpoint);
+    this.provForm.get('endpoint')!.valueChanges
+      .subscribe((ep: string) => this.syncIdentities(ep));
+  }
+
+  /// rpi<endpoint>@cloud.local — must match server::lwm2m::format_identity.
+  private formatIdentity(endpoint: string): string {
+    const ep = (endpoint || '').trim();
+    return ep ? `rpi${ep}@cloud.local` : '';
+  }
+
+  private syncIdentities(endpoint: string | null): void {
+    const id = this.formatIdentity(endpoint || '');
+    this.provForm.patchValue({ sec_identity: id, dm_psk_id: id }, { emitEvent: false });
   }
 
   saveBs(): void {
@@ -105,12 +125,12 @@ export class BsConfigComponent implements OnInit {
     });
   }
 
-  /// Copy server-config into the provision form.
+  /// Copy server-config into the provision form. PSK identities are NOT
+  /// copied — they are derived from the endpoint (see syncIdentities).
   fillFromServer(): void {
     const v = this.bsForm.value;
     this.provForm.patchValue({
       sec_uri:      v.dm_uri,
-      sec_identity: v.psk_id,
       sec_key:      v.psk_key,
       sec_mode:     v.security_mode === 'None' ? 3 : 0,
     });


### PR DESCRIPTION
## Summary
In the cloud-ui **Provision Device** form (`bs-config`), the **PSK Identity — RID 3** and **DM PSK Identity** fields now auto-derive from the **Endpoint Name** as `rpi<endpoint>@cloud.local` (mirrors `server::lwm2m::format_identity`) and are rendered **read-only**, so an installer can't enter a mismatching value.

- Identities update live as the Endpoint Name is typed (`valueChanges` → `syncIdentities`).
- `fillFromServer()` no longer overwrites the derived identity.
- Added a helper line under each field: "Auto-derived from Endpoint Name — not editable."

## Notes
- This form's keys (`cloud.provision.configs`) are not consumed by the backend (the live provisioning path is the Endpoints page, which already derives the identity server-side); this is a UX-correctness fix on that form.
- Both fields use the fully-qualified `rpi<endpoint>@cloud.local` per request. (Strictly, only the DM identity is `rpi…`; the real BS security instance uses `sha256(endpoint)[:32]`.)

## Verification
cloud-ui builds clean (`ng build`, Angular 14) in podman — exit 0, only the pre-existing unrelated `wifi-scan` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)