### PR TITLE
feat(cloud): iot-cloudd host networking (ds-only proxy-port range, no publish)

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -40,12 +40,17 @@ services:
   iot-cloudd:
     image: ${CLOUD_IMAGE:-docker.io/naushada/iot-cloud:latest}
     container_name: iot-cloudd
+    # Host networking: iot-cloudd runs the OpenVPN server AND installs the
+    # per-device nftables DNAT (proxy_port -> tun_ip:ui_port). On the host
+    # netns there is nothing to publish — openvpn 1194 + every DNAT'd proxy
+    # port are reachable directly on the host, so the proxy-port range is
+    # 100% ds-driven (cloud.vpn.proxy.port.{start,end}) with no env / no
+    # published-range to keep in sync. Host firewall still gates access.
+    network_mode: host
     command: >
       iot-cloudd
       ds-socket=/var/run/iot/data_store.sock
       vpn-subnet=${VPN_SUBNET:-10.9.0.0/24}
-      proxy-start=${PROXY_START:-5001}
-      proxy-end=${PROXY_END:-6000}
       sync-interval=5
     volumes:
       - iot-run:/var/run/iot
@@ -53,20 +58,12 @@ services:
       - iot-vpn:/etc/iot/vpn
       - iot-ca-key:/run/secrets/iot-ca-key:ro
     cap_add:
-      - NET_ADMIN           # openvpn tun + per-device nftables DNAT
-    sysctls:
-      - net.ipv4.ip_forward=1   # route the DNAT'd device-UI flow over the tunnel
+      - NET_ADMIN           # openvpn tun + per-device nftables DNAT + ip_forward
     devices:
       - /dev/net/tun        # openvpn(8) server spawned by iot-cloudd
-    ports:
-      - "1194:1194/tcp"     # OpenVPN server (TCP)
-      # Per-device device-UI-over-VPN proxy ports. Publishing the range makes
-      # cloud:<proxy_port> reachable from the operator's browser; iot-cloudd
-      # DNATs each to <tun_ip>:ui_port. The range is env-parameterised to match
-      # the same PROXY_START/PROXY_END passed to iot-cloudd above, which seed
-      # the ds keys cloud.vpn.proxy.port.{start,end} (Docker can't read ds, so
-      # this publish must be kept in sync with that ds range).
-      - "${PROXY_START:-5001}-${PROXY_END:-6000}:${PROXY_START:-5001}-${PROXY_END:-6000}"
+    # No sysctls block: net.* sysctls aren't settable per-container under host
+    # networking. iot-cloudd's enable_ip_forward() sets net.ipv4.ip_forward at
+    # startup (NET_ADMIN on the host netns); ensure it's enabled on the host.
     depends_on:
       ds-server:
         condition: service_healthy


### PR DESCRIPTION
Makes the per-device proxy-port range **fully ds-driven with zero env** by switching `iot-cloudd` to `network_mode: host`.

**Why:** Docker publishes ports at container-creation time, before `ds-server` runs, so a published `ports:` range can't follow ds — it needed `PROXY_START/PROXY_END` env. With host networking there's nothing to publish: the OpenVPN server (1194) and every DNAT'd proxy port are reachable directly on the host, so `cloud.vpn.proxy.port.{start,end}` is the single source of truth.

**Changes (`apps/cloud/docker-compose.yml`, iot-cloudd only):**
- `network_mode: host`; removed the `ports:` block and the `PROXY_START/END` CLI args (ds + built-in default drive the range).
- Removed `sysctls: net.ipv4.ip_forward` — not settable per-container under host networking; `iot-cloudd`'s `enable_ip_forward()` (main.cpp:480) sets it at startup with NET_ADMIN on the host netns.

**Trade-offs:** less network isolation (iot-cloudd shares the host netns); host firewall still gates the proxy-port range; on macOS/podman dev, host networking differs from the Linux host (dev/prod parity caveat). Compose validated with `podman compose config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)