### PR TITLE
fix(openvpn-client): report vpn.state=connected via state query

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -223,6 +223,22 @@ bzcat $IMG | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
 # macOS: target the raw node /dev/rdiskN instead of /dev/diskN — much faster.
 ```
 
+> **Pick the right disk — `dd` is irreversible and writes the whole device.**
+> On macOS run `diskutil list` and identify the card by **size** (e.g. a 32 GB
+> card), *not* the internal Mac disk (`disk0`, usually the largest with an
+> `APFS`/`Apple_APFS` container). Writing to the wrong `/dev/diskN` destroys
+> that disk with no undo. Full macOS sequence:
+>
+> ```sh
+> diskutil list                                   # find the card by size
+> diskutil unmountDisk /dev/diskN                 # unmount (don't eject yet)
+> bzcat $IMG | sudo dd of=/dev/rdiskN bs=4m       # raw node = much faster
+> sync                                            # flush write cache
+> diskutil eject /dev/diskN                       # safe to remove
+> ```
+>
+> (`bs=4m` is the BSD `dd` spelling on macOS; `bs=4M` is the GNU/Linux one.)
+
 > The build does **not** emit a `.bmap` file: `bmaptool` needs the FIEMAP
 > ioctl / `SEEK_HOLE`, which the macOS-podman build filesystem doesn't
 > support, so `wic.bmap` is omitted from `IMAGE_FSTYPES`. If you build on a

--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -246,6 +246,61 @@ mirror).
 `apps/config/`) are also copied into the cloud image at `/etc/iot/` so
 the lwm2m binary finds the schema and provisioning data it expects.
 
+## Device UI over VPN
+
+Each registered device runs its own web UI behind NAT, reachable from the
+operator only through the tunnel. The cloud exposes it via a per-device DNAT.
+
+**Per-device mapping.** When a device registers it is assigned a VPN virtual
+IP (`tun_ip`, e.g. `10.9.0.x`) and a proxy port (`proxy_port`, allocated by
+`VpnRegistry`); both live in the `cloud.endpoints` ds JSON. Operator access is
+`http://<cloud-host>:<proxy_port>/` — the Endpoints page **Launch UI** link —
+which DNATs to the device's UI over the tunnel.
+
+**nftables DNAT (`modules/server/dnat`).** `iot-cloudd` installs a per-device
+DNAT for every endpoint that has both a `tun_ip` and a `proxy_port`:
+
+```
+tcp dport <proxy_port> dnat to <tun_ip>:<ui_port>     # prerouting (nat)
+oifname "tun0" masquerade                              # postrouting (nat)
+oifname/iifname "tun0" accept                          # forward (filter)
+```
+
+The whole ruleset lives in its own table `ip iot_cloud_dnat` so re-applying
+flushes only our rules (never NetworkManager / docker / openvpn chains). It is
+built (`build_device_dnat_ruleset`) from `cloud.endpoints` and applied with
+`nft -f -` (`apply_ruleset`) at startup and on every provision / deprovision /
+registration change — idempotent (full-table flush + rebuild). `iot-cloudd`
+also enables IPv4 forwarding (`enable_ip_forward` → `net.ipv4.ip_forward=1`)
+once at startup.
+
+**ds-driven ports** (no Docker publish — see host-networking note below):
+
+| Key | Default | Meaning |
+|-----|---------|---------|
+| `cloud.proxy.device.ui.port` | `80` | the device's web-UI port (DNAT target port); seeded at startup |
+| `cloud.vpn.proxy.port.start` | `5001` | low end of the proxy-port range `VpnRegistry` allocates from |
+| `cloud.vpn.proxy.port.end` | `6000` | high end of the proxy-port range |
+
+The range is read from ds at startup (CLI `proxy-start=`/`proxy-end=` are
+fallbacks) and written back so it is visible/editable; changing
+`cloud.proxy.device.ui.port` triggers a DNAT rebuild.
+
+**Host networking.** `iot-cloudd` runs with `network_mode: host` and **no**
+published `ports:` — it runs the OpenVPN server *and* installs the DNAT on the
+host netns, so the entire proxy-port range plus 1194 are reachable directly on
+the host with nothing to keep in sync. Consequences:
+
+- The proxy range is 100% ds-controlled (no Docker publish, no env).
+- The **host firewall** must allow the proxy range + `1194/tcp` to operators
+  (ideally scoped to admin source IPs — see `host-firewall.sh`).
+- `net.* ` sysctls aren't settable per-container under host networking, so
+  `iot-cloudd` sets `net.ipv4.ip_forward=1` itself at startup (needs
+  `NET_ADMIN` on the host netns); ensure it stays enabled on the host.
+
+The cloud also pushes the VPN *endpoint* (host/port/proto) down to the device
+over LwM2M Object 2048 — see `apps/docs/lwm2m-object-handling.md` §2.8.
+
 ## Log Levels
 
 Default is `INFO` for all daemons. Per-daemon keys override the global

--- a/apps/docs/lwm2m-object-handling.md
+++ b/apps/docs/lwm2m-object-handling.md
@@ -198,6 +198,34 @@ re-provision differently:
   (`docker restart iot-cloudd` / restart the `lwm2m-bs` unit) so it picks up the
   new credential.
 
+### 2.8 Pushing the VPN server endpoint (Object 2048 RIDs 5/6/7)
+
+The device needs to know *where* to dial the OpenVPN server. Rather than seed
+it through docker-compose env (those seeds were removed — **ds is the source of
+truth**), the cloud DM server pushes the endpoint down the same Object 2048
+delivery that carries the VPN cert family.
+
+**Cloud side** (`build_cert_push`, `apps/src/lwm2m_dm_server.cpp`). Alongside
+the ca/cert/key chunks (instances 0/1/2 → RID 1), it appends three small
+plain-text WRITEs to **instance 0**:
+
+| RID | ds key derived from | Notes |
+|-----|---------------------|-------|
+| 5 (VPN host)  | `cloud.dm.uri` (host parsed out) | only emitted when known; empty host → cert-only push (back-compatible) |
+| 6 (VPN port)  | `cloud.vpn.listen.port` | as a decimal string |
+| 7 (VPN proto) | `cloud.vpn.proto`, mapped `tcp-server` → `tcp-client` | the device dials, so the role is flipped |
+
+The push (`apps/src/main.cpp`, DM wiring) is sent on each registration/cert-push
+cycle until `cloud.vpn.connected` lists the endpoint, then it stops. The push is
+finalised by the same **RID 3 (Apply) EXECUTE** that commits the cert family.
+
+**Device side** (`certHooks.set_vpn_endpoint`, `apps/src/main.cpp`). At Apply,
+the staged values are materialised into `vpn.remote.host` / `vpn.remote.port`
+(parsed to the schema's integer) / `vpn.remote.proto`. The cert hook's
+`false→true` gate-flip on `services.openvpn.client.enable` (see §2 of
+`modules/openvpn/client/docs/design.md`) then hot-reloads openvpn-client, which
+re-execs reading the new `vpn.remote.*` — no compose seed, no manual restart.
+
 ---
 
 ## 3. Registration interface — `POST /rd`

--- a/modules/openvpn/client/docs/design.md
+++ b/modules/openvpn/client/docs/design.md
@@ -275,6 +275,41 @@ two more transitions out of every state above:
 
 Auto-restart on bare child crash (no WAN event) is still FUP-L12-1.
 
+## Known issue: `vpn.state` stuck at `connecting`
+
+> **Status: known issue, fix pending.** The tunnel itself works.
+
+**Symptom.** The tunnel is fully up — `tun0` has the assigned IP,
+openvpn logged `Initialization Sequence Completed`, and the cloud's
+`cloud.vpn.connected` lists the endpoint — yet `vpn.state` reads
+`connecting` and never advances to `connected`. `vpn.assigned.ip` is still
+set correctly.
+
+**Cause.** On attach the supervisor sends `state on` (`supervisor.cpp`),
+which enables *future* real-time `>STATE:` notifications. It does **not**
+issue a query for the *current* state. If openvpn already reached
+`CONNECTED` before the daemon attached the mgmt socket, that transition
+was emitted before notifications were on and is therefore missed — so the
+Lifecycle never sees the `CONNECTED` `>STATE:` event that would write
+`vpn.state=connected`. `vpn.assigned.ip` still gets set because the
+`>PUSH_REPLY` line is parsed independently.
+
+The mgmt parser (`mgmt_protocol.cpp`) only recognises the prefixed
+`>STATE:` / `>PUSH_REPLY:` events. A bare `state` *query response* (the
+state record without the `>STATE:` prefix) is classified as a `DataLine`
+response payload and ignored by the Lifecycle — so even if the current
+state were requested today, the reply wouldn't update `vpn.state`.
+
+> Note: the inline comment at `supervisor.cpp` (`state on` "makes it emit
+> the CURRENT state immediately") describes the *intended* behavior; in
+> practice the current-state emission arrives as the bare state-record
+> response that the parser drops, which is why this issue persists.
+
+**Pending fix.** After `state on`, also send `state 1` (query the current
+state) **and** teach the parser to surface the bare state-record response
+as a `State` event so the Lifecycle promotes `vpn.state` to `connected`
+even when the daemon attached late.
+
 ## Related docs
 
 - [L12 plan](../../../log/L12/plan.md) — phase plan + risk register

--- a/modules/openvpn/client/src/mgmt_protocol.cpp
+++ b/modules/openvpn/client/src/mgmt_protocol.cpp
@@ -1,6 +1,7 @@
 #include "mgmt_protocol.hpp"
 
 #include <algorithm>
+#include <cctype>
 #include <cstddef>
 #include <string>
 #include <string_view>
@@ -119,8 +120,25 @@ void Parser::emit(std::string line) {
         // raw stays empty
     }
     else if (!line.empty()) {
-        ev.kind = Event::Kind::DataLine;
-        ev.raw = std::move(line);
+        // The `state` query (as opposed to the `>STATE:` async form) replies
+        // with bare comma-records `<unix_ts>,<STATE>,<desc>,<localip>,...`
+        // terminated by END — the same layout as a `>STATE:` body without the
+        // prefix. Surface a leading-numeric-timestamp record as a State event
+        // so the Lifecycle advances vpn.state from a current-state query (the
+        // case where openvpn reached CONNECTED before `state on` was sent).
+        auto fields = comma_split(line);
+        const bool is_state_record =
+            fields.size() >= 2 && !fields[0].empty() &&
+            std::all_of(fields[0].begin(), fields[0].end(),
+                        [](unsigned char c) { return std::isdigit(c) != 0; });
+        if (is_state_record) {
+            ev.kind   = Event::Kind::State;
+            ev.fields = std::move(fields);
+            ev.raw    = std::move(line);
+        } else {
+            ev.kind = Event::Kind::DataLine;
+            ev.raw  = std::move(line);
+        }
     }
     else {
         // Empty line — drop, don't enqueue.

--- a/modules/openvpn/client/src/supervisor.cpp
+++ b/modules/openvpn/client/src/supervisor.cpp
@@ -186,18 +186,28 @@ bool Supervisor::serve_one_session(const std::string& iface) {
 
     // Subscribe to real-time state notifications. Real openvpn keeps the
     // management interface silent after the `>INFO:` banner until a client
-    // asks for them; `state on` makes it emit the CURRENT state immediately
-    // (covers the case where openvpn reached CONNECTED before we attached)
-    // AND every subsequent transition as a `>STATE:` event the Lifecycle
-    // consumes. Without this, vpn.state never advances past "connecting"
-    // against real openvpn — the L12/L14 fake openvpn masked the gap by
-    // pushing STATE/PUSH_REPLY lines unsolicited.
+    // asks for them. `state on` enables FUTURE `>STATE:` transitions, but it
+    // does NOT replay the current state — so if openvpn already reached
+    // CONNECTED before we attached the mgmt socket (the common race), that
+    // event is missed and vpn.state stalls at "connecting" forever (even
+    // though PUSH_REPLY still sets vpn.assigned.*). Fix: also query `state 1`
+    // for the most-recent state right now. Its reply is a bare comma-record
+    // (no `>STATE:` prefix) terminated by END; the mgmt Parser surfaces that
+    // as a State event too, so the Lifecycle advances vpn.state to "connected".
     {
         static const char kStateOn[] = "state on\r\n";
         if (stream.send_n(kStateOn, sizeof(kStateOn) - 1) < 0) {
             ACE_ERROR((LM_WARNING,
                        ACE_TEXT("%D [ovpn:%t] %M %N:%l mgmt 'state on' send "
                                 "failed errno=%d; vpn.state may stall\n"),
+                       errno));
+        }
+        static const char kStateQuery[] = "state 1\r\n";
+        if (stream.send_n(kStateQuery, sizeof(kStateQuery) - 1) < 0) {
+            ACE_ERROR((LM_WARNING,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l mgmt 'state 1' query "
+                                "failed errno=%d; vpn.state may stall at "
+                                "connecting\n"),
                        errno));
         }
     }

--- a/modules/openvpn/client/test/mgmt_protocol_test.cpp
+++ b/modules/openvpn/client/test/mgmt_protocol_test.cpp
@@ -69,6 +69,23 @@ TEST(MgmtParser, StateAssignIpCarriesAssignedIpInFieldThree) {
     EXPECT_EQ("10.8.0.6",  evs[0].fields[3]);
 }
 
+TEST(MgmtParser, StateQueryBareRecordClassifiedAsState) {
+    // Reply to the `state 1` current-state query: a bare comma-record with NO
+    // `>STATE:` prefix, terminated by END. It must be surfaced as a State
+    // event (not a DataLine) so the Lifecycle can advance vpn.state from a
+    // current-state query — covering openvpn reaching CONNECTED before the
+    // daemon enabled real-time notifications with `state on`.
+    Parser p;
+    p.feed("1701420000,CONNECTED,SUCCESS,10.8.0.6,vpn.example.com,1194,,\nEND\n");
+    auto evs = drain(p);
+    ASSERT_EQ(2u, evs.size());
+    EXPECT_EQ(Event::Kind::State, evs[0].kind);
+    ASSERT_GE(evs[0].fields.size(), 4u);
+    EXPECT_EQ("CONNECTED", evs[0].fields[1]);
+    EXPECT_EQ("10.8.0.6",  evs[0].fields[3]);
+    EXPECT_EQ(Event::Kind::EndMarker, evs[1].kind);
+}
+
 /* ─────────────────────────── PUSH_REPLY ──────────────────────────── */
 
 TEST(MgmtParser, PushReplyCommaSplitsOptions) {

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -186,7 +186,7 @@ end-to-end push from the cloud UI.
 | `iot_git.bb`             | `PN=iot`; sub-packages: `iot-ds-server`, `iot-ds-cli`, `iot-lwm2m`, `iot-openvpn-client`, `iot-net-router`, `iot-wifi-client`, `iot-httpd`, `iot-config` |
 | `images/iot-image.bb`    | Full bootable distribution (`packagegroup-iot-full` + kernel modules + RPi Wi-Fi/BT firmware + sshd + opkg) → `*.wic.bz2` |
 | `ace-tao_7.0.0.bb`       | `libACE.so.7.0.0`, `libACE_SSL.so.7.0.0`, dev headers       |
-| `tinydtls_git.bb`        | `libtinydtls.a` (static archive)                             |
+| `tinydtls_git.bb`        | `libtinydtls.a` (static archive). Carries `0002-add-dtls-log-sink.patch` — adds `dtls_set_log_sink()` (present in the in-tree fork `apps/3rdparty/tinydtls`, absent from the legatoproject SRCREV) so the iot binary's DTLS log-sink in `apps/src/main.cpp` links. See the patch header for detail. |
 | `mongo-c-driver_1.19.bb` | `libbson-1.0.so`, `libmongoc-1.0.so`                        |
 | `mongo-cxx-driver_3.6.bb`| `libbsoncxx.so`, `libmongocxx.so`                            |
 | `packagegroup-iot.bb`    | Meta-packages: `packagegroup-iot-core`, `-full`, `-debug`   |


### PR DESCRIPTION
`vpn.state` stalled at `connecting` even with the tunnel fully up (tun0 assigned, `Initialization Sequence Completed`, cloud's `cloud.vpn.connected` lists the endpoint).

**Cause:** the supervisor sends `state on` (enables only *future* `>STATE:` notifications); if openvpn reached CONNECTED before the daemon attached the mgmt socket, that event is missed and `vpn.state` never advances. (`vpn.assigned.ip` still got set via `>PUSH_REPLY`.)

**Fix:**
- Supervisor: after `state on`, also query `state 1` (current state).
- Parser: a bare comma-record beginning with a unix timestamp (the `state` query reply, no `>STATE:` prefix) is now surfaced as a `State` event, so the Lifecycle advances `vpn.state` → `connected`.
- Adds a parser unit test for the bare state-record path.

**Follow-up (not in this PR):** `vpn.assigned.netmask/gateway` come from `>PUSH_REPLY`, which the same attach race can miss; capturing those reliably needs `--management-hold`. DNS isn't pushed by the cloud server at all (separate cloud-side change).

Verified: device image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)