### PR TITLE
feat(lwm2m): resolve per-endpoint PSK live from ds at handshake

### DIFF
--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -7,6 +7,7 @@
 #include <algorithm>
 #include <iostream>
 #include <unordered_map>
+#include <functional>
 
 #include "coap_adapter.hpp"
 
@@ -181,6 +182,18 @@ class DTLSAdapter {
             return(std::string());
         }
 
+        /// Server-role PSK resolver: looks the secret up live from the data
+        /// store for the identity the client presented during the handshake,
+        /// so newly-provisioned endpoints authenticate without a restart and
+        /// ds stays the single source of truth (no in-memory pre-load/watch).
+        /// Runs on the handshake/reactor thread — NOT the ds listener thread —
+        /// so a blocking ds get() here is safe. Returns "" when unset/unknown.
+        using PskResolver = std::function<std::string(const std::string& identity)>;
+        void set_psk_resolver(PskResolver r) { m_psk_resolver = std::move(r); }
+        std::string resolve_secret(const std::string& identity) {
+            return m_psk_resolver ? m_psk_resolver(identity) : std::string();
+        }
+
         /**
          * @brief 
          * 
@@ -345,6 +358,7 @@ class DTLSAdapter {
         //std::unique_ptr<dtls_context_t, decltype(&dtls_free_context)> dtls_ctx;
         dtls_context_t *m_dtls_ctx;
         std::unordered_map<std::string, std::string> device_credentials;
+        PskResolver m_psk_resolver;
         std::int32_t dtlsFd;
         std::shared_ptr<CoAPAdapter> m_coapAdapter;
         session_t m_session;

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -170,7 +170,12 @@ std::int32_t dtlsGetPskInfoCb(dtls_context_t *ctx, const session_t *session, dtl
         }
         case DTLS_PSK_KEY:
         {
+            // In-memory store first (client's derived identity / explicit
+            // creds); then the server's ds-backed resolver, which looks the
+            // key up live from cloud.endpoint.credentials by the presented
+            // identity — so provisioning takes effect without a restart.
             auto secret = inst.get_secret(in);
+            if (secret.empty()) secret = inst.resolve_secret(in);
             if (secret.empty()) {
                 dtls_warn("PSK for unknown identity requested\n");
                 return dtls_alert_fatal_create(DTLS_ALERT_ILLEGAL_PARAMETER);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1315,46 +1315,50 @@ int main(std::int32_t argc, char *argv[]) {
         }
     }
 
-    // Server role: (re)register per-device BS/DM PSKs from the cloud's
-    // cloud.endpoint.credentials array. BS identity = sha256(serial) — exactly
-    // what the device derives from its endpoint — and DM identity = dm.psk.id.
-    // add_credential() is a keyed store, so this is additive + idempotent.
-    // Reading the array requires gid:cloud-svc (the BS runs as cloud-svc).
-    auto register_endpoint_creds = [&](auto dtls) {   // dtls: shared_ptr<DTLSAdapter>
+    // Server role: resolve per-device BS/DM PSKs LIVE from the cloud's
+    // cloud.endpoint.credentials array for the identity the client presents at
+    // the DTLS handshake — no startup pre-load and no watch. The presented id
+    // is BS = sha256(serial)[:32] (exactly what the device derives from its
+    // endpoint) or DM = dm.psk.id. The resolver runs on the handshake/reactor
+    // thread (NOT the ds listener thread), so the blocking ds get() is safe;
+    // this mirrors the BS provisioning_resolver that already reads ds per /bs.
+    // Reading the array requires gid:cloud-svc (the servers run as cloud-svc).
+    // Net effect: a device provisioned after the server started authenticates
+    // immediately, and ds stays the single source of truth.
+    auto install_psk_resolver = [&](auto dtls) {   // dtls: shared_ptr<DTLSAdapter>
         if (!dtls || UDPAdapter::Role_t::SERVER != role || !ds.client()) return;
         const bool is_bs = argValueMap["lwm2m-instance"] == "bs";
-        std::vector<data_store::Client::GetResult> got;
-        auto rs = ds.client()->get({std::string("cloud.endpoint.credentials")}, got);
-        if (!rs.ok || got.empty() || !got[0].has_value) return;
-        auto s = data_store::to_string(got[0].value);
-        if (!s || s->empty()) return;
-        try {
-            auto arr = nlohmann::json::parse(*s);
-            if (!arr.is_array()) return;
-            int n = 0;
-            for (auto& e : arr) {
-                if (!e.is_object()) continue;
-                std::string ident, key;
-                if (is_bs) {
-                    const std::string serial = e.value("serial", std::string());
-                    key = e.value("bs.psk.key", std::string());
-                    // 128-bit identity (first 32 hex chars), matching the
-                    // device's iot::sha256_hex(endpoint).substr(0,32).
-                    if (!serial.empty()) ident = iot::sha256_hex(serial).substr(0, 32);
-                } else {
-                    ident = e.value("dm.psk.id", std::string());
-                    key   = e.value("dm.psk.key", std::string());
+        auto* cli = ds.client();
+        dtls->set_psk_resolver([cli, is_bs](const std::string& presented) -> std::string {
+            std::vector<data_store::Client::GetResult> got;
+            auto rs = cli->get({std::string("cloud.endpoint.credentials")}, got);
+            if (!rs.ok || got.empty() || !got[0].has_value) return std::string();
+            auto s = data_store::to_string(got[0].value);
+            if (!s || s->empty()) return std::string();
+            try {
+                auto arr = nlohmann::json::parse(*s);
+                if (!arr.is_array()) return std::string();
+                for (auto& e : arr) {
+                    if (!e.is_object()) continue;
+                    if (is_bs) {
+                        const std::string serial = e.value("serial", std::string());
+                        // 128-bit identity (first 32 hex chars), matching the
+                        // device's iot::sha256_hex(endpoint).substr(0,32).
+                        if (!serial.empty() &&
+                            iot::sha256_hex(serial).substr(0, 32) == presented)
+                            return e.value("bs.psk.key", std::string());
+                    } else if (e.value("dm.psk.id", std::string()) == presented) {
+                        return e.value("dm.psk.key", std::string());
+                    }
                 }
-                if (!ident.empty() && !key.empty()) { dtls->add_credential(ident, key); ++n; }
+            } catch (const std::exception& ex) {
+                ACE_ERROR((LM_ERROR,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l PSK resolver: "
+                                    "cloud.endpoint.credentials parse: %C\n"),
+                           ex.what()));
             }
-            ACE_DEBUG((LM_INFO,
-                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l registered %d per-endpoint %C PSK(s)\n"),
-                       n, is_bs ? "BS" : "DM"));
-        } catch (const std::exception& ex) {
-            ACE_ERROR((LM_ERROR,
-                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l cloud.endpoint.credentials parse: %C\n"),
-                       ex.what()));
-        }
+            return std::string();
+        });
     };
 
     if(UDPAdapter::Scheme_t::CoAPs == scheme) {
@@ -1366,10 +1370,10 @@ int main(std::int32_t argc, char *argv[]) {
             auto& ent = *it;
             // Only register a shared identity/secret when one was explicitly
             // provided (client: derived id + ds secret; dev server override).
-            // Empty → server relies solely on per-endpoint creds below.
+            // Empty → server relies solely on the ds-backed resolver below.
             if (!identity.empty() && !secret.empty())
                 ent.second->dtlsAdapter()->add_credential(identity, secret);
-            register_endpoint_creds(ent.second->dtlsAdapter());
+            install_psk_resolver(ent.second->dtlsAdapter());
         }
     }
 


### PR DESCRIPTION
Replace the startup pre-load of per-endpoint PSKs (`register_endpoint_creds`) with a **ds-backed resolver** invoked from the DTLS handshake callback. On a `DTLS_PSK_KEY` request the server reads `cloud.endpoint.credentials` live and returns the key for the presented identity:
- **BS**: `sha256(serial)[:32] == id` → `bs.psk.key`
- **DM**: `dm.psk.id == id` → `dm.psk.key`

**Why:** the in-memory pre-load ran once at startup, so a device provisioned *afterwards* couldn't handshake until the server restarted (and the map could be stale/empty). Reading live makes ds the single source of truth and lets newly-provisioned devices connect immediately. A watch was considered but is heavier (standing subscription + map upkeep + a mutex); the resolver only touches ds during a handshake.

**Safe:** the callback runs on the handshake/reactor thread, not the ds listener thread, so the blocking `get()` can't deadlock — the same live-ds pattern the BS `provisioning_resolver` already uses per `/bs`.

Builds on #162 (no hardcoded PSK). Verified: cloud image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)