### PR TITLE
fix(rpi): harden systemd device for cloud DTLS + VPN cert rotation

### DIFF
--- a/modules/openvpn/client/schemas/vpn.lua
+++ b/modules/openvpn/client/schemas/vpn.lua
@@ -4,9 +4,9 @@
 --   vpn.remote.host   - server hostname or IP (required)
 --   vpn.remote.port   - server port            (default 1194, 1..65535)
 --   vpn.remote.proto  - "tcp-client" or "udp"  (default "tcp-client")
---   vpn.cert.path     - client X.509 cert      (required, absolute path)
---   vpn.key.path      - client X.509 priv key  (required, absolute path)
---   vpn.ca.path       - server CA              (required, absolute path)
+--   vpn.cert.path     - client X.509 cert      (default /etc/iot/vpn/client.crt)
+--   vpn.key.path      - client X.509 priv key  (default /etc/iot/vpn/client.key)
+--   vpn.ca.path       - server CA              (default /etc/iot/vpn/ca.crt)
 --   vpn.cipher        - data-channel cipher    (default "AES-256-GCM")
 --   vpn.dev           - "tun" or "tap"         (default "tun")
 --   vpn.mgmt.port     - mgmt iface port        (default 7505, 1024..65535)
@@ -46,12 +46,16 @@ return {
     ["vpn.remote.proto"] = {
         access  = "Admin", type = "string",  default = "tcp-client" },
 
+    -- Default to where the lwm2m-client materialises the cloud-pushed cert
+    -- family (LwM2M Object 2048). This makes the openvpn client work on a
+    -- bare-metal/systemd RPi with no seed step — the docker stack's vpn-config
+    -- one-shot sets the same paths, so it stays a no-op override there.
     ["vpn.cert.path"]    = {
-        access  = "Admin", type = "string"  },
+        access  = "Admin", type = "string", default = "/etc/iot/vpn/client.crt" },
     ["vpn.key.path"]     = {
-        access  = "Admin", type = "string"  },
+        access  = "Admin", type = "string", default = "/etc/iot/vpn/client.key" },
     ["vpn.ca.path"]      = {
-        access  = "Admin", type = "string"  },
+        access  = "Admin", type = "string", default = "/etc/iot/vpn/ca.crt" },
 
     ["vpn.cipher"]       = {
         access  = "Admin", type = "string",  default = "AES-256-GCM" },

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vpn-cert.path
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vpn-cert.path
@@ -1,0 +1,16 @@
+[Unit]
+Description=Watch the VPN client cert for cloud rotation (LwM2M Object 2048)
+Documentation=https://github.com/naushada/iot
+# Bare-metal equivalent of the docker cert-watcher sidecar: the lwm2m-client
+# materialises the cloud-pushed cert family into /etc/iot/vpn, and when the
+# cloud re-mints it (e.g. after a CA rotation) openvpn must re-read it. The
+# openvpn supervisor only watches the ds *path* keys (vpn.cert.path), not the
+# file contents, so without this a rotated cert is never picked up.
+
+[Path]
+# IN_CLOSE_WRITE on the leaf cert — it is rewritten on every rotation (the CA
+# rotates with it), so watching the one file is enough and avoids multi-firing.
+PathChanged=/etc/iot/vpn/client.crt
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vpn-cert.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vpn-cert.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Reload openvpn-client after a VPN cert rotation
+Documentation=https://github.com/naushada/iot
+# Triggered by iot-vpn-cert.path (same stem). No [Install]: it is activated by
+# the path unit, not enabled directly.
+After=iot-openvpn-client.service
+
+[Service]
+Type=oneshot
+# try-restart restarts the client only if it is already running — a cert that
+# lands before the client comes up is a no-op, and the supervisor re-reads the
+# new cert/CA on restart. Runs as root (no DynamicUser) so it can systemctl.
+ExecStart=/bin/systemctl try-restart iot-openvpn-client.service

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-client.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-client.env
@@ -1,14 +1,23 @@
 # EnvironmentFile for iot-lwm2m-client.service.
 #
-# Edit LWM2M_ARGS to point at your bootstrap / DM server. Values below
-# match the smoke-harness defaults — they boot but sit in
-# AwaitingRegisterAck if no peer answers on bs=.
+# The client is fully data-store driven (same as the docker device stack):
+# NO local=/bs=/identity=/secret= on the command line. That matters because:
+#   * the local bind defaults to coaps://0.0.0.0:5684 — i.e. DTLS. Passing
+#     local=coap://… would force PLAIN CoAP, and the device could NOT do the
+#     PSK/DTLS handshake the cloud bootstrap server requires.
+#   * the bootstrap URI comes from ds (iot.bs.uri, commissioned via device-ui)
+#     and already wins over any CLI bs=; a hardcoded bs= here is at best dead
+#     and at worst points the device at the wrong server.
+#   * the PSK identity is derived from the serial and the secret comes from ds
+#     — never the command line.
 #
-# Hot-reloadable via ds-cli (preferred):
+# Commission the device once (serial + bootstrap URI + BS PSK in device-ui),
+# then everything below is hot-reloadable via ds-cli:
 #   iot.endpoint    — endpoint name
+#   iot.bs.uri      — bootstrap server URI (coaps://<cloud>:5684)
 #   iot.lifetime    — registration lifetime (uint32 seconds)
 #   iot.server.uri  — DM server URI (live rebind)
 #
 # See /etc/iot/ds-schemas/iot.lua for type + range constraints.
 
-LWM2M_ARGS="role=client local=coap://0.0.0.0:5684 bs=coap://127.0.0.1:5683 config=/etc/iot/config ds-sock=/run/iot/data_store.sock"
+LWM2M_ARGS="role=client config=/etc/iot/config ds-sock=/run/iot/data_store.sock"

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -23,6 +23,8 @@ SRC_URI = "\
     file://iot-lwm2m-client.service \
     file://iot-lwm2m-server.service \
     file://iot-openvpn-client.service \
+    file://iot-vpn-cert.path \
+    file://iot-vpn-cert.service \
     file://iot-net-router.service \
     file://iot-wifi-client.service \
     file://iot-httpd.service \
@@ -180,6 +182,8 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-lwm2m-client.service   ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-lwm2m-server.service   ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-openvpn-client.service ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-vpn-cert.path          ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-vpn-cert.service       ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-net-router.service     ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-wifi-client.service    ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-httpd.service          ${D}${systemd_system_unitdir}/
@@ -269,6 +273,8 @@ RRECOMMENDS:${PN}-lwm2m = "\
 FILES:${PN}-openvpn-client = "\
     ${bindir}/openvpn-client \
     ${systemd_system_unitdir}/iot-openvpn-client.service \
+    ${systemd_system_unitdir}/iot-vpn-cert.path \
+    ${systemd_system_unitdir}/iot-vpn-cert.service \
 "
 RDEPENDS:${PN}-openvpn-client = "ace-tao openvpn"
 RRECOMMENDS:${PN}-openvpn-client = "\
@@ -333,7 +339,9 @@ FILES:${PN}-config = "\
 # ── systemd ─────────────────────────────────────────────────────────
 SYSTEMD_SERVICE:${PN}-ds-server = "iot-ds.service"
 SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service"
-SYSTEMD_SERVICE:${PN}-openvpn-client = "iot-openvpn-client.service"
+# iot-vpn-cert.path is enabled (watches the cert); iot-vpn-cert.service is
+# activated by the path unit, not enabled directly (it has no [Install]).
+SYSTEMD_SERVICE:${PN}-openvpn-client = "iot-openvpn-client.service iot-vpn-cert.path"
 SYSTEMD_SERVICE:${PN}-net-router = "iot-net-router.service"
 SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
 SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service"


### PR DESCRIPTION
Auditing this session's bugs against the **bare-metal/systemd RPi** (which runs the same binaries but a different launch/networking model than the docker dev stack) surfaced three issues that would bite the RPi specifically:

**A) Plain-CoAP forced → no DTLS to the cloud.** `lwm2m-client.env` set `local=coap://0.0.0.0:5684`; the client's DTLS scheme is parsed from `local=` and PSK/DTLS only engages for `coaps`, so the RPi would run plain CoAP and never complete the cloud bootstrap PSK handshake. Dropped `local=`/`bs=` so it uses the `coaps://` default + ds-driven `iot.bs.uri` (fully ds-driven, like the docker device).

**B) No cert-rotation reload.** The docker device has a cert-watcher sidecar; the RPi had none, and the openvpn supervisor only watches the ds `vpn.cert.path` *key*, not file contents — so a cloud re-mint (CA rotation, exactly today's scenario) would strand it on a stale cert. Added `iot-vpn-cert.path` → `iot-vpn-cert.service` (try-restart `iot-openvpn-client`) + recipe wiring.

**C) No cert-path defaults.** `vpn.cert.path/key.path/ca.path` had no schema default; docker seeds them via `vpn-config`, the RPi doesn't → openvpn-client would have no cert paths. Defaulted to `/etc/iot/vpn/{client.crt,client.key,ca.crt}` (where the lwm2m-client materialises them).

Config/schema/recipe only — no code change. (Also confirmed the RPi `httpd.env` has no `http-workers/scheme/port` shadowing, and the PSK identity/secret are not on its command line — those are already clean.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)