### PR TITLE
fix(httpd): redirect-only instance forces http scheme (no cert)

### DIFF
--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -202,6 +202,14 @@ int main(int argc, char** argv) {
     if (!workersStr.empty()) httpWorkers = std::atoi(workersStr.c_str());
     if (httpWorkers < 0) httpWorkers = 0;
 
+    // A redirect-only instance (redirect-https-port set) is by definition a
+    // plain-http :80 listener that 301-redirects to https — it never terminates
+    // TLS itself. Force scheme=http so it doesn't inherit http.listen.scheme=
+    // https from the shared data store (the main https server's setting) and
+    // then crash-loop demanding a cert/key it has no reason to hold.
+    if (!arg_value(argc, argv, "redirect-https-port").empty())
+        httpScheme = "http";
+
     // ── TLS context (shared by every https session) ───────────
     http_server::TlsContext tlsCtx;
     const http_server::TlsContext* tlsPtr = nullptr;


### PR DESCRIPTION
## Problem
`iot-httpd-redirect` runs `iot-httpd … redirect-https-port=443` with **no `http-scheme=`** arg, so it inherited `http.listen.scheme=https` from the **shared data store** (set by the main https server), hit the `https requires http.tls.cert + http.tls.key` check at `main.cpp:210`, and **crash-looped (exit 1)** — the veth churn seen in `dmesg` every ~60 s.

## Fix
A redirect-only instance is by definition a plain-HTTP :80 listener that 301-redirects to https — it never terminates TLS. Force `scheme=http` when `redirect-https-port` is set, before the TLS requirement check.

## Verification
Cloud image builds clean. Runtime check couldn't be done locally — `podman compose` on macOS doesn't start the `https`-profile container (core services come up, profile service doesn't); the change is a straightforward scheme override, so on Linux the redirect container will start as plain http.

🤖 Generated with [Claude Code](https://claude.com/claude-code)