### PR TITLE
feat(cloud-ui): debug hints on Provision, Users, Software forms

### DIFF
--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -25,11 +25,13 @@ interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered
               <label>Serial Number</label>
               <input clrInput [(ngModel)]="provSerial" style="width:100%;"
                      placeholder="device serial (from device-ui)" />
+              <clr-control-helper *dsDebug><app-ds-hint key="cloud.provision.request"></app-ds-hint></clr-control-helper>
             </clr-input-container>
             <clr-input-container>
               <label>Bootstrap PSK (32 hex)</label>
               <input clrInput [(ngModel)]="provBsPsk" style="width:100%;font-family:monospace;"
                      placeholder="paste BS PSK from device-ui" />
+              <clr-control-helper *dsDebug><app-ds-hint key="cloud.provision.bs.psk"></app-ds-hint></clr-control-helper>
             </clr-input-container>
             <div></div>
             <div></div>

--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -23,6 +23,7 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
               <option value="">— select firmware —</option>
               <option *ngFor="let p of manifest" [value]="p.ipk_url">{{ p.pkg }} {{ p.version }} ({{ p.arch }})</option>
             </select>
+            <clr-control-helper *dsDebug><app-ds-hint key="cloud.firmware.manifest → cloud.update.request"></app-ds-hint></clr-control-helper>
           </clr-select-container>
           <div class="btn-cell">
             <button class="btn btn-primary" (click)="pushUpdate()"

--- a/apps/cloud/ui/src/app/users/users.component.ts
+++ b/apps/cloud/ui/src/app/users/users.component.ts
@@ -16,16 +16,19 @@ import { UserAccount } from '../../common/app-globals';
           <clr-input-container>
             <label>User ID</label>
             <input clrInput [(ngModel)]="newId" placeholder="alice" />
+            <clr-control-helper *dsDebug><app-ds-hint key="auth.users.accounts (via /api/v1/users)"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-password-container>
             <label>Password</label>
             <input clrPassword type="password" [(ngModel)]="newPassword" placeholder="••••••••" />
+            <clr-control-helper *dsDebug><app-ds-hint key="auth.users.accounts (SHA-256, write-only)"></app-ds-hint></clr-control-helper>
           </clr-password-container>
           <clr-select-container>
             <label>Access</label>
             <select clrSelect [(ngModel)]="newAccess">
               <option *ngFor="let a of accessLevels" [value]="a">{{ a }}</option>
             </select>
+            <clr-control-helper *dsDebug><app-ds-hint key="auth.users.accounts"></app-ds-hint></clr-control-helper>
           </clr-select-container>
           <div class="btn-cell">
             <button class="btn btn-primary" (click)="create()" [disabled]="saving">


### PR DESCRIPTION
Adds the Debug-mode ds-key hints (`*dsDebug` + `app-ds-hint`) to the cloud forms that were missing them:
- **Provision** (Endpoints): Serial → `cloud.provision.request`, Bootstrap PSK → `cloud.provision.bs.psk`
- **Users**: id / password / access → `auth.users.accounts` (REST-backed via `/api/v1/users`; password SHA-256, write-only)
- **Software**: Package → `cloud.firmware.manifest → cloud.update.request`

cloud-ui builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)