### PR TITLE
fix(cloud): gate Launch UI + DNAT on the live VPN tunnel

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -140,10 +140,13 @@ void rebuild_device_dnat(data_store::Client& ds, const std::string& tun_dev) {
         auto arr = nlohmann::json::parse(ds_str(ds, "cloud.endpoints", "[]"));
         if (arr.is_array()) for (const auto& e : arr) {
             if (!e.is_object()) continue;
-            // Prefer the openvpn-assigned address; fall back to the registry
-            // allocation before the device has connected (DNAT is moot then).
+            // Only the openvpn-assigned address (dev_tun_ip) — present iff the
+            // device's tunnel is currently up. We deliberately do NOT fall back
+            // to the registry-allocated tun_ip: before first connect / after a
+            // disconnect there is no live tunnel, so a DNAT to the allocation
+            // would just point at a dead vip (Launch UI would hang). No
+            // dev_tun_ip → no rule, matching the UI gating Launch UI off.
             std::string ip   = e.value("dev_tun_ip", std::string());
-            if (ip.empty()) ip = e.value("tun_ip", std::string());
             int         port = e.value("proxy_port", 0);
             if (ip.empty() || port <= 0) continue;
             in.devices.push_back({std::move(ip),
@@ -930,8 +933,15 @@ int main(int argc, char** argv) {
                 for (const auto& e : ep_reg.list_all()) {
                     auto it = ips.find(
                         server::openvpn::CertAuthority::sanitize_cn(e.ep));
-                    if (it != ips.end())
+                    if (it != ips.end()) {
                         ip_changed |= ep_reg.update_dev_tun_ip(e.ep, it->second);
+                    } else {
+                        // Tunnel down for this endpoint — clear the stale
+                        // assigned IP so the cloud UI gates Launch UI off and
+                        // the DNAT stops targeting a dead vip (dev_tun_ip is
+                        // the per-device "VPN up" signal the UI keys on).
+                        ip_changed |= ep_reg.update_dev_tun_ip(e.ep, "");
+                    }
                 }
                 if (ip_changed) {
                     sync_endpoints_to_ds(ds, ep_reg);

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -77,12 +77,17 @@ interface EpCred {
           <clr-dg-cell><code>{{ e.dev_tun_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
           <clr-dg-cell>
+            <!-- Launch UI only when the device's VPN tunnel is actually up
+                 (dev_tun_ip present). The DNAT target is the live tunnel IP, so
+                 a registered-but-VPN-down device has no reachable route — the
+                 cloud also drops its DNAT rule in that state. -->
             <a class="btn btn-sm" target="_blank" rel="noopener"
                [href]="'http://' + windowHost + ':' + e.proxy_port + '/'"
-               *ngIf="e.registered && e.proxy_port">
+               *ngIf="e.registered && e.proxy_port && e.dev_tun_ip">
               Launch UI <clr-icon shape="pop-out" size="12"></clr-icon>
             </a>
             <span *ngIf="!e.registered" class="hint">offline</span>
+            <span *ngIf="e.registered && !e.dev_tun_ip" class="hint">VPN down</span>
           </clr-dg-cell>
           <clr-dg-cell *ngIf="isAdmin">
             <button class="btn btn-sm btn-danger" (click)="deprovision(e.endpoint)">Remove</button>
@@ -100,8 +105,9 @@ interface EpCred {
             <dl class="cred-list" style="margin-bottom:16px;">
               <dt>VPN forwarding rule</dt>
               <dd>
-                <code>tcp dport {{ e.proxy_port }} &rarr; {{ e.tun_ip }}:{{ uiPort }}</code>
-                <span class="hint" style="margin-left:8px;">DNAT — device UI over VPN</span>
+                <code>tcp dport {{ e.proxy_port }} &rarr; {{ e.dev_tun_ip || e.tun_ip }}:{{ uiPort }}</code>
+                <span class="hint" style="margin-left:8px;" *ngIf="e.dev_tun_ip">DNAT — device UI over VPN</span>
+                <span class="hint" style="margin-left:8px;" *ngIf="!e.dev_tun_ip">VPN down — rule inactive</span>
               </dd>
             </dl>
             <ng-container *ngIf="credFor(e) as c; else noCred">


### PR DESCRIPTION
## Problem
A device can be LwM2M-registered while its VPN tunnel is **down** (e.g. right after a cloud VPN-server restart). Today:
- the Endpoints page still shows **Launch UI** (gated only on `registered`), and
- `iot-cloudd` keeps a DNAT rule pointing at the device's tun IP — but with the tunnel down that target is unreachable, so Launch UI just hangs.

Reported: *"Cloud Endpoint still showing 'Launch UI' while VPN is down … firewall rule will be deleted and launch UI will not work, right?"*

## Fix
Make `dev_tun_ip` (the openvpn-assigned address, populated from the VPN server's `ROUTING TABLE`) the authoritative per-device **"tunnel up"** signal:

- `iot-cloudd` now **clears** `dev_tun_ip` when an endpoint drops out of the connected set (it was only ever *set* before, so it went stale on disconnect).
- `rebuild_device_dnat` emits a rule **only when `dev_tun_ip` is present** — no more fallback to the registry-allocated `tun_ip` (a dead vip before first connect / after disconnect). Tunnel down → no DNAT rule.
- `endpoint-list`: Launch UI shows only when `registered && proxy_port && dev_tun_ip`; a registered-but-tunnel-down device shows a **"VPN down"** hint, and the per-endpoint forwarding-rule detail flags the rule inactive.

## Test
- `podman build --target builder` (iot-cloudd) + `--target ui-builder` (Angular) both compile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)