### PR TITLE
fix(cloud-ui): VPN server status + distinct Endpoints icon

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -16,7 +16,7 @@ export class MainComponent implements OnInit {
   selectedSubNav = '';
   menus = [
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg' },
-    { id: 'endpoints', label: 'Endpoints', svg: 'assets/icons/routing.svg' },
+    { id: 'endpoints', label: 'Endpoints', svg: 'assets/icons/endpoints.svg' },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg' },
     { id: 'http',      label: 'HTTP',      svg: 'assets/icons/lwm2m.svg' },
     { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg' },

--- a/apps/cloud/ui/src/app/vpn/vpn-status/vpn-status.component.ts
+++ b/apps/cloud/ui/src/app/vpn/vpn-status/vpn-status.component.ts
@@ -1,33 +1,63 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { DataStoreService } from '../../../common/datastore.service';
-import { VpnStatus } from '../../../common/app-globals';
+import { HttpsvcService } from '../../../common/httpsvc.service';
 
+/// Cloud VPN status = the OpenVPN **server** view (the cloud runs the server, not
+/// a client). The device's vpn.* client keys (assigned ip/gateway/dns/pid) never
+/// populate here, so this shows server state, listen config, and the connected
+/// clients instead — sourced from services.cloud.openvpn.server.state +
+/// cloud.vpn.* + cloud.vpn.connected (the live client list from the openvpn mgmt
+/// ROUTING TABLE).
 @Component({
   selector: 'app-vpn-status',
   template: `
     <div class="page">
-      <h3>VPN Connection Status</h3>
+      <h3>VPN Server Status</h3>
       <clr-datagrid *ngIf="!loading">
         <clr-dg-column>Property</clr-dg-column>
         <clr-dg-column>Value</clr-dg-column>
 
-        <clr-dg-row *clrDgItems="let row of rows">
-          <clr-dg-cell>
-            {{ row.key }}
-            <app-ds-hint *dsDebug [key]="row.dsKey"></app-ds-hint>
+        <clr-dg-row>
+          <clr-dg-cell>Server State
+            <app-ds-hint *dsDebug key="services.cloud.openvpn.server.state"></app-ds-hint>
+          </clr-dg-cell>
+          <clr-dg-cell><app-status-badge [label]="serverState" [state]="serverState"></app-status-badge></clr-dg-cell>
+        </clr-dg-row>
+        <clr-dg-row>
+          <clr-dg-cell>Listen
+            <app-ds-hint *dsDebug key="cloud.vpn.listen.port"></app-ds-hint>
+          </clr-dg-cell>
+          <clr-dg-cell>{{ listen }}</clr-dg-cell>
+        </clr-dg-row>
+        <clr-dg-row>
+          <clr-dg-cell>Tunnel Subnet
+            <app-ds-hint *dsDebug key="cloud.vpn.subnet"></app-ds-hint>
+          </clr-dg-cell>
+          <clr-dg-cell>{{ subnet || '—' }}</clr-dg-cell>
+        </clr-dg-row>
+        <clr-dg-row>
+          <clr-dg-cell>Cipher
+            <app-ds-hint *dsDebug key="cloud.vpn.cipher"></app-ds-hint>
+          </clr-dg-cell>
+          <clr-dg-cell>{{ cipher || '—' }}</clr-dg-cell>
+        </clr-dg-row>
+        <clr-dg-row>
+          <clr-dg-cell>TUN Device
+            <app-ds-hint *dsDebug key="cloud.vpn.dev"></app-ds-hint>
+          </clr-dg-cell>
+          <clr-dg-cell>{{ dev || '—' }}</clr-dg-cell>
+        </clr-dg-row>
+        <clr-dg-row>
+          <clr-dg-cell>Connected Clients
+            <app-ds-hint *dsDebug key="cloud.vpn.connected"></app-ds-hint>
           </clr-dg-cell>
           <clr-dg-cell>
-            <app-status-badge *ngIf="row.isBadge" [label]="row.value" [state]="v.state||''"></app-status-badge>
-            <ng-container *ngIf="row.isDns">
-              <span *ngFor="let d of dnsList" class="dns-item">{{ d }}</span>
-              <span *ngIf="!dnsList.length">—</span>
-            </ng-container>
-            <span *ngIf="!row.isBadge && !row.isDns">{{ row.value }}</span>
+            <span *ngFor="let c of clients" class="chip"><code>{{ c }}</code></span>
+            <span *ngIf="!clients.length" style="color:#888;">none</span>
           </clr-dg-cell>
         </clr-dg-row>
 
-        <clr-dg-footer>{{ rows.length }} properties</clr-dg-footer>
+        <clr-dg-footer>{{ clients.length }} client(s) connected</clr-dg-footer>
       </clr-datagrid>
       <p *ngIf="loading">Loading…</p>
     </div>
@@ -35,46 +65,63 @@ import { VpnStatus } from '../../../common/app-globals';
   styles: [`
     .page { padding: 24px; }
     h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 20px 0; }
-    .dns-item { display: inline-block; margin-right: 6px; padding: 1px 8px;
-                background: #eef2f7; border-radius: 10px; font-size: 12px; }
+    .chip { display: inline-block; margin: 2px 6px 2px 0; padding: 1px 8px;
+            background: #eef2f7; border-radius: 10px; font-size: 12px; }
   `]
 })
 export class VpnStatusComponent implements OnInit, OnDestroy {
-  v: VpnStatus = {};
+  serverState = 'unknown';
+  proto = ''; port = 0; subnet = ''; cipher = ''; dev = '';
+  clients: string[] = [];
   loading = true;
   private sub = new Subscription();
+  private active = true;
 
-  get rows(): { key: string; value: string; isBadge: boolean; isDns?: boolean; dsKey: string }[] {
-    return [
-      { key: 'State',           value: this.v.state || 'unknown', isBadge: true,  dsKey: 'vpn.state' },
-      { key: 'Assigned IP',     value: this.v.ip || '—',          isBadge: false, dsKey: 'vpn.assigned.ip' },
-      { key: 'Gateway',         value: this.v.gateway || '—',     isBadge: false, dsKey: 'vpn.assigned.gateway' },
-      { key: 'Netmask',         value: this.v.netmask || '—',     isBadge: false, dsKey: 'vpn.assigned.netmask' },
-      { key: 'DNS',             value: this.v.dns || '—',         isBadge: false, isDns: true, dsKey: 'vpn.assigned.dns' },
-      { key: 'PID',             value: String(this.v.pid || '—'), isBadge: false, dsKey: 'vpn.pid' },
-      { key: 'Exit Code',       value: this.v.exit_code != null ? String(this.v.exit_code) : '—', isBadge: false, dsKey: 'vpn.exit_code' },
-      { key: 'Gate Reason',     value: this.v.gate_reason || '—', isBadge: false, dsKey: 'vpn.gate.reason' },
-      { key: 'Bound Interface', value: this.v.bound_iface || '—', isBadge: false, dsKey: 'vpn.bound.iface' },
-    ];
+  /// "TCP :1194" — proto with the openvpn -server/-client suffix dropped.
+  get listen(): string {
+    if (!this.port) return '—';
+    const p = this.proto.replace(/-server$|-client$/, '').toUpperCase();
+    return (p ? p + ' ' : '') + ':' + this.port;
   }
 
-  /// VPN servers can push several DNS resolvers; the daemon stores them
-  /// comma/space-joined in vpn.assigned.dns. Split for per-entry display.
-  get dnsList(): string[] {
-    return (this.v.dns || '').split(/[\s,]+/).filter(Boolean);
-  }
+  constructor(private http: HttpsvcService) {}
 
-  constructor(private ds: DataStoreService) {}
+  ngOnInit(): void { this.refresh(); this.poll(); }
+  ngOnDestroy(): void { this.active = false; this.sub.unsubscribe(); }
 
-  /// Read vpn.* live off the single shared /status stream — no per-page
-  /// long-poll. The BehaviorSubject replays the latest snapshot, so this
-  /// paints instantly on revisit.
-  ngOnInit(): void {
-    this.sub.add(this.ds.observeStatus().subscribe((s) => {
-      this.v = s.vpn || {};
-      this.loading = false;
+  private refresh(): void {
+    this.sub.add(this.http.dbGet([
+      'services.cloud.openvpn.server.state', 'cloud.vpn.proto',
+      'cloud.vpn.listen.port', 'cloud.vpn.subnet', 'cloud.vpn.cipher',
+      'cloud.vpn.dev', 'cloud.vpn.connected',
+    ]).subscribe({
+      next: (r) => {
+        if (r.ok && r.data) {
+          const d = r.data as Record<string, unknown>;
+          this.serverState = String(d['services.cloud.openvpn.server.state'] || 'unknown');
+          this.proto  = String(d['cloud.vpn.proto'] || '');
+          this.port   = Number(d['cloud.vpn.listen.port']) || 0;
+          this.subnet = String(d['cloud.vpn.subnet'] || '');
+          this.cipher = String(d['cloud.vpn.cipher'] || '');
+          this.dev    = String(d['cloud.vpn.dev'] || '');
+          try {
+            const a = JSON.parse(String(d['cloud.vpn.connected'] || '[]'));
+            this.clients = Array.isArray(a) ? a : [];
+          } catch { this.clients = []; }
+        }
+        this.loading = false;
+      },
+      error: () => { this.loading = false; }
     }));
   }
 
-  ngOnDestroy(): void { this.sub.unsubscribe(); }
+  /// Live updates: long-poll the connected-client list; on each change/timeout
+  /// re-read the row data, then poll again.
+  private poll(): void {
+    if (!this.active) return;
+    this.sub.add(this.http.dbGetLongPoll('cloud.vpn.connected', 30).subscribe({
+      next: () => { this.refresh(); if (this.active) this.poll(); },
+      error: () => { if (this.active) setTimeout(() => this.poll(), 5000); }
+    }));
+  }
 }

--- a/apps/cloud/ui/src/assets/icons/endpoints.svg
+++ b/apps/cloud/ui/src/assets/icons/endpoints.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="4" y="4" width="16" height="16" rx="2" ry="2"/>
+  <rect x="9" y="9" width="6" height="6"/>
+  <line x1="9" y1="1" x2="9" y2="4"/>
+  <line x1="15" y1="1" x2="15" y2="4"/>
+  <line x1="9" y1="20" x2="9" y2="23"/>
+  <line x1="15" y1="20" x2="15" y2="23"/>
+  <line x1="20" y1="9" x2="23" y2="9"/>
+  <line x1="20" y1="14" x2="23" y2="14"/>
+  <line x1="1" y1="9" x2="4" y2="9"/>
+  <line x1="1" y1="14" x2="4" y2="14"/>
+</svg>


### PR DESCRIPTION
## VPN Status showed client fields on the cloud
The VPN Status page reused the device/**client** template, so every row read the never-populated client `vpn.*` keys → `State: unknown`, everything else `—`. The cloud runs the openvpn **server**, not a client.

Rewritten to the **server** view from the cloud's own ds keys:
- **Server State** — `services.cloud.openvpn.server.state` (badge)
- **Listen** — `cloud.vpn.proto` + `cloud.vpn.listen.port` (e.g. `TCP :1194`)
- **Tunnel Subnet** — `cloud.vpn.subnet`
- **Cipher** — `cloud.vpn.cipher`
- **TUN Device** — `cloud.vpn.dev`
- **Connected Clients** — live list from `cloud.vpn.connected` (long-polled)

## Endpoints/Routing shared an icon
Both used `assets/icons/routing.svg`. Added a device/chip `endpoints.svg` and pointed Endpoints at it.

## Test
- cloud-ui builds clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)