### PR TITLE
feat(device): derive vpn.remote.host from the bootstrap DM URI

### DIFF
--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -316,7 +316,11 @@ because it subjected `1194` to ufw (allow-22-only → connection refused). Notes
   to run the OpenVPN server tun + install the per-device DNAT.
 
 The cloud also pushes the VPN *endpoint* (host/port/proto) down to the device
-over LwM2M Object 2048 — see `apps/docs/lwm2m-object-handling.md` §2.8.
+over LwM2M Object 2048 — see `apps/docs/lwm2m-object-handling.md` §2.8. The VPN
+**host** is additionally *derived on the device* from the bootstrap-delivered
+DM URI (the VPN concentrator is co-located with the DM), so a co-located cloud
+needs no VPN-host config on the device; the Object-2048 push is the override for
+a split topology (derive-with-override).
 
 ## Log Levels
 

--- a/apps/docs/lwm2m-object-handling.md
+++ b/apps/docs/lwm2m-object-handling.md
@@ -226,6 +226,20 @@ the staged values are materialised into `vpn.remote.host` / `vpn.remote.port`
 `modules/openvpn/client/docs/design.md`) then hot-reloads openvpn-client, which
 re-execs reading the new `vpn.remote.*` — no compose seed, no manual restart.
 
+**VPN host is also derived at bootstrap (derive-with-override).** Because the
+VPN concentrator is co-located with the DM on the cloud VM, the VPN host equals
+the DM URI host. So the device sets `vpn.remote.host` *itself* at bootstrap
+commit — `DsConfig::set_vpn_remote_host(dmHost)` in the BS `on_done`
+(`apps/src/main.cpp`), right after it persists `iot.dm.uri`. This means a
+co-located cloud needs **zero** VPN-host config on the device (only the
+commissioned bootstrap URI + BS PSK), and the device learns the host before
+registration rather than waiting on the Object-2048 endpoint push. The push
+(RID 5) above remains the **override**: for a split topology where the VPN
+concentrator ≠ DM host, the operator-driven push wins; in the common single-VM
+case both write the identical host, so the override is idempotent. Port/proto
+have no on-device default and still come from the push (the cloud knows them
+authoritatively).
+
 ---
 
 ## 3. Registration interface — `POST /rd`

--- a/apps/inc/ds_config.hpp
+++ b/apps/inc/ds_config.hpp
@@ -109,6 +109,12 @@ public:
     /// display the URI the device actually registered to. Write-only here —
     /// the client is the sole writer, so there's nothing to mirror locally.
     bool set_dm_uri(const std::string& uri);
+    /// Derive the VPN server host from the bootstrap-delivered DM URI and
+    /// persist it → vpn.remote.host, so a co-located cloud (VPN concentrator
+    /// on the same VM as the DM) needs no separate VPN-host config on the
+    /// device. The cloud's Object-2048 endpoint push still overrides it for a
+    /// split topology. No-op when !connected() or host is empty.
+    bool set_vpn_remote_host(const std::string& host);
     /// Publish the LwM2M connection lifecycle token to iot.conn.state so
     /// the device-ui can render real-time progress. One of: idle /
     /// bootstrapping / bootstrapped / dm-connecting / dm-connected /

--- a/apps/src/ds_config.cpp
+++ b/apps/src/ds_config.cpp
@@ -32,6 +32,10 @@ constexpr const char* kKeyDevMode     = "iot.dev.mode";
 constexpr const char* kKeyConnState   = "iot.conn.state";
 // Bootstrap-delivered DM Server URI, published to the device-ui (write-only).
 constexpr const char* kKeyDmUri       = "iot.dm.uri";
+// VPN server endpoint host. Derived from the DM URI at bootstrap (the VPN
+// concentrator is co-located with the DM on the cloud VM); the cloud's
+// Object-2048 endpoint push can still override it (write-only here).
+constexpr const char* kKeyVpnRemoteHost = "vpn.remote.host";
 
 } // namespace
 
@@ -257,6 +261,18 @@ bool DsConfig::set_dm_uri(const std::string& uri) {
     // is the sole writer, so there's nothing to mirror locally.
     auto s = m_impl->client.set({
         {kKeyDmUri, data_store::Value{uri}},
+    });
+    return s.ok;
+}
+
+bool DsConfig::set_vpn_remote_host(const std::string& host) {
+    if (!m_ok || !m_impl || host.empty()) return false;
+    // Derived from the bootstrap-delivered DM URI host. The cloud's LwM2M
+    // Object-2048 endpoint push may later overwrite this with an explicit
+    // value (split VPN/DM topology); in the common single-VM case the two
+    // agree, so the override is idempotent. Write-only — nothing to mirror.
+    auto s = m_impl->client.set({
+        {kKeyVpnRemoteHost, data_store::Value{host}},
     });
     return s.ok;
 }

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -891,6 +891,18 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
                                 "data-store (iot.dm.uri=%C)\n"),
                        dmUri.c_str()));
         }
+        // Derive the VPN server host from the DM URI: the VPN concentrator is
+        // co-located with the DM on the cloud VM, so its host == dmHost. This
+        // gives a co-located cloud zero VPN-host config on the device (just the
+        // commissioned bootstrap URI + BS PSK). The cloud's Object-2048 endpoint
+        // push (set_vpn_endpoint) still overrides this for a split topology;
+        // in the common case both write the same value (idempotent).
+        if (ds.set_vpn_remote_host(dmHost)) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l VPN remote host "
+                                "derived from DM URI (vpn.remote.host=%C)\n"),
+                       dmHost.c_str()));
+        }
         // Point the LwM2MClient peer at the DM, pin the DM PSK identity, and
         // force a fresh DTLS handshake against the DM.
         for (auto& [type, ctx] : a->udpAdapter()->services()) {

--- a/modules/openvpn/client/schemas/vpn.lua
+++ b/modules/openvpn/client/schemas/vpn.lua
@@ -1,12 +1,15 @@
 -- vpn.* schema for openvpn-client (L12).
 --
 -- Read keys (operator configures via ds-cli):
---   The remote endpoint (host/port/proto) has NO default — it is the cloud's
---   to define and is pushed to the device over LwM2M Object 2048 (or set by an
---   operator for a manual deployment). All three are required-to-start, so the
---   client stays gated until the cloud provides them; baking defaults would
---   risk dialing the wrong port/proto before the push lands.
---   vpn.remote.host   - server hostname or IP (required; cloud-pushed)
+--   The remote endpoint (host/port/proto) has NO schema default — it is the
+--   cloud's to define. vpn.remote.host is *derived on the device* from the
+--   bootstrap-delivered DM URI (the VPN concentrator is co-located with the DM
+--   on the cloud VM), so a co-located cloud needs no VPN-host config here. The
+--   cloud's LwM2M Object 2048 endpoint push still overrides all three — and is
+--   the source for port/proto (which the cloud knows authoritatively; baking
+--   defaults would risk dialing the wrong port/proto). The client stays gated
+--   until host+port+proto are present (derived host + pushed port/proto).
+--   vpn.remote.host   - server hostname or IP (device-derived from DM URI; cloud-override)
 --   vpn.remote.port   - server port            (required; cloud-pushed, 1..65535)
 --   vpn.remote.proto  - "tcp-client" or "udp"  (required; cloud-pushed)
 --   vpn.cert.path     - client X.509 cert      (default /etc/iot/vpn/client.crt)
@@ -43,6 +46,9 @@ return {
   namespace = "vpn",
   keys = {
     -- ───────── Read keys (operator → daemon) ─────────
+    -- Derived on the device from the bootstrap-delivered DM URI host (the VPN
+    -- concentrator is co-located with the DM); the cloud's Object-2048 endpoint
+    -- push overrides it for a split topology. No schema default either way.
     ["vpn.remote.host"]  = {
         access  = "Admin", type = "string"  },
     ["vpn.remote.port"]  = {


### PR DESCRIPTION
## Summary
The VPN concentrator is co-located with the DM on the cloud VM, so the VPN server **host == the DM URI host**. The device already parses the DM host out of the bootstrap-delivered DM URI (BS `on_done`); now it also persists it to `vpn.remote.host` (new `DsConfig::set_vpn_remote_host`), right after `iot.dm.uri`.

**Result:** a co-located cloud needs **zero** VPN-host config on the device — only the commissioned bootstrap URI + BS PSK. The device also learns the host at bootstrap (before registration), instead of waiting on the Object-2048 endpoint push.

## Derive-with-override
The cloud's Object-2048 endpoint push (`set_vpn_endpoint`) still **overrides** all three keys for a split topology (VPN concentrator ≠ DM host). In the common single-VM case both write the identical host, so the override is idempotent. Port/proto have no on-device default and still come from the push (the cloud knows them authoritatively).

## Changes
- `DsConfig::set_vpn_remote_host` (`apps/inc/ds_config.hpp`, `apps/src/ds_config.cpp`)
- wire into BS `on_done` (`apps/src/main.cpp`)
- `vpn.lua`: document host as device-derived / cloud-override
- docs: `lwm2m-object-handling.md` §2.8 + `apps/cloud/CLAUDE.md`

## Test
- `podman build --target builder` compiles clean (114/114 targets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)