### PR TITLE
feat(ui): render all clr-icons + redesign dashboard status cards

### DIFF
--- a/apps/cloud/ui/src/app/dashboard/dashboard.component.ts
+++ b/apps/cloud/ui/src/app/dashboard/dashboard.component.ts
@@ -36,7 +36,8 @@ interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered
       <p *ngIf="!endpoints.length" style="color:#888;">No devices provisioned yet.</p>
     </div>
   `,
-  styles: [`.page{padding:24px;} h3,h4{color:#333;margin:0 0 16px 0;} h4{font-size:14px;margin-top:20px;}`]
+  styles: [`.page{padding:24px;} h3,h4{color:#333;margin:0 0 16px 0;} h4{font-size:14px;margin-top:20px;}
+    .clr-row > [class*="clr-col"]{margin-bottom:1rem;}`]
 })
 export class DashboardComponent implements OnInit {
   endpoints: EpInfo[] = [];

--- a/apps/cloud/ui/src/main.ts
+++ b/apps/cloud/ui/src/main.ts
@@ -3,6 +3,12 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
+// Register the legacy <clr-icon> custom element + all icon shapes. Clarity's
+// icon CSS is loaded via angular.json, but the icon JS must be imported
+// explicitly — without it every <clr-icon> renders blank.
+import '@clr/icons';
+import '@clr/icons/shapes/all-shapes';
+
 if (environment.production) {
   enableProdMode();
 }

--- a/apps/cloud/ui/src/styles.scss
+++ b/apps/cloud/ui/src/styles.scss
@@ -205,16 +205,26 @@ $iot-grey:   #9e9e9e;
 
 // Dashboard cards
 .status-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  padding: 1.5rem;
+  padding: 1.75rem 1rem;
+  border-top: 3px solid $iot-grey;
+  transition: box-shadow .15s ease;
 
-  .card-label { font-size: 13px; opacity: 0.7; margin-top: 8px; }
-  .card-value { font-size: 20px; font-weight: 600; }
+  &:hover { box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08); }
 
-  &.connected   { border-top: 3px solid $iot-green; }
-  &.disconnected { border-top: 3px solid $iot-red; }
-  &.starting    { border-top: 3px solid $iot-yellow; }
-  &.disabled    { border-top: 3px solid $iot-grey; }
+  clr-icon { margin-bottom: 14px; color: $iot-grey; }
+  .card-value { font-size: 22px; font-weight: 600; line-height: 1.3; }
+  .card-label { font-size: 13px; opacity: 0.7; margin-top: 6px; }
+
+  &.connected    { border-top-color: $iot-green;  clr-icon { color: $iot-green; } }
+  &.disconnected { border-top-color: $iot-red;    clr-icon { color: $iot-red; } }
+  &.starting     { border-top-color: $iot-yellow; clr-icon { color: #c77a00; } }
+  &.disabled     { border-top-color: $iot-grey;   clr-icon { color: $iot-grey; } }
 }
 
 .signal-bars {

--- a/iot-ui/src/main.ts
+++ b/iot-ui/src/main.ts
@@ -3,6 +3,12 @@ import { platformBrowserDynamic } from '@angular/platform-browser-dynamic';
 import { AppModule } from './app/app.module';
 import { environment } from './environments/environment';
 
+// Register the legacy <clr-icon> custom element + all icon shapes. Clarity's
+// icon CSS is loaded via angular.json, but the icon JS must be imported
+// explicitly — without it every <clr-icon> renders blank.
+import '@clr/icons';
+import '@clr/icons/shapes/all-shapes';
+
 if (environment.production) {
   enableProdMode();
 }

--- a/iot-ui/src/styles.scss
+++ b/iot-ui/src/styles.scss
@@ -176,19 +176,33 @@ $iot-grey:   #9e9e9e;
   }
 }
 
-// Dashboard cards
+// Dashboard cards — equal height (fill the flex column), centred content,
+// state-coloured icon + top accent.
 .status-card {
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
   text-align: center;
-  padding: 1.5rem;
+  padding: 1.75rem 1rem;
+  border-top: 3px solid $iot-grey;
+  transition: box-shadow .15s ease;
 
-  .card-label { font-size: 13px; opacity: 0.7; margin-top: 8px; }
-  .card-value { font-size: 20px; font-weight: 600; }
+  &:hover { box-shadow: 0 4px 14px rgba(0, 0, 0, 0.08); }
 
-  &.connected   { border-top: 3px solid $iot-green; }
-  &.disconnected { border-top: 3px solid $iot-red; }
-  &.starting    { border-top: 3px solid $iot-yellow; }
-  &.disabled    { border-top: 3px solid $iot-grey; }
+  clr-icon { margin-bottom: 14px; color: $iot-grey; }
+  .card-value { font-size: 19px; font-weight: 600; line-height: 1.3; }
+  .card-label { font-size: 13px; opacity: 0.7; margin-top: 6px; }
+
+  &.connected    { border-top-color: $iot-green;  clr-icon { color: $iot-green; } }
+  &.disconnected { border-top-color: $iot-red;    clr-icon { color: $iot-red; } }
+  &.starting     { border-top-color: $iot-yellow; clr-icon { color: #c77a00; } }
+  &.disabled     { border-top-color: $iot-grey;   clr-icon { color: $iot-grey; } }
 }
+
+// Even vertical spacing when the card row wraps (md/sm breakpoints).
+.dashboard .clr-row > [class*="clr-col"] { margin-bottom: 1rem; }
 
 .signal-bars {
   display: inline-flex;


### PR DESCRIPTION
## clr-icons
`clr-icon` rendered nothing **anywhere** — expand chevron, live-strip (world/cog/sync), toast (check/info/exclamation), login (lock/user), submenus, endpoint-list, and the dashboard card icons. Clarity's icon **CSS** is loaded via `angular.json`, but the **JS** that registers the `<clr-icon>` element + shapes was never imported. Added `import '@clr/icons'` + `all-shapes` to both `main.ts` — fixes every `clr-icon` at once (no per-file sweep needed).

## Dashboard cards
Redesigned `.status-card` (both UIs): equal height (fills the flex column), vertically-centred content, icon coloured by state to match the top accent (green / red / amber / grey), subtle hover shadow, and even spacing when the row wraps. The device **Connection Status** cards and cloud **Online/Offline/Total** cards now look uniform and professional (no more ragged heights).

## Verification
Both device-ui and cloud-ui build clean (Angular 14, podman) — `@clr/icons` import compiles, no bundle-budget warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)