### PR TITLE
feat(cloud-ui): software-update push status on shared /status

### DIFF
--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -1,6 +1,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { HttpsvcService } from '../../common/httpsvc.service';
+import { DataStoreService } from '../../common/datastore.service';
 import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 
@@ -106,14 +107,19 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, private session: SessionService,
-              private toast: ToastService) {}
+  constructor(private http: HttpsvcService, private ds: DataStoreService,
+              private session: SessionService, private toast: ToastService) {}
 
   ngOnInit(): void {
     if (!this.isAdmin) return;
     this.loadManifest();
     this.pollEndpoints();
-    this.pollStatus();
+    // Per-device OTA push progress live off the single shared /status stream
+    // (the long-poll wakes on cloud.update.status) — no per-page 5s self-poll.
+    this.sub.add(this.ds.observe('cloud.update.status').subscribe((v) => {
+      try { const a = JSON.parse(String(v ?? '[]')); this.status = Array.isArray(a) ? a : []; }
+      catch { this.status = []; }
+    }));
   }
 
   private loadManifest(): void {
@@ -135,19 +141,6 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     });
   }
 
-  private pollStatus(): void {
-    if (!this.active) return;
-    this.http.dbGet(['cloud.update.status']).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          try { const a = JSON.parse(String((r.data as Record<string, unknown>)['cloud.update.status'] || '[]'));
-                this.status = Array.isArray(a) ? a : []; } catch { this.status = []; }
-        }
-        if (this.active) setTimeout(() => this.pollStatus(), 5000);
-      },
-      error: () => { if (this.active) setTimeout(() => this.pollStatus(), 5000); }
-    });
-  }
 
   installedVersion(serial: string): string {
     const s = this.status.find(x => x.serial === serial);

--- a/apps/cloud/ui/src/common/datastore.service.ts
+++ b/apps/cloud/ui/src/common/datastore.service.ts
@@ -70,6 +70,8 @@ export class DataStoreService {
     'services.cloud.lwm2m.dm.cpu.permille', 'services.cloud.lwm2m.dm.cpu.count',
     'services.cloud.lwm2m.dm.mem.rss.kb', 'services.cloud.lwm2m.dm.fd.count',
     'services.cloud.lwm2m.dm.threads',
+    // Cloud OTA push status (per-device), rendered live on the Software page.
+    'cloud.update.status',
   ];
 
   private cache = new Map<string, unknown>();

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -442,9 +442,13 @@ void install_handlers(Router& router,
                 // SPA needs no per-page long-poll (avoids worker starvation).
                 ds->watch("services.stats.version", notify, &wh_stats);
                 ds->watch("log.version", notify, &wh_log);
-                // OTA progress: wake on iot.update.state so the Software page
-                // tracks an in-flight update live off this same stream.
+                // OTA progress: wake on iot.update.state (device self-update)
+                // and cloud.update.status (cloud→device push progress) so the
+                // Software pages track an in-flight update live off this stream.
                 ds->watch("iot.update.state", notify, &wh_update);
+                data_store::Client::WatchHandle wh_cupd =
+                    data_store::Client::kInvalidHandle;
+                ds->watch("cloud.update.status", notify, &wh_cupd);
                 if (ws.ok) {
                     std::unique_lock<std::mutex> lk(st->m);
                     st->cv.wait_for(lk, std::chrono::seconds(timeout),
@@ -460,6 +464,8 @@ void install_handlers(Router& router,
                     ds->unwatch(wh_log);
                 if (wh_update != data_store::Client::kInvalidHandle)
                     ds->unwatch(wh_update);
+                if (wh_cupd != data_store::Client::kInvalidHandle)
+                    ds->unwatch(wh_cupd);
                 // Fall through to build the full status snapshot
             }
             std::vector<data_store::Client::GetResult> got;
@@ -531,6 +537,7 @@ void install_handlers(Router& router,
                 "services.cloud.lwm2m.dm.fd.count", "services.cloud.lwm2m.dm.threads",
                 // Domain bump keys — echoed back so the SPA can observe them.
                 "services.stats.version", "log.version",
+                "cloud.update.status",
             }, got);
             json resp;
             resp["ok"] = true;
@@ -649,6 +656,9 @@ void install_handlers(Router& router,
                 // Cloud Service rows + bump keys: pass through verbatim under
                 // their ds key, typed by suffix (state→string, enable→bool,
                 // everything else numeric).
+                // Cloud OTA push status: a JSON array string, passed through
+                // verbatim so the cloud Software page observes it off /status.
+                else if (k == "cloud.update.status") cloud[k] = sv();
                 else if (k.rfind("services.cloud.", 0) == 0 ||
                          k == "services.stats.version" || k == "log.version") {
                     if (g.has_value) {


### PR DESCRIPTION
The cloud Software page polled `cloud.update.status` (per-device OTA push progress) every 5s with its own `dbGet`. Route it through the single shared `/status` long-poll, matching the device-ui sweep (#166).

- `handler.cpp` `/status`: `cloud.update.status` passed through verbatim in the flat `cloud` section + added as a long-poll **wake key** so push progress refreshes promptly.
- `cloud-ui datastore.service`: `cloud.update.status` in the global `ALL_KEYS` (`ingestStatus` already republishes the `cloud` passthrough).
- `cloud-ui software-update`: `pollStatus()` → `observe('cloud.update.status')`.

`pollEndpoints` (push-target device list) stays a REST poll — an aggregation shared with other pages, a separate broader sweep.

Verified: cloud image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)