### PR TITLE
feat(vpn): capture assigned netmask/gateway/dns reliably

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -357,6 +357,9 @@ int main(int argc, char** argv) {
     ovpn_cfg.port      = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.listen.port", 1194));
     ovpn_cfg.mgmt_port = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.mgmt.port", 7506));
     ovpn_cfg.verb      = ds_int(ds, "cloud.vpn.verb", 3);
+    // DNS resolver pushed to devices (so the device surfaces vpn.assigned.dns).
+    // Empty disables the push; default 1.1.1.1 so the field is populated.
+    ovpn_cfg.dns       = ds_str(ds, "cloud.vpn.dns", "1.1.1.1");
     // Seed the effective config back to ds so every cloud.vpn.* key exists
     // with its default (visible in the cloud UI / ds-cli).
     ds.set({
@@ -369,6 +372,7 @@ int main(int argc, char** argv) {
         {"cloud.vpn.listen.port", data_store::Value{static_cast<std::int32_t>(ovpn_cfg.port)}},
         {"cloud.vpn.mgmt.port",   data_store::Value{static_cast<std::int32_t>(ovpn_cfg.mgmt_port)}},
         {"cloud.vpn.verb",        data_store::Value{static_cast<std::int32_t>(ovpn_cfg.verb)}},
+        {"cloud.vpn.dns",         data_store::Value{ovpn_cfg.dns}},
     });
     // ── Runtime VPN PKI (Phase 2) ─────────────────────────────────
     // The cloud image generates a CA + server cert at build time but PURGES

--- a/apps/cloud/troubleshoot.md
+++ b/apps/cloud/troubleshoot.md
@@ -320,3 +320,32 @@ update, you likely started with `RESET_CONFIG=0`; drop the volume:
 docker volume rm cloud_iot-etc
 ./run.sh
 ```
+
+## Redeploys leave orphan containers / `rmi` says "image is being used"
+
+Symptoms after pulling a new image:
+
+```
+docker rmi -f <id>   → conflict: image is being used by running container <c>
+./run.sh stop        → ! Network cloud_default Resource is still in use
+```
+
+Cause: `docker compose down` only stops the services in the **current**
+compose file. When the service set changes between releases (e.g. a service
+is renamed/removed, or this release moved `iot-cloudd` to host networking),
+the old container becomes an **orphan** — still `Up` (often
+`restart: unless-stopped`), still attached to `cloud_default`, still holding
+the old image. `down` skips it, so the network can't be removed and the image
+stays in use. (Same redeploy-staleness family as the bootstrap provision-watch
+going stale after a redeploy — `docker restart iot-cloudd`.)
+
+Fix — tear down **with orphan removal**, then pull + up:
+
+```bash
+docker compose down --remove-orphans     # or: docker rm -f <orphan-name>
+docker rmi -f naushada/iot-cloud:latest  # now free
+docker compose pull
+./run.sh
+```
+
+Make `--remove-orphans` the default teardown whenever the service set changes.

--- a/modules/openvpn/client/src/process.cpp
+++ b/modules/openvpn/client/src/process.cpp
@@ -42,6 +42,12 @@ std::string build_openvpn_config(const OpenVpnConfig& c) {
     ss << "cipher " << c.cipher      << "\n";
     ss << "verb 3\n";
     ss << "management 127.0.0.1 " << c.mgmt_port << "\n";
+    // Start held: openvpn opens the mgmt socket but does NOT connect until the
+    // supervisor sends `hold release`. This lets the supervisor attach + enable
+    // state notifications FIRST, so the CONNECTED state and the PUSH_REPLY
+    // (assigned ip/netmask/gateway/dns) are captured in real time instead of
+    // racing — they previously fired before we subscribed and were lost.
+    ss << "management-hold\n";
     return ss.str();
 }
 

--- a/modules/openvpn/client/src/supervisor.cpp
+++ b/modules/openvpn/client/src/supervisor.cpp
@@ -210,6 +210,19 @@ bool Supervisor::serve_one_session(const std::string& iface) {
                                 "connecting\n"),
                        errno));
         }
+        // openvpn was spawned with `management-hold`, so it is paused until we
+        // release it. Now that real-time state notifications are enabled, let
+        // it connect — the CONNECTED state + PUSH_REPLY (assigned
+        // ip/netmask/gateway/dns) then arrive while we're already listening,
+        // so vpn.assigned.* is captured rather than raced.
+        static const char kHoldRelease[] = "hold release\r\n";
+        if (stream.send_n(kHoldRelease, sizeof(kHoldRelease) - 1) < 0) {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l mgmt 'hold release' "
+                                "failed errno=%d; openvpn will stay held and "
+                                "never connect\n"),
+                       errno));
+        }
     }
 
     Lifecycle::Sinks sinks;

--- a/modules/openvpn/client/test/process_test.cpp
+++ b/modules/openvpn/client/test/process_test.cpp
@@ -62,6 +62,9 @@ TEST(BuildOpenvpnConfig, EmitsExpectedDirectives) {
     EXPECT_NE(std::string::npos, body.find("\nkey  /etc/iot/vpn/client.key\n"));
     EXPECT_NE(std::string::npos, body.find("\ncipher AES-256-GCM\n"));
     EXPECT_NE(std::string::npos, body.find("\nmanagement 127.0.0.1 7505\n"));
+    // Held at startup so the supervisor subscribes before openvpn connects
+    // (captures CONNECTED + PUSH_REPLY rather than racing them).
+    EXPECT_NE(std::string::npos, body.find("\nmanagement-hold\n"));
 }
 
 TEST(BuildOpenvpnConfig, OverridesFlowThrough) {

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -269,6 +269,13 @@ return {
       max     = 11,
     },
 
+    -- DNS resolver pushed to VPN clients (`push "dhcp-option DNS …"`), so the
+    -- device surfaces vpn.assigned.dns. Empty disables the push.
+    ["cloud.vpn.dns"] = {
+      type    = "string",
+      default = "1.1.1.1",
+    },
+
     -- Next available proxy port (bump-counter).
     ["cloud.vpn.port.next"] = {
       type    = "integer",

--- a/modules/server/openvpn/inc/openvpn_server.hpp
+++ b/modules/server/openvpn/inc/openvpn_server.hpp
@@ -30,6 +30,8 @@ struct OpenVpnServerConfig {
     std::string   cert_path  = "/etc/iot/vpn/server.crt";
     std::string   key_path   = "/etc/iot/vpn/server.key";
     std::string   cipher     = "AES-256-GCM";
+    std::string   dns;                          // empty → no DNS pushed;
+                                                // else `push "dhcp-option DNS …"`
     std::uint16_t mgmt_port  = 7506;            // management 127.0.0.1 <port>
     int           verb       = 3;
 };

--- a/modules/server/openvpn/src/openvpn_server.cpp
+++ b/modules/server/openvpn/src/openvpn_server.cpp
@@ -54,6 +54,12 @@ std::string build_server_config(const OpenVpnServerConfig& c) {
     ss << "port "  << c.port  << "\n";
     ss << "topology subnet\n";
     ss << "server " << net << " " << mask << "\n";
+    // Push a DNS resolver to clients (when configured) so the device learns
+    // it in the PUSH_REPLY and surfaces vpn.assigned.dns. topology subnet
+    // already auto-pushes route-gateway + ifconfig (ip+netmask).
+    if (!c.dns.empty()) {
+        ss << "push \"dhcp-option DNS " << c.dns << "\"\n";
+    }
     ss << "ca   " << c.ca_path   << "\n";
     ss << "cert " << c.cert_path << "\n";
     ss << "key  " << c.key_path  << "\n";

--- a/modules/server/openvpn/test/openvpn_server_test.cpp
+++ b/modules/server/openvpn/test/openvpn_server_test.cpp
@@ -49,4 +49,19 @@ TEST(BuildServerConfig, badSubnetReturnsEmpty) {
     EXPECT_TRUE(build_server_config(c).empty());
 }
 
+TEST(BuildServerConfig, pushesDnsWhenSet) {
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";
+    c.dns = "1.1.1.1";
+    const std::string conf = build_server_config(c);
+    EXPECT_NE(conf.find("push \"dhcp-option DNS 1.1.1.1\""), std::string::npos);
+}
+
+TEST(BuildServerConfig, noDnsPushWhenEmpty) {
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";   // c.dns left empty
+    const std::string conf = build_server_config(c);
+    EXPECT_EQ(conf.find("dhcp-option DNS"), std::string::npos);
+}
+
 }  // namespace


### PR DESCRIPTION
`vpn.assigned.netmask`/`gateway` stayed empty even with the tunnel up — they come from openvpn's `>PUSH_REPLY`, which fired before the daemon attached the mgmt socket (same race as the vpn.state bug) and was missed. DNS was never populated because the cloud server didn't push one.

**Device (openvpn-client):**
- Spawn openvpn with `management-hold`; the supervisor attaches, enables `state on`, then sends `hold release`. openvpn stays paused until we're subscribed, so the `CONNECTED` state + `PUSH_REPLY` (assigned ip/netmask/gateway/dns) are captured in real time, not raced.

**Cloud (openvpn server):**
- `push "dhcp-option DNS <dns>"` when `cloud.vpn.dns` is set (default `1.1.1.1`) so the device surfaces `vpn.assigned.dns`. New schema key `cloud.vpn.dns`, read + mirrored by iot-cloudd.

**Tests:** `management-hold` in the device config; DNS push present/absent in the server config.
**Docs:** troubleshoot note on redeploy orphan containers (`docker compose down --remove-orphans`).

Verified: device + cloud image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)