### PR TITLE
feat(cloud): ds-driven per-device proxy-port range

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -60,10 +60,13 @@ services:
       - /dev/net/tun        # openvpn(8) server spawned by iot-cloudd
     ports:
       - "1194:1194/tcp"     # OpenVPN server (TCP)
-      # Per-device device-UI-over-VPN proxy ports (VpnRegistry allocates
-      # 5001-6000). Publishing the range makes cloud:<proxy_port> reachable
-      # from the operator's browser; iot-cloudd DNATs each to <tun_ip>:ui_port.
-      - "5001-6000:5001-6000"
+      # Per-device device-UI-over-VPN proxy ports. Publishing the range makes
+      # cloud:<proxy_port> reachable from the operator's browser; iot-cloudd
+      # DNATs each to <tun_ip>:ui_port. The range is env-parameterised to match
+      # the same PROXY_START/PROXY_END passed to iot-cloudd above, which seed
+      # the ds keys cloud.vpn.proxy.port.{start,end} (Docker can't read ds, so
+      # this publish must be kept in sync with that ds range).
+      - "${PROXY_START:-5001}-${PROXY_END:-6000}:${PROXY_START:-5001}-${PROXY_END:-6000}"
     depends_on:
       ds-server:
         condition: service_healthy

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -262,6 +262,19 @@ int main(int argc, char** argv) {
         return 1;
     }
 
+    // Proxy-port range is ds-driven (cloud.vpn.proxy.port.{start,end}); the
+    // CLI arg / built-in default is only the fallback so the range is never
+    // hardcoded. Seed the effective values back so they're visible/editable
+    // in ds (idempotent: an operator-set value is read then re-set unchanged).
+    // NB: the docker-compose port-publish range must still cover this — Docker
+    // can't read ds, so that publish stays a deployment knob.
+    proxy_port_start = ds_int(ds, "cloud.vpn.proxy.port.start", proxy_port_start);
+    proxy_port_end   = ds_int(ds, "cloud.vpn.proxy.port.end",   proxy_port_end);
+    ds.set("cloud.vpn.proxy.port.start",
+           data_store::Value{static_cast<std::uint32_t>(proxy_port_start)});
+    ds.set("cloud.vpn.proxy.port.end",
+           data_store::Value{static_cast<std::uint32_t>(proxy_port_end)});
+
     // ── Core services ─────────────────────────────────────────────
     server::openvpn::VpnRegistry vpn_reg(vpn_subnet,
         static_cast<std::uint16_t>(proxy_port_start),

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -277,6 +277,24 @@ return {
       max     = 6000,
     },
 
+    -- Per-device proxy-port allocation range for device-UI-over-VPN DNAT.
+    -- ds-driven so it isn't hardcoded; iot-cloudd reads these to size the
+    -- VpnRegistry pool. The docker-compose published port range must cover
+    -- this (Docker publishes ports before ds is consulted, so it can't follow
+    -- ds automatically).
+    ["cloud.vpn.proxy.port.start"] = {
+      type    = "integer",
+      default = 5001,
+      min     = 1,
+      max     = 65535,
+    },
+    ["cloud.vpn.proxy.port.end"] = {
+      type    = "integer",
+      default = 6000,
+      min     = 1,
+      max     = 65535,
+    },
+
     -- VPN PKI paths.  CA + server certs are generated at image build
     -- time (per-build CA, xpmile pattern).  ca.key is NOT in the image
     -- — mount at runtime via secret volume.


### PR DESCRIPTION
The device-UI-over-VPN DNAT proxy-port range (5001-6000) was effectively hardcoded. This makes it **data-store driven**, consistent with the other `cloud.vpn.*` keys.

- `iot-cloudd` reads `cloud.vpn.proxy.port.start` / `cloud.vpn.proxy.port.end` from ds (CLI arg / built-in default only as fallback), seeds the effective values back (idempotent), and sizes `VpnRegistry` from them.
- `cloud.lua`: declared both keys (integer, default 5001/6000) — required since ds is schema-enforced.
- `docker-compose`: published range is now `${PROXY_START:-5001}-${PROXY_END:-6000}` (the same env that seeds the ds keys).

**Inherent limitation (documented inline):** Docker publishes ports at container creation, before ds is consulted, so the *publish* range can't literally follow ds — it follows `PROXY_START/PROXY_END`, which also seed the ds keys, keeping them aligned.

Verified: cloud image builds clean (exit 0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)