### PR TITLE
fix(lwm2m): retry bootstrap forever with backoff; pump DTLS retransmit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,3 +69,6 @@ apps/test/build/
 # Yocto build output
 yocto/build/
 build/
+
+# Image export tarballs
+iot-cloud.tar.gz

--- a/apps/docs/lwm2m-design.md
+++ b/apps/docs/lwm2m-design.md
@@ -208,6 +208,46 @@ the readline prompt. Driving this from `App` requires:
 - A "bootstrap pending writes" buffer so `apply` is atomic — partial
   writes are discarded on `/bs` finish failure.
 
+#### 5.1.1 Bootstrap retry & backoff (driver in `main.cpp` client tick)
+
+The above FSM is *driven* by the 1 Hz client tick (`UDPAdapter::on_tick_client`
+in `apps/src/main.cpp`), which owns a small `BootPhase` state
+(`NotStarted → InProgress → Done | Skipped`). The connection must **never
+wedge** — a dropped ClientHello, a briefly-unavailable Bootstrap Server, or an
+unanswered `POST /bs` all self-heal by retrying forever with capped backoff.
+Two cooperating mechanisms make that happen:
+
+1. **DTLS handshake retransmission.** Every tick calls
+   `DTLSAdapter::check_retransmit()` → tinydtls `dtls_check_retransmit()`.
+   Without this, an unanswered handshake flight (the bootstrap ClientHello) is
+   never retransmitted and the client stalls after one packet. Pumping it makes
+   tinydtls resend the in-flight flight on its own timers until the BS answers.
+
+2. **Bootstrap-level retry loop with backoff.** State carried across ticks:
+   - `bootRetryAfter` — earliest `steady_clock` time the next bootstrap action
+     may run (default-constructed = epoch ⇒ first attempt is immediate).
+   - `bootBackoff` — current wait in seconds, starts at **2**, doubles on each
+     failed attempt and is capped at **30** (`2 → 4 → 8 → 16 → 30 → 30 …`).
+
+   Per-tick logic while `Unregistered` and not yet `Done`:
+
+   | Phase | Condition | Action |
+   |-------|-----------|--------|
+   | `NotStarted` | no BS configured | → `Skipped` (plain-DM fallback) |
+   | `NotStarted` | `now ≥ bootRetryAfter` **and** DTLS up | send `POST /bs` → `InProgress`, set 15 s `bootDeadline` |
+   | `NotStarted` | `now ≥ bootRetryAfter` **and** DTLS not up | re-kick `connect(bsHost,bsPort)` (covers a peer dropped after max retransmits); `bootRetryAfter = now + bootBackoff`; then grow `bootBackoff` |
+   | `InProgress` | `now ≥ bootDeadline` (15 s, `/bs` didn't complete) | `bootRetryAfter = now + bootBackoff`; grow `bootBackoff`; → `NotStarted` (re-send `/bs` after the backoff window) |
+
+   `bootDeadline` bounds a single `/bs` attempt (15 s); `bootRetryAfter` +
+   `bootBackoff` space out the *retries*. The loop is unbounded by design — a
+   gateway must eventually reach the cloud — so a bootstrap timeout **no longer
+   falls back to a direct DM register**; only an explicitly BS-less config takes
+   the `Skipped` path. On success the FSM leaves `NotStarted/InProgress` for
+   `Done`, so the backoff state is simply abandoned (no reset needed).
+
+   The device-ui sees this via `iot.conn.state` (`bootstrapping` while looping;
+   see `compute_conn_state`).
+
 ### 5.2 Bootstrap Server (replaces today's static reply in `processRequest`)
 
 ```

--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -234,6 +234,20 @@ class DTLSAdapter {
             return(m_dtls_ctx);
         }
 
+        /// Pump tinydtls' handshake retransmission timer. Without periodic
+        /// calls, an unanswered handshake flight (e.g. the bootstrap
+        /// ClientHello) is never retransmitted and the connection wedges.
+        /// Driven from the client's 1 Hz tick. Returns true if tinydtls has
+        /// exhausted its max retransmits for some peer (handshake gave up) —
+        /// the caller may then re-initiate via connect().
+        bool check_retransmit() {
+            if(!m_dtls_ctx) return(false);
+            clock_time_t next = 0;
+            bool isMaxRetransmit = false;
+            dtls_check_retransmit(m_dtls_ctx, &next, &isMaxRetransmit);
+            return(isMaxRetransmit);
+        }
+
         std::string& data() {
             return(m_data);
         }

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -769,6 +769,14 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     auto bootPhase    = std::make_shared<BootPhase>(BootPhase::NotStarted);
     auto bootDeadline =
         std::make_shared<std::chrono::steady_clock::time_point>();
+    // Bootstrap retry-with-backoff so a dropped ClientHello / briefly-down BS /
+    // an unanswered /bs never wedges us permanently at "bootstrapping".
+    // bootRetryAfter gates the next bootstrap action; bootBackoff (seconds)
+    // doubles 2→4→…→cap each failed attempt. Default-constructed time_point =
+    // epoch, so the first attempt fires immediately.
+    auto bootRetryAfter =
+        std::make_shared<std::chrono::steady_clock::time_point>();
+    auto bootBackoff  = std::make_shared<int>(2);   // seconds; doubles, cap 30
 
     // After the Bootstrap commit, switch the LwM2MClient peer + DTLS identity
     // to the DM and (re)connect; the tick sends Register once the DM
@@ -868,6 +876,7 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     auto lastConn = std::make_shared<std::string>();
     app->udpAdapter()->on_tick_client([wreg, wdm, wapp, rebind, wbs,
                                        reboot_after, bootPhase, bootDeadline,
+                                       bootRetryAfter, bootBackoff, bsHost, bsPort,
                                        dtls, &ds, lastConn]() {
         auto reg = wreg.lock();
         auto dm  = wdm.lock();
@@ -876,6 +885,12 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
 
         const auto svc = ::UDPAdapter::ServiceType_t::LwM2MClient;
         const auto now = std::chrono::steady_clock::now();
+
+        // Pump tinydtls' handshake retransmission so an unanswered flight
+        // (e.g. the bootstrap ClientHello) is retried instead of wedging the
+        // connection. Without this, a single dropped packet stalls bootstrap
+        // forever.
+        if (dtls) dtls->check_retransmit();
 
         // Publish the connection lifecycle for the device-ui (only on change).
         {
@@ -930,24 +945,44 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
             if (*bootPhase == BootPhase::NotStarted) {
                 if (!bs) {
                     *bootPhase = BootPhase::Skipped;        // plain-DM / no BS
-                } else if (dtlsReady) {
-                    ACE_DEBUG((LM_INFO,
-                               ACE_TEXT("%D lwm2m:thread:%t %M %N:%l initiating "
-                                        "bootstrap: POST /bs\n")));
-                    auto payload = bs->build_bs_request(
-                        next_msgid(), std::string{static_cast<char>(0x40)});
-                    tx_via(*a, payload, svc);
-                    *bootPhase    = BootPhase::InProgress;
-                    *bootDeadline = now + std::chrono::seconds(15);
+                } else if (now >= *bootRetryAfter) {
+                    if (dtlsReady) {
+                        ACE_DEBUG((LM_INFO,
+                                   ACE_TEXT("%D lwm2m:thread:%t %M %N:%l initiating "
+                                            "bootstrap: POST /bs\n")));
+                        auto payload = bs->build_bs_request(
+                            next_msgid(), std::string{static_cast<char>(0x40)});
+                        tx_via(*a, payload, svc);
+                        *bootPhase    = BootPhase::InProgress;
+                        *bootDeadline = now + std::chrono::seconds(15);
+                    } else if (dtls) {
+                        // BS DTLS isn't up yet. check_retransmit() (above) retries
+                        // in-flight handshake flights; re-kick connect() too in
+                        // case the peer was dropped after max retransmits, on a
+                        // growing backoff. Retry forever — a gateway must
+                        // eventually reach the cloud.
+                        dtls->connect(bsHost, bsPort);
+                        *bootRetryAfter = now + std::chrono::seconds(*bootBackoff);
+                        ACE_DEBUG((LM_INFO,
+                                   ACE_TEXT("%D lwm2m:thread:%t %M %N:%l BS DTLS not "
+                                            "up — re-kicking handshake, next retry "
+                                            "in %d s\n"), *bootBackoff));
+                        *bootBackoff = (*bootBackoff * 2 > 30) ? 30 : (*bootBackoff * 2);
+                    }
                 }
-                // else: wait for the BS handshake, retry next tick.
+                // else: within the backoff window; retry on a later tick.
             } else if (*bootPhase == BootPhase::InProgress &&
                        now >= *bootDeadline) {
+                // /bs didn't complete in time. Loop back and retry the whole
+                // bootstrap on a growing backoff instead of giving up — never
+                // wedge at "bootstrapping".
+                *bootRetryAfter = now + std::chrono::seconds(*bootBackoff);
                 ACE_ERROR((LM_WARNING,
-                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l bootstrap did "
-                                    "not complete in time — registering "
-                                    "directly\n")));
-                *bootPhase = BootPhase::Skipped;
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l bootstrap did not "
+                                    "complete in time — retrying in %d s\n"),
+                           *bootBackoff));
+                *bootBackoff = (*bootBackoff * 2 > 30) ? 30 : (*bootBackoff * 2);
+                *bootPhase = BootPhase::NotStarted;
             }
 
             // Register when ready: bootstrap committed + the DM DTLS session


### PR DESCRIPTION
## Problem
The client could wedge **permanently at `bootstrapping`**. Two causes:
1. **Nothing pumped tinydtls' retransmission timer** — an unanswered handshake flight (the bootstrap ClientHello) was never resent, so a single dropped packet / briefly-down BS stalled the handshake forever.
2. The bootstrap driver was **one-shot** — on the 15 s `/bs` timeout it gave up to a direct DM register, and if DTLS never came up it waited forever with no retry.

(Observed live: client sent one ClientHello, then 17 min of silence; `iot.conn.state` stuck at `bootstrapping`.)

## Fix
- `DTLSAdapter::check_retransmit()` → `dtls_check_retransmit()`, driven every tick (1 Hz). In-flight handshake flights are now retried.
- Bootstrap driver (`main.cpp` client tick) **retries forever with capped backoff** (`2→4→8→16→30 s`):
  - `NotStarted` + DTLS not up → re-kick `connect(bsHost,bsPort)` on backoff (covers a peer dropped after max retransmits).
  - `InProgress` + 15 s timeout → loop back to `NotStarted` + resend `POST /bs`, instead of giving up.
  - New `bootRetryAfter` / `bootBackoff` state.
- **Behavior change:** a bootstrap timeout no longer falls back to a direct DM register; only a BS-less config takes the `Skipped` path (per design, a gateway must eventually reach the cloud).
- Documented in `apps/docs/lwm2m-design.md` §5.1.1 (state table + backoff).

## Verification
- Device image **builds clean** in podman (the build caught a real `std::min` vs `min(...)` macro collision from the ACE/tinydtls headers, fixed with a ternary).
- Runtime e2e against the live cloud is the maintainer's next step (can't self-verify here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)