### PR TITLE
feat(cloud): show Device Tunnel IP (openvpn-assigned) + allocated

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -108,7 +108,8 @@ void sync_endpoints_to_ds(data_store::Client& ds,
         nlohmann::json item;
         item["endpoint"]      = ep.ep;
         item["state"]         = ep.registered ? "online" : "offline";
-        item["tun_ip"]        = ep.tun_ip;
+        item["tun_ip"]        = ep.tun_ip;       // registry allocation
+        item["dev_tun_ip"]    = ep.dev_tun_ip;   // openvpn-assigned (actual)
         item["proxy_port"]    = ep.proxy_port;
         item["registered"]    = ep.registered;
         item["last_seen_unix"] = ep.last_seen_unix;
@@ -139,7 +140,10 @@ void rebuild_device_dnat(data_store::Client& ds, const std::string& tun_dev) {
         auto arr = nlohmann::json::parse(ds_str(ds, "cloud.endpoints", "[]"));
         if (arr.is_array()) for (const auto& e : arr) {
             if (!e.is_object()) continue;
-            std::string ip   = e.value("tun_ip", std::string());
+            // Prefer the openvpn-assigned address; fall back to the registry
+            // allocation before the device has connected (DNAT is moot then).
+            std::string ip   = e.value("dev_tun_ip", std::string());
+            if (ip.empty()) ip = e.value("tun_ip", std::string());
             int         port = e.value("proxy_port", 0);
             if (ip.empty() || port <= 0) continue;
             in.devices.push_back({std::move(ip),
@@ -293,6 +297,7 @@ std::size_t rehydrate_registry(data_store::Client& ds,
                     ep, e.value("tun_ip", std::string()),
                     static_cast<std::uint16_t>(e.value("proxy_port", 0)),
                     e.value("registered", false));
+                info.dev_tun_ip     = e.value("dev_tun_ip", std::string());
                 info.last_seen_unix = e.value("last_seen_unix", std::int64_t{0});
                 if (reg.add(info)) {
                     vpn.reserve(info.ep, info.tun_ip, info.proxy_port);
@@ -916,16 +921,17 @@ int main(int argc, char** argv) {
                 for (const auto& kv : ips) arr.push_back(kv.first);
                 ds.set("cloud.vpn.connected", data_store::Value{arr.dump()});
 
-                // Point each connected endpoint's tun_ip (and thus the DNAT) at
-                // the address openvpn actually assigned, so device-UI-over-VPN
-                // (Launch UI) reaches the device. Match the registry endpoint to
-                // a connected client via sanitize_cn(endpoint) == CN serial.
+                // Record each connected endpoint's REAL openvpn-assigned IP as
+                // dev_tun_ip (the DNAT targets it), keeping the registry-
+                // allocated tun_ip for reference. Both surface in the cloud UI.
+                // Match the registry endpoint to a connected client via
+                // sanitize_cn(endpoint) == CN serial.
                 bool ip_changed = false;
                 for (const auto& e : ep_reg.list_all()) {
                     auto it = ips.find(
                         server::openvpn::CertAuthority::sanitize_cn(e.ep));
                     if (it != ips.end())
-                        ip_changed |= ep_reg.update_tun_ip(e.ep, it->second);
+                        ip_changed |= ep_reg.update_dev_tun_ip(e.ep, it->second);
                 }
                 if (ip_changed) {
                     sync_endpoints_to_ds(ds, ep_reg);

--- a/apps/cloud/ui/src/app/dashboard/dashboard.component.ts
+++ b/apps/cloud/ui/src/app/dashboard/dashboard.component.ts
@@ -3,7 +3,7 @@ import { HttpsvcService } from '../../common/httpsvc.service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 
-interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered:boolean; }
+interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; proxy_port:number; registered:boolean; }
 
 @Component({
   selector: 'app-dashboard',
@@ -24,11 +24,13 @@ interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered
         <clr-dg-column>Endpoint</clr-dg-column>
         <clr-dg-column>State</clr-dg-column>
         <clr-dg-column>Tunnel IP</clr-dg-column>
+        <clr-dg-column>Device Tunnel IP</clr-dg-column>
         <clr-dg-column>Port</clr-dg-column>
         <clr-dg-row *clrDgItems="let e of endpoints">
           <clr-dg-cell><code>{{e.endpoint}}</code></clr-dg-cell>
           <clr-dg-cell><app-status-badge [label]="e.registered?'online':'offline'" [state]="e.registered?'connected':'exited'"></app-status-badge></clr-dg-cell>
           <clr-dg-cell>{{e.tun_ip}}</clr-dg-cell>
+          <clr-dg-cell>{{ e.dev_tun_ip || '—' }}</clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
         </clr-dg-row>
         <clr-dg-footer>{{endpoints.length}} endpoints</clr-dg-footer>

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -4,7 +4,7 @@ import { HttpsvcService } from '../../common/httpsvc.service';
 import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 
-interface EpInfo { endpoint:string; tun_ip:string; proxy_port:number; registered:boolean; }
+interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; proxy_port:number; registered:boolean; }
 
 /** Per-endpoint credential record, as minted by iot-cloudd into the
  *  cloud.endpoint.credentials ds key (JSON array). Field names follow the
@@ -62,6 +62,7 @@ interface EpCred {
         <clr-dg-column>Endpoint</clr-dg-column>
         <clr-dg-column>State</clr-dg-column>
         <clr-dg-column>Tunnel IP</clr-dg-column>
+        <clr-dg-column>Device Tunnel IP</clr-dg-column>
         <clr-dg-column>Proxy Port</clr-dg-column>
         <clr-dg-column>Device UI</clr-dg-column>
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
@@ -73,6 +74,7 @@ interface EpCred {
               [state]="e.registered?'connected':'exited'"></app-status-badge>
           </clr-dg-cell>
           <clr-dg-cell><code>{{e.tun_ip}}</code></clr-dg-cell>
+          <clr-dg-cell><code>{{ e.dev_tun_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
           <clr-dg-cell>
             <a class="btn btn-sm" target="_blank" rel="noopener"

--- a/modules/http-server/src/handler_cloud.cpp
+++ b/modules/http-server/src/handler_cloud.cpp
@@ -41,6 +41,7 @@ void install_cloud_handlers(Router& router,
                 json item;
                 item["endpoint"]   = e.ep;
                 item["tun_ip"]     = e.tun_ip;
+                item["dev_tun_ip"] = e.dev_tun_ip;
                 item["proxy_port"] = e.proxy_port;
                 item["registered"] = e.registered;
                 arr.push_back(item);
@@ -79,6 +80,7 @@ void install_cloud_handlers(Router& router,
             resp["ok"]         = true;
             resp["endpoint"]   = info->ep;
             resp["tun_ip"]     = info->tun_ip;
+            resp["dev_tun_ip"] = info->dev_tun_ip;
             resp["proxy_port"] = info->proxy_port;
             resp["registered"] = info->registered;
             r.body = resp.dump();

--- a/modules/server/lwm2m/inc/endpoint_registry.hpp
+++ b/modules/server/lwm2m/inc/endpoint_registry.hpp
@@ -18,7 +18,10 @@ namespace lwm2m {
 
 struct EndpointInfo {
     std::string ep;          // "urn:dev:gateway-42"
-    std::string tun_ip;      // "10.9.0.12"
+    std::string tun_ip;      // registry-ALLOCATED tunnel IP, e.g. "10.9.0.10"
+    std::string dev_tun_ip;  // device's ACTUAL openvpn-assigned IP (from the
+                             // server mgmt status), e.g. "10.9.0.2"; the DNAT
+                             // targets this. Empty until the device connects.
     std::uint16_t proxy_port = 0;  // 5001+
     bool registered = false;       // LwM2M registration active
     std::int64_t last_seen_unix = 0;  // last Register/Update, 0 = never
@@ -51,13 +54,12 @@ public:
     bool update_state(const std::string& ep, bool registered,
                       std::int64_t last_seen_unix);
 
-    /// Update the tunnel IP for an endpoint to the address openvpn actually
-    /// assigned it (learned from the server's management interface), so the
-    /// per-device DNAT targets the real IP rather than the registry's
-    /// pre-allocated one. Maintains the tun_ip→ep index. Returns true only if
-    /// the value changed (false if unknown ep, unchanged, or `ip` is held by a
-    /// different endpoint).
-    bool update_tun_ip(const std::string& ep, const std::string& ip);
+    /// Record the address openvpn actually assigned an endpoint (learned from
+    /// the server's management interface). Stored separately from the
+    /// registry-allocated tun_ip so both are visible; the per-device DNAT
+    /// targets this `dev_tun_ip`. Returns true only if the value changed
+    /// (false if unknown ep or unchanged).
+    bool update_dev_tun_ip(const std::string& ep, const std::string& ip);
 
     /// Lookup by endpoint name.  Returns nullptr when not found.
     const EndpointInfo* lookup_by_ep(const std::string& ep) const;

--- a/modules/server/lwm2m/src/endpoint_registry.cpp
+++ b/modules/server/lwm2m/src/endpoint_registry.cpp
@@ -48,20 +48,16 @@ bool EndpointRegistry::update_state(const std::string& ep, bool registered,
     return true;
 }
 
-bool EndpointRegistry::update_tun_ip(const std::string& ep,
-                                     const std::string& ip) {
+bool EndpointRegistry::update_dev_tun_ip(const std::string& ep,
+                                         const std::string& ip) {
     std::lock_guard<std::mutex> lk(m_mutex);
 
     auto it = m_by_ep.find(ep);
     if (it == m_by_ep.end()) return false;          // unknown endpoint
-    if (it->second.tun_ip == ip) return false;      // unchanged
-    auto held = m_tun_ip_to_ep.find(ip);
-    if (held != m_tun_ip_to_ep.end() && held->second != ep)
-        return false;                               // ip belongs to another ep
-
-    m_tun_ip_to_ep.erase(it->second.tun_ip);        // drop the old index entry
-    it->second.tun_ip = ip;
-    m_tun_ip_to_ep[ip] = ep;
+    if (it->second.dev_tun_ip == ip) return false;  // unchanged
+    // dev_tun_ip is not a unique lookup key (no reverse index), so just store
+    // it — the registry-allocated tun_ip + its index are left untouched.
+    it->second.dev_tun_ip = ip;
     return true;
 }
 

--- a/modules/server/lwm2m/test/endpoint_registry_test.cpp
+++ b/modules/server/lwm2m/test/endpoint_registry_test.cpp
@@ -44,9 +44,9 @@ TEST(EndpointRegistryTest, AddAndLookupByEp) {
     EXPECT_EQ(found->proxy_port, 5001);
 }
 
-// ── update_tun_ip: retarget to the openvpn-assigned address ─────────
+// ── update_dev_tun_ip: record the openvpn-assigned address separately ───
 
-TEST(EndpointRegistryTest, UpdateTunIpRetargetsAndReindexes) {
+TEST(EndpointRegistryTest, UpdateDevTunIpKeepsAllocationAndStoresActual) {
     EndpointRegistry reg;
     EndpointInfo info;
     info.ep         = "urn:dev:gateway-1";
@@ -54,17 +54,18 @@ TEST(EndpointRegistryTest, UpdateTunIpRetargetsAndReindexes) {
     info.proxy_port = 10000;
     ASSERT_TRUE(reg.add(info));
 
-    // openvpn actually assigned .2 → retarget.
-    EXPECT_TRUE(reg.update_tun_ip("urn:dev:gateway-1", "10.9.0.2"));
-    EXPECT_EQ(reg.lookup_by_ep("urn:dev:gateway-1")->tun_ip, "10.9.0.2");
-    // index moved: old IP gone, new IP resolves.
-    EXPECT_EQ(reg.lookup_by_tun_ip("10.9.0.10"), nullptr);
-    ASSERT_NE(reg.lookup_by_tun_ip("10.9.0.2"), nullptr);
-    EXPECT_EQ(reg.lookup_by_tun_ip("10.9.0.2")->ep, "urn:dev:gateway-1");
+    // openvpn actually assigned .2 → record as dev_tun_ip; allocation stays.
+    EXPECT_TRUE(reg.update_dev_tun_ip("urn:dev:gateway-1", "10.9.0.2"));
+    const auto* e = reg.lookup_by_ep("urn:dev:gateway-1");
+    ASSERT_NE(e, nullptr);
+    EXPECT_EQ(e->tun_ip, "10.9.0.10");      // allocation preserved
+    EXPECT_EQ(e->dev_tun_ip, "10.9.0.2");   // actual recorded
+    // tun_ip index untouched (still resolves the allocation).
+    ASSERT_NE(reg.lookup_by_tun_ip("10.9.0.10"), nullptr);
 
     // no-ops: unchanged value, and unknown endpoint.
-    EXPECT_FALSE(reg.update_tun_ip("urn:dev:gateway-1", "10.9.0.2"));
-    EXPECT_FALSE(reg.update_tun_ip("urn:dev:nope", "10.9.0.9"));
+    EXPECT_FALSE(reg.update_dev_tun_ip("urn:dev:gateway-1", "10.9.0.2"));
+    EXPECT_FALSE(reg.update_dev_tun_ip("urn:dev:nope", "10.9.0.9"));
 }
 
 // ── 3. Duplicate endpoint rejected ──────────────────────────────────


### PR DESCRIPTION
The endpoint had a single "Tunnel IP" that #171 overwrote with the openvpn-assigned address, hiding the registry allocation. Track + show **both**:

- `EndpointInfo` gains **`dev_tun_ip`** — the address openvpn actually assigned (from the server mgmt ROUTING TABLE); `tun_ip` stays the registry allocation. `update_tun_ip` → `update_dev_tun_ip` (stores the actual without touching the allocation/index); test updated.
- `main.cpp`: poll records `dev_tun_ip`; sync writes both into `cloud.endpoints`; rehydrate restores it; the per-device **DNAT now targets `dev_tun_ip`** (falls back to `tun_ip` before connect).
- **cloud-ui:** Dashboard + Endpoints tables get a **Device Tunnel IP** column (`—` until connected). `/api/v1/cloud/endpoints` passes `cloud.endpoints` through verbatim so the field flows automatically.

Verified: cloud image build + `update_dev_tun_ip` unit test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)