### PR TITLE
fix(cloud-ui): surface real per-endpoint creds, drop dead config fields

### DIFF
--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -1,9 +1,21 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 
 interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered:boolean; }
+
+/** Per-endpoint credential record, as minted by iot-cloudd into the
+ *  cloud.endpoint.credentials ds key (JSON array). Field names follow the
+ *  dotted convention used server-side (see cloud_credentials.cpp). */
+interface EpCred {
+  serial?: string;
+  identity?: string;
+  'bs.psk.key'?: string;
+  'dm.psk.id'?: string;
+  'dm.psk.key'?: string;
+}
 
 @Component({
   selector: 'app-endpoint-list',
@@ -75,6 +87,28 @@ interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered
           </clr-dg-cell>
         </clr-dg-row>
 
+        <!-- Read-only per-endpoint credentials minted into
+             cloud.endpoint.credentials by the provisioning flow. PSK secrets
+             are admin-gated; non-admins see a placeholder. -->
+        <clr-dg-detail *clrIfDetail="let e">
+          <clr-dg-detail-header>Provisioned Credentials — {{e.endpoint}}</clr-dg-detail-header>
+          <clr-dg-detail-body>
+            <ng-container *ngIf="credFor(e) as c; else noCred">
+              <dl class="cred-list">
+                <dt>Serial</dt><dd><code>{{ c.serial || '—' }}</code></dd>
+                <dt>DM PSK Identity</dt><dd><code>{{ c.identity || c['dm.psk.id'] || '—' }}</code></dd>
+                <dt>BS PSK Key</dt><dd><code>{{ secret(c['bs.psk.key']) }}</code></dd>
+                <dt>DM PSK Identity (key id)</dt><dd><code>{{ c['dm.psk.id'] || '—' }}</code></dd>
+                <dt>DM PSK Key</dt><dd><code>{{ secret(c['dm.psk.key']) }}</code></dd>
+              </dl>
+              <p *ngIf="!isAdmin" class="hint">Sign in as an admin to reveal PSK secrets.</p>
+            </ng-container>
+            <ng-template #noCred>
+              <p class="hint">No provisioned credentials found for this endpoint.</p>
+            </ng-template>
+          </clr-dg-detail-body>
+        </clr-dg-detail>
+
         <clr-dg-footer>{{endpoints.length}} endpoint{{endpoints.length===1?'':'s'}}</clr-dg-footer>
       </clr-datagrid>
 
@@ -87,24 +121,51 @@ interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered
     .page{padding:24px;} h3{color:#333;margin:0;font-size:16px;font-weight:600;}
     .header-row{display:flex;align-items:center;justify-content:space-between;margin:0 0 16px 0;}
     .hint{font-size:12px;color:#888;}
+    .cred-list{display:grid;grid-template-columns:auto 1fr;gap:6px 16px;margin:0;}
+    .cred-list dt{color:#666;font-weight:600;}
+    .cred-list dd{margin:0;word-break:break-all;}
   `]
 })
 export class EndpointListComponent implements OnInit, OnDestroy {
   endpoints: EpInfo[] = [];
+  creds: EpCred[] = [];
   windowHost = window.location.hostname;
-  isAdmin = true; // TODO: from SessionService
   // PSK provisioning (task O).
   provSerial = ''; provBsPsk = ''; provisioning = false; devMode = false;
   private sub = new Subscription(); private active = true;
 
-  constructor(private http: HttpsvcService, private toast: ToastService) {}
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpsvcService, private session: SessionService, private toast: ToastService) {}
 
   ngOnInit(): void {
     this.startLongPoll();
-    this.http.dbGet(['cloud.dev.mode']).subscribe({
-      next: (r) => { if (r.ok && r.data) this.devMode = (r.data as Record<string, unknown>)['cloud.dev.mode'] === true; },
+    this.http.dbGet(['cloud.dev.mode', 'cloud.endpoint.credentials']).subscribe({
+      next: (r) => {
+        if (r.ok && r.data) {
+          const d = r.data as Record<string, unknown>;
+          this.devMode = d['cloud.dev.mode'] === true;
+          try {
+            const arr = JSON.parse(String(d['cloud.endpoint.credentials'] || '[]'));
+            this.creds = Array.isArray(arr) ? arr : [];
+          } catch { this.creds = []; }
+        }
+      },
       error: () => {}
     });
+  }
+
+  /** Join an endpoint to its credential record on serial, falling back to the
+   *  formatted DM PSK identity. */
+  credFor(e: EpInfo): EpCred | undefined {
+    return this.creds.find(c => c.serial === e.endpoint)
+        || this.creds.find(c => c.identity === e.endpoint);
+  }
+
+  /** Render a PSK secret only to admins; mask it otherwise. */
+  secret(v?: string): string {
+    if (!v) return '—';
+    return this.isAdmin ? v : '•••••• (admin only)';
   }
 
   /**

--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
@@ -8,42 +8,11 @@
   <form [formGroup]="bsForm" (ngSubmit)="saveBs()" *ngIf="!loading">
     <div class="form-grid">
       <clr-input-container>
-        <label>Endpoint <span class="hint">(BS server identity)</span></label>
-        <input clrInput [disabled]="!isAdmin" formControlName="endpoint"
-               placeholder="urn:dev:gateway-" />
-        <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.endpoint"></app-ds-hint></clr-control-helper>
-      </clr-input-container>
-
-      <clr-input-container>
         <label>BS URI <span class="hint">(Bootstrap endpoint)</span></label>
         <input clrInput [disabled]="!isAdmin" formControlName="bs_uri"
                placeholder="coaps://0.0.0.0:5684" />
         <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.uri"></app-ds-hint></clr-control-helper>
       </clr-input-container>
-
-      <clr-select-container>
-        <label>Security Mode</label>
-        <select clrSelect [disabled]="!isAdmin" formControlName="security_mode">
-          <option value="PSK">PSK — Pre-Shared Key</option>
-          <option value="None">None — No DTLS (dev only)</option>
-        </select>
-        <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.security.mode"></app-ds-hint></clr-control-helper>
-      </clr-select-container>
-
-      <ng-container *ngIf="bsForm.value.security_mode === 'PSK'">
-        <clr-input-container>
-          <label>PSK Identity (RID 3)</label>
-          <input clrInput [disabled]="!isAdmin" formControlName="psk_id"
-                 placeholder="iot-client" />
-          <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.psk.id"></app-ds-hint></clr-control-helper>
-        </clr-input-container>
-        <clr-input-container>
-          <label>PSK Key — RID 5 <span class="hint">(hex secret)</span></label>
-          <input clrInput [disabled]="!isAdmin" formControlName="psk_key"
-                 placeholder="0102030405060708090a0b0c0d0e0f10" />
-          <clr-control-helper *dsDebug><app-ds-hint key="cloud.bs.psk.key"></app-ds-hint></clr-control-helper>
-        </clr-input-container>
-      </ng-container>
 
       <clr-input-container>
         <label>DM URI — RID 0 <span class="hint">(pushed to device)</span></label>
@@ -51,7 +20,16 @@
                placeholder="coaps://cloud:5683" />
         <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.uri"></app-ds-hint></clr-control-helper>
       </clr-input-container>
+
+      <div></div>
+      <div></div>
     </div>
+
+    <p class="hint" style="margin-top:12px;">
+      Per-device bootstrap credentials (PSK identity and key) are minted
+      per-endpoint during provisioning and shown read-only on the
+      <strong>Endpoints</strong> page — they are not configured here.
+    </p>
 
     <div style="margin-top:20px;" *ngIf="isAdmin">
       <button type="submit" class="btn btn-primary" [disabled]="savingBs">

--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
@@ -28,30 +28,25 @@ export class BsConfigComponent implements OnInit {
     private session: SessionService,
     private toast: ToastService
   ) {
+    // Only the keys the bootstrap server actually consumes at /bs:
+    // cloud.bs.uri (Security/0 RID0) and cloud.dm.uri (Security/1 RID0).
+    // Per-device PSK identity/key are minted per-endpoint into
+    // cloud.endpoint.credentials — see the Endpoints page.
     this.bsForm = fb.group({
-      endpoint:      ['urn:dev:gateway-'],
       bs_uri:        ['coaps://0.0.0.0:5684'],
-      security_mode: ['PSK'],
-      psk_id:        ['iot-client'],
-      psk_key:       [''],
       dm_uri:        ['coaps://0.0.0.0:5683'],
     });
   }
 
   ngOnInit(): void {
     this.http.dbGet([
-      'cloud.bs.endpoint', 'cloud.bs.uri', 'cloud.bs.security.mode',
-      'cloud.bs.psk.id', 'cloud.bs.psk.key', 'cloud.dm.uri'
+      'cloud.bs.uri', 'cloud.dm.uri'
     ]).subscribe({
       next: (r) => {
         if (r.ok && r.data) {
           const d = r.data as Record<string, unknown>;
           this.bsForm.patchValue({
-            endpoint:      d['cloud.bs.endpoint']      || 'urn:dev:gateway-',
             bs_uri:        d['cloud.bs.uri']           || 'coaps://0.0.0.0:5684',
-            security_mode: d['cloud.bs.security.mode'] || 'PSK',
-            psk_id:        d['cloud.bs.psk.id']        || 'iot-client',
-            psk_key:       d['cloud.bs.psk.key']       || '',
             dm_uri:        d['cloud.dm.uri']           || 'coaps://0.0.0.0:5683',
           });
         }
@@ -65,11 +60,7 @@ export class BsConfigComponent implements OnInit {
     this.savingBs = true;
     const v = this.bsForm.value;
     this.http.dbSet([
-      { key: 'cloud.bs.endpoint',      value: v.endpoint },
       { key: 'cloud.bs.uri',           value: v.bs_uri },
-      { key: 'cloud.bs.security.mode', value: v.security_mode },
-      { key: 'cloud.bs.psk.id',        value: v.psk_id },
-      { key: 'cloud.bs.psk.key',       value: v.psk_key },
       { key: 'cloud.dm.uri',           value: v.dm_uri },
     ]).subscribe({
       next: (r) => {

--- a/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
+++ b/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
@@ -31,30 +31,14 @@
         <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.binding"></app-ds-hint></clr-control-helper>
       </clr-select-container>
 
-      <clr-input-container>
-        <label>DM PSK Identity</label>
-        <input clrInput [disabled]="!isAdmin" formControlName="dm_psk_id"
-               placeholder="iot-dm-client" />
-        <clr-control-helper>Device identity for post-bootstrap DM communication</clr-control-helper>
-        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.psk.id"></app-ds-hint></clr-control-helper>
-      </clr-input-container>
-
-      <clr-input-container>
-        <label>DM PSK Key <span class="hint">(hex secret)</span></label>
-        <input clrInput [disabled]="!isAdmin" formControlName="dm_psk_key"
-               placeholder="hex-encoded PSK" />
-        <clr-control-helper>Separate from BS PSK — used after bootstrap</clr-control-helper>
-        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.psk.key"></app-ds-hint></clr-control-helper>
-      </clr-input-container>
-
-      <clr-input-container>
-        <label>LwM2M Version</label>
-        <input clrInput [disabled]="!isAdmin" formControlName="lwm2m_version"
-               placeholder="1.1" />
-        <clr-control-helper>Default version for provisioned devices</clr-control-helper>
-        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.lwm2m.version"></app-ds-hint></clr-control-helper>
-      </clr-input-container>
+      <div></div>
     </div>
+
+    <p class="hint" style="margin-top:12px;">
+      Per-device DM credentials (PSK identity and key) are minted per-endpoint
+      during provisioning and shown read-only on the <strong>Endpoints</strong>
+      page — they are not configured here.
+    </p>
 
     <div class="info-card" style="margin-top:24px;">
       <p><strong>Device flow after bootstrap:</strong> Device sends <code>Register</code> to the DM URI above.

--- a/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -21,20 +21,20 @@ export class Lwm2mConfigComponent implements OnInit {
     private session: SessionService,
     private toast: ToastService
   ) {
+    // Only the keys the DM server actually consumes when building the
+    // Security/Server TLVs at /bs: cloud.dm.uri, cloud.dm.lifetime,
+    // cloud.dm.binding. Per-device DM PSK identity/key are minted
+    // per-endpoint into cloud.endpoint.credentials — see the Endpoints page.
     this.dmForm = fb.group({
       dm_uri:        ['coaps://0.0.0.0:5683'],
       lifetime:      [86400],
       binding:       ['U'],
-      dm_psk_id:     ['iot-dm-client'],
-      dm_psk_key:    [''],
-      lwm2m_version: ['1.1'],
     });
   }
 
   ngOnInit(): void {
     this.http.dbGet([
-      'cloud.dm.uri', 'cloud.dm.lifetime', 'cloud.dm.binding',
-      'cloud.dm.psk.id', 'cloud.dm.psk.key', 'cloud.dm.lwm2m.version'
+      'cloud.dm.uri', 'cloud.dm.lifetime', 'cloud.dm.binding'
     ]).subscribe({
       next: (r) => {
         if (r.ok && r.data) {
@@ -43,9 +43,6 @@ export class Lwm2mConfigComponent implements OnInit {
             dm_uri:        d['cloud.dm.uri']             || 'coaps://0.0.0.0:5683',
             lifetime:      d['cloud.dm.lifetime']        || 86400,
             binding:       d['cloud.dm.binding']         || 'U',
-            dm_psk_id:     d['cloud.dm.psk.id']          || 'iot-dm-client',
-            dm_psk_key:    d['cloud.dm.psk.key']         || '',
-            lwm2m_version: d['cloud.dm.lwm2m.version']   || '1.1',
           });
         }
         this.loading = false;
@@ -61,9 +58,6 @@ export class Lwm2mConfigComponent implements OnInit {
       { key: 'cloud.dm.uri',              value: v.dm_uri },
       { key: 'cloud.dm.lifetime',         value: v.lifetime },
       { key: 'cloud.dm.binding',          value: v.binding },
-      { key: 'cloud.dm.psk.id',           value: v.dm_psk_id },
-      { key: 'cloud.dm.psk.key',          value: v.dm_psk_key },
-      { key: 'cloud.dm.lwm2m.version',    value: v.lwm2m_version },
     ]).subscribe({
       next: (r) => {
         this.saving = false;


### PR DESCRIPTION
## Summary

The two global LwM2M config forms exposed per-device credential inputs that the bootstrap server **never consumes** and rendered hardcoded fake defaults (`iot-client`, `010203…`, `iot-dm-client`) via `d[key] || '<default>'`, misleading operators. This PR surfaces the **real** per-endpoint credentials (minted into `cloud.endpoint.credentials`) on the Endpoints page, read-only, and trims the dead config fields.

## Part 1 — Real per-endpoint creds on the Endpoints page

`endpoint-list.component.{ts}`:
- Reads `cloud.endpoint.credentials` (JSON array) via the existing `dbGet` path alongside `cloud.dev.mode`.
- Joins each device to its credential record on `serial == endpoint`, falling back to `identity == endpoint`.
- Renders a Clarity **clr-datagrid expandable detail row** (`clr-dg-detail` / `*clrIfDetail`) showing `serial`, DM PSK identity, `bs.psk.key`, `dm.psk.id`, `dm.psk.key`.
- PSK secrets are gated behind the existing admin check (now wired to `SessionService.isAdmin`, replacing the hardcoded `isAdmin = true` TODO); non-admins see a masked placeholder.

## Part 2 — Trim dead config fields

Verified via grep over `apps/src` + `apps/cloud/server/src` that the removed keys are read **nowhere** server-side. The `/bs` handler reads only `cloud.endpoint.credentials`, `cloud.dm.uri`, `cloud.dm.lifetime`, `cloud.dm.binding`, `cloud.bs.uri`.

**bs-config** — removed: `cloud.bs.endpoint`, `cloud.bs.security.mode`, `cloud.bs.psk.id`, `cloud.bs.psk.key`. Kept: `cloud.bs.uri`, `cloud.dm.uri`.

**lwm2m-config** — removed: `cloud.dm.psk.id`, `cloud.dm.psk.key`, `cloud.dm.lwm2m.version`. Kept: `cloud.dm.uri`, `cloud.dm.lifetime`, `cloud.dm.binding`.

Both `.ts` (form controls, get-key list, save payload) and `.html` updated together — no dangling `formControlName`/key references. `.form-grid` rows padded with empty `<div></div>` cells to fill the 4-column grid.

## Verify

Production Angular build (node:18-alpine + anonymous `/app/node_modules` volume, same recipe as `apps/cloud/Dockerfile`) passes:

```
Build at: 2026-06-13T15:36:53.077Z - Hash: d07d499ca5861e8a - Time: 9022ms
```

Only pre-existing warnings (wifi-scan NG8107, @clr/icons CommonJS, bundle-budget) — no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)