### PR TITLE
feat(device-ui): add custom firewall rules page to Routing

### DIFF
--- a/iot-ui/src/app/app.module.ts
+++ b/iot-ui/src/app/app.module.ts
@@ -23,6 +23,7 @@ import { IfacePriorityComponent } from './wan/iface-priority/iface-priority.comp
 
 import { RoutingSubmenuComponent } from './routing/routing-submenu/routing-submenu.component';
 import { PortForwardComponent } from './routing/port-forward/port-forward.component';
+import { CustomRulesComponent } from './routing/custom-rules/custom-rules.component';
 
 import { Lwm2mSubmenuComponent } from './lwm2m/lwm2m-submenu/lwm2m-submenu.component';
 import { Lwm2mConfigComponent } from './lwm2m/lwm2m-config/lwm2m-config.component';
@@ -49,7 +50,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     StatusBadgeComponent,
     VpnSubmenuComponent, VpnConfigComponent, VpnStatusComponent,
     WanSubmenuComponent, WifiConfigComponent, WifiScanComponent, IfacePriorityComponent,
-    RoutingSubmenuComponent, PortForwardComponent,
+    RoutingSubmenuComponent, PortForwardComponent, CustomRulesComponent,
     Lwm2mSubmenuComponent, Lwm2mConfigComponent,
     ServicesSubmenuComponent, ServicesListComponent,
     LogLevelComponent, LogViewerComponent, ToastComponent,

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -95,6 +95,7 @@
       <!-- Routing -->
       <ng-container *ngIf="selectedMenu==='routing'">
         <app-port-forward *ngIf="!selectedSubNav || selectedSubNav==='ports' || selectedSubNav==='dnat'"></app-port-forward>
+        <app-custom-rules *ngIf="selectedSubNav==='rules'"></app-custom-rules>
       </ng-container>
 
       <!-- LwM2M -->

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -31,7 +31,7 @@ export class MainComponent {
     { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg',
       children: [{id:'wifi',label:'WiFi Config'},{id:'scan',label:'Scan Results'},{id:'priority',label:'Priority'}] },
     { id: 'routing',   label: 'Routing',   svg: 'assets/icons/routing.svg',
-      children: [{id:'ports',label:'Port Forward'},{id:'dnat',label:'DNAT Target'}] },
+      children: [{id:'ports',label:'Port Forward'},{id:'dnat',label:'DNAT Target'},{id:'rules',label:'Firewall Rules'}] },
     { id: 'lwm2m',     label: 'LwM2M',     svg: 'assets/icons/lwm2m.svg',
       children: [{id:'server',label:'Server'},{id:'security',label:'Security'}] },
     { id: 'services',  label: 'Services',  svg: 'assets/icons/services.svg',

--- a/iot-ui/src/app/routing/custom-rules/custom-rules.component.ts
+++ b/iot-ui/src/app/routing/custom-rules/custom-rules.component.ts
@@ -1,0 +1,184 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpsvcService } from '../../../common/httpsvc.service';
+import { SessionService } from '../../../common/session.service';
+import { ToastService } from '../../../common/toast.service';
+import { DataStoreService } from '../../../common/datastore.service';
+
+/// One firewall rule as stored in net.custom.rules (JSON array).
+/// Mirrors the CustomRule POD parsed by the net-router daemon
+/// (modules/net/router/src/nft_rules.cpp): action + proto are required;
+/// to_ip/to_port apply only to action="forward".
+interface CustomRule {
+  action: string;            // "accept" | "drop" | "forward"
+  proto: string;             // "tcp" | "udp"
+  dport?: number;
+  sport?: number;
+  to_ip?: string;
+  to_port?: number;
+}
+
+@Component({
+  selector: 'app-custom-rules',
+  template: `
+    <div class="page">
+      <div class="header-row">
+        <h3>Firewall Rules</h3>
+        <app-status-badge [label]="'router ' + (routeState||'unknown')" [state]="routeState||''"></app-status-badge>
+      </div>
+      <p *ngIf="routeState==='bad_custom_rules'" class="bad">
+        Malformed rules JSON — the daemon kept the previous ruleset.
+      </p>
+
+      <!-- Add rule (admin) -->
+      <div class="card" *ngIf="isAdmin" style="margin-bottom:20px;">
+        <div class="card-header">Add Firewall Rule</div>
+        <div class="card-block">
+          <div class="form-grid" style="align-items:end;">
+            <clr-select-container>
+              <label>Action</label>
+              <select clrSelect [(ngModel)]="nAction">
+                <option *ngFor="let a of actions" [value]="a">{{ a }}</option>
+              </select>
+            </clr-select-container>
+            <clr-select-container>
+              <label>Protocol</label>
+              <select clrSelect [(ngModel)]="nProto">
+                <option *ngFor="let p of protos" [value]="p">{{ p }}</option>
+              </select>
+            </clr-select-container>
+            <clr-input-container>
+              <label>Dest Port</label>
+              <input clrInput type="number" [(ngModel)]="nDport" placeholder="optional" />
+            </clr-input-container>
+            <clr-input-container>
+              <label>Src Port</label>
+              <input clrInput type="number" [(ngModel)]="nSport" placeholder="optional" />
+            </clr-input-container>
+            <clr-input-container *ngIf="nAction==='forward'">
+              <label>Forward To IP</label>
+              <input clrInput [(ngModel)]="nToIp" placeholder="10.9.0.12" />
+            </clr-input-container>
+            <clr-input-container *ngIf="nAction==='forward'">
+              <label>Forward To Port</label>
+              <input clrInput type="number" [(ngModel)]="nToPort" placeholder="5684" />
+            </clr-input-container>
+            <!-- pad the forward row to a full 4 columns -->
+            <div *ngIf="nAction==='forward'"></div>
+            <div *ngIf="nAction==='forward'"></div>
+            <!-- ds-key hint (debug mode) -->
+            <clr-control-helper *dsDebug><app-ds-hint key="net.custom.rules"></app-ds-hint></clr-control-helper>
+          </div>
+          <button class="btn btn-primary" (click)="addRule()" [disabled]="saving">
+            {{ saving ? 'Saving…' : 'Add Rule' }}
+          </button>
+        </div>
+      </div>
+
+      <!-- Firewall (custom) rules -->
+      <h4>Firewall Rules <span class="hint">(net.custom.rules)</span></h4>
+      <clr-datagrid>
+        <clr-dg-column>Action</clr-dg-column>
+        <clr-dg-column>Protocol</clr-dg-column>
+        <clr-dg-column>Dest Port</clr-dg-column>
+        <clr-dg-column>Src Port</clr-dg-column>
+        <clr-dg-column>Forward To</clr-dg-column>
+        <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
+
+        <clr-dg-row *clrDgItems="let r of rules">
+          <clr-dg-cell>
+            <app-status-badge [label]="r.action"
+              [state]="r.action==='drop' ? 'exited' : 'connected'"></app-status-badge>
+          </clr-dg-cell>
+          <clr-dg-cell>{{ r.proto }}</clr-dg-cell>
+          <clr-dg-cell>{{ r.dport != null ? r.dport : '—' }}</clr-dg-cell>
+          <clr-dg-cell>{{ r.sport != null ? r.sport : '—' }}</clr-dg-cell>
+          <clr-dg-cell>{{ r.action==='forward' ? (r.to_ip + (r.to_port!=null ? ':'+r.to_port : '')) : '—' }}</clr-dg-cell>
+          <clr-dg-cell *ngIf="isAdmin">
+            <button class="btn btn-sm btn-danger" (click)="removeRule(r)" [disabled]="saving">Delete</button>
+          </clr-dg-cell>
+        </clr-dg-row>
+
+        <clr-dg-footer>{{ rules.length }} rule{{ rules.length===1?'':'s' }}</clr-dg-footer>
+      </clr-datagrid>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; }
+    .header-row { display: flex; align-items: center; gap: 12px; margin: 0 0 16px 0; }
+    h3 { color: #333; margin: 0; font-size: 16px; font-weight: 600; }
+    h4 { color: #555; margin: 18px 0 10px 0; font-size: 13px; font-weight: 600; }
+    .hint { color: #888; font-weight: normal; font-size: 11px; }
+    .bad { color: #c62828; font-size: 12px; margin: 0 0 12px 0; }
+  `]
+})
+export class CustomRulesComponent implements OnInit {
+  rules: CustomRule[] = [];
+  routeState = '';
+
+  // Add-rule form state
+  nAction = 'accept';
+  nProto = 'tcp';
+  nDport: number | null = null;
+  nSport: number | null = null;
+  nToIp = '';
+  nToPort: number | null = null;
+  actions = ['accept', 'drop', 'forward'];
+  protos = ['tcp', 'udp'];
+  saving = false;
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpsvcService, private session: SessionService,
+              private toast: ToastService, private ds: DataStoreService) {}
+
+  ngOnInit(): void {
+    // Instant paint from the prefetched cache, then refresh from the wire.
+    this.applyData(this.ds.snapshot());
+    this.http.dbGet(['net.custom.rules', 'net.state']).subscribe({
+      next: (r) => { if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>); }
+    });
+  }
+
+  private applyData(d: Record<string, unknown>): void {
+    if (d['net.custom.rules'] != null) {
+      try { const arr = JSON.parse(String(d['net.custom.rules'])); this.rules = Array.isArray(arr) ? arr : []; }
+      catch { this.rules = []; }
+    }
+    if (d['net.state'] != null) this.routeState = String(d['net.state']);
+  }
+
+  addRule(): void {
+    if (!this.nAction || !this.nProto) { this.toast.error('Action and protocol are required'); return; }
+    const rule: CustomRule = { action: this.nAction, proto: this.nProto };
+    if (this.nDport != null && String(this.nDport) !== '') rule.dport = Number(this.nDport);
+    if (this.nSport != null && String(this.nSport) !== '') rule.sport = Number(this.nSport);
+    if (this.nAction === 'forward') {
+      if (!this.nToIp) { this.toast.error('forward action needs a target IP'); return; }
+      rule.to_ip = this.nToIp;
+      if (this.nToPort != null && String(this.nToPort) !== '') rule.to_port = Number(this.nToPort);
+    }
+    this.persist([...this.rules, rule], 'Rule added');
+  }
+
+  removeRule(rule: CustomRule): void {
+    const next = this.rules.filter(r => r !== rule);
+    this.persist(next, 'Rule deleted');
+  }
+
+  private persist(next: CustomRule[], okMsg: string): void {
+    this.saving = true;
+    this.http.dbSet([{ key: 'net.custom.rules', value: JSON.stringify(next) }]).subscribe({
+      next: (r) => {
+        this.saving = false;
+        if (r.ok) { this.rules = next; this.toast.success(okMsg); this.resetForm(); }
+        else { this.toast.error(r.err || 'Save failed'); }
+      },
+      error: () => { this.saving = false; this.toast.error('Save failed'); }
+    });
+  }
+
+  private resetForm(): void {
+    this.nAction = 'accept'; this.nProto = 'tcp';
+    this.nDport = null; this.nSport = null; this.nToIp = ''; this.nToPort = null;
+  }
+}

--- a/iot-ui/src/app/routing/routing-submenu/routing-submenu.component.ts
+++ b/iot-ui/src/app/routing/routing-submenu/routing-submenu.component.ts
@@ -6,6 +6,7 @@ import { Component, Output, EventEmitter } from '@angular/core';
     <nav class="subnav">
       <a class="subnav-item" [class.active]="active==='ports'" (click)="s('ports')">Port Forward</a>
       <a class="subnav-item" [class.active]="active==='dnat'" (click)="s('dnat')">DNAT Target</a>
+      <a class="subnav-item" [class.active]="active==='rules'" (click)="s('rules')">Firewall Rules</a>
     </nav>
   `,
   styles: [`


### PR DESCRIPTION
## Summary
Adds a **Custom Firewall Rules** page to the **device-ui** (`iot-ui`) Routing section, mirroring the cloud-ui's existing one. `net-router` runs on the real device, so device-side custom firewall rules (`net.custom.rules`) are functional there.

## What's included
- **New** `iot-ui/src/app/routing/custom-rules/custom-rules.component.ts` (`CustomRulesComponent`)
  - "Add Firewall Rule" form: Action / Protocol / Dest Port / Src Port (+ Forward To IP/Port when action is `forward`), padded to a 4-column `.form-grid`.
  - Writes the `net.custom.rules` JSON array; lists existing rules in a Clarity `clr-datagrid` with per-row Delete; admin-gated.
  - Debug ds-key hint: `<clr-control-helper *dsDebug><app-ds-hint key="net.custom.rules"></app-ds-hint></clr-control-helper>`.
  - Reuses the existing `net.custom.rules` ds key (no new keys).
- **Data service**: uses the device-ui services like the sibling `port-forward` component — `HttpsvcService` (`dbGet`/`dbSet`), `SessionService`, `ToastService`, `DataStoreService` — not the cloud-ui wiring.

## Wiring
- `main.component.ts`: added a `{id:'rules',label:'Firewall Rules'}` child to the **Routing** sidebar menu (device-ui navigation is sidebar-driven via `selectedMenu`/`selectedSubNav`, which is how `port-forward` is actually reached).
- `main.component.html`: renders `<app-custom-rules>` when `selectedSubNav==='rules'` under the Routing container.
- `app.module.ts`: imported + declared `CustomRulesComponent`.
- `routing-submenu.component.ts`: added a "Firewall Rules" tab for parity.
- `app-routing.module.ts`: unchanged — `port-forward` and all routing feature pages are not registered as Angular routes (they render in `main.component`), so mirroring `port-forward` means no route entry.

## Scope
Only the custom firewall rules page was ported. DNAT-target/port-forward changes were not touched (device-ui already has a `port-forward` page).

## Build
Built the device-ui production bundle in `node:18-alpine` (anonymous `/app/node_modules`, `npx ng build --configuration production`), matching `apps/device/Dockerfile`. **Passes** — only pre-existing warnings (`@clr/icons` CommonJS, bundle budget, an unrelated wifi-scan NG8107). No errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)