### PR TITLE
fix(device-ui): render DM Server URI live from shared /status

### DIFF
--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -1,6 +1,8 @@
-import { Component, Input, OnInit } from '@angular/core';
+import { Component, Input, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpsvcService } from '../../../common/httpsvc.service';
+import { DataStoreService } from '../../../common/datastore.service';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 
@@ -9,7 +11,7 @@ import { ToastService } from '../../../common/toast.service';
   templateUrl: './lwm2m-config.component.html',
   styleUrls: ['./lwm2m-config.component.scss']
 })
-export class Lwm2mConfigComponent implements OnInit {
+export class Lwm2mConfigComponent implements OnInit, OnDestroy {
   // Which tab is rendering this component: 'server' shows the registration
   // fields (Server Object), 'security' shows serial + Bootstrap PSK
   // (Security Object). Same form-group backs both; we just show a subset.
@@ -24,9 +26,11 @@ export class Lwm2mConfigComponent implements OnInit {
   generatedPsk = '';           // last generated BS PSK (hex), shown once to copy
   generatingPsk = false;
 
+  private sub = new Subscription();
+
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, fb: FormBuilder, private session: SessionService, private toast: ToastService) {
+  constructor(private http: HttpsvcService, private ds: DataStoreService, fb: FormBuilder, private session: SessionService, private toast: ToastService) {
     this.serverForm = fb.group({
       serial:     [''],
       bs_uri:     ['coaps://'],
@@ -67,6 +71,25 @@ export class Lwm2mConfigComponent implements OnInit {
       },
       error: () => { this.loading = false; }
     });
+
+    // The Server (Device Management) tab is read-only STATUS — the DM URI is
+    // pushed by the bootstrap server after the client registers. Subscribe to
+    // the shared store so it renders live (off the single /status long-poll)
+    // and never shows a stale "(set by bootstrap)" once iot.dm.uri is written.
+    // The Security tab is an editable form, so it stays load-once (no live
+    // subscription that could clobber in-progress edits).
+    if (this.mode === 'server') {
+      this.sub.add(this.ds.observe('iot.dm.uri').subscribe(() => this.refreshDmUri()));
+      this.sub.add(this.ds.observe('iot.server.uri').subscribe(() => this.refreshDmUri()));
+    }
+  }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
+
+  private refreshDmUri(): void {
+    const dm = this.ds.getString('iot.dm.uri');
+    const legacy = this.ds.getString('iot.server.uri');
+    this.serverForm.patchValue({ server_uri: dm || legacy || '(set by bootstrap)' });
   }
 
   // Only the Security (commissioning) tab saves — the Server tab is

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -15,6 +15,9 @@ export interface StatusSnapshot {
 
 export interface Lwm2mStatus {
   server_uri?: string;
+  // Bootstrap-delivered DM server URI the client persisted to iot.dm.uri
+  // (preferred over the legacy ds-driven server_uri on the DM status tab).
+  dm_uri?: string;
   endpoint?: string;
   // Connection lifecycle token published by the client on iot.conn.state:
   // idle / bootstrapping / bootstrapped / dm-connecting / dm-connected /

--- a/iot-ui/src/common/datastore.service.ts
+++ b/iot-ui/src/common/datastore.service.ts
@@ -36,7 +36,7 @@ export class DataStoreService {
     'net.state', 'net.rules.applied.count', 'net.last.apply.unix',
     'net.iface.active',
     // LwM2M client
-    'iot.serial', 'iot.dev.mode', 'iot.bs.uri', 'iot.server.uri',
+    'iot.serial', 'iot.dev.mode', 'iot.bs.uri', 'iot.server.uri', 'iot.dm.uri',
     'iot.binding', 'iot.lifetime',
     // Log levels
     'log.level', 'log.level.httpd', 'log.level.lwm2m',
@@ -98,6 +98,12 @@ export class DataStoreService {
       if (s.routing.state != null) this.set('net.state', s.routing.state);
       if (s.routing.rules_applied != null) this.set('net.rules.applied.count', s.routing.rules_applied);
       if (s.routing.last_apply_unix != null) this.set('net.last.apply.unix', s.routing.last_apply_unix);
+    }
+    if (s.lwm2m) {
+      // Republish read-only LwM2M status to per-key subjects so the DM tab's
+      // observe('iot.dm.uri') updates live (e.g. when registration completes).
+      if (s.lwm2m.dm_uri != null)     this.set('iot.dm.uri', s.lwm2m.dm_uri);
+      if (s.lwm2m.server_uri != null) this.set('iot.server.uri', s.lwm2m.server_uri);
     }
     if (s.wan && s.wan.active_iface != null) this.set('net.iface.active', s.wan.active_iface);
     // Flat passthrough keys (log.version / services.stats.version bump keys)

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -458,7 +458,7 @@ void install_handlers(Router& router,
             std::vector<data_store::Client::GetResult> got;
             auto rs = ds->get({
                 // LwM2M
-                "iot.server.uri", "iot.endpoint", "iot.conn.state",
+                "iot.server.uri", "iot.dm.uri", "iot.endpoint", "iot.conn.state",
                 // VPN
                 "vpn.state", "vpn.assigned.ip", "vpn.assigned.gateway",
                 "vpn.assigned.netmask", "vpn.assigned.dns", "vpn.pid",
@@ -561,6 +561,7 @@ void install_handlers(Router& router,
                 };
 
                 if (k == "iot.server.uri")        lwm2m["server_uri"] = sv();
+                else if (k == "iot.dm.uri")       lwm2m["dm_uri"] = sv();
                 else if (k == "iot.endpoint")     lwm2m["endpoint"] = sv();
                 else if (k == "iot.conn.state")   lwm2m["conn_state"] = sv();
 


### PR DESCRIPTION
The device LwM2M **Server (Device Management)** tab did a one-shot `dbGet` in `ngOnInit`, so the bootstrap-delivered DM URI (`iot.dm.uri`, written by the client after it registers) showed a stale `(set by bootstrap)` until a manual reload.

Route this **read-only** status through the single shared `/status` long-poll so it never misses an update:
- `handler.cpp` `/status`: add `iot.dm.uri` → `lwm2m.dm_uri` (shared by device + cloud httpd; harmless when unset).
- `iot-ui` `app-globals`: `Lwm2mStatus.dm_uri`.
- `iot-ui` `datastore.service`: `iot.dm.uri` in the global `ALL_KEYS` read + republished from each `/status` tick.
- `iot-ui` `lwm2m-config`: the Server (read-only) tab subscribes to `observe('iot.dm.uri')` (+ `iot.server.uri`) and renders live (prefer `iot.dm.uri` → `iot.server.uri` → placeholder).

The Security tab stays load-once (editable form — live subscription would clobber edits), per the agreed "read-only views only" scope.

Verified: device image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)