### PR TITLE
fix(cloud): rehydrate endpoint registry from ds on startup

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -247,6 +247,72 @@ std::vector<std::string> poll_vpn_connected(std::uint16_t mgmt_port) {
     return out;
 }
 
+// Rehydrate the in-memory EndpointRegistry + VpnRegistry from persisted ds at
+// startup. Both are in-memory only; without this they come up EMPTY after a
+// restart/upgrade, and the main loop's first sync_endpoints_to_ds() then
+// clobbers the persisted cloud.endpoints to [] — so a provisioned device
+// "disappears" from the table on every cloud update and loses its tun_ip /
+// proxy_port (→ no DNAT, no VPN cert push). We:
+//   1) exact-restore tun_ip/proxy_port/registered from the last persisted
+//      cloud.endpoints (stable ports across restarts), and
+//   2) heal any provisioned endpoint (cloud.endpoint.credentials) that lacks a
+//      registry row — e.g. a cloud.endpoints already clobbered to [] by the
+//      pre-fix bug — by allocating a fresh tun_ip/proxy_port.
+// PSKs are never touched: provision() only assigns tun_ip/port + registry row.
+std::size_t rehydrate_registry(data_store::Client& ds,
+                               server::lwm2m::EndpointRegistry& reg,
+                               server::openvpn::VpnRegistry& vpn,
+                               server::lwm2m::BootstrapProvisioner& prov) {
+    std::size_t restored = 0, healed = 0;
+
+    try {
+        auto eps = nlohmann::json::parse(ds_str(ds, "cloud.endpoints", "[]"));
+        if (eps.is_array()) {
+            for (const auto& e : eps) {
+                if (!e.is_object()) continue;
+                auto ep = e.value("endpoint", std::string());
+                if (ep.empty()) continue;
+                server::lwm2m::EndpointInfo info(
+                    ep, e.value("tun_ip", std::string()),
+                    static_cast<std::uint16_t>(e.value("proxy_port", 0)),
+                    e.value("registered", false));
+                info.last_seen_unix = e.value("last_seen_unix", std::int64_t{0});
+                if (reg.add(info)) {
+                    vpn.reserve(info.ep, info.tun_ip, info.proxy_port);
+                    ++restored;
+                }
+            }
+        }
+    } catch (const std::exception& ex) {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("%D cloudd:thread:%t %M %N:%l rehydrate "
+                   "cloud.endpoints parse: %C\n"), ex.what()));
+    }
+
+    try {
+        auto creds = nlohmann::json::parse(
+            ds_str(ds, "cloud.endpoint.credentials", "[]"));
+        if (creds.is_array()) {
+            for (const auto& c : creds) {
+                if (!c.is_object()) continue;
+                auto serial = c.value("serial", std::string());
+                if (serial.empty() || reg.lookup_by_ep(serial)) continue;
+                if (prov.provision(serial)) ++healed;
+            }
+        }
+    } catch (const std::exception& ex) {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("%D cloudd:thread:%t %M %N:%l rehydrate "
+                   "cloud.endpoint.credentials parse: %C\n"), ex.what()));
+    }
+
+    if (restored || healed)
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D cloudd:thread:%t %M %N:%l rehydrated "
+                  "%u endpoint(s) from ds (%u restored, %u healed)\n"),
+                  static_cast<unsigned>(restored + healed),
+                  static_cast<unsigned>(restored),
+                  static_cast<unsigned>(healed)));
+    return restored + healed;
+}
+
 } // namespace
 
 int main(int argc, char** argv) {
@@ -304,6 +370,11 @@ int main(int argc, char** argv) {
         static_cast<std::uint16_t>(proxy_port_end));
     server::lwm2m::EndpointRegistry ep_reg;
     server::lwm2m::BootstrapProvisioner provisioner(ep_reg, vpn_reg);
+
+    // Restore persisted endpoints into the in-memory registries BEFORE the
+    // main loop's first sync — otherwise the empty registry overwrites
+    // cloud.endpoints with [] and every restart "loses" provisioning.
+    rehydrate_registry(ds, ep_reg, vpn_reg, provisioner);
 
     ::signal(SIGINT, on_signal);
     ::signal(SIGTERM, on_signal);

--- a/modules/server/openvpn/inc/vpn_registry.hpp
+++ b/modules/server/openvpn/inc/vpn_registry.hpp
@@ -40,6 +40,14 @@ public:
     /// the subnet or port range is exhausted.
     std::optional<VpnAllocation> allocate(const std::string& ep);
 
+    /// Restore a previously-persisted allocation at startup (rehydration).
+    /// Marks `ip` / `port` as in-use for `ep` so the pools never hand them
+    /// out again — unlike allocate(), the caller supplies the exact values
+    /// read back from the persisted cloud.endpoints. Empty ip / zero port
+    /// are ignored; an already-allocated ip/port is left as-is.
+    void reserve(const std::string& ep, const std::string& ip,
+                 std::uint16_t port);
+
     /// Allocate only an IP.  Returns nullopt when exhausted.
     std::optional<std::string> allocate_ip();
 

--- a/modules/server/openvpn/src/vpn_registry.cpp
+++ b/modules/server/openvpn/src/vpn_registry.cpp
@@ -86,6 +86,24 @@ std::optional<VpnAllocation> VpnRegistry::allocate(const std::string& ep) {
     return a;
 }
 
+void VpnRegistry::reserve(const std::string& ep, const std::string& ip,
+                          std::uint16_t port) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    if (!ip.empty()) {
+        m_free_ips.erase(ip);
+        m_allocated_ips.insert(ip);
+    }
+    if (port != 0) {
+        m_free_ports.erase(port);
+        m_allocated_ports.insert(port);
+    }
+    VpnAllocation a;
+    a.ep         = ep;
+    a.tun_ip     = ip;
+    a.proxy_port = port;
+    m_ep_to_alloc[ep] = a;
+}
+
 std::optional<std::string> VpnRegistry::allocate_ip() {
     std::lock_guard<std::mutex> lk(m_mutex);
     if (m_free_ips.empty()) return std::nullopt;


### PR DESCRIPTION
## Symptom
A provisioned, registered device shows **0 endpoints** in the cloud table/dashboard ("No devices provisioned yet"), and its VPN is stuck **"reconnecting"** — even though `cloud.endpoint.credentials` (BS+DM PSK) is persisted and the device DID register (`cloud.lwm2m.registrations` shows it).

## Root cause
`EndpointRegistry` + `VpnRegistry` are **in-memory only** and were never rebuilt at startup (`main.cpp` just default-constructs them). After any restart/upgrade they come up empty, then the first `sync_endpoints_to_ds()` overwrites the persisted `cloud.endpoints` with `[]`. So the endpoint vanishes from the table and loses its `tun_ip`/`proxy_port` → no DNAT, no VPN cert push. The PSKs survive only because `cloud.endpoint.credentials` is a separate persisted key.

This is why provisioning *appeared* to be lost on every cloud-iot update.

## Fix
`rehydrate_registry()` at startup, before the first sync:
1. **Exact-restore** `tun_ip`/`proxy_port`/`registered` from the persisted `cloud.endpoints` (stable ports across restarts), reserving each in the `VpnRegistry` (new `reserve()`).
2. **Heal** any provisioned endpoint in `cloud.endpoint.credentials` lacking a registry row (e.g. a `cloud.endpoints` already clobbered to `[]`) by allocating a fresh `tun_ip`/`proxy_port`.

PSKs are never touched — `provision()` only assigns tun_ip/port + registry row.

Verified: cloud image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)