### PR TITLE
fix(httpd): configurable session cookie name — stop cloud/device login clobber

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -636,6 +636,14 @@ int main(int argc, char** argv) {
     ds.set("cloud.proxy.device.ui.port",
            data_store::Value{static_cast<std::int32_t>(
                ds_int(ds, "cloud.proxy.device.ui.port", 8080))});
+    // Give the cloud httpd a session-cookie name distinct from the device's
+    // default ("iot-session"). The device UI is reverse-proxied through the
+    // cloud on the same host/different port; cookies ignore ports, so a shared
+    // name makes a device-UI login clobber the cloud session (and vice-versa).
+    // The cloud httpd hot-reloads this key (watch loop), so start order with
+    // iot-cloudd doesn't matter.
+    ds.set("http.auth.cookie.name",
+           data_store::Value{std::string("iot-cloud-session")});
     if (!server::dnat::enable_ip_forward()) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l could not enable "

--- a/modules/http-server/inc/auth.hpp
+++ b/modules/http-server/inc/auth.hpp
@@ -63,10 +63,17 @@ public:
     bool enabled() const { return m_enabled.load(std::memory_order_acquire); }
     void set_enabled(bool v) { m_enabled.store(v, std::memory_order_release); }
 
+    /// Session cookie name (mirrors http.auth.cookie.name). Must differ
+    /// between same-host/different-port instances (cloud vs proxied device
+    /// UI) so their cookies don't clobber each other. Thread-safe.
+    std::string cookie_name() const;
+    void set_cookie_name(const std::string& name);
+
 private:
-    std::mutex m_mutex;
+    mutable std::mutex m_mutex;
     std::map<std::string, Session> m_sessions;   // token → session
     std::atomic<bool> m_enabled{true};
+    std::string m_cookie_name{"iot-session"};    // guarded by m_mutex
 
     /// Random token (URL-safe base64, 32 bytes of entropy).
     static std::string make_token();
@@ -108,15 +115,20 @@ public:
 /// "Admin" can modify anything; "Viewer" is read-only.
 bool can_write(const std::string& access_level, const std::string& key);
 
-/// Extract the session token from a Cookie header.
-/// Returns empty string when no session cookie is present.
+/// Extract the session token from a Cookie header, looking up the cookie
+/// named `cookie_name`. Returns empty string when not present.
 std::string extract_session_cookie(
-    const std::map<std::string, std::string>& headers);
+    const std::map<std::string, std::string>& headers,
+    const std::string& cookie_name = "iot-session");
 
-/// Build a Set-Cookie header value for the session token.
+/// Build a Set-Cookie header value for the session token under `cookie_name`.
 /// path=/; HttpOnly; SameSite=Strict. Max-Age defaults to 8h.
 std::string make_set_cookie(const std::string& token,
+                             const std::string& cookie_name = "iot-session",
                              int max_age_sec = 28800);
+
+/// Build a Set-Cookie header value that clears the session cookie (Max-Age=0).
+std::string make_clear_cookie(const std::string& cookie_name = "iot-session");
 
 /// Wrap a HandlerFn with an auth check.  When the request carries a
 /// valid session cookie the wrapped handler is called normally;

--- a/modules/http-server/schemas/auth.lua
+++ b/modules/http-server/schemas/auth.lua
@@ -51,5 +51,17 @@ return {
       type    = "boolean",
       default = true,
     },
+
+    -- Name of the session cookie. MUST differ between two iot-httpd
+    -- instances reachable on the SAME host/domain but different ports
+    -- (cookies are not isolated by port) — e.g. the cloud UI and a device
+    -- UI reverse-proxied through the cloud. If they share a name, logging
+    -- into one clobbers the other's session. The cloud sets this to
+    -- "iot-cloud-session" (seeded by iot-cloudd); the device keeps the
+    -- default. Hot-reloaded with the other auth keys.
+    ["http.auth.cookie.name"] = {
+      type    = "string",
+      default = "iot-session",
+    },
   },
 }

--- a/modules/http-server/src/auth.cpp
+++ b/modules/http-server/src/auth.cpp
@@ -134,6 +134,16 @@ void SessionStore::sweep_expired() {
     }
 }
 
+std::string SessionStore::cookie_name() const {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    return m_cookie_name;
+}
+
+void SessionStore::set_cookie_name(const std::string& name) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    if (!name.empty()) m_cookie_name = name;
+}
+
 // ── SHA-256 ─────────────────────────────────────────────────────────
 
 std::string sha256_hex(const std::string& input) {
@@ -197,20 +207,26 @@ bool can_write(const std::string& access_level, const std::string& /*key*/) {
 // ── Cookie helpers ─────────────────────────────────────────────────
 
 std::string extract_session_cookie(
-    const std::map<std::string, std::string>& headers) {
+    const std::map<std::string, std::string>& headers,
+    const std::string& cookie_name) {
     auto it = headers.find("cookie");
     if (it == headers.end()) return {};
-    return cookie_value(it->second, "iot-session");
+    return cookie_value(it->second, cookie_name);
 }
 
-std::string make_set_cookie(const std::string& token, int max_age_sec) {
+std::string make_set_cookie(const std::string& token,
+                            const std::string& cookie_name, int max_age_sec) {
     std::ostringstream oss;
-    oss << "iot-session=" << token
+    oss << cookie_name << "=" << token
         << "; Path=/"
         << "; HttpOnly"
         << "; SameSite=Strict"
         << "; Max-Age=" << max_age_sec;
     return oss.str();
+}
+
+std::string make_clear_cookie(const std::string& cookie_name) {
+    return cookie_name + "=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0";
 }
 
 // ── Auth guard ─────────────────────────────────────────────────────
@@ -235,7 +251,8 @@ Router::HandlerFn with_auth(Router::HandlerFn next,
         if (is_public_route(req.path)) return next(req);
 
         // Validate session cookie
-        std::string token = extract_session_cookie(req.headers);
+        std::string token = extract_session_cookie(req.headers,
+                                                   store.cookie_name());
         if (token.empty()) {
             HttpResponse r;
             r.status = 401;

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -146,7 +146,8 @@ void install_handlers(Router& router,
             // ── Access control ─────────────────────────────────
             std::string access_level = "Admin";  // default: full access
             if (auth && auth->enabled()) {
-                std::string token = extract_session_cookie(req.headers);
+                std::string token = extract_session_cookie(req.headers,
+                                                           auth->cookie_name());
                 if (!token.empty()) {
                     const auto* session = auth->validate(token);
                     if (session) access_level = session->access;
@@ -368,7 +369,8 @@ void install_handlers(Router& router,
             resp["access"] = access;
             r.body = resp.dump();
             if (!token.empty()) {
-                r.headers["Set-Cookie"] = make_set_cookie(token);
+                r.headers["Set-Cookie"] = make_set_cookie(
+                    token, auth ? auth->cookie_name() : "iot-session");
             }
             return r;
         });
@@ -377,13 +379,13 @@ void install_handlers(Router& router,
     router.add("POST", "/api/v1/auth/logout",
         [auth](const HttpParser::Request& req) -> HttpResponse {
             HttpResponse r;
+            const std::string cname = auth ? auth->cookie_name() : "iot-session";
             if (auth) {
-                std::string token = extract_session_cookie(req.headers);
+                std::string token = extract_session_cookie(req.headers, cname);
                 if (!token.empty()) auth->destroy(token);
             }
             r.body = R"({"ok":true})";
-            r.headers["Set-Cookie"] =
-                "iot-session=; Path=/; HttpOnly; SameSite=Strict; Max-Age=0";
+            r.headers["Set-Cookie"] = make_clear_cookie(cname);
             return r;
         });
 
@@ -981,7 +983,8 @@ void install_handlers(Router& router,
             // Access control (mirrors db/set): Viewer is forbidden.
             std::string access_level = "Admin";
             if (auth && auth->enabled()) {
-                std::string token = extract_session_cookie(req.headers);
+                std::string token = extract_session_cookie(req.headers,
+                                                           auth->cookie_name());
                 if (!token.empty()) {
                     const auto* session = auth->validate(token);
                     if (session) access_level = session->access;
@@ -1050,7 +1053,8 @@ void install_handlers(Router& router,
             }
             std::string access_level = "Admin";
             if (auth && auth->enabled()) {
-                std::string token = extract_session_cookie(req.headers);
+                std::string token = extract_session_cookie(req.headers,
+                                                           auth->cookie_name());
                 if (!token.empty()) {
                     const auto* session = auth->validate(token);
                     if (session) access_level = session->access;

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -248,6 +248,20 @@ int main(int argc, char** argv) {
         }
     }
 
+    // Session cookie name (http.auth.cookie.name). MUST differ between two
+    // iot-httpd instances on the same host/domain but different ports (the
+    // cloud UI and a device UI reverse-proxied through it) — cookies ignore
+    // ports, so a shared name makes logging into one clobber the other. The
+    // cloud seeds "iot-cloud-session"; device keeps the default "iot-session".
+    {
+        std::vector<data_store::Client::GetResult> got;
+        auto rs = ds.get({"http.auth.cookie.name"}, got);
+        if (rs.ok && !got.empty() && got[0].has_value) {
+            if (auto s = data_store::to_string(got[0].value))
+                auth_store.set_cookie_name(*s);
+        }
+    }
+
     // ── Static file serving (SPA) ─────────────────────────────
     std::string wwwDir = arg_value(argc, argv, "www-dir");
     if (wwwDir.empty()) {
@@ -458,6 +472,14 @@ int main(int argc, char** argv) {
                 if (rs.ok && !got.empty() && got[0].has_value) {
                     if (auto b = data_store::to_bool(got[0].value))
                         auth_store.set_enabled(*b);
+                }
+                // Reload the session cookie name (the cloud seeds a distinct
+                // name; pick it up regardless of cloudd/httpd start order).
+                std::vector<data_store::Client::GetResult> cgot;
+                auto crs = ds.get({"http.auth.cookie.name"}, cgot);
+                if (crs.ok && !cgot.empty() && cgot[0].has_value) {
+                    if (auto s = data_store::to_string(cgot[0].value))
+                        auth_store.set_cookie_name(*s);
                 }
                 // Password hash is reloaded on each login attempt
                 // (stateless — no cache to invalidate).


### PR DESCRIPTION
## Problem
Launching a device UI from the cloud **Endpoints** page logged the operator **out of the cloud UI** — and logging into the cloud logged you out of the device UI.

**Cause:** the cloud UI and the proxied device UI are served from the **same host** (the cloud's IP) on **different ports**, and **cookies are not isolated by port** (RFC 6265). Both run the same `iot-httpd` with the same hardcoded session-cookie name `iot-session`, so a login on one overwrote the other's cookie for the whole domain.

## Fix
Make the cookie name configurable and give the two roles distinct names.

- New ds key **`http.auth.cookie.name`** (`auth.lua`, default `iot-session`), hot-reloaded with the other auth keys.
- `SessionStore` carries the name (`cookie_name()`/`set_cookie_name()`); `extract_session_cookie()`/`make_set_cookie()` take the name; new `make_clear_cookie()` for logout. Defaults keep `iot-session`, so the device and all existing call sites are unchanged.
- `iot-httpd` loads the key at startup **and** re-reads it in the config watch loop (so the cloud picks up the seed regardless of cloudd/httpd start order).
- `iot-cloudd` seeds **`http.auth.cookie.name="iot-cloud-session"`** → cloud and device no longer share a cookie. Device keeps `iot-session`.

## Known follow-up
Multiple device UIs proxied through one cloud still share `iot-session` (device↔device clobber); a per-device path-scoped reverse proxy is the longer-term fix. This PR fixes the reported **cloud↔device** case.

## Test
- `podman build --target builder` compiles `iot-httpd` + `iot-cloudd` clean (114/114).

🤖 Generated with [Claude Code](https://claude.com/claude-code)