### PR TITLE
fix(cloud): Launch-UI — DNAT to openvpn-assigned IP + http scheme

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -38,6 +38,7 @@
 #include <cstdint>
 #include <csignal>
 #include <fstream>
+#include <map>
 #include <set>
 #include <thread>
 #include <unordered_map>
@@ -206,13 +207,17 @@ bool reconcile_registrations(data_store::Client& ds,
     return changed;
 }
 
-// Poll the openvpn server's management interface (127.0.0.1:mgmt_port) for
-// connected clients and return their device serials. The minted client CN is
-// rpi<serial>@cloud.local, so a connected client's CN appears in the `status`
-// output; we scan for that pattern and extract the serial. Best-effort —
-// returns empty on any connect/IO failure (e.g. openvpn not up yet).
-std::vector<std::string> poll_vpn_connected(std::uint16_t mgmt_port) {
-    std::vector<std::string> out;
+// Poll the openvpn server's management interface (127.0.0.1:mgmt_port) and
+// return each connected client's *assigned* tunnel IP, keyed by the serial
+// embedded in its CN (rpi<serial>@cloud.local). We parse the ROUTING TABLE
+// section of `status`, whose lines are `<virtual-ip>,<CN>,<real-addr>,<ref>`
+// — so this gives the address openvpn actually handed the device (the pool
+// assignment), which is what the per-device DNAT must target (the registry's
+// pre-allocated IP is not honored by openvpn). The serial here is already in
+// the cert-CN sanitized form (':' → '_'), matching sanitize_cn(endpoint).
+// Best-effort — empty map on any connect/IO failure (openvpn not up yet).
+std::map<std::string, std::string> poll_vpn_client_ips(std::uint16_t mgmt_port) {
+    std::map<std::string, std::string> out;   // sanitized-serial → virtual IP
     ACE_INET_Addr addr(mgmt_port, "127.0.0.1");
     ACE_SOCK_Connector conn;
     ACE_SOCK_Stream stream;
@@ -231,17 +236,29 @@ std::vector<std::string> poll_vpn_connected(std::uint16_t mgmt_port) {
     }
     stream.close();
 
+    // Scan only within the ROUTING TABLE (skip CLIENT LIST, whose lines lead
+    // with the real address, not the virtual IP).
     const std::string suffix = "@cloud.local";
-    std::set<std::string> seen;
-    for (std::size_t pos = 0; (pos = resp.find("rpi", pos)) != std::string::npos; ) {
+    std::size_t rt = resp.find("ROUTING TABLE");
+    if (rt == std::string::npos) return out;
+    std::size_t end = resp.find("GLOBAL STATS", rt);
+    if (end == std::string::npos) end = resp.size();
+    for (std::size_t pos = rt; (pos = resp.find("rpi", pos)) != std::string::npos
+                               && pos < end; ) {
         std::size_t at = resp.find(suffix, pos);
-        if (at == std::string::npos) break;
+        if (at == std::string::npos || at >= end) break;
         std::string serial = resp.substr(pos + 3, at - (pos + 3));
+        // Virtual IP = the first comma-field of this client's line.
+        std::size_t ls = resp.rfind('\n', pos);
+        std::size_t vstart = (ls == std::string::npos) ? 0 : ls + 1;
+        std::size_t comma = resp.find(',', vstart);
+        std::string vip = (comma != std::string::npos && comma < pos)
+                              ? resp.substr(vstart, comma - vstart) : std::string();
         pos = at + suffix.size();
-        if (!serial.empty() &&
+        if (!serial.empty() && !vip.empty() &&
             serial.find_first_of(",\n\r ") == std::string::npos &&
-            seen.insert(serial).second) {
-            out.push_back(std::move(serial));
+            vip.find_first_of(",\n\r ") == std::string::npos) {
+            out[serial] = vip;
         }
     }
     return out;
@@ -894,9 +911,26 @@ int main(int argc, char** argv) {
             // cert once the device's tunnel is up — the end-goal "done" signal,
             // and it needs no server→device request.
             {
+                auto ips = poll_vpn_client_ips(ovpn_cfg.mgmt_port);
                 nlohmann::json arr = nlohmann::json::array();
-                for (auto& s : poll_vpn_connected(ovpn_cfg.mgmt_port)) arr.push_back(s);
+                for (const auto& kv : ips) arr.push_back(kv.first);
                 ds.set("cloud.vpn.connected", data_store::Value{arr.dump()});
+
+                // Point each connected endpoint's tun_ip (and thus the DNAT) at
+                // the address openvpn actually assigned, so device-UI-over-VPN
+                // (Launch UI) reaches the device. Match the registry endpoint to
+                // a connected client via sanitize_cn(endpoint) == CN serial.
+                bool ip_changed = false;
+                for (const auto& e : ep_reg.list_all()) {
+                    auto it = ips.find(
+                        server::openvpn::CertAuthority::sanitize_cn(e.ep));
+                    if (it != ips.end())
+                        ip_changed |= ep_reg.update_tun_ip(e.ep, it->second);
+                }
+                if (ip_changed) {
+                    sync_endpoints_to_ds(ds, ep_reg);
+                    rebuild_device_dnat(ds, tun_dev);
+                }
             }
 
             if (++sync_tick >= 3) {

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -76,7 +76,7 @@ interface EpCred {
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
           <clr-dg-cell>
             <a class="btn btn-sm" target="_blank" rel="noopener"
-               [href]="'https://' + windowHost + ':' + e.proxy_port + '/'"
+               [href]="'http://' + windowHost + ':' + e.proxy_port + '/'"
                *ngIf="e.registered && e.proxy_port">
               Launch UI <clr-icon shape="pop-out" size="12"></clr-icon>
             </a>

--- a/modules/server/lwm2m/inc/endpoint_registry.hpp
+++ b/modules/server/lwm2m/inc/endpoint_registry.hpp
@@ -51,6 +51,14 @@ public:
     bool update_state(const std::string& ep, bool registered,
                       std::int64_t last_seen_unix);
 
+    /// Update the tunnel IP for an endpoint to the address openvpn actually
+    /// assigned it (learned from the server's management interface), so the
+    /// per-device DNAT targets the real IP rather than the registry's
+    /// pre-allocated one. Maintains the tun_ip→ep index. Returns true only if
+    /// the value changed (false if unknown ep, unchanged, or `ip` is held by a
+    /// different endpoint).
+    bool update_tun_ip(const std::string& ep, const std::string& ip);
+
     /// Lookup by endpoint name.  Returns nullptr when not found.
     const EndpointInfo* lookup_by_ep(const std::string& ep) const;
 

--- a/modules/server/lwm2m/src/endpoint_registry.cpp
+++ b/modules/server/lwm2m/src/endpoint_registry.cpp
@@ -48,6 +48,23 @@ bool EndpointRegistry::update_state(const std::string& ep, bool registered,
     return true;
 }
 
+bool EndpointRegistry::update_tun_ip(const std::string& ep,
+                                     const std::string& ip) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+
+    auto it = m_by_ep.find(ep);
+    if (it == m_by_ep.end()) return false;          // unknown endpoint
+    if (it->second.tun_ip == ip) return false;      // unchanged
+    auto held = m_tun_ip_to_ep.find(ip);
+    if (held != m_tun_ip_to_ep.end() && held->second != ep)
+        return false;                               // ip belongs to another ep
+
+    m_tun_ip_to_ep.erase(it->second.tun_ip);        // drop the old index entry
+    it->second.tun_ip = ip;
+    m_tun_ip_to_ep[ip] = ep;
+    return true;
+}
+
 const EndpointInfo* EndpointRegistry::lookup_by_ep(const std::string& ep) const {
     std::lock_guard<std::mutex> lk(m_mutex);
     auto it = m_by_ep.find(ep);

--- a/modules/server/lwm2m/test/endpoint_registry_test.cpp
+++ b/modules/server/lwm2m/test/endpoint_registry_test.cpp
@@ -44,6 +44,29 @@ TEST(EndpointRegistryTest, AddAndLookupByEp) {
     EXPECT_EQ(found->proxy_port, 5001);
 }
 
+// ── update_tun_ip: retarget to the openvpn-assigned address ─────────
+
+TEST(EndpointRegistryTest, UpdateTunIpRetargetsAndReindexes) {
+    EndpointRegistry reg;
+    EndpointInfo info;
+    info.ep         = "urn:dev:gateway-1";
+    info.tun_ip     = "10.9.0.10";   // registry pre-allocation
+    info.proxy_port = 10000;
+    ASSERT_TRUE(reg.add(info));
+
+    // openvpn actually assigned .2 → retarget.
+    EXPECT_TRUE(reg.update_tun_ip("urn:dev:gateway-1", "10.9.0.2"));
+    EXPECT_EQ(reg.lookup_by_ep("urn:dev:gateway-1")->tun_ip, "10.9.0.2");
+    // index moved: old IP gone, new IP resolves.
+    EXPECT_EQ(reg.lookup_by_tun_ip("10.9.0.10"), nullptr);
+    ASSERT_NE(reg.lookup_by_tun_ip("10.9.0.2"), nullptr);
+    EXPECT_EQ(reg.lookup_by_tun_ip("10.9.0.2")->ep, "urn:dev:gateway-1");
+
+    // no-ops: unchanged value, and unknown endpoint.
+    EXPECT_FALSE(reg.update_tun_ip("urn:dev:gateway-1", "10.9.0.2"));
+    EXPECT_FALSE(reg.update_tun_ip("urn:dev:nope", "10.9.0.9"));
+}
+
 // ── 3. Duplicate endpoint rejected ──────────────────────────────────
 
 TEST(EndpointRegistryTest, DuplicateEpRejected) {


### PR DESCRIPTION
"Launch UI" (device-UI-over-VPN) was broken two ways:

**1) tun_ip mismatch.** `VpnRegistry` pre-allocates a tunnel IP (`10.9.0.10`) and the DNAT targets it, but the openvpn server hands out its own pool IP (`10.9.0.2`). They were never reconciled → the DNAT pointed at a non-existent host → "server dropped the connection." `iot-cloudd` now learns each connected client's **real** assigned IP from the openvpn mgmt ROUTING TABLE (`poll_vpn_client_ips`) and retargets the endpoint's `tun_ip` + DNAT. Endpoints are matched to mgmt clients via `sanitize_cn(endpoint)` == the CN serial. Adds `EndpointRegistry::update_tun_ip` + a unit test.

**2) wrong scheme.** The Launch-UI link used `https://`, but the device serves **plain HTTP** on 8080 over the already-encrypted tunnel → HTTPS-to-non-TLS dropped the connection. Use `http://`.

`cloud.vpn.connected` now derives from the same ROUTING-TABLE poll.

Verified: cloud image build + `update_tun_ip` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)