### PR TITLE
feat(device): persist bootstrap-received DM URI to ds + show in UI

### DIFF
--- a/apps/inc/ds_config.hpp
+++ b/apps/inc/ds_config.hpp
@@ -104,6 +104,11 @@ public:
     /// Bootstrap delivered DM credentials → iot.dm.psk.identity / .key.
     bool set_dm_credentials(const std::string& identity,
                             const std::string& key_hex);
+    /// Persist the bootstrap-delivered DM Server URI (Security Object RID 0
+    /// of the non-bootstrap PSK account) → iot.dm.uri, so the device-ui can
+    /// display the URI the device actually registered to. Write-only here —
+    /// the client is the sole writer, so there's nothing to mirror locally.
+    bool set_dm_uri(const std::string& uri);
     /// Publish the LwM2M connection lifecycle token to iot.conn.state so
     /// the device-ui can render real-time progress. One of: idle /
     /// bootstrapping / bootstrapped / dm-connecting / dm-connected /

--- a/apps/src/ds_config.cpp
+++ b/apps/src/ds_config.cpp
@@ -30,6 +30,8 @@ constexpr const char* kKeyDmPskKey    = "iot.dm.psk.key";
 constexpr const char* kKeyDevMode     = "iot.dev.mode";
 // LwM2M connection lifecycle published to the device-ui (write-only here).
 constexpr const char* kKeyConnState   = "iot.conn.state";
+// Bootstrap-delivered DM Server URI, published to the device-ui (write-only).
+constexpr const char* kKeyDmUri       = "iot.dm.uri";
 
 } // namespace
 
@@ -246,6 +248,16 @@ bool DsConfig::set_dm_credentials(const std::string& identity,
         m_impl->dm_psk_identity = identity;
         m_impl->dm_psk_key = key_hex;
     }
+    return s.ok;
+}
+
+bool DsConfig::set_dm_uri(const std::string& uri) {
+    if (!m_ok || !m_impl) return false;
+    // iot.dm.uri is published, never read back into the cache — the client
+    // is the sole writer, so there's nothing to mirror locally.
+    auto s = m_impl->client.set({
+        {kKeyDmUri, data_store::Value{uri}},
+    });
     return s.ok;
 }
 

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -882,6 +882,15 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
             *bootPhase = BootPhase::Skipped;
             return;
         }
+        // Persist the bootstrap-delivered DM Server URI (Security Object
+        // RID 0) to the data-store so the device-ui can display the URI the
+        // device actually registered to (otherwise iot.dm.uri stays empty).
+        if (ds.set_dm_uri(dmUri)) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l DM URI persisted to "
+                                "data-store (iot.dm.uri=%C)\n"),
+                       dmUri.c_str()));
+        }
         // Point the LwM2MClient peer at the DM, pin the DM PSK identity, and
         // force a fresh DTLS handshake against the DM.
         for (auto& [type, ctx] : a->udpAdapter()->services()) {

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
@@ -16,7 +16,7 @@
         <clr-input-container>
           <label>DM Server URI</label>
           <input clrInput readonly formControlName="server_uri" />
-          <clr-control-helper *dsDebug><app-ds-hint key="iot.server.uri"></app-ds-hint></clr-control-helper>
+          <clr-control-helper *dsDebug><app-ds-hint key="iot.dm.uri"></app-ds-hint></clr-control-helper>
         </clr-input-container>
         <clr-input-container>
           <label>Binding Mode</label>

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -40,7 +40,7 @@ export class Lwm2mConfigComponent implements OnInit {
   ngOnInit(): void {
     this.http.dbGet([
       'iot.serial', 'iot.dev.mode', 'iot.bs.uri',
-      'iot.server.uri', 'iot.binding', 'iot.lifetime'
+      'iot.dm.uri', 'iot.server.uri', 'iot.binding', 'iot.lifetime'
     ]).subscribe({
       next: (r) => {
         if (r.ok && r.data) {
@@ -53,8 +53,12 @@ export class Lwm2mConfigComponent implements OnInit {
           this.serverForm.patchValue({
             serial:     serial,
             bs_uri:     d['iot.bs.uri']    || 'coaps://',
-            // DM config below is pushed by the bootstrap server — read-only.
-            server_uri: d['iot.server.uri'] || '(set by bootstrap)',
+            // DM Server URI: prefer the actual bootstrap-delivered URI the
+            // client persisted (iot.dm.uri); fall back to the legacy
+            // ds-driven server.uri, then to the placeholder when both empty.
+            server_uri: (d['iot.dm.uri'] as string)
+                        || (d['iot.server.uri'] as string)
+                        || '(set by bootstrap)',
             binding:    d['iot.binding']    || 'U',
             lifetime:   d['iot.lifetime']   || 86400,
           });

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -134,6 +134,17 @@ return {
         default = "idle",
     },
 
+    -- ── DM Server URI (client → device-ui) ───────────────────────────
+    -- The lwm2m client publishes the bootstrap-delivered DM Server URI
+    -- (Security Object RID 0 of the non-bootstrap PSK account) here once
+    -- the bootstrap commit lands, so the device-ui can show the URI the
+    -- device actually registered to. Single string, read-only to the UI.
+    ["iot.dm.uri"] = {
+        access  = "Viewer",
+        type    = "string",
+        default = "",
+    },
+
     -- ── OTA software update (mirrors LwM2M Object 5 onto ds) ──────────
     -- Self-update trigger: device-ui (or the Object-5 RID2 apply) sets the
     -- .ipk URL here; the lwm2m client watches it and runs iot-ota-apply.


### PR DESCRIPTION
Device-ui LwM2M Server (Device Management) showed DM Server URI as "(set by bootstrap)" because `iot.dm.uri` was never populated — the URI bootstrap delivered landed in the LwM2M object store but not the ds key the UI reads.

- ds_config: `set_dm_uri()` publishes `iot.dm.uri` (write-only); new schema key `iot.dm.uri`.
- main.cpp: after the device registers, persist the DM URI it registered to into `iot.dm.uri`.
- device-ui: show `iot.dm.uri`, fall back to "(set by bootstrap)" only when empty.

Verified: device image + device-ui builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)