### PR TITLE
fix(ui): HTTP page Listen IP/Port/Scheme read-only (both UIs)

### DIFF
--- a/apps/cloud/ui/src/app/http-config/http-config.component.ts
+++ b/apps/cloud/ui/src/app/http-config/http-config.component.ts
@@ -12,9 +12,12 @@ import { DataStoreService } from '../../common/datastore.service';
       <h3>HTTP Server Configuration</h3>
 
       <div class="info-card">
-        <p>Reuses the same <code>http.*</code> schema as the device.
-        All keys except <code>http.workers</code> are hot-reloaded —
-        iot-httpd re-binds / rotates certs within ~2s, no restart.</p>
+        <p>Reuses the same <code>http.*</code> schema as the device. TLS paths
+        + Auth hot-reload within ~2s; <code>http.workers</code> needs a restart.
+        <strong>Listen IP / Port / Scheme are read-only</strong> — they're
+        fixed at deploy by the container's published port + <code>HTTPS=1</code>;
+        editing them here would just rebind the server into a publish mismatch
+        and lock you out.</p>
       </div>
 
       <form [formGroup]="form" (ngSubmit)="save()" *ngIf="!loading">
@@ -130,6 +133,12 @@ export class HttpConfigComponent implements OnInit {
       key:     [''],
       ca:      [''],
     });
+    // Listener (ip/port/scheme) is DEPLOY-controlled: the container's published
+    // port + HTTPS=1 are fixed at start, but the httpd hot-reloads these from
+    // ds and rebinds — editing them in the UI just rebinds into a publish
+    // mismatch and locks you out. Show them read-only; never write them in
+    // save(). They remain visible for reference.
+    ['ip', 'port', 'scheme'].forEach(k => this.form.get(k)?.disable());
   }
 
   ngOnInit(): void {
@@ -175,10 +184,9 @@ export class HttpConfigComponent implements OnInit {
   save(): void {
     this.saving = true;
     const v = this.form.value;
+    // Listener (ip/port/scheme) is deploy-controlled + read-only here, so it
+    // is intentionally NOT written — only the safe runtime keys are saved.
     this.http.dbSet([
-      { key: 'http.listen.ip',     value: v.ip },
-      { key: 'http.listen.port',   value: v.port },
-      { key: 'http.listen.scheme', value: v.scheme },
       { key: 'http.workers',       value: v.workers },
       { key: 'http.tls.cert',      value: v.cert },
       { key: 'http.tls.key',       value: v.key },

--- a/iot-ui/src/app/http-config/http-config.component.ts
+++ b/iot-ui/src/app/http-config/http-config.component.ts
@@ -13,12 +13,12 @@ import { DataStoreService } from '../../common/datastore.service';
 
       <div class="info-card">
         <p>The device web UI / REST API is served by <code>iot-httpd</code>
-        from the <code>http.*</code> schema. Most keys hot-reload within ~2s
-        (no restart); <code>http.workers</code> needs a restart. The
-        <strong>listen port is fixed by the container</strong> (the cloud
-        reaches this UI through its VPN proxy on that port), so changing
-        <code>http.listen.port</code> here has no effect on a containerised
-        device.</p>
+        from the <code>http.*</code> schema. TLS paths + Auth hot-reload within
+        ~2s; <code>http.workers</code> needs a restart.
+        <strong>Listen IP / Port / Scheme are read-only</strong> — the device
+        container publishes a fixed port (and the cloud reaches this UI through
+        its VPN proxy on it); editing them would rebind the server into a
+        publish mismatch and lock the device UI out.</p>
       </div>
 
       <form [formGroup]="form" (ngSubmit)="save()" *ngIf="!loading">
@@ -135,6 +135,11 @@ export class HttpConfigComponent implements OnInit {
       key:     [''],
       ca:      [''],
     });
+    // Listener (ip/port/scheme) is DEPLOY-controlled: the device container
+    // publishes host:8081 -> container:8080 (fixed), but the httpd hot-reloads
+    // these from ds and rebinds — editing them in the UI rebinds into a
+    // publish mismatch and locks the device UI out. Read-only; never saved.
+    ['ip', 'port', 'scheme'].forEach(k => this.form.get(k)?.disable());
   }
 
   ngOnInit(): void {
@@ -180,10 +185,9 @@ export class HttpConfigComponent implements OnInit {
   save(): void {
     this.saving = true;
     const v = this.form.value;
+    // Listener (ip/port/scheme) is deploy-controlled + read-only here, so it
+    // is intentionally NOT written — only the safe runtime keys are saved.
     this.http.dbSet([
-      { key: 'http.listen.ip',     value: v.ip },
-      { key: 'http.listen.port',   value: v.port },
-      { key: 'http.listen.scheme', value: v.scheme },
       { key: 'http.workers',       value: v.workers },
       { key: 'http.tls.cert',      value: v.cert },
       { key: 'http.tls.key',       value: v.key },


### PR DESCRIPTION
Editing the listener in the HTTP config page **locks operators out**: the httpd hot-reloads `http.listen.{ip,port,scheme}` from ds and **rebinds**, but the container's published port (and the cloud VPN proxy) is fixed at deploy — so changing port/scheme rebinds the server into a publish mismatch and the UI becomes unreachable. Hit live on the device by setting `443`.

The listener is **deploy-controlled** (container publish + `HTTPS=1`), not a safe runtime knob:
- Disable the `ip`/`port`/`scheme` form controls — shown **read-only** for reference.
- `save()` no longer writes them; only the safe runtime keys (`http.workers`, `http.tls.cert/key/ca`, `http.auth.enabled`) stay editable + saved.
- Info-card notes updated on both UIs.

Verified: cloud + device image builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)