### PR TITLE
feat(vpn): ds-driven, cloud-provisioned VPN config with hot-reload

### DIFF
--- a/apps/device/README.md
+++ b/apps/device/README.md
@@ -65,17 +65,24 @@ without port clashes.
 ## Test against the real cloud
 
 Start the cloud stack (`apps/cloud/run.sh`) — it publishes the Bootstrap
-server on host `5684` and DM on `5683` — then point the device client at
-it:
+server on host `5684` and DM on `5683` — then start the device and
+provision its bootstrap target in the data store (it is **not** an env
+var; ds is the single source of truth and persists in the `dev-lib`
+volume):
 
 ```bash
-DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh
+./run.sh
+# point the client at the cloud BS (one-time; persists in ds):
+./run.sh ds set iot.bs.uri '"coaps://host.docker.internal:5684"'
+./run.sh ds set iot.bs.psk.key '"…"'    # see apps/cloud/CLAUDE.md
+# (or commission interactively in device-ui: ./run.sh commission on)
 ```
 
 `host.docker.internal` resolves to the host via the `host-gateway`
-mapping already wired into the client service. (For a DTLS/PSK bootstrap
-seed the client's PSK keys first, e.g. `./run.sh ds set iot.bs.psk.key …`
-— see `apps/cloud/CLAUDE.md` for the PSK provisioning flow.)
+mapping already wired into the client service. The **VPN server endpoint**
+(`vpn.remote.host/port/proto`) is not set here at all — the cloud pushes it
+over LwM2M Object 2048 after the device registers, and openvpn-client
+hot-reloads on the change.
 
 ## Environment knobs
 
@@ -83,8 +90,12 @@ seed the client's PSK keys first, e.g. `./run.sh ds set iot.bs.psk.key …`
 |-----|---------|---------|
 | `DEVICE_IMAGE` | `docker.io/naushada/iot-device:latest` | image tag |
 | `HTTP_PORT` | `8081` | host port for the device UI |
-| `DEVICE_BS_URI` | `coap://lwm2m-server:5685` | client's bootstrap server |
 | `RESET_CONFIG` | `1` | refresh the `dev-etc` config volume on start |
+
+> The bootstrap target (`iot.bs.uri`) and VPN endpoint (`vpn.remote.*`) are
+> **data-store** values, not env vars — see above. `iot.bs.uri` is set once
+> (commissioning / `ds set`, persisted in `dev-lib`); `vpn.remote.*` is
+> cloud-pushed via LwM2M Object 2048.
 
 ## Relationship to the other device build paths
 

--- a/apps/device/docker-compose.yml
+++ b/apps/device/docker-compose.yml
@@ -10,10 +10,11 @@
 #   lwm2m-client  → device client: bootstraps from the cloud BS, registers to DM
 #   iot-httpd     → device REST API (/api/v1/*) + device UI (served at /)
 #
-# Point the client at your cloud Bootstrap server with DEVICE_BS_URI (the
-# cloud compose publishes BS on 5684/DM on 5683 to the host;
-# host.docker.internal resolves via the host-gateway extra_hosts entry):
-#   DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh
+# The bootstrap server (iot.bs.uri) and VPN server endpoint (vpn.remote.*)
+# are data-store driven, not env: iot.bs.uri is provisioned once via device-ui
+# commissioning (persists in the dev-lib volume); the VPN endpoint is pushed
+# by the cloud over LwM2M Object 2048 after registration. host.docker.internal
+# still resolves via the host-gateway extra_hosts entry for a host-local cloud.
 #
 # Usage:
 #   docker compose up -d
@@ -83,12 +84,16 @@ services:
         condition: service_healthy
     restart: unless-stopped
 
-  # ── VPN config seed (one-shot, declarative) ───────────────────
-  # Replaces the old ad-hoc "seed keys by hand" shell step. Sets the
-  # vpn.* config + opens the gate, then exits. In production these come
-  # from provisioning/net-router; here they're env-driven so the compose
-  # is self-contained. cert.path/key.path/ca.path point at the shared
-  # dev-vpn-certs volume the cert-watcher populates.
+  # ── VPN local-paths + dev gate seed (one-shot, declarative) ──────
+  # The VPN *server endpoint* (vpn.remote.host/port/proto) is NO LONGER
+  # seeded here — the cloud provisions it over LwM2M Object 2048 alongside
+  # the cert family, and openvpn-client hot-reloads on the change. ds (the
+  # persisted dev-lib volume) is the single source of truth for it.
+  #
+  # What remains is purely local + non-env: the on-disk cert paths (where
+  # the lwm2m client materialises the cloud-pushed cert family / the
+  # cert-watcher reads) and the WAN/dep gate keys that net-router would own
+  # in production but isn't in this dev stack.
   vpn-config:
     image: ${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}
     container_name: iot-dev-vpn-config
@@ -97,9 +102,6 @@ services:
       - |
         S=--socket=/run/iot/data_store.sock
         set -e
-        ds-cli $$S set vpn.remote.host  '"'"${VPN_REMOTE_HOST:-host.docker.internal}"'"'
-        ds-cli $$S set vpn.remote.port  ${VPN_REMOTE_PORT:-1194}
-        ds-cli $$S set vpn.remote.proto '"tcp-client"'
         ds-cli $$S set vpn.cert.path    '"/etc/iot/vpn/client.crt"'
         ds-cli $$S set vpn.key.path     '"/etc/iot/vpn/client.key"'
         ds-cli $$S set vpn.ca.path      '"/etc/iot/vpn/ca.crt"'
@@ -108,7 +110,7 @@ services:
         # the WAN/dep gate opens. Add a net-router service to own them live.
         ds-cli $$S set services.net.router.state '"running"'
         ds-cli $$S set net.iface.active '"eth0"'
-        echo "vpn-config: seeded vpn.* + opened gate"
+        echo "vpn-config: seeded local cert paths + opened gate"
     volumes:
       - dev-run:/run/iot
     depends_on:

--- a/apps/device/run.sh
+++ b/apps/device/run.sh
@@ -21,9 +21,14 @@
 #   ./run.sh ds get log.text    # run ds-cli inside the ds-server container
 #
 #   HTTP_PORT=9090 ./run.sh                          # custom UI host port
-#   DEVICE_BS_URI=coaps://host.docker.internal:5684 ./run.sh
-#                               # point the client at a real cloud stack
-#                               # (cloud compose publishes BS 5684 / DM 5683)
+#
+# The bootstrap server (iot.bs.uri) and the VPN server endpoint
+# (vpn.remote.*) are NOT set via env — they live in the data store
+# (persisted in the dev-lib volume). Provision iot.bs.uri once by
+# commissioning in device-ui (./run.sh commission on, then set serial +
+# bootstrap URI + generate BS PSK); the VPN endpoint is pushed by the cloud
+# over LwM2M Object 2048 after the device registers. ds is the single
+# source of truth.
 #
 # Persistent state (named volumes):
 #   - dev-etc   volume: /etc/iot      (schemas, env files, LwM2M config)
@@ -34,7 +39,6 @@ set -euo pipefail
 
 IMAGE="${DEVICE_IMAGE:-docker.io/naushada/iot-device:latest}"
 HTTP_PORT="${HTTP_PORT:-8081}"
-DEVICE_BS_URI="${DEVICE_BS_URI:-coaps://host.docker.internal:5684}"
 # Reset the dev-etc config volume on start so the latest schema/config
 # from the image is always loaded (set to 0 to preserve manual edits).
 RESET_CONFIG="${RESET_CONFIG:-1}"
@@ -68,7 +72,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
 # Export env so docker-compose.yml can reference them.
 export DEVICE_IMAGE="$IMAGE"
-export HTTP_PORT DEVICE_BS_URI
+export HTTP_PORT
 export COMPOSE_PROJECT_NAME="$PROJECT"
 
 case "${1:-start}" in
@@ -111,7 +115,7 @@ case "${1:-start}" in
         sleep 3
         echo ""
         echo -e "  ${GREEN}Device UI:${NC}    http://localhost:$HTTP_PORT"
-        echo -e "  ${GREEN}Bootstrap:${NC}    client → ${DEVICE_BS_URI}"
+        echo -e "  ${GREEN}Bootstrap:${NC}    iot.bs.uri (data-store) — set via device-ui commissioning"
         echo ""
         echo "  ./run.sh logs [service]  — tail logs"
         echo "  ./run.sh ps              — list services"

--- a/apps/docs/lwm2m-object-handling.md
+++ b/apps/docs/lwm2m-object-handling.md
@@ -175,6 +175,29 @@ This is consistent on every leg:
 Both sides hex-decode the same string → the same raw key → the handshake
 matches.
 
+### 2.7 Re-provisioning a PSK at runtime (hot change)
+
+PSK credentials are read **once at process start** and registered with DTLS
+(`add_credential`). They are not re-read on every handshake, so the two sides
+re-provision differently:
+
+- **Device client — auto self-restart.** The client subscribes to its own
+  `iot.bs.psk.key` (`ds.on_change`, `apps/src/main.cpp`). When the key changes
+  underneath it — e.g. an engineer edits it via `ds-cli`, or the cloud
+  re-provisions — `should_restart_on_psk_change` fires and the client calls
+  `::exit(0)`. systemd (`Restart=always`) relaunches it, which reloads the new
+  BS PSK, re-registers the DTLS credential, and re-runs bootstrap → DM with the
+  fresh key. **So yes: the device LwM2M client re-initialises itself on a BS PSK
+  change — no manual restart needed.** (The client never writes `iot.bs.psk.key`
+  itself, so any observed change is genuinely external; the initial provisioning
+  write while uninitialised does *not* trigger a restart.)
+- **Cloud BS/DM server — manual restart.** The per-endpoint creds in
+  `cloud.endpoint.credentials` are loaded once at startup
+  (`register_endpoint_creds`); there is **no** watch re-loading them. After
+  changing an endpoint's `bs.psk.key`/`dm.psk.*`, restart the cloud daemon
+  (`docker restart iot-cloudd` / restart the `lwm2m-bs` unit) so it picks up the
+  new credential.
+
 ---
 
 ## 3. Registration interface — `POST /rd`

--- a/apps/inc/lwm2m_dm_server.hpp
+++ b/apps/inc/lwm2m_dm_server.hpp
@@ -98,6 +98,13 @@ constexpr std::uint32_t kCredInstCert  = 1;   ///< instance 1, Type="cert"
 constexpr std::uint32_t kCredInstKey   = 2;   ///< instance 2, Type="key"
 constexpr std::uint32_t kCredRidData   = 1;   ///< RID 1 Certificate Data (opaque, W)
 constexpr std::uint32_t kCredRidApply  = 3;   ///< RID 3 Apply (Execute)
+// VPN server endpoint, written on instance 0 alongside the cert family so the
+// device knows *where* the just-delivered cert lets it connect. The device
+// materialises these into vpn.remote.{host,port,proto} at Apply time, making
+// the device tunnel config fully cloud-provisioned (no docker-compose seed).
+constexpr std::uint32_t kCredRidVpnHost  = 5; ///< RID 5 VPN remote host  (string, W)
+constexpr std::uint32_t kCredRidVpnPort  = 6; ///< RID 6 VPN remote port  (string, W)
+constexpr std::uint32_t kCredRidVpnProto = 7; ///< RID 7 VPN remote proto (string, W)
 
 /// Build the server→device push sequence for a VPN cert family over Object
 /// 2048. Each artifact (CA/cert/key) is zipped + chunked (see
@@ -106,11 +113,21 @@ constexpr std::uint32_t kCredRidApply  = 3;   ///< RID 3 Apply (Execute)
 /// an EXECUTE of Apply /2048/0/3 commits the family. Every frame draws a fresh
 /// id from `next_msgid` and carries `token`; ship them to the client's peer in
 /// order via UDPAdapter::send_async. Returns the frames in send order.
+///
+/// `vpn_host` is the cloud's public host (parsed by the caller from
+/// cloud.dm.uri), `vpn_port`/`vpn_proto` the openvpn server endpoint (e.g.
+/// "1194"/"tcp-client"). When `vpn_host` is non-empty these are emitted as
+/// plain-text WRITEs to /2048/0/{5,6,7} before the Apply, so the device's
+/// Apply commits the cert family AND the endpoint atomically. Empty `vpn_host`
+/// → only the cert family is pushed (back-compat with the cert-only path).
 std::vector<std::string> build_cert_push(const std::function<std::uint16_t()>& next_msgid,
                                          const std::string& token,
                                          const std::string& ca_pem,
                                          const std::string& cert_pem,
-                                         const std::string& key_pem);
+                                         const std::string& key_pem,
+                                         const std::string& vpn_host  = "",
+                                         const std::string& vpn_port  = "",
+                                         const std::string& vpn_proto = "");
 
 }} // namespace lwm2m::dmsrv
 

--- a/apps/inc/lwm2m_object_cert.hpp
+++ b/apps/inc/lwm2m_object_cert.hpp
@@ -68,9 +68,22 @@ struct CertHooks {
 
     /// Commit/reload trigger, called once after all artifacts are stored.
     /// Default: no-op (a cert sidecar watching certDir detects the change
-    /// and reloads). Wire a ds gate-flip of services.openvpn.client.enable
-    /// here for an immediate reload without a sidecar. Returns 0 on success.
+    /// and reloads). The client wiring (apps/src/main.cpp) supplies a ds
+    /// gate-flip of services.openvpn.client.enable (false→true) so the
+    /// openvpn-client supervisor respawns openvpn with the freshly
+    /// materialised cert without a sidecar — see the openvpn-client design
+    /// doc, "Cert-arrival respawn". Returns 0 on success.
     std::function<int()> apply;
+
+    /// Persist the cloud-pushed VPN server endpoint (Object 2048 /0/5,6,7)
+    /// into the data store so openvpn-client targets the right server. Called
+    /// at Apply when a non-empty host was staged, before `apply`. `port` is a
+    /// decimal string ("" if unset), `proto` e.g. "tcp-client" ("" if unset).
+    /// Default: unset → endpoint ignored. The client wiring (main.cpp) supplies
+    /// a lambda writing vpn.remote.{host,port,proto}. Returns 0 on success.
+    std::function<int(const std::string& host,
+                      const std::string& port,
+                      const std::string& proto)> set_vpn_endpoint;
 
     /// Optional integrity check, called per artifact at commit if a hash
     /// was written to RID 2. Returns 0 if the hash matches `pem`, non-zero

--- a/apps/inc/lwm2m_object_stubs.hpp
+++ b/apps/inc/lwm2m_object_stubs.hpp
@@ -5,6 +5,7 @@
 
 #include "lwm2m_object_3_device.hpp"
 #include "lwm2m_object_firmware.hpp"
+#include "lwm2m_object_cert.hpp"
 #include "lwm2m_object_store.hpp"
 
 /**
@@ -55,7 +56,8 @@ int install_firmware(ObjectStore& store, const std::string& configDir);
 int install_canonical_objects(ObjectStore& store,
                               const std::string& configDir,
                               DeviceHooks deviceHooks = {},
-                              FwHooks fwHooks = {});
+                              FwHooks fwHooks = {},
+                              CertHooks certHooks = {});
 
 }} // namespace lwm2m::objects
 

--- a/apps/src/lwm2m_dm_server.cpp
+++ b/apps/src/lwm2m_dm_server.cpp
@@ -139,7 +139,10 @@ std::vector<std::string> build_cert_push(const std::function<std::uint16_t()>& n
                                          const std::string& token,
                                          const std::string& ca_pem,
                                          const std::string& cert_pem,
-                                         const std::string& key_pem) {
+                                         const std::string& key_pem,
+                                         const std::string& vpn_host,
+                                         const std::string& vpn_port,
+                                         const std::string& vpn_proto) {
     std::vector<std::string> f;
     // Each artifact: zip+chunk into opaque WRITEs (CF_OctetStream) to its
     // instance's data RID. The device reassembles + inflates, then Apply
@@ -154,6 +157,20 @@ std::vector<std::string> build_cert_push(const std::function<std::uint16_t()>& n
     push_artifact(kCredInstCa,   ca_pem);
     push_artifact(kCredInstCert, cert_pem);
     push_artifact(kCredInstKey,  key_pem);
+    // VPN server endpoint (instance 0, RID 5/6/7), small plain-text WRITEs.
+    // The device stages these and the Apply EXECUTE materialises them into
+    // vpn.remote.{host,port,proto}. Only emitted when the cloud knows its
+    // public host — the cert-only push stays back-compatible.
+    if (!vpn_host.empty()) {
+        f.push_back(build_write(next_msgid(), token, kCredObjectOid, kCredInstCa,
+                                kCredRidVpnHost, CF_PlainText, vpn_host, false));
+        if (!vpn_port.empty())
+            f.push_back(build_write(next_msgid(), token, kCredObjectOid, kCredInstCa,
+                                    kCredRidVpnPort, CF_PlainText, vpn_port, false));
+        if (!vpn_proto.empty())
+            f.push_back(build_write(next_msgid(), token, kCredObjectOid, kCredInstCa,
+                                    kCredRidVpnProto, CF_PlainText, vpn_proto, false));
+    }
     f.push_back(build_execute(next_msgid(), token,
                               kCredObjectOid, kCredInstCa, kCredRidApply, ""));
     return f;

--- a/apps/src/lwm2m_object_cert.cpp
+++ b/apps/src/lwm2m_object_cert.cpp
@@ -31,6 +31,15 @@ struct Staged {
 /// "key"). shared_ptr so all the std::function captures see the same map.
 using Staging = std::map<std::string, Staged>;
 
+/// Cloud-pushed VPN server endpoint (Object 2048 /0/5,6,7), staged like the
+/// cert artifacts and materialised into the data store at Apply via
+/// CertHooks::set_vpn_endpoint. Empty host → no endpoint was pushed.
+struct VpnEndpoint {
+    std::string host;
+    std::string port;
+    std::string proto;
+};
+
 /// Map an artifact type to the default file name under certDir.
 const char* default_filename(const std::string& type) {
     if (type == "ca")   return "ca.crt";
@@ -115,7 +124,8 @@ ObjectInstance make_instance(std::uint32_t iid,
                              const std::string& certDir,
                              std::shared_ptr<CertHooks> hooks,
                              bool require_complete,
-                             std::shared_ptr<std::string> applied) {
+                             std::shared_ptr<std::string> applied,
+                             std::shared_ptr<VpnEndpoint> vpn) {
     ObjectInstance inst;
     inst.iid = iid;
 
@@ -174,7 +184,7 @@ ObjectInstance make_instance(std::uint32_t iid,
         Resource r;
         r.rid = 3; r.name = "Apply";
         r.type = ResourceType::None; r.ops = Operations::E;
-        r.execute = [staging, certDir, hooks, require_complete, applied]
+        r.execute = [staging, certDir, hooks, require_complete, applied, vpn]
                     (const std::string& /*args*/) -> int {
             // Completeness gate: don't half-provision. If we require a full
             // family, hold the commit until ca+cert+key are all staged. The
@@ -218,6 +228,16 @@ ObjectInstance make_instance(std::uint32_t iid,
             // Clear staging so a later partial push can't re-commit stale bytes.
             staging->clear();
             if (applied) *applied = fnv1a_hex(fpInput);
+            // Materialise the cloud-pushed VPN endpoint (if any) into ds before
+            // the reload hook, so openvpn (re)starts against the right server.
+            if (vpn && !vpn->host.empty() && hooks->set_vpn_endpoint) {
+                int vrc = hooks->set_vpn_endpoint(vpn->host, vpn->port, vpn->proto);
+                ACE_DEBUG((LM_INFO,
+                    ACE_TEXT("%D [cert-obj] %M %N:%l applied VPN endpoint "
+                             "host=%C port=%C proto=%C rc=%d\n"),
+                    vpn->host.c_str(), vpn->port.c_str(),
+                    vpn->proto.c_str(), vrc));
+            }
             int rc = hooks->apply ? hooks->apply() : 0;
             ACE_DEBUG((LM_INFO,
                 ACE_TEXT("%D [cert-obj] %M %N:%l applied %d artifact(s) fp=%C, "
@@ -235,6 +255,31 @@ ObjectInstance make_instance(std::uint32_t iid,
         st.type = ResourceType::String; st.ops = Operations::R;
         st.read = [applied]() { return applied ? *applied : std::string(); };
         inst.resources[4] = std::move(st);
+
+        // RID 5/6/7 — VPN server endpoint (write-only; staged, materialised at
+        // Apply). The cloud writes these before the Apply EXECUTE so the device
+        // learns its tunnel target without a docker-compose seed.
+        {
+            Resource r;
+            r.rid = 5; r.name = "VPN Remote Host";
+            r.type = ResourceType::String; r.ops = Operations::W;
+            r.write = [vpn](const std::string& v) { if (vpn) vpn->host = v; return 0; };
+            inst.resources[5] = std::move(r);
+        }
+        {
+            Resource r;
+            r.rid = 6; r.name = "VPN Remote Port";
+            r.type = ResourceType::String; r.ops = Operations::W;
+            r.write = [vpn](const std::string& v) { if (vpn) vpn->port = v; return 0; };
+            inst.resources[6] = std::move(r);
+        }
+        {
+            Resource r;
+            r.rid = 7; r.name = "VPN Remote Proto";
+            r.type = ResourceType::String; r.ops = Operations::W;
+            r.write = [vpn](const std::string& v) { if (vpn) vpn->proto = v; return 0; };
+            inst.resources[7] = std::move(r);
+        }
     }
     return inst;
 }
@@ -248,6 +293,7 @@ int install_cert(ObjectStore& store,
     auto staging = std::make_shared<Staging>();
     auto hooksp  = std::make_shared<CertHooks>(std::move(hooks));
     auto applied = std::make_shared<std::string>();   // RID 4 fingerprint
+    auto vpn     = std::make_shared<VpnEndpoint>();    // RID 5/6/7 staging
 
     ObjectDescriptor desc;
     desc.oid              = kCertObjectOid;
@@ -259,9 +305,9 @@ int install_cert(ObjectStore& store,
     // Apply trigger + Applied status live on instance 0 (the CA instance) so
     // the server has a single, well-known commit point: EXECUTE /2048/0/3,
     // READ /2048/0/4.
-    desc.instances[0] = make_instance(0, "ca",   staging, /*withApply*/true,  certDir, hooksp, require_complete, applied);
-    desc.instances[1] = make_instance(1, "cert", staging, /*withApply*/false, certDir, hooksp, require_complete, applied);
-    desc.instances[2] = make_instance(2, "key",  staging, /*withApply*/false, certDir, hooksp, require_complete, applied);
+    desc.instances[0] = make_instance(0, "ca",   staging, /*withApply*/true,  certDir, hooksp, require_complete, applied, vpn);
+    desc.instances[1] = make_instance(1, "cert", staging, /*withApply*/false, certDir, hooksp, require_complete, applied, vpn);
+    desc.instances[2] = make_instance(2, "key",  staging, /*withApply*/false, certDir, hooksp, require_complete, applied, vpn);
 
     store.add_object(std::move(desc));
     return 0;

--- a/apps/src/lwm2m_object_stubs.cpp
+++ b/apps/src/lwm2m_object_stubs.cpp
@@ -156,7 +156,8 @@ int install_firmware(ObjectStore& store, const std::string& configDir) {
 int install_canonical_objects(ObjectStore& store,
                               const std::string& configDir,
                               DeviceHooks deviceHooks,
-                              FwHooks fwHooks) {
+                              FwHooks fwHooks,
+                              CertHooks certHooks) {
     int rc = 0;
     rc |= install_access_control(store, configDir);
     rc |= install_device(store, configDir, std::move(deviceHooks));
@@ -167,7 +168,7 @@ int install_canonical_objects(ObjectStore& store,
     // Custom OID 2048 — cloud-pushed VPN/TLS credential family. Default
     // store writes the cert family under /etc/iot/vpn (= vpn.{ca,cert,key}.path
     // defaults); a cert sidecar reloads openvpn-client on the change.
-    rc |= install_cert(store, "/etc/iot/vpn");
+    rc |= install_cert(store, "/etc/iot/vpn", std::move(certHooks));
     return rc;
 }
 

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -459,6 +459,38 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                 if (auto s = data_store::to_string(got[0].value)) credsJson = *s;
             }
         }
+
+        // VPN server endpoint pushed to the device alongside the cert family,
+        // so the tunnel target is cloud-provisioned (no docker-compose seed).
+        // Host = the cloud's public host (parsed from cloud.dm.uri the device
+        // already registers against); port/proto = the openvpn server's
+        // listen config (published to ds by iot-cloudd). proto is mapped to
+        // the client form (tcp-server → tcp-client). Empty host → cert-only
+        // push (back-compat).
+        std::string vpnHost, vpnPort, vpnProto;
+        if (dsCertPush) {
+            std::vector<data_store::Client::GetResult> g;
+            if (dsCertPush->get({std::string("cloud.dm.uri"),
+                                 std::string("cloud.vpn.listen.port"),
+                                 std::string("cloud.vpn.proto")}, g).ok
+                && g.size() >= 3) {
+                if (g[0].has_value)
+                    if (auto s = data_store::to_string(g[0].value)) {
+                        // Strip scheme + port/path → bare host.
+                        std::string u = *s;
+                        auto p = u.find("://");
+                        if (p != std::string::npos) u = u.substr(p + 3);
+                        u = u.substr(0, u.find_first_of(":/"));
+                        vpnHost = u;
+                    }
+                if (g[1].has_value)
+                    if (auto n = data_store::to_int32(g[1].value))
+                        vpnPort = std::to_string(*n);
+                if (g[2].has_value)
+                    if (auto s = data_store::to_string(g[2].value))
+                        vpnProto = (*s == "tcp-server") ? "tcp-client" : *s;
+            }
+        }
         // Pull one endpoint's complete VPN cert family out of the array.
         auto vpn_family = [&credsJson](const std::string& ep, std::string& ca,
                                        std::string& cert, std::string& key) -> bool {
@@ -581,7 +613,8 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                 if (vpn_family(reg.endpoint, ca, cert, key)) {
                     std::string ctok{static_cast<char>(0x04)};
                     for (auto& fr : ::lwm2m::dmsrv::build_cert_push(
-                             next_msgid, ctok, ca, cert, key))
+                             next_msgid, ctok, ca, cert, key,
+                             vpnHost, vpnPort, vpnProto))
                         ctx->send_async(fr, reg.peerHost, reg.peerPort);
                     ACE_DEBUG((LM_INFO,
                         ACE_TEXT("%D lwm2m:thread:%t %M %N:%l pushed VPN cert to "
@@ -710,7 +743,36 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
             if (auto s = data_store::to_string(got[0].value)) return *s;
         return {};
     };
-    ::lwm2m::objects::install_canonical_objects(*plumb.store, configDir, {}, std::move(fwHooks));
+    // Cert apply (OID 2048): the systemd/RPi image ships no cert sidecar, so
+    // when a fresh VPN cert family is materialised, gate-flip the openvpn
+    // client service to make its supervisor (re)start openvpn with the new
+    // cert. Watches fire on change, so toggle false→true for a real transition.
+    ::lwm2m::objects::CertHooks certHooks;
+    certHooks.apply = [dsc]() -> int {
+        if (!dsc) return 0;
+        dsc->set("services.openvpn.client.enable", data_store::Value{false});
+        dsc->set("services.openvpn.client.enable", data_store::Value{true});
+        return 0;
+    };
+    // Cloud-provisioned VPN server endpoint (Object 2048 /0/5,6,7): persist it
+    // to ds so openvpn-client targets the right server with no compose seed.
+    // vpn.remote.port is an integer in schema, so the decimal string is parsed.
+    certHooks.set_vpn_endpoint = [dsc](const std::string& host,
+                                       const std::string& port,
+                                       const std::string& proto) -> int {
+        if (!dsc || host.empty()) return 0;
+        dsc->set("vpn.remote.host", data_store::Value{host});
+        if (!port.empty()) {
+            try {
+                dsc->set("vpn.remote.port",
+                         data_store::Value{static_cast<std::int32_t>(std::stoi(port))});
+            } catch (...) {}
+        }
+        if (!proto.empty()) dsc->set("vpn.remote.proto", data_store::Value{proto});
+        return 0;
+    };
+    ::lwm2m::objects::install_canonical_objects(*plumb.store, configDir, {},
+                                                std::move(fwHooks), std::move(certHooks));
 
     // device-ui self-update: a write to iot.update.request launches the same
     // detached apply locally (no CoAP round-trip).

--- a/modules/openvpn/client/docs/design.md
+++ b/modules/openvpn/client/docs/design.md
@@ -152,6 +152,42 @@ no I/O, no threading; fully unit-tested in `test/gate_test.cpp`.
 The Supervisor (`src/supervisor.{hpp,cpp}`) wires it to DsBridge +
 OpenVpnProcess.
 
+## Enable gate + cert-arrival respawn (L16/D4)
+
+Alongside the WAN gate, the Supervisor watches
+`services.openvpn.client.enable` via `data_store::ServiceGate`
+(`src/supervisor.cpp` — L16/D4). Setting it `false` tears the child
+down within one event-loop tick (NFR-SVC-001); setting it `true`
+lets the outer loop respawn openvpn once WAN + deps are healthy.
+
+This same enable gate is how a **cloud-pushed VPN certificate** takes
+effect on the RPi/systemd image, which ships **no cert sidecar**
+watching `/etc/iot/vpn`:
+
+1. The cloud pushes the cert family over LwM2M custom **Object 2048**
+   (instances 0/1/2 = ca/cert/key) and EXECUTEs RID 3 (Apply).
+2. On the device, `install_cert` (`apps/src/lwm2m_object_stubs.cpp`)
+   materialises `/etc/iot/vpn/{ca.crt,client.crt,client.key}`, then
+   calls its `CertHooks::apply`.
+3. The client wiring (`apps/src/main.cpp`) supplies that hook as a
+   **ds gate-flip**: it `set`s `services.openvpn.client.enable`
+   `false` then `true`. ds watches fire on *change*, so the deliberate
+   `false→true` edge is what guarantees the gate sees a transition (a
+   bare `true` write over an already-`true` value emits no event).
+4. The gate-flip wakes this Supervisor: openvpn is (re)spawned and
+   reads the just-written cert family at exec time — picking up the
+   new credentials with no sidecar and no manual restart.
+
+For the primary flow (first-time provisioning — openvpn was down or
+crash-looping because the cert was absent), even a single coalesced
+`true` edge re-spawns the idle supervisor, so the cert is picked up.
+A *rotation* while the tunnel is already connected relies on the
+`false` edge being delivered to tear the live child down first; if
+the data-store coalesces the two rapid writes to the final `true`
+only, an already-connected session keeps the old cert until its next
+natural respawn (WAN/dep/enable event). Initial provisioning — the
+case that lets the device connect at all — is unaffected.
+
 ## Why ACE (not libevent like grace-server)
 
 The rest of this repo (lwm2m, ds-server, ds-cli) all run on

--- a/modules/openvpn/client/src/ds_bridge.cpp
+++ b/modules/openvpn/client/src/ds_bridge.cpp
@@ -183,12 +183,14 @@ DsBridge::DsBridge(std::string socketPath)
                 else if (ev.key == kMgmtPort)    { m_impl->mgmt_port    = data_store::to_uint32(ev.value); changed = Key::MgmtPort;    }
             }
             if (!changed) return;
-            // First-cut policy (L12 R4): log "needs restart"; live
-            // re-application lives in FUP-L12-1.
+            // Live hot-reload: the Supervisor's on_change handler tears the
+            // current session down and respawns openvpn with the regenerated
+            // config, so the new value (e.g. a cloud-pushed vpn.remote.host)
+            // takes effect without a daemon restart.
             ACE_DEBUG((LM_INFO,
                        ACE_TEXT("%D [ovpn:%t] %M %N:%l vpn config key "
-                                "'%C' changed — restart openvpn-client to "
-                                "apply (live hot-reload is FUP-L12-1)\n"),
+                                "'%C' changed — hot-reloading openvpn-client "
+                                "(respawn with fresh config)\n"),
                        ev.key.c_str()));
             ChangeCallback cbcopy;
             {

--- a/modules/openvpn/client/src/supervisor.cpp
+++ b/modules/openvpn/client/src/supervisor.cpp
@@ -132,13 +132,23 @@ std::optional<std::string> Supervisor::drain_target() {
     return m_pending_target;
 }
 
+void Supervisor::on_config_event() {
+    m_cfg_dirty.store(true, std::memory_order_release);
+    m_cv.notify_all();
+}
+
+bool Supervisor::cfg_dirty() {
+    return m_cfg_dirty.load(std::memory_order_acquire);
+}
+
 bool Supervisor::wait_for_event() {
     std::unique_lock<std::mutex> g(m_mtx);
     m_cv.wait(g, [&]{
         return m_shutdown
             || m_wan_dirty
             || m_svc_dirty.load(std::memory_order_acquire)
-            || m_dep_dirty.load(std::memory_order_acquire);
+            || m_dep_dirty.load(std::memory_order_acquire)
+            || m_cfg_dirty.load(std::memory_order_acquire);
     });
     return !m_shutdown;
 }
@@ -241,6 +251,17 @@ bool Supervisor::serve_one_session(const std::string& iface) {
                        iface.c_str()));
             break;
         }
+        // Live config hot-reload: a vpn.* key changed (e.g. cloud pushed a new
+        // vpn.remote.host). Tear down; the outer loop respawns openvpn with a
+        // freshly snapshotted config.
+        if (cfg_dirty()) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l vpn config changed during "
+                                "session on iface=%C; respawning with fresh "
+                                "config\n"),
+                       iface.c_str()));
+            break;
+        }
         {
             std::lock_guard<std::mutex> g(m_mtx);
             if (m_shutdown) break;
@@ -277,6 +298,10 @@ bool Supervisor::serve_one_session(const std::string& iface) {
 
 Status Supervisor::run() {
     m_ds.on_wan_change([this](auto t) { this->on_wan_event(t); });
+    // Live hot-reload: any vpn.* config change tears the session down and
+    // respawns openvpn with the regenerated config (e.g. a cloud-pushed
+    // vpn.remote.host). DsBridge already updated its cache before this fires.
+    m_ds.on_change([this](DsBridge::Key) { this->on_config_event(); });
 
     // Initial publish: until proven otherwise we are gated.
     m_ds.set_state("disconnected");
@@ -297,6 +322,9 @@ Status Supervisor::run() {
         // of the svc gate or WAN state.
         m_dep_dirty.store(false, std::memory_order_release);
         m_svc_dirty.store(false, std::memory_order_release);
+        // Cleared before (re)evaluating gates + respawning; a config change
+        // arriving during the new session re-sets it for the next iteration.
+        m_cfg_dirty.store(false, std::memory_order_release);
         if (m_dep && !m_dep->healthy()) {
             if (m_gate.running()) m_gate.note_terminated();
             m_ds.set_state("disabled");

--- a/modules/openvpn/client/src/supervisor.hpp
+++ b/modules/openvpn/client/src/supervisor.hpp
@@ -83,8 +83,21 @@ private:
     bool                       m_wan_dirty = false;
     bool                       m_shutdown  = false;
 
+    /// FUP-L12-1 → done: a vpn.* config key (remote host/port/proto, cert
+    /// paths, cipher, dev, mgmt port) changed. Signals the run loop to tear
+    /// the session down and respawn openvpn with the regenerated config —
+    /// live hot-reload instead of requiring a daemon restart.
+    std::atomic<bool>          m_cfg_dirty{false};
+
     /// Called from the DsBridge listener thread.
     void on_wan_event(const std::optional<std::string>& target);
+
+    /// Called from the DsBridge listener thread when a vpn.* config key
+    /// changes; flags a respawn so the new config takes effect live.
+    void on_config_event();
+
+    /// Cheap snapshot of m_cfg_dirty for the inner event-loop.
+    bool cfg_dirty();
 
     /// Snapshot the latest WAN target under lock, clearing the dirty
     /// flag. Returns nullopt on shutdown OR when target is empty.


### PR DESCRIPTION
## Summary
Makes the device's VPN server endpoint **fully data-store driven** (no docker-compose env seeds), and adds **live hot-reload** so a cloud-pushed config takes effect without restarting the daemon.

### Cloud push (Object 2048)
- `build_cert_push` now also emits `vpn.remote.host/port/proto` as WRITEs to `/2048/0/{5,6,7}` before the Apply (back-compatible: empty host → cert-only).
- The DM push tick (`apps/src/main.cpp`) derives them from existing ds keys: host from `cloud.dm.uri`, port from `cloud.vpn.listen.port`, proto `tcp-server`→`tcp-client`. No new ds keys.

### Device receive
- Object-2048 handler stages RIDs 5/6/7 and materialises them into `vpn.remote.{host,port,proto}` at Apply via the new `CertHooks::set_vpn_endpoint` (port string→int for the integer schema).

### openvpn-client hot-reload
- The supervisor tears down + respawns openvpn with a freshly snapshotted config on any `vpn.*` change (e.g. a cloud-pushed `vpn.remote.host`). Removes the FUP-L12-1 "restart to apply" limitation.

### Remove compose env seeds
- Dropped the `VPN_REMOTE_HOST` seed (cloud-pushed now) and the **vestigial** `DEVICE_BS_URI` plumbing (it was never wired to a seed). ds (persisted `dev-lib` volume) is the single source of truth; `iot.bs.uri` is provisioned once via commissioning. Docs/README updated.

### Also folded in
- The Object-2048 **cert gate-flip** (restart openvpn-client on a cert apply via `services.openvpn.client.enable`) + design docs.

## Verification
- **Device image build: PASS** (`podman build`, exit 0) — compiles every changed file (`apps/src/*` incl. the cloud-push tick, `modules/openvpn/client/*`).

## Known gap
- No unit test for the supervisor hot-reload respawn: the Supervisor has no existing test harness (Gate/DsBridge/Lifecycle/mgmt/process are tested in isolation against a disconnected ds); a respawn test needs a connected-ds + fake-openvpn integration rig that doesn't exist. Flagged for follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)