### PR TITLE
feat(ui): icons for VPN/WiFi status badges in the live-strip

### DIFF
--- a/apps/cloud/ui/src/app/common/status-badge/status-badge.component.ts
+++ b/apps/cloud/ui/src/app/common/status-badge/status-badge.component.ts
@@ -6,7 +6,8 @@ import { Component, Input } from '@angular/core';
   selector: 'app-status-badge',
   template: `
     <span class="status-badge" [ngClass]="stateClass">
-      <span class="status-dot"></span>
+      <clr-icon *ngIf="icon" [attr.shape]="icon" class="status-ico"></clr-icon>
+      <span class="status-dot" *ngIf="!icon"></span>
       {{ label }}
     </span>
   `,
@@ -25,6 +26,7 @@ import { Component, Input } from '@angular/core';
       border-radius: 50%;
       display: inline-block;
     }
+    .status-ico { width: 14px; height: 14px; }
     .connected, .running {
       background: rgba(46,125,50,0.15); color: #2e7d32;
     }
@@ -46,6 +48,7 @@ import { Component, Input } from '@angular/core';
 export class StatusBadgeComponent {
   @Input() label = '';
   @Input() state = '';
+  @Input() icon = '';
 
   get stateClass(): string {
     const s = this.state.toLowerCase();

--- a/iot-ui/src/app/common/status-badge/status-badge.component.ts
+++ b/iot-ui/src/app/common/status-badge/status-badge.component.ts
@@ -6,7 +6,8 @@ import { Component, Input } from '@angular/core';
   selector: 'app-status-badge',
   template: `
     <span class="status-badge" [ngClass]="stateClass">
-      <span class="status-dot"></span>
+      <clr-icon *ngIf="icon" [attr.shape]="icon" class="status-ico"></clr-icon>
+      <span class="status-dot" *ngIf="!icon"></span>
       {{ label }}
     </span>
   `,
@@ -25,6 +26,7 @@ import { Component, Input } from '@angular/core';
       border-radius: 50%;
       display: inline-block;
     }
+    .status-ico { width: 14px; height: 14px; }
     .connected, .running {
       background: rgba(46,125,50,0.15); color: #2e7d32;
     }
@@ -46,6 +48,7 @@ import { Component, Input } from '@angular/core';
 export class StatusBadgeComponent {
   @Input() label = '';
   @Input() state = '';
+  @Input() icon = '';
 
   get stateClass(): string {
     const s = this.state.toLowerCase();

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -62,8 +62,8 @@
       </div>
       <span class="live-date">{{ today }}</span>
 
-      <app-status-badge [label]="'VPN ' + vpnState" [state]="vpnState"></app-status-badge>
-      <app-status-badge [label]="'WiFi ' + wifiState" [state]="wifiState"></app-status-badge>
+      <app-status-badge icon="shield" [label]="'VPN ' + vpnState" [state]="vpnState"></app-status-badge>
+      <app-status-badge icon="wifi" [label]="'WiFi ' + wifiState" [state]="wifiState"></app-status-badge>
       <span class="live-stat"><clr-icon shape="world"></clr-icon> {{ wanIface }}</span>
       <span class="live-stat"><clr-icon shape="cog"></clr-icon> {{ serviceCount }} services</span>
       <span class="access-badge" [class.viewer]="!isAdmin">{{ isAdmin ? 'Admin' : 'Viewer' }}</span>


### PR DESCRIPTION
The live-strip VPN/WiFi indicators are `app-status-badge` pills (dot + label) and had no icon, unlike eth0 (world) / services (cog).

Adds an optional `icon` input to the reusable `status-badge`: when set it renders a `clr-icon` in the pill's state colour instead of the dot (backward-compatible — no icon = existing dot). Wires the device live-strip **VPN → shield** and **WiFi → wifi**; mirrors the component change into the cloud copy for parity.

Both UIs build clean (Angular 14, podman).

🤖 Generated with [Claude Code](https://claude.com/claude-code)