### PR TITLE
feat(cloud-ui): per-device Forwarding rules table under Routing

### DIFF
--- a/apps/cloud/ui/src/app/app.module.ts
+++ b/apps/cloud/ui/src/app/app.module.ts
@@ -26,6 +26,7 @@ import { IfacePriorityComponent } from './wan/iface-priority/iface-priority.comp
 import { RoutingSubmenuComponent } from './routing/routing-submenu/routing-submenu.component';
 import { PortForwardComponent } from './routing/port-forward/port-forward.component';
 import { CustomRulesComponent } from './routing/custom-rules/custom-rules.component';
+import { DeviceForwardingComponent } from './routing/device-forwarding/device-forwarding.component';
 import { Lwm2mSubmenuComponent } from './lwm2m/lwm2m-submenu/lwm2m-submenu.component';
 import { Lwm2mConfigComponent } from './lwm2m/lwm2m-config/lwm2m-config.component';
 import { BsConfigComponent } from './lwm2m/bs-config/bs-config.component';
@@ -46,7 +47,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     DashboardComponent, EndpointListComponent, StatusBadgeComponent, ToastComponent, LogViewerComponent,
     VpnSubmenuComponent, VpnConfigComponent, VpnStatusComponent,
     WanSubmenuComponent, WifiConfigComponent, WifiScanComponent, IfacePriorityComponent,
-    RoutingSubmenuComponent, PortForwardComponent, CustomRulesComponent,
+    RoutingSubmenuComponent, PortForwardComponent, CustomRulesComponent, DeviceForwardingComponent,
     Lwm2mSubmenuComponent, Lwm2mConfigComponent, BsConfigComponent,
     ServicesSubmenuComponent, ServicesListComponent, HttpConfigComponent,
     UsersComponent, SoftwareUpdateComponent,

--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -53,6 +53,7 @@
         <app-routing-submenu (nav)="onSubNavSelect($event)"></app-routing-submenu>
         <div class="content-area">
           <app-port-forward *ngIf="!selectedSubNav || selectedSubNav==='ports' || selectedSubNav==='dnat'"></app-port-forward>
+          <app-device-forwarding *ngIf="selectedSubNav==='forward'"></app-device-forwarding>
           <app-custom-rules *ngIf="selectedSubNav==='rules'"></app-custom-rules>
         </div>
       </ng-container>

--- a/apps/cloud/ui/src/app/routing/device-forwarding/device-forwarding.component.ts
+++ b/apps/cloud/ui/src/app/routing/device-forwarding/device-forwarding.component.ts
@@ -1,0 +1,98 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpsvcService } from '../../../common/httpsvc.service';
+
+/** One verbose forwarding (DNAT) rule row, one per provisioned endpoint. */
+interface FwdRule {
+  endpoint:   string;
+  srcIp:      string;   // where the operator connects (the cloud host)
+  srcPort:    number;   // published proxy_port on the cloud
+  dstIp:      string;   // device tunnel IP (openvpn-assigned, else allocated)
+  dstPort:    number;   // device UI port reached over the tunnel
+  proto:      string;   // transport (tcp for the UI DNAT)
+  registered: boolean;
+}
+
+// getCloudEndpoints() passes the cloud.endpoints JSON through verbatim, so
+// dev_tun_ip rides along even though the service's declared type omits it.
+interface RawEp { endpoint:string; tun_ip:string; dev_tun_ip?:string; proxy_port:number; registered:boolean; }
+
+@Component({
+  selector: 'app-device-forwarding',
+  template: `
+    <div class="page">
+      <h3>Device Forwarding Rules</h3>
+      <p class="sub">
+        Per-device DNAT installed by iot-cloudd: each rule forwards the cloud's
+        published proxy port to the device's web UI over the VPN tunnel
+        (<code>cloud:proxy_port → dev_tun_ip:{{ uiPort }}</code>).
+      </p>
+
+      <clr-datagrid *ngIf="rules.length">
+        <clr-dg-column>Endpoint</clr-dg-column>
+        <clr-dg-column>Source IP</clr-dg-column>
+        <clr-dg-column>Source Port</clr-dg-column>
+        <clr-dg-column>Destination IP</clr-dg-column>
+        <clr-dg-column>Destination Port</clr-dg-column>
+        <clr-dg-column>Protocol</clr-dg-column>
+        <clr-dg-column>State</clr-dg-column>
+        <clr-dg-row *clrDgItems="let r of rules">
+          <clr-dg-cell><code>{{ r.endpoint }}</code></clr-dg-cell>
+          <clr-dg-cell>{{ r.srcIp }}</clr-dg-cell>
+          <clr-dg-cell>{{ r.srcPort }}</clr-dg-cell>
+          <clr-dg-cell>{{ r.dstIp || '—' }}</clr-dg-cell>
+          <clr-dg-cell>{{ r.dstPort }}</clr-dg-cell>
+          <clr-dg-cell><span class="label">{{ r.proto }}</span></clr-dg-cell>
+          <clr-dg-cell>
+            <app-status-badge [label]="r.registered?'online':'offline'"
+                              [state]="r.registered?'connected':'exited'"></app-status-badge>
+          </clr-dg-cell>
+        </clr-dg-row>
+        <clr-dg-footer>{{ rules.length }} forwarding rule(s)</clr-dg-footer>
+      </clr-datagrid>
+      <p *ngIf="!rules.length" class="empty">No devices provisioned — no forwarding rules yet.</p>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; } h3 { color: #333; margin: 0 0 8px 0; font-size: 16px; font-weight: 600; }
+    .sub { color: #666; font-size: 13px; margin: 0 0 20px 0; }
+    .empty { color: #888; }
+  `]
+})
+export class DeviceForwardingComponent implements OnInit {
+  rules: FwdRule[] = [];
+  uiPort = 80;
+  // The cloud host the operator reaches the proxy on — the same origin this
+  // UI is served from. Shown as the rule's source IP.
+  private cloudHost = window.location.hostname;
+
+  constructor(private http: HttpsvcService) {}
+
+  ngOnInit(): void {
+    this.http.dbGet(['cloud.proxy.device.ui.port']).subscribe({
+      next: (r) => {
+        if (r.ok && r.data) {
+          const p = Number((r.data as Record<string, unknown>)['cloud.proxy.device.ui.port']);
+          if (Number.isFinite(p) && p > 0) this.uiPort = p;
+        }
+        this.loadRules();
+      },
+      error: () => this.loadRules()
+    });
+  }
+
+  private loadRules(): void {
+    this.http.getCloudEndpoints().subscribe({
+      next: (eps) => {
+        this.rules = (eps as RawEp[]).map(e => ({
+          endpoint:   e.endpoint,
+          srcIp:      this.cloudHost,
+          srcPort:    e.proxy_port,
+          dstIp:      e.dev_tun_ip || e.tun_ip,
+          dstPort:    this.uiPort,
+          proto:      'tcp',
+          registered: e.registered,
+        }));
+      }
+    });
+  }
+}

--- a/apps/cloud/ui/src/app/routing/routing-submenu/routing-submenu.component.ts
+++ b/apps/cloud/ui/src/app/routing/routing-submenu/routing-submenu.component.ts
@@ -14,6 +14,11 @@ import { Component, Output, EventEmitter } from '@angular/core';
         <clr-icon shape="target"></clr-icon>
         <span>DNAT Target</span>
       </a>
+      <a class="subnav-tab" [class.active]="active === 'forward'"
+         (click)="select('forward')">
+        <clr-icon shape="network-globe"></clr-icon>
+        <span>Forwarding</span>
+      </a>
       <a class="subnav-tab" [class.active]="active === 'rules'"
          (click)="select('rules')">
         <clr-icon shape="firewall"></clr-icon>


### PR DESCRIPTION
## Summary
Adds a **Forwarding** tab to the cloud-ui **Routing** page: a Clarity `clr-datagrid` listing the per-device DNAT (device-UI-over-VPN) rule for every provisioned endpoint, in verbose source→destination form.

| Column | Value |
|--------|-------|
| Endpoint | endpoint name |
| Source IP | cloud host (this UI's origin) |
| Source Port | published `proxy_port` |
| Destination IP | `dev_tun_ip` (openvpn-assigned), else allocated `tun_ip` |
| Destination Port | `cloud.proxy.device.ui.port` |
| Protocol | `tcp` |
| State | online / offline |

This mirrors exactly the nftables DNAT `iot-cloudd` installs (`cloud:proxy_port -> dev_tun_ip:ui_port`). Data is read from `/api/v1/cloud/endpoints` + `cloud.proxy.device.ui.port` — no new ds keys, no backend change.

## Changes
- new `DeviceForwardingComponent` (`routing/device-forwarding`)
- `routing-submenu`: new `forward` tab
- `main.component.html`: render under `selectedSubNav==='forward'`
- `app.module`: declare the component

## Test
- `podman build --target ui-builder` compiles clean (only pre-existing warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)