### PR TITLE
fix(device): openvpn client wedged in HOLD after a cloud VPN-server restart

### DIFF
--- a/modules/openvpn/client/src/process.cpp
+++ b/modules/openvpn/client/src/process.cpp
@@ -36,6 +36,14 @@ std::string build_openvpn_config(const OpenVpnConfig& c) {
     ss << "proto " << c.remote_proto << "\n";
     ss << "remote " << c.remote_host << " " << c.remote_port << "\n";
     ss << "nobind\n";
+    // Survive a cloud VPN-server restart / link drop: keep retrying DNS for an
+    // FQDN remote (vpn.remote.host is derived from the DM URI, which may be a
+    // name) and keep the tun device + keys across in-session restarts so the
+    // client re-dials on its own instead of exiting. Reconnect is also gated by
+    // `management-hold` — the supervisor re-releases the hold on each >HOLD:.
+    ss << "resolv-retry infinite\n";
+    ss << "persist-tun\n";
+    ss << "persist-key\n";
     ss << "ca   " << c.ca_path       << "\n";
     ss << "cert " << c.cert_path     << "\n";
     ss << "key  " << c.key_path      << "\n";

--- a/modules/openvpn/client/src/supervisor.cpp
+++ b/modules/openvpn/client/src/supervisor.cpp
@@ -294,6 +294,27 @@ bool Supervisor::serve_one_session(const std::string& iface) {
         if (n > 0) {
             parser.feed(std::string_view(buf, n));
             while (auto ev = parser.next()) {
+                // openvpn was spawned with `management-hold`, so it re-enters
+                // HOLD before EVERY (re)connection attempt — not just at
+                // startup. We release once at attach (above), but on a cloud
+                // VPN-server restart / link drop it holds again and emits a
+                // fresh >HOLD:. Without re-releasing, the client wedges in hold
+                // forever (device shows "reconnecting" but never reconnects).
+                // Re-release on each HOLD so reconnects actually proceed.
+                if (ev->kind == mgmt::Event::Kind::Hold) {
+                    static const char kHoldRelease[] = "hold release\r\n";
+                    if (stream.send_n(kHoldRelease, sizeof(kHoldRelease) - 1) < 0) {
+                        ACE_ERROR((LM_WARNING,
+                                   ACE_TEXT("%D [ovpn:%t] %M %N:%l mgmt re-'hold "
+                                            "release' on reconnect failed "
+                                            "errno=%d\n"), errno));
+                    } else {
+                        ACE_DEBUG((LM_INFO,
+                                   ACE_TEXT("%D [ovpn:%t] %M %N:%l openvpn "
+                                            "re-entered HOLD (server restart/link "
+                                            "drop); released to reconnect\n")));
+                    }
+                }
                 cli.step(*ev);
             }
             if (m_opt.once && cli.saw_push_reply()) break;

--- a/modules/openvpn/client/test/process_test.cpp
+++ b/modules/openvpn/client/test/process_test.cpp
@@ -65,6 +65,10 @@ TEST(BuildOpenvpnConfig, EmitsExpectedDirectives) {
     // Held at startup so the supervisor subscribes before openvpn connects
     // (captures CONNECTED + PUSH_REPLY rather than racing them).
     EXPECT_NE(std::string::npos, body.find("\nmanagement-hold\n"));
+    // Reconnect resilience after a cloud VPN-server restart / link drop.
+    EXPECT_NE(std::string::npos, body.find("\nresolv-retry infinite\n"));
+    EXPECT_NE(std::string::npos, body.find("\npersist-tun\n"));
+    EXPECT_NE(std::string::npos, body.find("\npersist-key\n"));
 }
 
 TEST(BuildOpenvpnConfig, OverridesFlowThrough) {


### PR DESCRIPTION
## Problem
*"I restarted vpn server on cloud-ui, device is disconnected and still in reconnecting."*

The client is spawned with `management-hold` so the supervisor can attach + enable state notifications **before** the first connect (so `CONNECTED`/`PUSH_REPLY` aren't raced). But `management-hold` makes openvpn re-enter HOLD before **every** (re)connection attempt — and the supervisor released the hold only **once**, at attach. So when the cloud VPN server restarts (or the link drops), openvpn re-holds, emits a fresh `>HOLD:`, and the supervisor never releases it → the device shows "reconnecting" but never reconnects.

## Fix
- Re-send `hold release` on **every** `>HOLD:` event in the mgmt event loop, so reconnects proceed (`supervisor.cpp`).
- Harden the generated client config (`process.cpp`):
  - `resolv-retry infinite` — keep retrying DNS for an FQDN remote (`vpn.remote.host` is now derived from the DM URI, which may be a name)
  - `persist-tun` / `persist-key` — keep the tun device + keys across in-session restarts so the client re-dials on its own

## Test
- `process_test` asserts the three new directives in `build_openvpn_config`.
- Device image build (podman) compiles + runs the openvpn-client tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)