### PR TITLE
fix(httpd): reliable worker→reactor response handoff; ds-only http.workers

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -136,7 +136,6 @@ services:
       http-key=/etc/iot/tls/server.key
       www-dir=/usr/share/iot/cloud-www
       firmware-dir=/var/lib/iot/firmware
-      http-workers=${HTTP_WORKERS:-4}
     ports:
       - "${HTTP_PORT:-80}:${HTTP_PORT:-80}"
     volumes:

--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -64,7 +64,10 @@ VPN_SUBNET="${VPN_SUBNET:-10.9.0.0/24}"
 # large fleet (no per-port proxy).
 PROXY_START="${PROXY_START:-10000}"
 PROXY_END="${PROXY_END:-10050}"
-HTTP_WORKERS="${HTTP_WORKERS:-4}"
+# http.workers is NOT passed on the command line — it is read from the data
+# store (key http.workers, schema default 0 = inline). ds is the single
+# source of truth so the cloud-ui HTTP page reflects the live value; a CLI
+# arg would silently override ds and the UI would show the wrong number.
 # Reset the iot-etc config volume on start so the latest schema/config
 # from the image is always loaded (set to 0 to preserve manual edits).
 RESET_CONFIG="${RESET_CONFIG:-1}"
@@ -151,7 +154,7 @@ COMPOSE_PROFILES=""
 
 # Export env vars so docker-compose.yml can reference them
 export CLOUD_IMAGE="$IMAGE"
-export HTTP_PORT HTTP_WORKERS HTTP_SCHEME HTTPS_PORT
+export HTTP_PORT HTTP_SCHEME HTTPS_PORT
 export VPN_SUBNET PROXY_START PROXY_END
 export COMPOSE_PROJECT_NAME="$PROJECT"
 

--- a/apps/device/docker-compose.yml
+++ b/apps/device/docker-compose.yml
@@ -180,7 +180,6 @@ services:
       iot-httpd
       ds-socket=/run/iot/data_store.sock
       http-port=8080
-      http-workers=${HTTP_WORKERS:-4}
       www-dir=/usr/share/iot/www
     ports:
       - "${HTTP_PORT:-8081}:8080"

--- a/modules/http-server/inc/session.hpp
+++ b/modules/http-server/inc/session.hpp
@@ -34,10 +34,13 @@ public:
                          SessionStore* auth = nullptr);
 
     int handle_input(ACE_HANDLE fd) override;
-    // Off-loaded handler finished on a worker thread and notify()'d the
-    // reactor; this runs on the reactor thread to send the response.
-    int handle_exception(ACE_HANDLE fd) override;
     int handle_close(ACE_HANDLE fd, ACE_Reactor_Mask mask) override;
+
+    // Send the worker-computed response and re-arm (keep-alive) or tear down
+    // the connection. Queued by the worker via WorkerPool::post_to_reactor()
+    // and run on the reactor thread by WorkerPool::drain_reactor() — replaces
+    // the old notify()/handle_exception() handoff, whose wakeups were lossy.
+    void deliver_response();
 
 private:
     const Router& m_router;

--- a/modules/http-server/inc/worker.hpp
+++ b/modules/http-server/inc/worker.hpp
@@ -43,6 +43,23 @@ public:
     /// the caller's thread (so callers need no special-casing).
     void submit(Job job);
 
+    /// Queue a callback to be executed on the reactor thread. A worker that
+    /// has finished computing a response uses this to deliver it (socket /
+    /// TLS I/O is reactor-thread-only). The reactor loop must call
+    /// drain_reactor() once per iteration to run the queued callbacks.
+    ///
+    /// This deliberately replaces the old `reactor()->notify(this,
+    /// EXCEPT_MASK)` handoff: that dispatch dropped ~half its wakeups under
+    /// load, leaving the response unsent and the client hung. A mutex-guarded
+    /// queue drained by the reactor is reliable; an optional bare notify()
+    /// only nudges the reactor awake so the drain runs without tick latency.
+    void post_to_reactor(Job fn);
+
+    /// Run every callback queued via post_to_reactor() since the last call.
+    /// MUST be called only from the reactor thread (the callbacks touch
+    /// sockets / delete handlers).
+    void drain_reactor();
+
     std::size_t size() const { return m_threads; }
 
 private:
@@ -55,6 +72,10 @@ private:
     std::condition_variable  m_cv;
     bool                     m_stop = false;
     bool                     m_started = false;
+
+    // Reactor-thread completion queue (worker → reactor response handoff).
+    std::vector<Job> m_reactor_jobs;
+    std::mutex       m_reactor_mtx;
 };
 
 } // namespace http_server

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -438,6 +438,12 @@ int main(int argc, char** argv) {
             break;
         }
 
+        // Deliver any worker-computed responses on this (the reactor) thread.
+        // Workers queue a deliver_response() callback per finished request;
+        // draining here is the reliable handoff that replaced the lossy
+        // reactor notify() dispatch. No-op when running inline (0 workers).
+        pool.drain_reactor();
+
         // ~Every 2s, check for operator config changes via the data store.
         // Also sweep expired sessions and reload auth config every ~60s.
         if (++reload_tick >= kReloadEvery) {

--- a/modules/http-server/src/session.cpp
+++ b/modules/http-server/src/session.cpp
@@ -115,15 +115,21 @@ int HttpSession::handle_input(ACE_HANDLE /*fd*/) {
     if (m_pool && m_pool->size() > 0) {
         // Off-load the handler to a worker thread. Suspend reads so no other
         // request (or close) is dispatched on this connection while the
-        // worker owns it; the worker routes, stores m_response, and notifies
-        // the reactor, which sends from handle_exception() on this thread.
+        // worker owns it; the worker routes, stores m_response, then hands
+        // delivery back to the reactor thread via the pool's completion queue.
+        //
+        // We deliberately do NOT use reactor()->notify(this, EXCEPT_MASK) to
+        // drive handle_exception(): that dispatch dropped ~half its wakeups
+        // under load, leaving m_response unsent and the client hung. The
+        // completion queue (drained every reactor tick) is reliable; the bare
+        // notify() below only wakes the reactor so the drain runs promptly,
+        // and is harmless if coalesced or lost.
         if (reactor()) reactor()->suspend_handler(this);
         m_pool->submit([this, req = std::move(req)]() mutable {
             auto route_resp = m_router.route(req);
             m_response = route_resp.to_string(m_keep_alive);
-            if (reactor()) {
-                reactor()->notify(this, ACE_Event_Handler::EXCEPT_MASK);
-            }
+            m_pool->post_to_reactor([this]() { deliver_response(); });
+            if (reactor()) reactor()->notify();  // wake; not a handler dispatch
         });
         return 0;
     }
@@ -133,14 +139,23 @@ int HttpSession::handle_input(ACE_HANDLE /*fd*/) {
     return finish_response();
 }
 
-int HttpSession::handle_exception(ACE_HANDLE /*fd*/) {
-    // A worker finished and notify()'d us; we're back on the reactor thread,
-    // so it's safe to touch the socket / TLS engine.
+void HttpSession::deliver_response() {
+    // Runs on the reactor thread (invoked from WorkerPool::drain_reactor),
+    // so it is safe to touch the socket / TLS engine and to tear ourselves
+    // down here. Exactly one deliver_response() is queued per request.
     int rc = finish_response();
-    if (rc == 0 && reactor()) {
-        reactor()->resume_handler(this);  // keep-alive: re-enable reads
+    if (rc == 0) {
+        if (reactor()) reactor()->resume_handler(this);  // keep-alive: re-arm
+        return;
     }
-    return rc;  // -1 → reactor removes us → handle_close → delete this
+    // Close: detach from the reactor without a second callback (DONT_CALL),
+    // then run our own close — which closes the socket and deletes us. After
+    // this returns, `this` is gone; touch no members.
+    if (ACE_Reactor* r = reactor()) {
+        r->remove_handler(this, ACE_Event_Handler::READ_MASK |
+                                ACE_Event_Handler::DONT_CALL);
+    }
+    handle_close(ACE_INVALID_HANDLE, ACE_Event_Handler::READ_MASK);
 }
 
 int HttpSession::finish_response() {

--- a/modules/http-server/src/worker.cpp
+++ b/modules/http-server/src/worker.cpp
@@ -45,6 +45,22 @@ void WorkerPool::submit(Job job) {
     m_cv.notify_one();
 }
 
+void WorkerPool::post_to_reactor(Job fn) {
+    std::lock_guard<std::mutex> lk(m_reactor_mtx);
+    m_reactor_jobs.push_back(std::move(fn));
+}
+
+void WorkerPool::drain_reactor() {
+    // Swap out under the lock, then run unlocked so a callback may re-enter
+    // post_to_reactor() (or block on I/O) without deadlocking the workers.
+    std::vector<Job> jobs;
+    {
+        std::lock_guard<std::mutex> lk(m_reactor_mtx);
+        jobs.swap(m_reactor_jobs);
+    }
+    for (auto& j : jobs) j();
+}
+
 void WorkerPool::run() {
     for (;;) {
         Job job;

--- a/modules/http-server/test/worker_test.cpp
+++ b/modules/http-server/test/worker_test.cpp
@@ -75,3 +75,40 @@ TEST(WorkerPool, SubmitAfterStopRunsInline) {
     pool.submit([&ran] { ran = true; });
     EXPECT_TRUE(ran);
 }
+
+// The reactor-completion queue is the response handoff: workers post()
+// callbacks from any thread; the reactor thread runs them via drain_reactor().
+// post_to_reactor() must NOT run the callback itself (that would touch the
+// socket off the reactor thread) — only drain_reactor() runs them.
+TEST(WorkerPool, PostToReactorDefersUntilDrain) {
+    WorkerPool pool(4);
+    pool.start();
+
+    std::atomic<int> delivered{0};
+    pool.post_to_reactor([&] { delivered.fetch_add(1); });
+    EXPECT_EQ(delivered.load(), 0);   // not run on post
+
+    pool.drain_reactor();             // reactor thread runs it
+    EXPECT_EQ(delivered.load(), 1);
+
+    pool.drain_reactor();             // already drained → no double-run
+    EXPECT_EQ(delivered.load(), 1);
+}
+
+// Every posted completion is delivered exactly once, even when many workers
+// post concurrently — this is the property whose absence (lost notify()
+// wakeups) hung ~half of all requests.
+TEST(WorkerPool, EveryPostedCompletionDeliveredExactlyOnce) {
+    WorkerPool pool(8);
+    pool.start();
+
+    constexpr int N = 2000;
+    std::atomic<int> delivered{0};
+    for (int i = 0; i < N; ++i) {
+        pool.submit([&] { pool.post_to_reactor([&] { delivered.fetch_add(1); }); });
+    }
+    pool.stop();                      // joins workers → all post()s done
+
+    pool.drain_reactor();             // single reactor-thread drain
+    EXPECT_EQ(delivered.load(), N);   // none lost, none duplicated
+}


### PR DESCRIPTION
## Symptom
The cloud/device UI intermittently **"failed to load"**. Measured on the live cloud: **~50% of HTTP responses were never sent** (sequential `curl` to `/webui/` → ok=10 fail=10). A page load fires ~6 requests, so it almost never completed; a reload occasionally squeaked through.

## Root cause
With `http.workers>0`, the worker→reactor handoff used `reactor()->notify(this, EXCEPT_MASK)` to drive `handle_exception()`. That dispatch **drops ~half its wakeups under load**, so the computed response sat unsent in `m_response` and the handler was leaked suspended → client hangs. (The trailing-slash/`/webui/` correlation was a red herring from worker-pool exhaustion cascading.)

## Fix
- Replace the lossy `notify()`-dispatch with a **reliable reactor-drained completion queue**: workers post a `deliver_response()` callback via `WorkerPool::post_to_reactor()`; the reactor loop runs them via `drain_reactor()` each tick. `notify()` stays only as a wake hint (harmless if coalesced/lost). The `ACE_Svc_Handler`/reactor connection path is unchanged — only the cross-thread handoff.
- Make `http.workers` **ds-only** (single source of truth): drop the `http-workers` CLI arg + `HTTP_WORKERS` env from both compose files and `run.sh`. The CLI arg silently overrode the `http.workers` ds key the UI edits (UI showed 0, daemon ran 4). httpd now reads it from ds (schema default `0` = inline).

## Tests
`worker_test` asserts every posted completion is delivered exactly once across concurrent workers — the property whose absence hung requests.

Verified: cloud image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)