### PR TITLE
chore(cloud): make vpn subnet ds-driven, drop VPN_SUBNET env/CLI

### DIFF
--- a/apps/cloud/INSTALL.md
+++ b/apps/cloud/INSTALL.md
@@ -177,12 +177,10 @@ Override on the command line — they pass through to `docker-compose.yml`:
 
 | Variable | Default | Meaning |
 |----------|---------|---------|
-| `HTTPS` | `0` | `1` = serve https on 443 (self-signed cert auto-generated) + redirect 80→443 (see §5) |
+| `HTTPS` | `0` | `1` = serve https on 443 (self-signed cert auto-generated) |
 | `TLS_HOST` | host primary IP | Cert subject/SAN when `HTTPS=1` (set to your IP or domain) |
 | `HTTP_PORT` | `80` (`443` if `HTTPS=1`) | Cloud UI / REST port |
-| `VPN_SUBNET` | `10.9.0.0/24` | OpenVPN tunnel subnet |
-| `PROXY_START` / `PROXY_END` | `5001` / `6000` | Device-UI reverse-proxy port pool |
-| `HTTP_WORKERS` | `4` | iot-httpd handler threads |
+| `PROXY_START` / `PROXY_END` | `10000` / `10050` | Device-UI reverse-proxy port pool (published range; must cover the ds `cloud.vpn.proxy.port.*` range) |
 | `CLOUD_IMAGE` | `docker.io/naushada/iot-cloud:latest` | Image to run |
 | `PULL` | `1` | Pull the image on start. `0` = use a local `./run.sh build` as-is |
 | `PLATFORM` | auto (`uname -m`) | Image arch to pull. The published image is multi-arch (`linux/amd64` + `linux/arm64`), so the host arch is selected automatically; override e.g. `linux/amd64` |
@@ -191,8 +189,13 @@ Override on the command line — they pass through to `docker-compose.yml`:
 Example:
 
 ```bash
-HTTP_PORT=8443 VPN_SUBNET=10.8.0.0/24 ./run.sh
+HTTP_PORT=8443 ./run.sh
 ```
+
+Runtime config (VPN subnet, iot-httpd worker count, etc.) is **not** env —
+it lives in the data store so the cloud UI is the single source of truth.
+For example: `./run.sh ds set cloud.vpn.subnet '"10.8.0.0/24"'` or
+`./run.sh ds set http.workers 4` (schema defaults: `10.9.0.0/24`, `0`).
 
 ### LwM2M server URIs — devices must reach these
 

--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -41,9 +41,8 @@ services:
     command: >
       iot-cloudd
       ds-socket=/var/run/iot/data_store.sock
-      vpn-subnet=${VPN_SUBNET:-10.9.0.0/24}
-      proxy-start=${PROXY_START:-5001}
-      proxy-end=${PROXY_END:-6000}
+      proxy-start=${PROXY_START:-10000}
+      proxy-end=${PROXY_END:-10050}
       sync-interval=5
     volumes:
       - iot-run:/var/run/iot

--- a/apps/cloud/run.sh
+++ b/apps/cloud/run.sh
@@ -23,7 +23,10 @@
 #   ./run.sh ds set KEY VAL     #   e.g. ./run.sh ds get cloud.endpoint.credentials
 #
 #   HTTP_PORT=8443 ./run.sh     # custom HTTP port
-#   VPN_SUBNET=10.8.0.0/24 ./run.sh  # custom VPN subnet
+#
+# The VPN subnet is NOT an env/CLI knob — it lives in the data store
+# (cloud.vpn.subnet, schema default 10.9.0.0/24). Change it on the VPN page
+# or with: ./run.sh ds set cloud.vpn.subnet '"10.8.0.0/24"'
 #
 # Secrets (first run auto-generates):
 #   - iot-cloud-ca-key  volume: /run/secrets/iot-ca-key  (CA private key)
@@ -56,7 +59,6 @@ else
     HTTP_PORT="${HTTP_PORT:-80}"
 fi
 HTTPS_PORT="$HTTP_PORT"
-VPN_SUBNET="${VPN_SUBNET:-10.9.0.0/24}"
 # Per-device device-UI proxy ports. Kept ABOVE the CoAP ports (5683 DM /
 # 5684 BS that lwm2m-dm/bs publish) and SMALL on purpose: each published port
 # spawns a docker-proxy process, so a 1000-wide range exhausts the host. Bump
@@ -155,7 +157,7 @@ COMPOSE_PROFILES=""
 # Export env vars so docker-compose.yml can reference them
 export CLOUD_IMAGE="$IMAGE"
 export HTTP_PORT HTTP_SCHEME HTTPS_PORT
-export VPN_SUBNET PROXY_START PROXY_END
+export PROXY_START PROXY_END
 export COMPOSE_PROJECT_NAME="$PROJECT"
 
 case "${1:-start}" in

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -327,8 +327,6 @@ int main(int argc, char** argv) {
         std::string a{argv[i]};
         if (a.rfind("ds-socket=", 0) == 0)
             ds_path = a.substr(10);
-        else if (a.rfind("vpn-subnet=", 0) == 0)
-            vpn_subnet = a.substr(11);
         else if (a.rfind("proxy-start=", 0) == 0)
             proxy_port_start = std::stoi(a.substr(12));   // "proxy-start=" = 12 chars
         else if (a.rfind("proxy-end=", 0) == 0)
@@ -363,6 +361,13 @@ int main(int argc, char** argv) {
            data_store::Value{static_cast<std::uint32_t>(proxy_port_start)});
     ds.set("cloud.vpn.proxy.port.end",
            data_store::Value{static_cast<std::uint32_t>(proxy_port_end)});
+
+    // Tunnel subnet is ds-driven too (cloud.vpn.subnet, schema default
+    // 10.9.0.0/24) — no env/CLI needed. ds is the single source of truth so a
+    // VPN-page edit isn't clobbered on restart; seed the effective value back
+    // so it's visible/editable.
+    vpn_subnet = ds_str(ds, "cloud.vpn.subnet", vpn_subnet);
+    ds.set("cloud.vpn.subnet", data_store::Value{vpn_subnet});
 
     // ── Core services ─────────────────────────────────────────────
     server::openvpn::VpnRegistry vpn_reg(vpn_subnet,
@@ -422,8 +427,7 @@ int main(int argc, char** argv) {
                    ws_update.err.c_str()));
     }
 
-    // Seed initial VPN config in ds
-    ds.set("cloud.vpn.subnet", data_store::Value{vpn_subnet});
+    // Seed initial VPN config in ds (subnet already seeded above from ds).
     ds.set("cloud.vpn.port.next",
            data_store::Value{static_cast<std::uint32_t>(proxy_port_start)});
 


### PR DESCRIPTION
Sanitise the compose file so runtime config lives in ds, not env. The VPN tunnel subnet is operator config the cloud UI edits, so `cloud.vpn.subnet` (schema default `10.9.0.0/24`) is the single source of truth.

**Before:** iot-cloudd seeded `cloud.vpn.subnet` from the `vpn-subnet=${VPN_SUBNET}` CLI arg on every boot — clobbering any VPN-page edit — and the `VpnRegistry` IP pool used the CLI value while the openvpn server read ds (could diverge).

**After:**
- `main.cpp` reads `cloud.vpn.subnet` from ds (CLI/default fallback) *before* building the VpnRegistry; CLI parse + redundant later `ds.set` removed.
- `docker-compose.yml`: dropped `vpn-subnet=${VPN_SUBNET}`; fixed stale `proxy-start/end` env defaults `5001/6000` → `10000/10050`.
- `run.sh`: removed `VPN_SUBNET`; documented it's a ds key.
- `INSTALL.md`: removed `VPN_SUBNET` + `HTTP_WORKERS` env rows (both ds-driven now), fixed proxy defaults + obsolete redirect mention.

Env stays only for deploy-time infra Docker/the entrypoint need before ds exists (image tag, published ports, `TLS_HOST`, `http-port/scheme`).

Verified: cloud image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)