### PR TITLE
feat(ui): add icons to Dark/Debug/Sign out sidebar items

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -9,13 +9,13 @@
     </a>
     <div class="sidebar-spacer"></div>
     <a class="nav-item" (click)="theme.toggle()" title="Toggle theme">
-      <clr-icon [attr.shape]="theme.dark ? 'sun' : 'moon'"></clr-icon><span>{{theme.dark ? 'Light' : 'Dark'}}</span>
+      <img [src]="theme.dark ? 'assets/icons/sun.svg' : 'assets/icons/moon.svg'" class="nav-icon" alt="" /><span>{{theme.dark ? 'Light' : 'Dark'}}</span>
     </a>
     <a class="nav-item" [class.active]="debug.on" (click)="debug.toggle()"
-       title="Show the data-store key + editable raw value under each form field">
-      <clr-icon [attr.shape]="debug.on ? 'eye-hide' : 'eye'"></clr-icon><span>{{debug.on ? 'Debug Off' : 'Debug'}}</span>
+       title="Show the data-store key under each form field">
+      <img src="assets/icons/debug.svg" class="nav-icon" alt="" /><span>{{debug.on ? 'Debug Off' : 'Debug'}}</span>
     </a>
-    <a class="nav-item nav-logout" (click)="onLogout()"><clr-icon shape="logout"></clr-icon><span>Sign out</span></a>
+    <a class="nav-item nav-logout" (click)="onLogout()"><img src="assets/icons/logout.svg" class="nav-icon" alt="" /><span>Sign out</span></a>
   </nav>
   <div class="main-area">
     <div class="live-strip">

--- a/apps/cloud/ui/src/assets/icons/debug.svg
+++ b/apps/cloud/ui/src/assets/icons/debug.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="16 18 22 12 16 6"/>
+  <polyline points="8 6 2 12 8 18"/>
+</svg>

--- a/apps/cloud/ui/src/assets/icons/logout.svg
+++ b/apps/cloud/ui/src/assets/icons/logout.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+  <polyline points="16 17 21 12 16 7"/>
+  <line x1="21" y1="12" x2="9" y2="12"/>
+</svg>

--- a/apps/cloud/ui/src/assets/icons/moon.svg
+++ b/apps/cloud/ui/src/assets/icons/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+</svg>

--- a/apps/cloud/ui/src/assets/icons/sun.svg
+++ b/apps/cloud/ui/src/assets/icons/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="5"/>
+  <line x1="12" y1="1" x2="12" y2="3"/>
+  <line x1="12" y1="21" x2="12" y2="23"/>
+  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+  <line x1="1" y1="12" x2="3" y2="12"/>
+  <line x1="21" y1="12" x2="23" y2="12"/>
+  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+</svg>

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -36,18 +36,18 @@
     <div class="sidebar-spacer"></div>
 
     <a class="nav-item" (click)="theme.toggle()" title="Toggle theme">
-      <clr-icon [attr.shape]="theme.dark ? 'sun' : 'moon'"></clr-icon>
+      <img [src]="theme.dark ? 'assets/icons/sun.svg' : 'assets/icons/moon.svg'" class="nav-icon" alt="" />
       <span>{{ theme.dark ? 'Light' : 'Dark' }}</span>
     </a>
 
     <a class="nav-item" [class.active]="debug.on" (click)="debug.toggle()"
-       title="Show the data-store key + editable raw value under each form field">
-      <clr-icon [attr.shape]="debug.on ? 'eye-hide' : 'eye'"></clr-icon>
+       title="Show the data-store key under each form field">
+      <img src="assets/icons/debug.svg" class="nav-icon" alt="" />
       <span>{{ debug.on ? 'Debug Off' : 'Debug' }}</span>
     </a>
 
     <a class="nav-item nav-logout" (click)="onLogout()">
-      <clr-icon shape="logout"></clr-icon>
+      <img src="assets/icons/logout.svg" class="nav-icon" alt="" />
       <span>Sign out</span>
     </a>
   </nav>

--- a/iot-ui/src/assets/icons/debug.svg
+++ b/iot-ui/src/assets/icons/debug.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="16 18 22 12 16 6"/>
+  <polyline points="8 6 2 12 8 18"/>
+</svg>

--- a/iot-ui/src/assets/icons/logout.svg
+++ b/iot-ui/src/assets/icons/logout.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M9 21H5a2 2 0 0 1-2-2V5a2 2 0 0 1 2-2h4"/>
+  <polyline points="16 17 21 12 16 7"/>
+  <line x1="21" y1="12" x2="9" y2="12"/>
+</svg>

--- a/iot-ui/src/assets/icons/moon.svg
+++ b/iot-ui/src/assets/icons/moon.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/>
+</svg>

--- a/iot-ui/src/assets/icons/sun.svg
+++ b/iot-ui/src/assets/icons/sun.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <circle cx="12" cy="12" r="5"/>
+  <line x1="12" y1="1" x2="12" y2="3"/>
+  <line x1="12" y1="21" x2="12" y2="23"/>
+  <line x1="4.22" y1="4.22" x2="5.64" y2="5.64"/>
+  <line x1="18.36" y1="18.36" x2="19.78" y2="19.78"/>
+  <line x1="1" y1="12" x2="3" y2="12"/>
+  <line x1="21" y1="12" x2="23" y2="12"/>
+  <line x1="4.22" y1="19.78" x2="5.64" y2="18.36"/>
+  <line x1="18.36" y1="5.64" x2="19.78" y2="4.22"/>
+</svg>


### PR DESCRIPTION
The bottom sidebar items (Dark/Light, Debug, Sign out) showed **no icon**: they used `<clr-icon>`, but Clarity's icon set is never imported, so `clr-icon` renders nothing — only the menu items (which use `<img>` SVGs from `assets/icons/`) had icons.

Adds Feather-style SVGs (`moon`, `sun`, `debug`, `logout`) to **both** UIs' `assets/icons/` and switches the three bottom items to the same `<img class="nav-icon">` pattern as the menu (so they pick up the existing hover/active styling):
- Theme toggle → moon/sun by state
- Debug → `</>` code glyph
- Sign out → logout arrow

Also corrected the stale Debug tooltip (no longer mentions the removed value box).

Both device-ui and cloud-ui build clean (Angular 14, podman).

🤖 Generated with [Claude Code](https://claude.com/claude-code)