### PR TITLE
feat(cloud-ui): icons on Routing & WAN submenu tabs

### DIFF
--- a/apps/cloud/ui/src/app/routing/routing-submenu/routing-submenu.component.ts
+++ b/apps/cloud/ui/src/app/routing/routing-submenu/routing-submenu.component.ts
@@ -5,11 +5,20 @@ import { Component, Output, EventEmitter } from '@angular/core';
   template: `
     <div class="subnav-bar">
       <a class="subnav-tab" [class.active]="active === 'ports'"
-         (click)="select('ports')">Port Forward</a>
+         (click)="select('ports')">
+        <clr-icon shape="forward"></clr-icon>
+        <span>Port Forward</span>
+      </a>
       <a class="subnav-tab" [class.active]="active === 'dnat'"
-         (click)="select('dnat')">DNAT Target</a>
+         (click)="select('dnat')">
+        <clr-icon shape="target"></clr-icon>
+        <span>DNAT Target</span>
+      </a>
       <a class="subnav-tab" [class.active]="active === 'rules'"
-         (click)="select('rules')">Firewall Rules</a>
+         (click)="select('rules')">
+        <clr-icon shape="firewall"></clr-icon>
+        <span>Firewall Rules</span>
+      </a>
     </div>
   `,
   // styles provided by global .subnav-bar / .subnav-tab in styles.scss

--- a/apps/cloud/ui/src/app/wan/wan-submenu/wan-submenu.component.ts
+++ b/apps/cloud/ui/src/app/wan/wan-submenu/wan-submenu.component.ts
@@ -5,11 +5,20 @@ import { Component, Output, EventEmitter } from '@angular/core';
   template: `
     <div class="subnav-bar">
       <a class="subnav-tab" [class.active]="active === 'wifi'"
-         (click)="select('wifi')">WiFi</a>
+         (click)="select('wifi')">
+        <clr-icon shape="wifi"></clr-icon>
+        <span>WiFi</span>
+      </a>
       <a class="subnav-tab" [class.active]="active === 'scan'"
-         (click)="select('scan')">Scan Results</a>
+         (click)="select('scan')">
+        <clr-icon shape="search"></clr-icon>
+        <span>Scan Results</span>
+      </a>
       <a class="subnav-tab" [class.active]="active === 'priority'"
-         (click)="select('priority')">Priority</a>
+         (click)="select('priority')">
+        <clr-icon shape="bars"></clr-icon>
+        <span>Priority</span>
+      </a>
     </div>
   `,
   // styles provided by global .subnav-bar / .subnav-tab in styles.scss


### PR DESCRIPTION
The Routing (Port Forward / DNAT Target / Firewall Rules) and WAN (WiFi / Scan Results / Priority) submenu tabs were **text-only**, unlike the LwM2M submenu which has `clr-icon`s. Added matching icons:
- Routing → `forward` / `target` / `firewall`
- WAN → `wifi` / `search` / `bars`

All shapes verified present in the loaded `@clr/icons` all-shapes set. cloud-ui builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)