### PR TITLE
chore(run.sh): prune dangling images after build (device + cloud)

### DIFF
--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -78,6 +78,14 @@ RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 log_section() { echo -e "\n${GREEN}=== $1 ===${NC}"; }
 log_info()    { echo -e "${YELLOW} → $1${NC}"; }
 
+# Remove dangling (<none>) images left behind by a rebuild. Works on both
+# docker and podman (same CLI). `|| true` keeps set -e happy when there is
+# nothing to prune.
+prune_dangling() {
+    log_info "Pruning dangling images…"
+    $CR image prune -f >/dev/null 2>&1 || true
+}
+
 detect_runtime() {
     # Prefer docker; fall back to podman only if docker is unavailable.
     if command -v docker &>/dev/null; then echo "docker"
@@ -144,12 +152,14 @@ case "${1:-start}" in
         log_section "Building $IMAGE (${PLATFORM:-host} arch)"
         $CR build -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" \
             "$SCRIPT_DIR/../../"
+        prune_dangling
         log_info "Built locally — start it without re-pulling: PULL=0 ./run.sh"
         ;;
     nocache|build-nocache)
         log_section "Building $IMAGE (no cache, ${PLATFORM:-host} arch)"
         $CR build --no-cache -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" \
             "$SCRIPT_DIR/../../"
+        prune_dangling
         log_info "Built locally — start it without re-pulling: PULL=0 ./run.sh"
         ;;
 

--- a/apps/device/run.sh
+++ b/apps/device/run.sh
@@ -48,6 +48,14 @@ GREEN='\033[0;32m'; YELLOW='\033[1;33m'; NC='\033[0m'
 log_section() { echo -e "\n${GREEN}=== $1 ===${NC}"; }
 log_info()    { echo -e "${YELLOW} → $1${NC}"; }
 
+# Remove dangling (<none>) images left behind by a rebuild. Works on both
+# docker and podman (same CLI). `|| true` keeps set -e happy when there is
+# nothing to prune.
+prune_dangling() {
+    log_info "Pruning dangling images…"
+    $CR image prune -f >/dev/null 2>&1 || true
+}
+
 detect_runtime() {
     if command -v docker &>/dev/null; then echo "docker"
     elif command -v podman &>/dev/null; then echo "podman"
@@ -67,11 +75,13 @@ case "${1:-start}" in
     build)
         log_section "Building $IMAGE"
         $CR build -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR/../../"
+        prune_dangling
         log_info "Built — start it with: ./run.sh"
         ;;
     nocache|build-nocache)
         log_section "Building $IMAGE (no cache)"
         $CR build --no-cache -t "$IMAGE" -f "$SCRIPT_DIR/Dockerfile" "$SCRIPT_DIR/../../"
+        prune_dangling
         log_info "Built — start it with: ./run.sh"
         ;;
 


### PR DESCRIPTION
Each `./run.sh build` retags `:latest` and leaves the previous image as a dangling `<none>` entry; over many rebuilds these accumulate. Adds a `prune_dangling()` helper (`$CR image prune -f` — works for both docker and podman) called after `build`/`nocache` in both device and cloud `run.sh`. `|| true` keeps it `set -e`-safe when nothing to prune.

Verified: `bash -n` clean on both; prune cleared 14 dangling images → 0 locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)