### PR TITLE
fix: stop ACE reactor busy-spin across all daemons (+ openvpn backoff)

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -362,7 +362,16 @@ int main(int argc, char** argv) {
             ovpn_retry_after = {};
             state = "disabled";
         } else if (ovpn.running()) {
-            ovpn_fails = 0;                 // stable run — clear backoff
+            // Clear the backoff only after a SUSTAINED run (>=60s). A process
+            // that survives a few ticks but keeps dying inside the 30s "quick"
+            // window is a crash loop, not stable — resetting every running tick
+            // (the previous behaviour) pinned ovpn_fails at 1 so the backoff
+            // never escalated ("failure #1 … retry in 2s" forever).
+            if (ovpn_last_start.time_since_epoch().count() != 0 &&
+                (std::chrono::steady_clock::now() - ovpn_last_start)
+                    >= std::chrono::seconds(60)) {
+                ovpn_fails = 0;
+            }
             state = "running";
         } else {
             const auto now = std::chrono::steady_clock::now();

--- a/apps/src/udp_adapter.cpp
+++ b/apps/src/udp_adapter.cpp
@@ -397,8 +397,13 @@ int UDPAdapter::svc() {
     // reach log.lwm2m.text. Attach the (main-thread-registered) callback.
     data_store::LogBuffer::attach_current_thread();
 
-    ACE_Time_Value to(1, 0);
     while (!m_stop.load()) {
+        // Reset the timeout every iteration: ACE_Reactor::handle_events()
+        // decrements the passed ACE_Time_Value in place (ACE_Countdown_Time),
+        // so a single shared value drains to zero after the first idle wait and
+        // the reactor then busy-spins at ~100% CPU. A fresh 1s budget each loop
+        // keeps it blocking when idle.
+        ACE_Time_Value to(1, 0);
         int ret = ACE_Reactor::instance()->handle_events(to);
         if (ret < 0) {
             ACE_DEBUG((LM_DEBUG,

--- a/modules/data-store/src/server/main.cpp
+++ b/modules/data-store/src/server/main.cpp
@@ -202,8 +202,11 @@ int main(int argc, char** argv) {
 
     // Reactor loop on the main thread. Wakes on SIGINT/TERM via
     // on_signal's end_reactor_event_loop call.
-    ACE_Time_Value tv(1, 0);
     while (!g_stop.load()) {
+        // Reset each iteration: handle_events() decrements the timeout in place
+        // (ACE_Countdown_Time), so a shared value drains to zero after the first
+        // idle wait and the reactor then busy-spins at ~100% CPU.
+        ACE_Time_Value tv(1, 0);
         int rc = ACE_Reactor::instance()->handle_events(tv);
         if (rc < 0) {
             // -1 with errno=EINTR is normal during shutdown.

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -398,10 +398,13 @@ int main(int argc, char** argv) {
                    httpIp.c_str(), httpPort));
     };
 
-    ACE_Time_Value tv(0, 50 * 1000);  // 50ms tick for accept
     int reload_tick = 0;
     constexpr int kReloadEvery = 40;  // 40 * 50ms ≈ 2s
     while (!g_stop.load()) {
+        // Reset each iteration: handle_events() decrements the timeout in place
+        // (ACE_Countdown_Time), so a shared value drains to zero and the reactor
+        // then busy-spins at ~100% CPU.
+        ACE_Time_Value tv(0, 50 * 1000);  // 50ms tick for accept
         // Accept pending connections
         ACE_SOCK_Stream stream;
         ACE_INET_Addr peer;


### PR DESCRIPTION
## Problem
Every ACE reactor loop declared its `handle_events()` timeout (`ACE_Time_Value`) **outside** the `while` loop. `handle_events()` decrements that value in place (`ACE_Countdown_Time`), so after the first idle wait it drains to `0` and the reactor then polls non-blocking — **busy-spinning at ~100% CPU**.

Measured before fix (live):
| Daemon | CPU |
|---|---|
| `ds-server` | 108% |
| `lwm2m-client` | 99% |
| `lwm2m-bs` / `dm` | ~80% |
| `iot-httpd` | 57% |

## Fix
Reset the timeout each iteration in all four reactor loops:
- `apps/src/udp_adapter.cpp` (lwm2m client + bs/dm)
- `modules/data-store/src/server/main.cpp` (ds-server)
- `modules/http-server/src/main.cpp` (iot-httpd)

Plus the cloudd openvpn supervisor backoff: it reset `ovpn_fails=0` on every *running* tick, so a sub-30 s crash loop never escalated ("failure #1 / retry 2 s" forever). Now clears the counter only after a sustained ≥60 s run.

## Verification
Cloud image builds clean (podman, all four binaries). Redeployed locally and re-measured — every daemon drops to **<0.1% CPU**:
```
ds-server 0.07%  lwm2m-bs 0.02%  lwm2m-dm 0.03%  httpd 0.04%  cloudd 2.1% (supervising)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)