### PR TITLE
fix(cloud): default proxy-port range to small window at 10000

### DIFF
--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -57,8 +57,13 @@ else
 fi
 HTTPS_PORT="$HTTP_PORT"
 VPN_SUBNET="${VPN_SUBNET:-10.9.0.0/24}"
-PROXY_START="${PROXY_START:-5001}"
-PROXY_END="${PROXY_END:-6000}"
+# Per-device device-UI proxy ports. Kept ABOVE the CoAP ports (5683 DM /
+# 5684 BS that lwm2m-dm/bs publish) and SMALL on purpose: each published port
+# spawns a docker-proxy process, so a 1000-wide range exhausts the host. Bump
+# the window for more devices, or switch iot-cloudd to host networking for a
+# large fleet (no per-port proxy).
+PROXY_START="${PROXY_START:-10000}"
+PROXY_END="${PROXY_END:-10050}"
 HTTP_WORKERS="${HTTP_WORKERS:-4}"
 # Reset the iot-etc config volume on start so the latest schema/config
 # from the image is always loaded (set to 0 to preserve manual edits).

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -253,8 +253,8 @@ int main(int argc, char** argv) {
     // ── CLI args ──────────────────────────────────────────────────
     std::string ds_path = "/var/run/iot/data_store.sock";
     std::string vpn_subnet = "10.9.0.0/24";
-    int proxy_port_start = 5001;
-    int proxy_port_end   = 6000;
+    int proxy_port_start = 10000;   // above CoAP 5683/5684; small window —
+    int proxy_port_end   = 10050;   // each published port = one docker-proxy
     int sync_interval    = 10;  // seconds
 
     for (int i = 1; i < argc; ++i) {

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -301,9 +301,9 @@ return {
     -- Next available proxy port (bump-counter).
     ["cloud.vpn.port.next"] = {
       type    = "integer",
-      default = 5001,
-      min     = 5001,
-      max     = 6000,
+      default = 10000,
+      min     = 1024,
+      max     = 65535,
     },
 
     -- Per-device proxy-port allocation range for device-UI-over-VPN DNAT.
@@ -311,16 +311,19 @@ return {
     -- VpnRegistry pool. The docker-compose published port range must cover
     -- this (Docker publishes ports before ds is consulted, so it can't follow
     -- ds automatically).
+    -- Default kept ABOVE the CoAP ports (5683 DM / 5684 BS) and a SMALL
+    -- window: every published proxy port spawns a docker-proxy, so a wide
+    -- range exhausts the host. Widen for more devices, or use host networking.
     ["cloud.vpn.proxy.port.start"] = {
       type    = "integer",
-      default = 5001,
-      min     = 1,
+      default = 10000,
+      min     = 1024,
       max     = 65535,
     },
     ["cloud.vpn.proxy.port.end"] = {
       type    = "integer",
-      default = 6000,
-      min     = 1,
+      default = 10050,
+      min     = 1024,
       max     = 65535,
     },
 


### PR DESCRIPTION
Publishing the 1000-wide `5001-6000` range spawned ~1000 `docker-proxy` processes and exhausted the host (`failed to start docker-proxy` at ~5190). It also **overlapped the published CoAP ports** `5683` (DM) / `5684` (BS).

Default the per-device device-UI proxy range to **`10000-10050`** (50 ports) — above the CoAP ports, small enough for docker-proxy. Aligned across `run.sh` (publish + CLI), `cloud.lua` (ds schema defaults + `port.next`), and `main.cpp` built-in. Widen for more devices, or use host networking for a large fleet.

Verified: cloud image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)