### PR TITLE
perf(yocto): upstream sstate mirror for faster cold builds

### DIFF
--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -117,6 +117,14 @@ INHERIT += "own-mirrors"
 DLCONF
 fi
 
+# ── Upstream shared-state mirror (network) ─────────────────────────
+# Pull prebuilt sstate for stock recipes (kernel, base distro, toolchain)
+# on a cold build instead of compiling them. Appended (+=) so any baked
+# local mirror above is tried first; bitbake builds anything the mirror
+# lacks. Best-effort — coverage varies by release (scarthgap)/MACHINE.
+echo 'SSTATE_MIRRORS += "file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"' \
+    >> conf/local.conf
+
 # ── 5. Run bitbake ─────────────────────────────────────────────────
 echo ""
 echo "→ Starting bitbake for $MACHINE: $@ ..."

--- a/yocto/kas-iot.yml
+++ b/yocto/kas-iot.yml
@@ -76,6 +76,13 @@ local_conf_header:
     # Serial console on the GPIO header (no-op on qemu machines).
     ENABLE_UART = "1"
 
+    # Upstream shared-state mirror — download prebuilt sstate for stock
+    # recipes (kernel, base distro, toolchain, ...) instead of compiling them
+    # on a cold build. Best-effort: bitbake builds anything the mirror lacks,
+    # and a local sstate-cache still takes precedence. Coverage varies by
+    # release (scarthgap) / MACHINE.
+    SSTATE_MIRRORS ?= "file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"
+
 bblayers_conf_header:
   meta-iot: |
     BBLAYERS += "${TOPDIR}/../meta-iot"


### PR DESCRIPTION
Adds the Yocto shared-state mirror (`http://sstate.yoctoproject.org/all`) so a cold build **downloads prebuilt sstate** for stock recipes (kernel, base distro, toolchain) instead of compiling them. Best-effort — bitbake builds anything the mirror lacks, and a local/baked `sstate-cache` still wins.

- `kas-iot.yml`: `SSTATE_MIRRORS` in `local_conf_header` (kas path)
- `entrypoint.sh`: appended (`+=`) after the baked-mirror block so `build.sh`'s container path benefits too (the two paths are kept in sync)

Note: doesn't affect an in-flight build (entrypoint is baked into the builder image); applies on the next build that rebuilds the builder image.

🤖 Generated with [Claude Code](https://claude.com/claude-code)