### PR TITLE
feat(device-ui): LwM2M status badge in the live status bar

### DIFF
--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -62,6 +62,7 @@
       </div>
       <span class="live-date">{{ today }}</span>
 
+      <app-status-badge icon="cloud" [label]="'LwM2M ' + lwm2mState" [state]="lwm2mBadgeState"></app-status-badge>
       <app-status-badge icon="shield" [label]="'VPN ' + vpnState" [state]="vpnState"></app-status-badge>
       <app-status-badge icon="wifi" [label]="'WiFi ' + wifiState" [state]="wifiState"></app-status-badge>
       <span class="live-stat"><clr-icon shape="world"></clr-icon> {{ wanIface }}</span>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -121,6 +121,17 @@ export class MainComponent {
   // Quick status helpers
   get vpnState(): string { return this.status?.vpn?.state || 'unknown'; }
   get wifiState(): string { return this.status?.wifi?.state || 'unknown'; }
+  // LwM2M connection lifecycle (iot.conn.state → status.lwm2m.conn_state):
+  // bootstrapping → bootstrapped → dm-connecting → dm-connected → registered.
+  // The raw token is already concise enough for the live bar; map it to a
+  // status-badge colour the same way the dashboard tile does.
+  get lwm2mState(): string { return this.status?.lwm2m?.conn_state || 'idle'; }
+  get lwm2mBadgeState(): string {
+    const s = this.status?.lwm2m?.conn_state;
+    if (s === 'registered') return 'connected';
+    if (!s || s === 'idle' || s === 'failed') return 'disconnected';
+    return 'starting';   // bootstrapping / bootstrapped / dm-* in progress
+  }
   get wanIface(): string { return this.status?.wan?.active_iface || '-'; }
   get serviceCount(): number {
     if (!this.status?.services) return 0;


### PR DESCRIPTION
## Summary
The device UI's live status bar already shows **VPN** and **WiFi** status badges. This adds an **LwM2M** badge beside them so the device's bootstrap→DM→registered lifecycle is visible at a glance on every page (not only the dashboard tile).

The backend is already in place — `/status` exposes `lwm2m.conn_state` (from `iot.conn.state`) and the `/status` long-poll already watches that key — so the badge updates live with no backend change. It maps `conn_state` to a colour the same way the dashboard tile does (registered → green, idle/failed → red, bootstrap/dm-* → amber) and shows the raw token as the label, e.g. `LwM2M registered`.

## Changes
- `main.component.ts`: `lwm2mState` + `lwm2mBadgeState` getters
- `main.component.html`: `<app-status-badge icon="cloud" …>` in the live bar

## Test
- `podman build --target ui-builder` (device UI) compiles clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)