### PR TITLE
fix(cloud): compose ports publish default 5001-6000 -> 10000-10050

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -63,7 +63,7 @@ services:
     # PROXY_START/PROXY_END.
     ports:
       - "1194:1194/tcp"
-      - "${PROXY_START:-5001}-${PROXY_END:-6000}:${PROXY_START:-5001}-${PROXY_END:-6000}"
+      - "${PROXY_START:-10000}-${PROXY_END:-10050}:${PROXY_START:-10000}-${PROXY_END:-10050}"
     depends_on:
       ds-server:
         condition: service_healthy


### PR DESCRIPTION
The iot-cloudd `ports:` publish line still defaulted to `5001-6000` while the `proxy-start/end` CLI args and `run.sh` had moved to `10000-10050`. It worked through `run.sh` (which exports `PROXY_START/END`), but a direct `docker compose up` — or a **stale `run.sh`** — would publish 1000 ports and exhaust `docker-proxy` (the `5189` failure seen on the live cloud). Align the publish default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)