### PR TITLE
fix(cloud): DNAT applies on fresh netns + ui_port default 8080

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -133,7 +133,7 @@ void rebuild_device_dnat(data_store::Client& ds, const std::string& tun_dev) {
     server::dnat::RulesetInput in;
     in.tun_dev = tun_dev;
     in.ui_port = static_cast<std::uint16_t>(
-        ds_int(ds, "cloud.proxy.device.ui.port", 80));
+        ds_int(ds, "cloud.proxy.device.ui.port", 8080));
     try {
         auto arr = nlohmann::json::parse(ds_str(ds, "cloud.endpoints", "[]"));
         if (arr.is_array()) for (const auto& e : arr) {
@@ -610,7 +610,7 @@ int main(int argc, char** argv) {
     // Seed the ui_port key so it's visible in the cloud UI / ds-cli.
     ds.set("cloud.proxy.device.ui.port",
            data_store::Value{static_cast<std::int32_t>(
-               ds_int(ds, "cloud.proxy.device.ui.port", 80))});
+               ds_int(ds, "cloud.proxy.device.ui.port", 8080))});
     if (!server::dnat::enable_ip_forward()) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l could not enable "

--- a/modules/server/dnat/src/device_dnat.cpp
+++ b/modules/server/dnat/src/device_dnat.cpp
@@ -24,6 +24,13 @@ std::string build_device_dnat_ruleset(const RulesetInput& in) {
     // Scope everything to our own table so re-applying flushes only our
     // rules (never NetworkManager / docker / openvpn-managed chains). We
     // use the `ip` family (IPv4) — the VPN subnet is IPv4.
+    //
+    // `add table` BEFORE `flush table`: on a fresh netns (every container
+    // start) the table doesn't exist yet, and `flush table` on a missing
+    // table is a hard error that aborts the whole ruleset — so the DNAT
+    // never applied. `add table` is idempotent (creates if absent, no-op if
+    // present), guaranteeing the subsequent flush + rebuild always succeed.
+    ss << "add table ip " << kTable << "\n";
     ss << "flush table ip " << kTable << "\n";
     ss << "table ip " << kTable << " {\n";
 

--- a/modules/server/dnat/test/device_dnat_test.cpp
+++ b/modules/server/dnat/test/device_dnat_test.cpp
@@ -20,7 +20,12 @@ bool contains(const std::string& hay, const std::string& needle) {
 TEST(DeviceDnat, EmptyStillEmitsScopedTableAndFlush) {
     RulesetInput in;  // no devices
     auto s = build_device_dnat_ruleset(in);
+    // `add table` MUST precede `flush table` so a fresh netns (no table yet)
+    // doesn't abort the whole apply on a "flush: No such file" error.
+    EXPECT_TRUE(contains(s, "add table ip iot_cloud_dnat"));
     EXPECT_TRUE(contains(s, "flush table ip iot_cloud_dnat"));
+    EXPECT_LT(s.find("add table ip iot_cloud_dnat"),
+              s.find("flush table ip iot_cloud_dnat"));
     EXPECT_TRUE(contains(s, "table ip iot_cloud_dnat {"));
     EXPECT_TRUE(contains(s, "type nat hook prerouting"));
     EXPECT_TRUE(contains(s, "type nat hook postrouting"));

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -214,11 +214,13 @@ return {
     -- per-device nftables DNAT (cloud:<proxy_port> → <tun_ip>:ui_port over
     -- tun0) so an operator can reach a device's local UI by hitting the
     -- cloud on the device's assigned proxy port. Global (same value for all
-    -- devices); read live by iot-cloudd. The device UI listens on 80/443
-    -- (NOT 8080), so the default is 80.
+    -- devices); read live by iot-cloudd. DNAT target = the port the device's
+    -- iot-httpd binds: http-port=8080, published host:8081 -> container:8080,
+    -- and over the VPN the cloud DNATs straight to the container's 8080 — so
+    -- the default is 8080 (override in ds if a device serves on another port).
     ["cloud.proxy.device.ui.port"] = {
       type    = "integer",
-      default = 80,
+      default = 8080,
       min     = 1,
       max     = 65535,
     },


### PR DESCRIPTION
Two device-UI-over-VPN fixes (seen live on the cloud).

**1) DNAT never applied on a fresh container netns.** The ruleset started with `flush table ip iot_cloud_dnat`, but on a fresh netns (every `iot-cloudd` start) the table doesn't exist, and `flush` on a missing table is a hard error that aborts the whole `nft -f -` (rc=256, repeating every sync tick) — so the per-device DNAT never came up. Prepend an idempotent `add table` before the flush. (Live cloud was unblocked manually with `nft add table`; this is the permanent fix.)

**2) `cloud.proxy.device.ui.port` default `80` → `8080`.** The device's iot-httpd binds `8080` (`http-port=8080`, published `host:8081 → container:8080`; over the VPN the cloud DNATs straight to the container's `8080`). Default `8080` so Launch-UI works out of the box — still ds-driven.

Test: `device_dnat_test` asserts `add table` precedes `flush table`. Verified: cloud image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)