### PR TITLE
chore(compose): drop iot-httpd-redirect + obsolete version: attr

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -11,8 +11,6 @@
 #
 #   HTTP_PORT=8443 docker compose up -d  # custom HTTP port
 
-version: "3.8"
-
 services:
   # ── Data Store (IPC backbone) ──────────────────────────────────
   ds-server:
@@ -147,29 +145,6 @@ services:
       - iot-tls:/etc/iot/tls                    # self-signed cert — auto-provisioned by the image entrypoint
     environment:
       - TLS_HOST=${TLS_HOST:-}                  # cert CN/SAN for https (run.sh passes the host IP)
-    depends_on:
-      ds-server:
-        condition: service_healthy
-    restart: unless-stopped
-
-  # ── HTTPS → HTTP redirect (only under the `https` profile) ─────
-  # A plain-http listener on :80 that 301-redirects everything to https.
-  # run.sh enables it (COMPOSE_PROFILES=https) when started with HTTPS=1,
-  # so users who type http:// land on https://. Off by default.
-  iot-httpd-redirect:
-    image: ${CLOUD_IMAGE:-docker.io/naushada/iot-cloud:latest}
-    container_name: iot-httpd-redirect
-    profiles: ["https"]
-    command: >
-      iot-httpd
-      ds-socket=/var/run/iot/data_store.sock
-      http-port=80
-      redirect-https-port=${HTTPS_PORT:-443}
-      www-dir=/usr/share/iot/cloud-www
-    ports:
-      - "80:80"
-    volumes:
-      - iot-run:/var/run/iot
     depends_on:
       ds-server:
         condition: service_healthy

--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -45,8 +45,8 @@ else
     IMAGE="${CLOUD_IMAGE:-docker.io/naushada/iot-cloud:latest}"
 fi
 # HTTPS=1 → iot-httpd terminates TLS on 443 with a self-signed cert
-# (auto-generated below), and a redirect container bounces :80 → :443.
-# Default (HTTPS=0) is plain http on port 80.
+# (auto-generated below). http://:80 is not served in this mode — browse
+# https:// directly. Default (HTTPS=0) is plain http on port 80.
 HTTPS="${HTTPS:-0}"
 if [ "$HTTPS" = "1" ]; then
     HTTP_SCHEME="https"
@@ -137,9 +137,10 @@ if [ "$HTTPS" = "1" ]; then
     log_info "HTTPS on — image will self-provision a self-signed cert for ${TLS_HOST}"
 fi
 
-# Compose profiles (additive): https redirect + autodeploy watchtower.
+# Compose profiles (additive): autodeploy watchtower. (HTTPS=1 no longer
+# needs a profile — the main iot-httpd terminates TLS on 443 directly; the
+# separate :80→:443 redirect container was removed.)
 COMPOSE_PROFILES=""
-[ "$HTTPS" = "1" ]      && COMPOSE_PROFILES="${COMPOSE_PROFILES:+$COMPOSE_PROFILES,}https"
 [ "$AUTODEPLOY" = "1" ] && COMPOSE_PROFILES="${COMPOSE_PROFILES:+$COMPOSE_PROFILES,}autodeploy"
 [ -n "$COMPOSE_PROFILES" ] && export COMPOSE_PROFILES
 

--- a/apps/device/docker-compose.yml
+++ b/apps/device/docker-compose.yml
@@ -23,8 +23,6 @@
 #
 #   HTTP_PORT=8081 docker compose up -d   # custom host port for the UI
 
-version: "3.8"
-
 services:
   # ── Data Store (IPC backbone) ──────────────────────────────────
   ds-server:

--- a/apps/device/run.sh
+++ b/apps/device/run.sh
@@ -125,7 +125,10 @@ case "${1:-start}" in
 
     stop|down)
         log_section "Stopping IoT Device stack"
-        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" down
+        # --remove-orphans clears containers left behind when the service set
+        # changes between releases (e.g. the one-shot vpn-config), so the
+        # compose network can always be torn down.
+        $COMPOSE -f "$SCRIPT_DIR/docker-compose.yml" down --remove-orphans
         ;;
 
     logs)


### PR DESCRIPTION
`iot-httpd-redirect` was a profile-gated (`profiles: ["https"]`) plain-http :80 listener that 301-redirected to https:443 — pure convenience. Because it's profiled, `docker compose down` (even with `--remove-orphans`) doesn't remove it, so it lingered as an orphan holding `cloud_default` ("Network ... Resource is still in use") on every redeploy.

- Remove the service. HTTPS=1 still terminates TLS on 443 via the main `iot-httpd` (`http://:80` simply isn't served — browse `https://` directly). Drop the now-empty `https` compose profile in run.sh.
- Remove the obsolete top-level `version:` from both composes (Compose v2 ignores it + warns).
- device `run.sh stop`: add `--remove-orphans` (parity with cloud).

Both composes validated with `podman compose config`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)