### PR TITLE
feat(cloud): device UI over VPN via per-device nftables DNAT

### DIFF
--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -117,7 +117,7 @@ FROM docker.io/library/ubuntu:22.04 AS runtime
 
 RUN apt-get -o Acquire::Check-Date=false update && \
     apt-get install -y --no-install-recommends \
-    libssl3 openssl zlib1g libreadline8 liblua5.3-0 iptables openvpn ca-certificates \
+    libssl3 openssl zlib1g libreadline8 liblua5.3-0 iptables nftables openvpn ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # PSK provisioning (task P): shared cloud service account/group. The cloud

--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -53,11 +53,17 @@ services:
       - iot-vpn:/etc/iot/vpn
       - iot-ca-key:/run/secrets/iot-ca-key:ro
     cap_add:
-      - NET_ADMIN
+      - NET_ADMIN           # openvpn tun + per-device nftables DNAT
+    sysctls:
+      - net.ipv4.ip_forward=1   # route the DNAT'd device-UI flow over the tunnel
     devices:
       - /dev/net/tun        # openvpn(8) server spawned by iot-cloudd
     ports:
       - "1194:1194/tcp"     # OpenVPN server (TCP)
+      # Per-device device-UI-over-VPN proxy ports (VpnRegistry allocates
+      # 5001-6000). Publishing the range makes cloud:<proxy_port> reachable
+      # from the operator's browser; iot-cloudd DNATs each to <tun_ip>:ui_port.
+      - "5001-6000:5001-6000"
     depends_on:
       ds-server:
         condition: service_healthy

--- a/apps/cloud/server/CMakeLists.txt
+++ b/apps/cloud/server/CMakeLists.txt
@@ -18,6 +18,7 @@ include_directories(
     ${CLOUD_SERVER_DIR}/../../../modules/data-store/inc
     ${CLOUD_SERVER_DIR}/../../../modules/server/lwm2m/inc
     ${CLOUD_SERVER_DIR}/../../../modules/server/openvpn/inc
+    ${CLOUD_SERVER_DIR}/../../../modules/server/dnat/inc
     ${NLOHMANN_JSON_INCLUDE}
     ${ACE_ROOT}/include
 )
@@ -29,7 +30,8 @@ add_executable(iot-cloudd
     ../../../modules/server/lwm2m/src/cloud_credentials.cpp
     ../../../modules/server/openvpn/src/vpn_registry.cpp
     ../../../modules/server/openvpn/src/openvpn_server.cpp
-    ../../../modules/server/openvpn/src/cert_authority.cpp)
+    ../../../modules/server/openvpn/src/cert_authority.cpp
+    ../../../modules/server/dnat/src/device_dnat.cpp)
 
 if(DEFINED DATASTORE_LIB)
     set(DS_LINK_LIB ${DATASTORE_LIB})

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -19,6 +19,7 @@
 #include "cert_authority.hpp"
 #include "bootstrap.hpp"
 #include "cloud_credentials.hpp"
+#include "device_dnat.hpp"
 
 #include "data_store/client.hpp"
 #include "data_store/value.hpp"
@@ -90,6 +91,50 @@ void sync_endpoints_to_ds(data_store::Client& ds,
         arr.push_back(item);
     }
     ds.set("cloud.endpoints", data_store::Value{arr.dump()});
+}
+
+// Rebuild + apply the per-device "device UI over VPN" DNAT ruleset.
+//
+// The device list is read from the *persisted* cloud.endpoints ds JSON (not
+// the in-memory EndpointRegistry, which is empty until devices re-provision),
+// so a fresh iot-cloudd reconstructs the full rule set on startup. nft -f -
+// is atomic and our scoped table is flushed first, so this is idempotent +
+// rebuildable: one call after each sync (and at startup) restores every
+// device's mapping. ui_port is read live from cloud.proxy.device.ui.port
+// (default 80 — the device UI is on 80/443).
+//
+// A device gets a rule once it has both a tun_ip and a proxy_port (i.e. it
+// has been provisioned); online/offline state doesn't gate it (the connection
+// simply fails if the tunnel is down, like any port-forward).
+void rebuild_device_dnat(data_store::Client& ds, const std::string& tun_dev) {
+    server::dnat::RulesetInput in;
+    in.tun_dev = tun_dev;
+    in.ui_port = static_cast<std::uint16_t>(
+        ds_int(ds, "cloud.proxy.device.ui.port", 80));
+    try {
+        auto arr = nlohmann::json::parse(ds_str(ds, "cloud.endpoints", "[]"));
+        if (arr.is_array()) for (const auto& e : arr) {
+            if (!e.is_object()) continue;
+            std::string ip   = e.value("tun_ip", std::string());
+            int         port = e.value("proxy_port", 0);
+            if (ip.empty() || port <= 0) continue;
+            in.devices.push_back({std::move(ip),
+                                  static_cast<std::uint16_t>(port)});
+        }
+    } catch (const std::exception& ex) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l device-UI DNAT: "
+                            "cloud.endpoints parse: %C\n"), ex.what()));
+        return;
+    }
+    const std::string script = server::dnat::build_device_dnat_ruleset(in);
+    if (server::dnat::apply_ruleset(script)) {
+        ACE_DEBUG((LM_DEBUG,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l device-UI DNAT applied "
+                            "(%u rule(s), ui_port=%d)\n"),
+                   static_cast<unsigned>(in.devices.size()),
+                   static_cast<int>(in.ui_port)));
+    }
 }
 
 // Merge lwm2m-dm's registration status into the EndpointRegistry. lwm2m-dm
@@ -406,6 +451,28 @@ int main(int argc, char** argv) {
     };
     supervise_ovpn();   // initial start
 
+    // ── Device-UI-over-VPN DNAT (per-device nftables) ─────────────
+    // iot-cloudd runs the openvpn server, so tun0 + CAP_NET_ADMIN live in
+    // this netns — the right place to install cloud:<proxy_port> →
+    // <tun_ip>:<ui_port> DNAT. Enable IPv4 forwarding once so the DNAT'd
+    // connection routes out over the tunnel, then rebuild the full ruleset
+    // from the (just-restored) endpoint registry so a restart re-installs
+    // every device's mapping atomically. openvpn names the first tun device
+    // <dev>0 (e.g. "tun" → "tun0").
+    const std::string tun_dev = ovpn_cfg.dev + "0";
+    // Seed the ui_port key so it's visible in the cloud UI / ds-cli.
+    ds.set("cloud.proxy.device.ui.port",
+           data_store::Value{static_cast<std::int32_t>(
+               ds_int(ds, "cloud.proxy.device.ui.port", 80))});
+    if (!server::dnat::enable_ip_forward()) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l could not enable "
+                            "net.ipv4.ip_forward (device-UI DNAT may not route)\n")));
+    }
+    // Reconstruct the full rule set from the persisted cloud.endpoints so a
+    // restart restores every device's mapping atomically before any sync.
+    rebuild_device_dnat(ds, tun_dev);
+
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("%D cloudd:thread:%t %M %N:%l started, ds=%C vpn-subnet=%C"
                         " proxy=%d-%d sync-interval=%d\n"),
@@ -664,8 +731,12 @@ int main(int argc, char** argv) {
                     ds.set("cloud.update.request", data_store::Value{std::string()});
                 }
             }
-            // Sync after every event so the UI sees changes quickly
+            // Sync after every event so the UI sees changes quickly, then
+            // rebuild the DNAT ruleset from the fresh endpoint set (a
+            // provision/deprovision/online-change may have added/removed a
+            // device → its cloud:<proxy_port> mapping must follow).
             sync_endpoints_to_ds(ds, ep_reg);
+            rebuild_device_dnat(ds, tun_dev);
             sync_tick = 0;
         } else {
             // recv_event timed out — periodic housekeeping
@@ -686,6 +757,9 @@ int main(int argc, char** argv) {
                 // Safety-net reconcile in case a watch notification was missed.
                 reconcile_registrations(ds, ep_reg);
                 sync_endpoints_to_ds(ds, ep_reg);
+                // Safety-net DNAT rebuild — also picks up a live
+                // cloud.proxy.device.ui.port change.
+                rebuild_device_dnat(ds, tun_dev);
                 ds.set("cloud.vpn.port.next",
                        data_store::Value{static_cast<std::uint32_t>(proxy_port_start)});
                 g_log.apply_level(ds);

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -93,6 +93,15 @@ interface EpCred {
         <clr-dg-detail *clrIfDetail="let e">
           <clr-dg-detail-header>Provisioned Credentials — {{e.endpoint}}</clr-dg-detail-header>
           <clr-dg-detail-body>
+            <!-- Device UI over VPN: the per-device nftables DNAT installed by
+                 iot-cloudd (cloud:<proxy_port> → <tun_ip>:<ui_port> over tun0). -->
+            <dl class="cred-list" style="margin-bottom:16px;">
+              <dt>VPN forwarding rule</dt>
+              <dd>
+                <code>tcp dport {{ e.proxy_port }} &rarr; {{ e.tun_ip }}:{{ uiPort }}</code>
+                <span class="hint" style="margin-left:8px;">DNAT — device UI over VPN</span>
+              </dd>
+            </dl>
             <ng-container *ngIf="credFor(e) as c; else noCred">
               <dl class="cred-list">
                 <dt>Serial</dt><dd><code>{{ c.serial || '—' }}</code></dd>
@@ -130,6 +139,9 @@ export class EndpointListComponent implements OnInit, OnDestroy {
   endpoints: EpInfo[] = [];
   creds: EpCred[] = [];
   windowHost = window.location.hostname;
+  // Device UI port reached over the VPN (cloud.proxy.device.ui.port,
+  // default 80). Shown in the per-endpoint "VPN forwarding rule" line.
+  uiPort = 80;
   // PSK provisioning (task O).
   provSerial = ''; provBsPsk = ''; provisioning = false; devMode = false;
   private sub = new Subscription(); private active = true;
@@ -140,11 +152,14 @@ export class EndpointListComponent implements OnInit, OnDestroy {
 
   ngOnInit(): void {
     this.startLongPoll();
-    this.http.dbGet(['cloud.dev.mode', 'cloud.endpoint.credentials']).subscribe({
+    this.http.dbGet(['cloud.dev.mode', 'cloud.endpoint.credentials',
+                     'cloud.proxy.device.ui.port']).subscribe({
       next: (r) => {
         if (r.ok && r.data) {
           const d = r.data as Record<string, unknown>;
           this.devMode = d['cloud.dev.mode'] === true;
+          const p = Number(d['cloud.proxy.device.ui.port']);
+          if (Number.isFinite(p) && p > 0) this.uiPort = p;
           try {
             const arr = JSON.parse(String(d['cloud.endpoint.credentials'] || '[]'));
             this.creds = Array.isArray(arr) ? arr : [];

--- a/modules/server/dnat/CMakeLists.txt
+++ b/modules/server/dnat/CMakeLists.txt
@@ -1,0 +1,36 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(server_dnat CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+set(DNAT_DIR ${CMAKE_CURRENT_SOURCE_DIR})
+
+if(NOT DEFINED ACE_ROOT)
+    set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
+endif()
+
+include_directories(${DNAT_DIR}/inc ${ACE_ROOT}/include)
+
+add_library(server_dnat STATIC
+    src/device_dnat.cpp)
+
+target_include_directories(server_dnat PUBLIC inc ${ACE_ROOT}/include)
+target_link_directories(server_dnat PUBLIC ${ACE_ROOT}/lib)
+target_link_libraries(server_dnat PUBLIC ACE pthread)
+
+option(BUILD_SERVER_DNAT_TESTS "Build server/dnat gtest suite" OFF)
+if(BUILD_SERVER_DNAT_TESTS)
+    find_package(GTest REQUIRED)
+    enable_testing()
+
+    add_executable(device-dnat-tests
+        test/device_dnat_test.cpp
+        src/device_dnat.cpp)
+    target_include_directories(device-dnat-tests
+        PRIVATE ${DNAT_DIR}/inc ${ACE_ROOT}/include)
+    target_link_directories(device-dnat-tests PRIVATE ${ACE_ROOT}/lib)
+    target_link_libraries(device-dnat-tests
+        GTest::gtest_main GTest::gtest ACE pthread)
+    add_test(NAME device-dnat-tests COMMAND device-dnat-tests)
+endif()

--- a/modules/server/dnat/inc/device_dnat.hpp
+++ b/modules/server/dnat/inc/device_dnat.hpp
@@ -1,0 +1,70 @@
+#ifndef __server_dnat_device_dnat_hpp__
+#define __server_dnat_device_dnat_hpp__
+
+/// Per-device "device UI over VPN" DNAT rule generator + applier.
+///
+/// An operator reaches a device's local web UI over the VPN by hitting
+/// the cloud on the device's assigned proxy port. The mechanism is
+/// nftables DNAT (NOT an application-layer reverse proxy):
+///
+///     cloud:<proxy_port>  →  DNAT  →  <tun_ip>:<ui_port>   over tun0
+///
+/// per device. This lives in iot-cloudd because iot-cloudd runs the
+/// OpenVPN *server*, so tun0 (and CAP_NET_ADMIN) are in its netns —
+/// the only place the DNAT can route over the tunnel.
+///
+/// build_device_dnat_ruleset() is pure (no syscalls, no nft, no logging)
+/// so it stays unit-testable; apply_ruleset() is the privileged step that
+/// pipes the script to `nft -f -` (mirrors how iot-cloudd shells out for
+/// openvpn). The generated script is scoped to its own table
+/// (`ip iot_cloud_dnat`) and is fully rebuildable — it always begins by
+/// flushing that table, so re-applying never doubles and a daemon restart
+/// restores all rules atomically from cloud.endpoints.
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace server {
+namespace dnat {
+
+/// One provisioned device's forwarding mapping.
+struct DeviceForward {
+    std::string   tun_ip;          ///< device VPN virtual IP (e.g. 10.9.0.12)
+    std::uint16_t proxy_port = 0;  ///< per-device cloud port (5001-6000)
+};
+
+/// Inputs to the ruleset generator. Plain POD so the tests stay pure.
+struct RulesetInput {
+    std::string                tun_dev = "tun0";  ///< openvpn tun device
+    std::uint16_t              ui_port = 80;       ///< device UI port (global)
+    std::vector<DeviceForward> devices;            ///< one entry per device
+};
+
+/// Render the full nft script text. Idempotent + rebuildable: always
+/// starts with `flush table ip iot_cloud_dnat` so re-applying never
+/// doubles, and a restart reconstructs the entire rule set from the
+/// current endpoint list. Skips devices missing a tun_ip or proxy_port.
+std::string build_device_dnat_ruleset(const RulesetInput& in);
+
+/// Render the human-readable mapping for one device, e.g.
+/// "tcp dport 5001 -> 10.9.0.12:80". Used by logging; the UI renders
+/// the same shape client-side.
+std::string format_mapping(const DeviceForward& d, std::uint16_t ui_port);
+
+/// Pipe `script` to `nft -f -`. Returns true on a clean (rc==0) apply.
+/// Shells out (mirrors the openvpn supervisor). On failure the caller
+/// keeps the previous live ruleset (this never partially applies because
+/// `nft -f -` is atomic per file).
+bool apply_ruleset(const std::string& script,
+                   const std::string& nft_path = "nft");
+
+/// Enable IPv4 forwarding (net.ipv4.ip_forward=1) so DNAT'd connections
+/// route out over the tunnel. Best-effort; returns false if the sysctl
+/// can't be written (logged by the caller).
+bool enable_ip_forward();
+
+} // namespace dnat
+} // namespace server
+
+#endif /* __server_dnat_device_dnat_hpp__ */

--- a/modules/server/dnat/src/device_dnat.cpp
+++ b/modules/server/dnat/src/device_dnat.cpp
@@ -1,0 +1,98 @@
+#include "device_dnat.hpp"
+
+#include <cstdio>
+#include <sstream>
+#include <string>
+
+#include <ace/Log_Msg.h>
+
+namespace server {
+namespace dnat {
+
+namespace {
+constexpr const char* kTable = "iot_cloud_dnat";
+} // namespace
+
+std::string format_mapping(const DeviceForward& d, std::uint16_t ui_port) {
+    std::ostringstream ss;
+    ss << "tcp dport " << d.proxy_port << " -> " << d.tun_ip << ":" << ui_port;
+    return ss.str();
+}
+
+std::string build_device_dnat_ruleset(const RulesetInput& in) {
+    std::ostringstream ss;
+    // Scope everything to our own table so re-applying flushes only our
+    // rules (never NetworkManager / docker / openvpn-managed chains). We
+    // use the `ip` family (IPv4) — the VPN subnet is IPv4.
+    ss << "flush table ip " << kTable << "\n";
+    ss << "table ip " << kTable << " {\n";
+
+    // ── prerouting (NAT): the per-device DNAT ──────────────────────
+    // cloud:<proxy_port> → <tun_ip>:<ui_port>. priority dstnat (-100)
+    // so it runs before routing, like the standard nat prerouting hook.
+    ss << "    chain prerouting {\n";
+    ss << "        type nat hook prerouting priority dstnat; policy accept;\n";
+    for (const auto& d : in.devices) {
+        if (d.tun_ip.empty() || d.proxy_port == 0) continue;
+        ss << "        tcp dport " << d.proxy_port
+           << " dnat to " << d.tun_ip << ":" << in.ui_port << "\n";
+    }
+    ss << "    }\n";
+
+    // ── postrouting (NAT): masquerade toward the tunnel ────────────
+    // So the device sees the connection coming from the cloud's tun IP
+    // (return path works without the device knowing a route back to the
+    // operator). Only masquerade traffic leaving via the tun device.
+    ss << "    chain postrouting {\n";
+    ss << "        type nat hook postrouting priority srcnat; policy accept;\n";
+    if (!in.tun_dev.empty())
+        ss << "        oifname \"" << in.tun_dev << "\" masquerade\n";
+    ss << "    }\n";
+
+    // ── forward (filter): accept the DNAT'd flow to/from the tunnel ─
+    // Default-accept chain; the explicit tun rules make intent clear and
+    // keep working even if a stricter policy is layered elsewhere.
+    ss << "    chain forward {\n";
+    ss << "        type filter hook forward priority filter; policy accept;\n";
+    if (!in.tun_dev.empty()) {
+        ss << "        oifname \"" << in.tun_dev << "\" accept\n";
+        ss << "        iifname \"" << in.tun_dev << "\" accept\n";
+    }
+    ss << "    }\n";
+
+    ss << "}\n";
+    return ss.str();
+}
+
+bool apply_ruleset(const std::string& script, const std::string& nft_path) {
+    const std::string cmd = nft_path + " -f -";
+    FILE* p = ::popen(cmd.c_str(), "w");
+    if (!p) {
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("%D cloudd:thread:%t %M %N:%l dnat popen(%C) "
+                                   "failed\n"),
+                          cmd.c_str()),
+                         false);
+    }
+    ::fwrite(script.data(), 1, script.size(), p);
+    const int rc = ::pclose(p);
+    if (rc != 0) {
+        ACE_ERROR_RETURN((LM_ERROR,
+                          ACE_TEXT("%D cloudd:thread:%t %M %N:%l dnat nft apply "
+                                   "rc=%d; ruleset:\n%C\n"),
+                          rc, script.c_str()),
+                         false);
+    }
+    return true;
+}
+
+bool enable_ip_forward() {
+    FILE* f = ::fopen("/proc/sys/net/ipv4/ip_forward", "w");
+    if (!f) return false;
+    const int n = ::fputs("1\n", f);
+    ::fclose(f);
+    return n >= 0;
+}
+
+} // namespace dnat
+} // namespace server

--- a/modules/server/dnat/test/device_dnat_test.cpp
+++ b/modules/server/dnat/test/device_dnat_test.cpp
@@ -1,0 +1,76 @@
+/// Table-driven tests for the pure per-device DNAT ruleset generator.
+
+#include <gtest/gtest.h>
+
+#include <string>
+
+#include "device_dnat.hpp"
+
+using server::dnat::build_device_dnat_ruleset;
+using server::dnat::DeviceForward;
+using server::dnat::format_mapping;
+using server::dnat::RulesetInput;
+
+namespace {
+bool contains(const std::string& hay, const std::string& needle) {
+    return hay.find(needle) != std::string::npos;
+}
+} // namespace
+
+TEST(DeviceDnat, EmptyStillEmitsScopedTableAndFlush) {
+    RulesetInput in;  // no devices
+    auto s = build_device_dnat_ruleset(in);
+    EXPECT_TRUE(contains(s, "flush table ip iot_cloud_dnat"));
+    EXPECT_TRUE(contains(s, "table ip iot_cloud_dnat {"));
+    EXPECT_TRUE(contains(s, "type nat hook prerouting"));
+    EXPECT_TRUE(contains(s, "type nat hook postrouting"));
+}
+
+TEST(DeviceDnat, SingleDeviceDnatRule) {
+    RulesetInput in;
+    in.ui_port = 80;
+    in.devices = {{"10.9.0.12", 5001}};
+    auto s = build_device_dnat_ruleset(in);
+    EXPECT_TRUE(contains(s, "tcp dport 5001 dnat to 10.9.0.12:80"));
+}
+
+TEST(DeviceDnat, MultipleDevicesEachGetARule) {
+    RulesetInput in;
+    in.ui_port = 80;
+    in.devices = {{"10.9.0.12", 5001}, {"10.9.0.13", 5002}};
+    auto s = build_device_dnat_ruleset(in);
+    EXPECT_TRUE(contains(s, "tcp dport 5001 dnat to 10.9.0.12:80"));
+    EXPECT_TRUE(contains(s, "tcp dport 5002 dnat to 10.9.0.13:80"));
+}
+
+TEST(DeviceDnat, NonDefaultUiPortHonored) {
+    RulesetInput in;
+    in.ui_port = 443;
+    in.devices = {{"10.9.0.12", 5001}};
+    auto s = build_device_dnat_ruleset(in);
+    EXPECT_TRUE(contains(s, "tcp dport 5001 dnat to 10.9.0.12:443"));
+}
+
+TEST(DeviceDnat, SkipsDevicesMissingTunIpOrPort) {
+    RulesetInput in;
+    in.devices = {{"", 5001}, {"10.9.0.13", 0}, {"10.9.0.14", 5003}};
+    auto s = build_device_dnat_ruleset(in);
+    EXPECT_FALSE(contains(s, "dport 5001"));
+    EXPECT_FALSE(contains(s, "10.9.0.13"));
+    EXPECT_TRUE(contains(s, "tcp dport 5003 dnat to 10.9.0.14:80"));
+}
+
+TEST(DeviceDnat, MasqueradeAndForwardScopedToTunDev) {
+    RulesetInput in;
+    in.tun_dev = "tun0";
+    in.devices = {{"10.9.0.12", 5001}};
+    auto s = build_device_dnat_ruleset(in);
+    EXPECT_TRUE(contains(s, "oifname \"tun0\" masquerade"));
+    EXPECT_TRUE(contains(s, "oifname \"tun0\" accept"));
+    EXPECT_TRUE(contains(s, "iifname \"tun0\" accept"));
+}
+
+TEST(DeviceDnat, FormatMappingShape) {
+    EXPECT_EQ("tcp dport 5001 -> 10.9.0.12:80",
+              format_mapping(DeviceForward{"10.9.0.12", 5001}, 80));
+}

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -210,6 +210,19 @@ return {
         write_acl = {"gid:cloud-svc"},
     },
 
+    -- Device web UI port reached over the VPN. iot-cloudd installs a
+    -- per-device nftables DNAT (cloud:<proxy_port> → <tun_ip>:ui_port over
+    -- tun0) so an operator can reach a device's local UI by hitting the
+    -- cloud on the device's assigned proxy port. Global (same value for all
+    -- devices); read live by iot-cloudd. The device UI listens on 80/443
+    -- (NOT 8080), so the default is 80.
+    ["cloud.proxy.device.ui.port"] = {
+      type    = "integer",
+      default = 80,
+      min     = 1,
+      max     = 65535,
+    },
+
     -- VPN subnet for tunnel IP allocation.
     ["cloud.vpn.subnet"] = {
       type    = "string",


### PR DESCRIPTION
## Goal
Let an operator reach a device's web UI over the VPN by hitting the cloud on the device's assigned proxy port. Mechanism = **nftables DNAT**, not an application-layer reverse proxy.

```
cloud:<proxy_port>  ->  DNAT  ->  <tun_ip>:<ui_port>   over tun0
```

per provisioned device. `modules/server/web` DeviceProxy is intentionally left as-is.

## How / where the rules are installed
New self-contained module **`modules/server/dnat`** (not net-router — kept self-contained in iot-cloudd per the brief):
- `build_device_dnat_ruleset()` — **pure, unit-tested** generator, scoped to its own table `ip iot_cloud_dnat`, flush-first so it's **idempotent + rebuildable**. Emits one `tcp dport <proxy_port> dnat to <tun_ip>:<ui_port>` per device plus `masquerade`/forward-accept on tun0.
- `apply_ruleset()` — **shells out to `nft -f -`** (atomic; mirrors the existing openvpn shell-out). Reused the existing `nft_rules` *pattern* but a dedicated builder, since net-router's `build_nft_ruleset` is tied to its single-target net.* model.
- `enable_ip_forward()` — sets `net.ipv4.ip_forward=1`.

iot-cloudd (`apps/cloud/server/src/main.cpp`) runs the OpenVPN server, so tun0 + CAP_NET_ADMIN are in its netns — the right place for the DNAT.

## Lifecycle
- **Startup**: enable ip_forward, then rebuild the full ruleset from the **persisted `cloud.endpoints` ds JSON** → a restart restores every device's mapping atomically (the in-memory EndpointRegistry is empty until re-provision, so cloud.endpoints is the authoritative source).
- **Provision/deprovision/online-change**: rebuild after each event sync.
- **Periodic tick**: safety-net rebuild (also picks up a live ui_port change).

## ds key
`cloud.proxy.device.ui.port` — **default 80** (device UI is on 80/443, not 8080). Declared in `modules/server/lwm2m/schemas/cloud.lua`; read live by iot-cloudd; seeded to ds at startup.

## Compose / Dockerfile
- `Dockerfile`: added **nftables** to the cloud runtime image (verified `nft v1.0.2` present).
- `docker-compose.yml` (iot-cloudd): publish **`5001-6000:5001-6000`** so `cloud:<proxy_port>` is reachable; added **`net.ipv4.ip_forward=1`** sysctl. `NET_ADMIN` + `/dev/net/tun` were already present.

## UI
`endpoint-list.component.ts`: kept the existing **Launch UI** link (correct for DNAT); added a **"VPN forwarding rule"** line in the per-endpoint detail panel (`tcp dport <proxy_port> → <tun_ip>:<ui_port>`), ui_port fetched via the existing `dbGet` path (fallback 80). Clarity datagrid only.

## Build results
- **Cloud image** (full Dockerfile): builds clean — iot-cloudd C++ compiles + links with the new DNAT source; nft present in the runtime image.
- **cloud-ui** (node:18-alpine prod build): passes; both new strings present in the production bundle.
- Added a gtest suite `device-dnat-tests` (`BUILD_SERVER_DNAT_TESTS`). The builder image has no gtest installed and `apt-get` in the ephemeral container was sandbox-blocked, so the suite wasn't executed here; logic was otherwise validated via the build + manual review.

## Deployment note
The proxy-port-range publish (`5001-6000`) opens 1000 host ports on iot-cloudd — fine for podman/compose; confirm any host firewall allows that range to the operator network.

🤖 Generated with [Claude Code](https://claude.com/claude-code)