### PR TITLE
docs: device UI over VPN DNAT, ds-driven VPN endpoint push, vpn.state known issue, RPi flashing

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -223,6 +223,22 @@ bzcat $IMG | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
 # macOS: target the raw node /dev/rdiskN instead of /dev/diskN — much faster.
 ```
 
+> **Pick the right disk — `dd` is irreversible and writes the whole device.**
+> On macOS run `diskutil list` and identify the card by **size** (e.g. a 32 GB
+> card), *not* the internal Mac disk (`disk0`, usually the largest with an
+> `APFS`/`Apple_APFS` container). Writing to the wrong `/dev/diskN` destroys
+> that disk with no undo. Full macOS sequence:
+>
+> ```sh
+> diskutil list                                   # find the card by size
+> diskutil unmountDisk /dev/diskN                 # unmount (don't eject yet)
+> bzcat $IMG | sudo dd of=/dev/rdiskN bs=4m       # raw node = much faster
+> sync                                            # flush write cache
+> diskutil eject /dev/diskN                       # safe to remove
+> ```
+>
+> (`bs=4m` is the BSD `dd` spelling on macOS; `bs=4M` is the GNU/Linux one.)
+
 > The build does **not** emit a `.bmap` file: `bmaptool` needs the FIEMAP
 > ioctl / `SEEK_HOLE`, which the macOS-podman build filesystem doesn't
 > support, so `wic.bmap` is omitted from `IMAGE_FSTYPES`. If you build on a

--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -246,6 +246,61 @@ mirror).
 `apps/config/`) are also copied into the cloud image at `/etc/iot/` so
 the lwm2m binary finds the schema and provisioning data it expects.
 
+## Device UI over VPN
+
+Each registered device runs its own web UI behind NAT, reachable from the
+operator only through the tunnel. The cloud exposes it via a per-device DNAT.
+
+**Per-device mapping.** When a device registers it is assigned a VPN virtual
+IP (`tun_ip`, e.g. `10.9.0.x`) and a proxy port (`proxy_port`, allocated by
+`VpnRegistry`); both live in the `cloud.endpoints` ds JSON. Operator access is
+`http://<cloud-host>:<proxy_port>/` — the Endpoints page **Launch UI** link —
+which DNATs to the device's UI over the tunnel.
+
+**nftables DNAT (`modules/server/dnat`).** `iot-cloudd` installs a per-device
+DNAT for every endpoint that has both a `tun_ip` and a `proxy_port`:
+
+```
+tcp dport <proxy_port> dnat to <tun_ip>:<ui_port>     # prerouting (nat)
+oifname "tun0" masquerade                              # postrouting (nat)
+oifname/iifname "tun0" accept                          # forward (filter)
+```
+
+The whole ruleset lives in its own table `ip iot_cloud_dnat` so re-applying
+flushes only our rules (never NetworkManager / docker / openvpn chains). It is
+built (`build_device_dnat_ruleset`) from `cloud.endpoints` and applied with
+`nft -f -` (`apply_ruleset`) at startup and on every provision / deprovision /
+registration change — idempotent (full-table flush + rebuild). `iot-cloudd`
+also enables IPv4 forwarding (`enable_ip_forward` → `net.ipv4.ip_forward=1`)
+once at startup.
+
+**ds-driven ports** (no Docker publish — see host-networking note below):
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `cloud.proxy.device.ui.port` | `80` | the device's web-UI port (DNAT target port); seeded at startup |
+| `cloud.vpn.proxy.port.start` | `5001` | low end of the proxy-port range `VpnRegistry` allocates from |
+| `cloud.vpn.proxy.port.end` | `6000` | high end of the proxy-port range |
+
+The range is read from ds at startup (CLI `proxy-start=`/`proxy-end=` are
+fallbacks) and written back so it is visible/editable; changing
+`cloud.proxy.device.ui.port` triggers a DNAT rebuild.
+
+**Host networking.** `iot-cloudd` runs with `network_mode: host` and **no**
+published `ports:` — it runs the OpenVPN server *and* installs the DNAT on the
+host netns, so the entire proxy-port range plus 1194 are reachable directly on
+the host with nothing to keep in sync. Consequences:
+
+- The proxy range is 100% ds-controlled (no Docker publish, no env).
+- The **host firewall** must allow the proxy range + `1194/tcp` to operators
+  (ideally scoped to admin source IPs — see `host-firewall.sh`).
+- `net.* ` sysctls aren't settable per-container under host networking, so
+  `iot-cloudd` sets `net.ipv4.ip_forward=1` itself at startup (needs
+  `NET_ADMIN` on the host netns); ensure it stays enabled on the host.
+
+The cloud also pushes the VPN *endpoint* (host/port/proto) down to the device
+over LwM2M Object 2048 — see `apps/docs/lwm2m-object-handling.md` §2.8.
+
 ## Log Levels
 
 Default is `INFO` for all daemons. Per-daemon keys override the global

--- a/apps/docs/lwm2m-object-handling.md
+++ b/apps/docs/lwm2m-object-handling.md
@@ -198,6 +198,34 @@ re-provision differently:
   (`docker restart iot-cloudd` / restart the `lwm2m-bs` unit) so it picks up the
   new credential.
 
+### 2.8 Pushing the VPN server endpoint (Object 2048 RIDs 5/6/7)
+
+The device needs to know *where* to dial the OpenVPN server. Rather than seed
+it through docker-compose env (those seeds were removed — **ds is the source of
+truth**), the cloud DM server pushes the endpoint down the same Object 2048
+delivery that carries the VPN cert family.
+
+**Cloud side** (`build_cert_push`, `apps/src/lwm2m_dm_server.cpp`). Alongside
+the ca/cert/key chunks (instances 0/1/2 → RID 1), it appends three small
+plain-text WRITEs to **instance 0**:
+
+| RID | ds key derived from | Notes |
+|-----|---------------------|-------|
+| 5 (VPN host)  | `cloud.dm.uri` (host parsed out) | only emitted when known; empty host → cert-only push (back-compatible) |
+| 6 (VPN port)  | `cloud.vpn.listen.port` | as a decimal string |
+| 7 (VPN proto) | `cloud.vpn.proto`, mapped `tcp-server` → `tcp-client` | the device dials, so the role is flipped |
+
+The push (`apps/src/main.cpp`, DM wiring) is sent on each registration/cert-push
+cycle until `cloud.vpn.connected` lists the endpoint, then it stops. The push is
+finalised by the same **RID 3 (Apply) EXECUTE** that commits the cert family.
+
+**Device side** (`certHooks.set_vpn_endpoint`, `apps/src/main.cpp`). At Apply,
+the staged values are materialised into `vpn.remote.host` / `vpn.remote.port`
+(parsed to the schema's integer) / `vpn.remote.proto`. The cert hook's
+`false→true` gate-flip on `services.openvpn.client.enable` (see §2 of
+`modules/openvpn/client/docs/design.md`) then hot-reloads openvpn-client, which
+re-execs reading the new `vpn.remote.*` — no compose seed, no manual restart.
+
 ---
 
 ## 3. Registration interface — `POST /rd`

--- a/modules/openvpn/client/docs/design.md
+++ b/modules/openvpn/client/docs/design.md
@@ -275,6 +275,41 @@ two more transitions out of every state above:
 
 Auto-restart on bare child crash (no WAN event) is still FUP-L12-1.
 
+## Known issue: `vpn.state` stuck at `connecting`
+
+> **Status: known issue, fix pending.** The tunnel itself works.
+
+**Symptom.** The tunnel is fully up — `tun0` has the assigned IP,
+openvpn logged `Initialization Sequence Completed`, and the cloud's
+`cloud.vpn.connected` lists the endpoint — yet `vpn.state` reads
+`connecting` and never advances to `connected`. `vpn.assigned.ip` is still
+set correctly.
+
+**Cause.** On attach the supervisor sends `state on` (`supervisor.cpp`),
+which enables *future* real-time `>STATE:` notifications. It does **not**
+issue a query for the *current* state. If openvpn already reached
+`CONNECTED` before the daemon attached the mgmt socket, that transition
+was emitted before notifications were on and is therefore missed — so the
+Lifecycle never sees the `CONNECTED` `>STATE:` event that would write
+`vpn.state=connected`. `vpn.assigned.ip` still gets set because the
+`>PUSH_REPLY` line is parsed independently.
+
+The mgmt parser (`mgmt_protocol.cpp`) only recognises the prefixed
+`>STATE:` / `>PUSH_REPLY:` events. A bare `state` *query response* (the
+state record without the `>STATE:` prefix) is classified as a `DataLine`
+response payload and ignored by the Lifecycle — so even if the current
+state were requested today, the reply wouldn't update `vpn.state`.
+
+> Note: the inline comment at `supervisor.cpp` (`state on` "makes it emit
+> the CURRENT state immediately") describes the *intended* behavior; in
+> practice the current-state emission arrives as the bare state-record
+> response that the parser drops, which is why this issue persists.
+
+**Pending fix.** After `state on`, also send `state 1` (query the current
+state) **and** teach the parser to surface the bare state-record response
+as a `State` event so the Lifecycle promotes `vpn.state` to `connected`
+even when the daemon attached late.
+
 ## Related docs
 
 - [L12 plan](../../../log/L12/plan.md) — phase plan + risk register

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -186,7 +186,7 @@ end-to-end push from the cloud UI.
 | `iot_git.bb`             | `PN=iot`; sub-packages: `iot-ds-server`, `iot-ds-cli`, `iot-lwm2m`, `iot-openvpn-client`, `iot-net-router`, `iot-wifi-client`, `iot-httpd`, `iot-config` |
 | `images/iot-image.bb`    | Full bootable distribution (`packagegroup-iot-full` + kernel modules + RPi Wi-Fi/BT firmware + sshd + opkg) → `*.wic.bz2` |
 | `ace-tao_7.0.0.bb`       | `libACE.so.7.0.0`, `libACE_SSL.so.7.0.0`, dev headers       |
-| `tinydtls_git.bb`        | `libtinydtls.a` (static archive)                             |
+| `tinydtls_git.bb`        | `libtinydtls.a` (static archive). Carries `0002-add-dtls-log-sink.patch` — adds `dtls_set_log_sink()` (present in the in-tree fork `apps/3rdparty/tinydtls`, absent from the legatoproject SRCREV) so the iot binary's DTLS log-sink in `apps/src/main.cpp` links. See the patch header for detail. |
 | `mongo-c-driver_1.19.bb` | `libbson-1.0.so`, `libmongoc-1.0.so`                        |
 | `mongo-cxx-driver_3.6.bb`| `libbsoncxx.so`, `libmongocxx.so`                            |
 | `packagegroup-iot.bb`    | Meta-packages: `packagegroup-iot-core`, `-full`, `-debug`   |


### PR DESCRIPTION
Documents features/findings landed this session (already merged to `main`, PRs #143–#150). **Markdown only — no code changes.**

## What changed, per file

- **`apps/cloud/CLAUDE.md`** — new **"Device UI over VPN"** section: each device gets a `tun_ip` + `proxy_port` (in `cloud.endpoints`); `iot-cloudd` installs a per-device nftables DNAT (`modules/server/dnat`, table `ip iot_cloud_dnat`, `tcp dport <proxy_port> dnat to <tun_ip>:<ui_port>` + tun0 masquerade + forward accept, rebuilt idempotently via `nft -f -`); ds-driven `cloud.proxy.device.ui.port` (80) and `cloud.vpn.proxy.port.{start,end}` (5001/6000); `network_mode: host` rationale + host-firewall / `ip_forward` consequences; operator `Launch UI` access.
- **`apps/docs/lwm2m-object-handling.md`** — new **§2.8**: cloud pushes `vpn.remote.host/port/proto` over **Object 2048 instance 0, RIDs 5/6/7** in `build_cert_push` (derived from `cloud.dm.uri` host + `cloud.vpn.listen.port` + `cloud.vpn.proto` with `tcp-server`→`tcp-client`), device materialises at Apply and openvpn-client hot-reloads; ds is the source of truth (compose seeds removed). Placed as a sibling to the existing §2.7 PSK hot-change note.
- **`modules/openvpn/client/docs/design.md`** — new **"Known issue: `vpn.state` stuck at `connecting`"**: `state on` enables future `>STATE:` only and the current state is missed if openvpn reached `CONNECTED` before attach; the bare `state`-query response is parsed as `DataLine` and dropped; `vpn.assigned.ip` still set via `>PUSH_REPLY`. Pending fix (query `state 1` + parse the bare record as State) outlined. Marked clearly as a known issue.
- **`DEPLOY.md`** — extended the existing **Path C** manual flash section with a strong macOS warning + full sequence (`diskutil list` by size, `unmountDisk`, `bzcat | dd of=/dev/rdiskN bs=4m`, `sync`, `diskutil eject`).
- **`yocto/meta-iot/README.md`** — noted `tinydtls_git.bb` carries `0002-add-dtls-log-sink.patch` (provides `dtls_set_log_sink()` for `apps/src/main.cpp`).

## Skipped (already documented)
- RPi flashing image path, `yocto/build.sh` (MACHINE=raspberrypi3-64), incremental-via-sstate, first-boot root ssh + GPIO serial console — already present in `DEPLOY.md` Path C and `yocto/meta-iot/README.md`; only the macOS-specific warning/steps were missing and were added.
- The host-networking compose rationale is already in `docker-compose.yml`; CLAUDE.md now summarizes + cross-references it rather than duplicating.

## Note
The branch was forked from a clean `main`. An external process applied the *pending fix* for the `vpn.state` known issue to the working tree during this session (touching `mgmt_protocol.cpp` / `supervisor.cpp` / `mgmt_protocol_test.cpp`); those code changes were deliberately **left out** of this PR to keep it markdown-only. The known-issue note reflects `main`'s current (unfixed) state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)