### PR TITLE
feat(device-ui): HTTP config page + software-update on shared /status

### DIFF
--- a/iot-ui/src/app/app.module.ts
+++ b/iot-ui/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { LogViewerComponent } from './log-level/log-viewer.component';
 import { ToastComponent } from './common/toast/toast.component';
 import { UsersComponent } from './users/users.component';
 import { SoftwareUpdateComponent } from './software-update/software-update.component';
+import { HttpConfigComponent } from './http-config/http-config.component';
 
 import { SsoAuthInterceptor } from '../common/sso-auth.interceptor';
 import { SessionService, initSession } from '../common/session.service';
@@ -54,7 +55,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     Lwm2mSubmenuComponent, Lwm2mConfigComponent,
     ServicesSubmenuComponent, ServicesListComponent,
     LogLevelComponent, LogViewerComponent, ToastComponent,
-    UsersComponent, SoftwareUpdateComponent,
+    UsersComponent, SoftwareUpdateComponent, HttpConfigComponent,
     DsHintComponent, DsDebugDirective,
   ],
   imports: [

--- a/iot-ui/src/app/http-config/http-config.component.ts
+++ b/iot-ui/src/app/http-config/http-config.component.ts
@@ -1,0 +1,200 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+import { ToastService } from '../../common/toast.service';
+import { DataStoreService } from '../../common/datastore.service';
+
+@Component({
+  selector: 'app-http-config',
+  template: `
+    <div class="page">
+      <h3>HTTP Server Configuration</h3>
+
+      <div class="info-card">
+        <p>The device web UI / REST API is served by <code>iot-httpd</code>
+        from the <code>http.*</code> schema. Most keys hot-reload within ~2s
+        (no restart); <code>http.workers</code> needs a restart. The
+        <strong>listen port is fixed by the container</strong> (the cloud
+        reaches this UI through its VPN proxy on that port), so changing
+        <code>http.listen.port</code> here has no effect on a containerised
+        device.</p>
+      </div>
+
+      <form [formGroup]="form" (ngSubmit)="save()" *ngIf="!loading">
+        <h4 style="margin-top:24px;">Listen</h4>
+        <div class="form-grid">
+          <clr-input-container>
+            <label>IP</label>
+            <input clrInput [disabled]="!isAdmin" formControlName="ip"
+                   placeholder="0.0.0.0" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.listen.ip"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>Port</label>
+            <input clrInput [disabled]="!isAdmin" type="number"
+                   formControlName="port" min="1" max="65535" />
+            <clr-control-helper>Fixed by the container on a device deploy.</clr-control-helper>
+            <clr-control-helper *dsDebug><app-ds-hint key="http.listen.port"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-select-container>
+            <label>Scheme</label>
+            <select clrSelect [disabled]="!isAdmin" formControlName="scheme">
+              <option value="http">HTTP</option>
+              <option value="https">HTTPS</option>
+            </select>
+            <clr-control-helper *dsDebug><app-ds-hint key="http.listen.scheme"></app-ds-hint></clr-control-helper>
+          </clr-select-container>
+          <clr-input-container>
+            <label>Worker Threads</label>
+            <input clrInput [disabled]="!isAdmin" type="number"
+                   formControlName="workers" min="0" max="64" />
+            <clr-control-helper>0 = inline. Requires restart to change.</clr-control-helper>
+            <clr-control-helper *dsDebug><app-ds-hint key="http.workers"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+        </div>
+
+        <h4 style="margin-top:32px;">TLS <span class="hint">(required for https)</span></h4>
+        <div class="form-grid">
+          <clr-input-container>
+            <label>Certificate (PEM)</label>
+            <input clrInput [disabled]="!isAdmin" formControlName="cert"
+                   placeholder="/etc/iot/certs/server.crt" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.tls.cert"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>Private Key (PEM)</label>
+            <input clrInput [disabled]="!isAdmin" formControlName="key"
+                   placeholder="/etc/iot/certs/server.key" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.tls.key"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>CA Bundle (PEM) <span class="hint">(optional — enables mTLS)</span></label>
+            <input clrInput [disabled]="!isAdmin" formControlName="ca"
+                   placeholder="/etc/iot/certs/ca.crt" />
+            <clr-control-helper *dsDebug><app-ds-hint key="http.tls.ca"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+        </div>
+
+        <h4 style="margin-top:32px;">Auth</h4>
+        <div class="form-grid">
+          <clr-checkbox-container>
+            <clr-checkbox-wrapper>
+              <input type="checkbox" clrCheckbox [disabled]="!isAdmin"
+                     [ngModel]="authEnabled"
+                     (ngModelChange)="toggleAuth($event)"
+                     [ngModelOptions]="{standalone: true}" />
+              <label>Enable Authentication</label>
+            </clr-checkbox-wrapper>
+            <clr-control-helper>When disabled, all /api/v1/* routes are public</clr-control-helper>
+          </clr-checkbox-container>
+        </div>
+
+        <div style="margin-top:24px;" *ngIf="isAdmin">
+          <button type="submit" class="btn btn-primary" [disabled]="saving">
+            {{ saving ? 'Saving…' : 'Save' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; }
+    h3 { color: #333; margin: 0 0 12px 0; font-size: 16px; font-weight: 600; }
+    h4 { color: #555; margin: 0 0 12px 0; font-size: 14px; font-weight: 600;
+         border-bottom: 1px solid #e0e0e0; padding-bottom: 8px; }
+    .hint { color: #888; font-weight: normal; font-size: 11px; }
+    .info-card {
+      background: #f0f5ff; border: 1px solid #b3d4ff; border-radius: 4px;
+      padding: 12px 16px; font-size: 13px; color: #333;
+    }
+    .info-card code { background: #d0e4ff; padding: 1px 4px; border-radius: 2px; font-size: 12px; }
+  `]
+})
+export class HttpConfigComponent implements OnInit {
+  form: FormGroup;
+  loading = true;
+  saving = false;
+  authEnabled = true;
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(
+    private http: HttpsvcService,
+    fb: FormBuilder,
+    private session: SessionService,
+    private toast: ToastService,
+    private ds: DataStoreService
+  ) {
+    this.form = fb.group({
+      ip:      ['0.0.0.0'],
+      port:    [8080],
+      scheme:  ['http'],
+      workers: [0],
+      cert:    [''],
+      key:     [''],
+      ca:      [''],
+    });
+  }
+
+  ngOnInit(): void {
+    // Instant paint from the prefetched cache, then refresh from the wire.
+    if (this.ds.has('http.listen.ip')) { this.applyData(this.ds.snapshot()); this.loading = false; }
+    this.http.dbGet([
+      'http.listen.ip', 'http.listen.port', 'http.listen.scheme',
+      'http.workers', 'http.tls.cert', 'http.tls.key', 'http.tls.ca',
+      'http.auth.enabled'
+    ]).subscribe({
+      next: (r) => {
+        if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>);
+        this.loading = false;
+      },
+      error: () => { this.loading = false; }
+    });
+  }
+
+  private applyData(d: Record<string, unknown>): void {
+    this.form.patchValue({
+      ip:      d['http.listen.ip']     ?? this.form.value.ip,
+      port:    d['http.listen.port']   ?? this.form.value.port,
+      scheme:  d['http.listen.scheme'] ?? this.form.value.scheme,
+      workers: d['http.workers']       ?? this.form.value.workers,
+      cert:    d['http.tls.cert']      ?? this.form.value.cert,
+      key:     d['http.tls.key']       ?? this.form.value.key,
+      ca:      d['http.tls.ca']        ?? this.form.value.ca,
+    });
+    const ae = d['http.auth.enabled'];
+    if (typeof ae === 'boolean') this.authEnabled = ae;
+  }
+
+  toggleAuth(v: boolean): void {
+    this.http.dbSet([{ key: 'http.auth.enabled', value: v }]).subscribe({
+      next: (r) => {
+        if (r.ok) { this.authEnabled = v; this.toast.success('Auth ' + (v ? 'enabled' : 'disabled')); }
+        else this.toast.error(r.err || 'Toggle failed');
+      },
+      error: () => this.toast.error('Toggle failed')
+    });
+  }
+
+  save(): void {
+    this.saving = true;
+    const v = this.form.value;
+    this.http.dbSet([
+      { key: 'http.listen.ip',     value: v.ip },
+      { key: 'http.listen.port',   value: v.port },
+      { key: 'http.listen.scheme', value: v.scheme },
+      { key: 'http.workers',       value: v.workers },
+      { key: 'http.tls.cert',      value: v.cert },
+      { key: 'http.tls.key',       value: v.key },
+      { key: 'http.tls.ca',        value: v.ca },
+    ]).subscribe({
+      next: (r) => {
+        this.saving = false;
+        if (r.ok) this.toast.success('HTTP config saved');
+        else this.toast.error(r.err || 'Save failed');
+      },
+      error: () => { this.saving = false; this.toast.error('Save failed'); }
+    });
+  }
+}

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -79,6 +79,9 @@
       <!-- Dashboard -->
       <app-dashboard *ngIf="selectedMenu==='dashboard'"></app-dashboard>
 
+      <!-- HTTP -->
+      <app-http-config *ngIf="selectedMenu==='http'"></app-http-config>
+
       <!-- VPN -->
       <ng-container *ngIf="selectedMenu==='vpn'">
         <app-vpn-config *ngIf="!selectedSubNav || selectedSubNav==='config'"></app-vpn-config>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -28,6 +28,7 @@ export class MainComponent {
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg', children: [] as {id:string,label:string}[] },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg',
       children: [{id:'config',label:'Configuration'},{id:'status',label:'Status'}] },
+    { id: 'http',      label: 'HTTP',      svg: 'assets/icons/lwm2m.svg', children: [] as {id:string,label:string}[] },
     { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg',
       children: [{id:'wifi',label:'WiFi Config'},{id:'scan',label:'Scan Results'},{id:'priority',label:'Priority'}] },
     { id: 'routing',   label: 'Routing',   svg: 'assets/icons/routing.svg',

--- a/iot-ui/src/app/software-update/software-update.component.ts
+++ b/iot-ui/src/app/software-update/software-update.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { HttpsvcService } from '../../common/httpsvc.service';
+import { DataStoreService } from '../../common/datastore.service';
 import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 
@@ -16,16 +17,19 @@ import { ToastService } from '../../common/toast.service';
           <clr-dg-column>Property</clr-dg-column>
           <clr-dg-column>Value</clr-dg-column>
           <clr-dg-row>
-            <clr-dg-cell>Installed Version</clr-dg-cell>
+            <clr-dg-cell>Installed Version
+              <app-ds-hint *dsDebug key="iot.update.version"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell>{{ version || '—' }}</clr-dg-cell>
           </clr-dg-row>
           <clr-dg-row>
-            <clr-dg-cell>State</clr-dg-cell>
+            <clr-dg-cell>State
+              <app-ds-hint *dsDebug key="iot.update.state"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell><app-status-badge [label]="stateLabel"
               [state]="state===0 ? 'connected' : 'idle'"></app-status-badge></clr-dg-cell>
           </clr-dg-row>
           <clr-dg-row>
-            <clr-dg-cell>Result</clr-dg-cell>
+            <clr-dg-cell>Result
+              <app-ds-hint *dsDebug key="iot.update.result"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell><app-status-badge [label]="resultLabel"
               [state]="result===1 ? 'connected' : (result>=5 ? 'exited' : 'idle')"></app-status-badge></clr-dg-cell>
           </clr-dg-row>
@@ -37,7 +41,8 @@ import { ToastService } from '../../common/toast.service';
           <clr-input-container style="grid-column: span 3;">
             <label>Package URL</label>
             <input clrInput [(ngModel)]="url" style="width:100%;"
-                   placeholder="http://10.9.0.1:8080/firmware/iot_0.2.0_aarch64.ipk?sha256=..." />
+                   placeholder="https://<cloud-host>/firmware/<package>.ipk?sha256=<hash>" />
+            <clr-control-helper *dsDebug><app-ds-hint key="iot.update.request"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <div class="btn-cell">
             <button class="btn btn-primary" (click)="apply()" [disabled]="busy || !url">
@@ -66,7 +71,6 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   result = 0;
   url = '';
   busy = false;
-  private active = true;
   private sub = new Subscription();
 
   get isAdmin(): boolean { return this.session.isAdmin; }
@@ -82,25 +86,23 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     return 'error ' + this.result;
   }
 
-  constructor(private http: HttpsvcService, private session: SessionService,
-              private toast: ToastService) {}
+  constructor(private http: HttpsvcService, private ds: DataStoreService,
+              private session: SessionService, private toast: ToastService) {}
 
-  ngOnInit(): void { if (this.isAdmin) this.poll(); }
-
-  private poll(): void {
-    if (!this.active) return;
-    this.http.dbGet(['iot.update.version', 'iot.update.state', 'iot.update.result']).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const d = r.data as Record<string, unknown>;
-          if (d['iot.update.version'] != null) this.version = String(d['iot.update.version']);
-          if (d['iot.update.state'] != null)   this.state = Number(d['iot.update.state']) || 0;
-          if (d['iot.update.result'] != null)  this.result = Number(d['iot.update.result']) || 0;
-        }
-        if (this.active) setTimeout(() => this.poll(), 5000);
-      },
-      error: () => { if (this.active) setTimeout(() => this.poll(), 5000); }
-    });
+  ngOnInit(): void {
+    if (!this.isAdmin) return;
+    // Read OTA progress live off the single shared /status stream — no
+    // per-page 5s self-poll. The long-poll wakes on iot.update.state changes,
+    // so download/install progress renders promptly without missing updates.
+    this.sub.add(this.ds.observe('iot.update.version').subscribe(v => {
+      if (v != null) this.version = String(v);
+    }));
+    this.sub.add(this.ds.observe('iot.update.state').subscribe(v => {
+      this.state = Number(v) || 0;
+    }));
+    this.sub.add(this.ds.observe('iot.update.result').subscribe(v => {
+      this.result = Number(v) || 0;
+    }));
   }
 
   apply(): void {
@@ -116,5 +118,5 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy(): void { this.active = false; this.sub.unsubscribe(); }
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 }

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -3,6 +3,7 @@
 export interface StatusSnapshot {
   ok: boolean;
   lwm2m:    Lwm2mStatus;
+  update?:  UpdateStatus;
   vpn:      VpnStatus;
   wifi:     WifiStatus;
   wan:      WanStatus;
@@ -11,6 +12,14 @@ export interface StatusSnapshot {
   /// Flat passthrough of ds keys the SPA caches verbatim (domain bump keys
   /// like log.version / services.stats.version, shared with the cloud build).
   cloud?:   Record<string, unknown>;
+}
+
+// OTA software-update progress (LwM2M Object 5). state/result are the
+// numeric LwM2M update state/result codes; version is the installed feed tag.
+export interface UpdateStatus {
+  version?: string;
+  state?: number;
+  result?: number;
 }
 
 export interface Lwm2mStatus {

--- a/iot-ui/src/common/datastore.service.ts
+++ b/iot-ui/src/common/datastore.service.ts
@@ -38,6 +38,8 @@ export class DataStoreService {
     // LwM2M client
     'iot.serial', 'iot.dev.mode', 'iot.bs.uri', 'iot.server.uri', 'iot.dm.uri',
     'iot.binding', 'iot.lifetime',
+    // OTA software update (read-only progress; rendered on the Software page)
+    'iot.update.version', 'iot.update.state', 'iot.update.result',
     // Log levels
     'log.level', 'log.level.httpd', 'log.level.lwm2m',
     'log.level.vpn', 'log.level.dtls',
@@ -104,6 +106,13 @@ export class DataStoreService {
       // observe('iot.dm.uri') updates live (e.g. when registration completes).
       if (s.lwm2m.dm_uri != null)     this.set('iot.dm.uri', s.lwm2m.dm_uri);
       if (s.lwm2m.server_uri != null) this.set('iot.server.uri', s.lwm2m.server_uri);
+    }
+    if (s.update) {
+      // OTA progress → per-key subjects so the Software page renders live off
+      // this stream (the long-poll wakes on iot.update.state changes).
+      if (s.update.version != null) this.set('iot.update.version', s.update.version);
+      if (s.update.state != null)   this.set('iot.update.state', s.update.state);
+      if (s.update.result != null)  this.set('iot.update.result', s.update.result);
     }
     if (s.wan && s.wan.active_iface != null) this.set('net.iface.active', s.wan.active_iface);
     // Flat passthrough keys (log.version / services.stats.version bump keys)

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -433,6 +433,8 @@ void install_handlers(Router& router,
                     data_store::Client::kInvalidHandle;
                 data_store::Client::WatchHandle wh_log =
                     data_store::Client::kInvalidHandle;
+                data_store::Client::WatchHandle wh_update =
+                    data_store::Client::kInvalidHandle;
                 auto ws = ds->watch("vpn.state", notify, &wh_vpn);
                 ds->watch("iot.conn.state", notify, &wh_conn);
                 // Also wake on the two domain bump keys so this single status
@@ -440,6 +442,9 @@ void install_handlers(Router& router,
                 // SPA needs no per-page long-poll (avoids worker starvation).
                 ds->watch("services.stats.version", notify, &wh_stats);
                 ds->watch("log.version", notify, &wh_log);
+                // OTA progress: wake on iot.update.state so the Software page
+                // tracks an in-flight update live off this same stream.
+                ds->watch("iot.update.state", notify, &wh_update);
                 if (ws.ok) {
                     std::unique_lock<std::mutex> lk(st->m);
                     st->cv.wait_for(lk, std::chrono::seconds(timeout),
@@ -453,12 +458,16 @@ void install_handlers(Router& router,
                     ds->unwatch(wh_stats);
                 if (wh_log != data_store::Client::kInvalidHandle)
                     ds->unwatch(wh_log);
+                if (wh_update != data_store::Client::kInvalidHandle)
+                    ds->unwatch(wh_update);
                 // Fall through to build the full status snapshot
             }
             std::vector<data_store::Client::GetResult> got;
             auto rs = ds->get({
                 // LwM2M
                 "iot.server.uri", "iot.dm.uri", "iot.endpoint", "iot.conn.state",
+                // OTA software update
+                "iot.update.version", "iot.update.state", "iot.update.result",
                 // VPN
                 "vpn.state", "vpn.assigned.ip", "vpn.assigned.gateway",
                 "vpn.assigned.netmask", "vpn.assigned.dns", "vpn.pid",
@@ -533,6 +542,7 @@ void install_handlers(Router& router,
             }
             // Build status sections
             json lwm2m      = json::object();
+            json update     = json::object();
             json vpn        = json::object();
             json wifi       = json::object();
             json wan        = json::object();
@@ -562,6 +572,9 @@ void install_handlers(Router& router,
 
                 if (k == "iot.server.uri")        lwm2m["server_uri"] = sv();
                 else if (k == "iot.dm.uri")       lwm2m["dm_uri"] = sv();
+                else if (k == "iot.update.version") update["version"] = sv();
+                else if (k == "iot.update.state")   update["state"] = iv();
+                else if (k == "iot.update.result")  update["result"] = iv();
                 else if (k == "iot.endpoint")     lwm2m["endpoint"] = sv();
                 else if (k == "iot.conn.state")   lwm2m["conn_state"] = sv();
 
@@ -648,6 +661,7 @@ void install_handlers(Router& router,
                 }
             }
             resp["lwm2m"]    = lwm2m;
+            resp["update"]   = update;
             resp["vpn"]      = vpn;
             resp["wifi"]     = wifi;
             resp["wan"]      = wan;


### PR DESCRIPTION
Two device-ui improvements, plus the shared `/status` handler change behind them.

### Software-update → single shared `/status` stream
- `handler.cpp` `/status`: new `update` section (`iot.update.version/state/result`) **and** `iot.update.state` added as a long-poll wake key, so OTA progress refreshes promptly on the one shared stream.
- `iot-ui`: `UpdateStatus` interface + `StatusSnapshot.update`; the three keys added to the global `ALL_KEYS` read + republished in `ingestStatus`; the Software page now `observe()`s them instead of its own 5s self-poll.
- Debug (`*dsDebug` / `app-ds-hint`) wired on the status rows + the package-URL input; the misleading hardcoded placeholder (`http://10.9.0.1:8080/...iot_0.2.0_aarch64.ipk`) genericised.

### HTTP config page (device-ui)
- New `iot-ui/http-config` component (mirrors cloud-ui; notes the listen port is container-fixed on a device), registered in `app.module`, **HTTP** nav item added (after VPN) + rendered in `main.component.html`. Full set of Debug key hints.

Read-only views go through the shared stream; editable forms stay load-once (per the agreed scope). Verified: device image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)