### PR TITLE
fix(rpi): vpn endpoint cloud-pushed (no defaults) + autoload tun

### DIFF
--- a/modules/openvpn/client/schemas/vpn.lua
+++ b/modules/openvpn/client/schemas/vpn.lua
@@ -1,9 +1,14 @@
 -- vpn.* schema for openvpn-client (L12).
 --
 -- Read keys (operator configures via ds-cli):
---   vpn.remote.host   - server hostname or IP (required)
---   vpn.remote.port   - server port            (default 1194, 1..65535)
---   vpn.remote.proto  - "tcp-client" or "udp"  (default "tcp-client")
+--   The remote endpoint (host/port/proto) has NO default — it is the cloud's
+--   to define and is pushed to the device over LwM2M Object 2048 (or set by an
+--   operator for a manual deployment). All three are required-to-start, so the
+--   client stays gated until the cloud provides them; baking defaults would
+--   risk dialing the wrong port/proto before the push lands.
+--   vpn.remote.host   - server hostname or IP (required; cloud-pushed)
+--   vpn.remote.port   - server port            (required; cloud-pushed, 1..65535)
+--   vpn.remote.proto  - "tcp-client" or "udp"  (required; cloud-pushed)
 --   vpn.cert.path     - client X.509 cert      (default /etc/iot/vpn/client.crt)
 --   vpn.key.path      - client X.509 priv key  (default /etc/iot/vpn/client.key)
 --   vpn.ca.path       - server CA              (default /etc/iot/vpn/ca.crt)
@@ -41,10 +46,9 @@ return {
     ["vpn.remote.host"]  = {
         access  = "Admin", type = "string"  },
     ["vpn.remote.port"]  = {
-        access  = "Admin", type = "integer", default = 1194,
-                             min = 1, max = 65535 },
+        access  = "Admin", type = "integer", min = 1, max = 65535 },
     ["vpn.remote.proto"] = {
-        access  = "Admin", type = "string",  default = "tcp-client" },
+        access  = "Admin", type = "string"  },
 
     -- Default to where the lwm2m-client materialises the cloud-pushed cert
     -- family (LwM2M Object 2048). This makes the openvpn client work on a

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-tun.conf
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-tun.conf
@@ -1,0 +1,7 @@
+# systemd-modules-load: load the TUN/TAP driver at boot.
+#
+# openvpn-client needs /dev/net/tun to create the VPN tunnel. kernel-module-tun
+# ships the module, but nothing loads it otherwise — and /dev/net/tun won't
+# exist until it is loaded, so on-demand autoload can't kick in either. Loading
+# it here guarantees the device node is present before iot-openvpn-client starts.
+tun

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -25,6 +25,7 @@ SRC_URI = "\
     file://iot-openvpn-client.service \
     file://iot-vpn-cert.path \
     file://iot-vpn-cert.service \
+    file://iot-tun.conf \
     file://iot-net-router.service \
     file://iot-wifi-client.service \
     file://iot-httpd.service \
@@ -185,6 +186,9 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-vpn-cert.path          ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-vpn-cert.service       ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-net-router.service     ${D}${systemd_system_unitdir}/
+        # TUN driver autoload for openvpn-client.
+        install -d ${D}${sysconfdir}/modules-load.d
+        install -m 0644 ${WORKDIR}/iot-tun.conf               ${D}${sysconfdir}/modules-load.d/
         install -m 0644 ${WORKDIR}/iot-wifi-client.service    ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-httpd.service          ${D}${systemd_system_unitdir}/
 
@@ -275,8 +279,11 @@ FILES:${PN}-openvpn-client = "\
     ${systemd_system_unitdir}/iot-openvpn-client.service \
     ${systemd_system_unitdir}/iot-vpn-cert.path \
     ${systemd_system_unitdir}/iot-vpn-cert.service \
+    ${sysconfdir}/modules-load.d/iot-tun.conf \
 "
-RDEPENDS:${PN}-openvpn-client = "ace-tao openvpn"
+# kernel-module-tun provides the TUN driver; iot-tun.conf autoloads it so
+# /dev/net/tun exists before the client starts.
+RDEPENDS:${PN}-openvpn-client = "ace-tao openvpn kernel-module-tun"
 RRECOMMENDS:${PN}-openvpn-client = "\
     ${PN}-ds-server \
     ${PN}-config \


### PR DESCRIPTION
Two RPi VPN-client refinements (follow-up to #172):

**1) Remote endpoint has no schema default.** `vpn.remote.{host,port,proto}` are all required-to-start (`ds_bridge` `missing_required`) and pushed together by the cloud (Object 2048), so default everything *except* the endpoint. Dropped `port=1194` / `proto=tcp-client` defaults (host already had none) → the client stays gated until the cloud provides the real endpoint, rather than risking a wrong-port dial before the push. Other keys keep defaults (cert paths, cipher, dev, mgmt.port).

**2) Autoload the TUN driver.** `kernel-module-tun` ships the module but nothing loaded it, and `/dev/net/tun` won't exist until it is (so on-demand autoload can't help) → openvpn-client can't create the tunnel on a fresh boot. Ship `/etc/modules-load.d/iot-tun.conf`, add `kernel-module-tun` to the openvpn-client `RDEPENDS`, wire through the recipe.

Config/schema/recipe only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)