### PR TITLE
fix(ui): distinct sidebar icons (cloud + device) + firewall form spacing

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -18,14 +18,14 @@ export class MainComponent implements OnInit {
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg' },
     { id: 'endpoints', label: 'Endpoints', svg: 'assets/icons/endpoints.svg' },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg' },
-    { id: 'http',      label: 'HTTP',      svg: 'assets/icons/lwm2m.svg' },
+    { id: 'http',      label: 'HTTP',      svg: 'assets/icons/http.svg' },
     { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg' },
     { id: 'routing',   label: 'Routing',   svg: 'assets/icons/routing.svg' },
     { id: 'lwm2m',     label: 'LwM2M',     svg: 'assets/icons/lwm2m.svg' },
     { id: 'services',  label: 'Services',  svg: 'assets/icons/services.svg' },
     { id: 'logs',      label: 'Logs',      svg: 'assets/icons/logs.svg' },
-    { id: 'users',     label: 'Users',     svg: 'assets/icons/services.svg' },
-    { id: 'software',  label: 'Software',  svg: 'assets/icons/services.svg' },
+    { id: 'users',     label: 'Users',     svg: 'assets/icons/users.svg' },
+    { id: 'software',  label: 'Software',  svg: 'assets/icons/software.svg' },
   ];
 
   get isAdmin(): boolean { return this.session.isAdmin; }

--- a/apps/cloud/ui/src/assets/icons/http.svg
+++ b/apps/cloud/ui/src/assets/icons/http.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="2" width="20" height="8" rx="2" ry="2"/>
+  <rect x="2" y="14" width="20" height="8" rx="2" ry="2"/>
+  <line x1="6" y1="6" x2="6.01" y2="6"/>
+  <line x1="6" y1="18" x2="6.01" y2="18"/>
+</svg>

--- a/apps/cloud/ui/src/assets/icons/software.svg
+++ b/apps/cloud/ui/src/assets/icons/software.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="8 17 12 21 16 17"/>
+  <line x1="12" y1="12" x2="12" y2="21"/>
+  <path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/>
+</svg>

--- a/apps/cloud/ui/src/assets/icons/users.svg
+++ b/apps/cloud/ui/src/assets/icons/users.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+  <circle cx="9" cy="7" r="4"/>
+  <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+</svg>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -28,7 +28,7 @@ export class MainComponent {
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg', children: [] as {id:string,label:string}[] },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg',
       children: [{id:'config',label:'Configuration'},{id:'status',label:'Status'}] },
-    { id: 'http',      label: 'HTTP',      svg: 'assets/icons/lwm2m.svg', children: [] as {id:string,label:string}[] },
+    { id: 'http',      label: 'HTTP',      svg: 'assets/icons/http.svg', children: [] as {id:string,label:string}[] },
     { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg',
       children: [{id:'wifi',label:'WiFi Config'},{id:'scan',label:'Scan Results'},{id:'priority',label:'Priority'}] },
     { id: 'routing',   label: 'Routing',   svg: 'assets/icons/routing.svg',
@@ -38,8 +38,8 @@ export class MainComponent {
     { id: 'services',  label: 'Services',  svg: 'assets/icons/services.svg',
       children: [{id:'list',label:'All Services'}] },
     { id: 'logs',      label: 'Logs',      svg: 'assets/icons/logs.svg', children: [] as {id:string,label:string}[] },
-    { id: 'users',     label: 'Users',     svg: 'assets/icons/services.svg', children: [] as {id:string,label:string}[] },
-    { id: 'software',  label: 'Software',  svg: 'assets/icons/services.svg', children: [] as {id:string,label:string}[] },
+    { id: 'users',     label: 'Users',     svg: 'assets/icons/users.svg', children: [] as {id:string,label:string}[] },
+    { id: 'software',  label: 'Software',  svg: 'assets/icons/software.svg', children: [] as {id:string,label:string}[] },
   ];
 
   expandedMenu: string | null = null;  // which menu is expanded in sidebar

--- a/iot-ui/src/app/routing/custom-rules/custom-rules.component.ts
+++ b/iot-ui/src/app/routing/custom-rules/custom-rules.component.ts
@@ -68,7 +68,7 @@ interface CustomRule {
             <!-- ds-key hint (debug mode) -->
             <clr-control-helper *dsDebug><app-ds-hint key="net.custom.rules"></app-ds-hint></clr-control-helper>
           </div>
-          <button class="btn btn-primary" (click)="addRule()" [disabled]="saving">
+          <button class="btn btn-primary add-rule-btn" (click)="addRule()" [disabled]="saving">
             {{ saving ? 'Saving…' : 'Add Rule' }}
           </button>
         </div>
@@ -109,6 +109,8 @@ interface CustomRule {
     h4 { color: #555; margin: 18px 0 10px 0; font-size: 13px; font-weight: 600; }
     .hint { color: #888; font-weight: normal; font-size: 11px; }
     .bad { color: #c62828; font-size: 12px; margin: 0 0 12px 0; }
+    /* Separate the action button from the form row above it. */
+    .add-rule-btn { margin-top: 20px; }
   `]
 })
 export class CustomRulesComponent implements OnInit {

--- a/iot-ui/src/assets/icons/http.svg
+++ b/iot-ui/src/assets/icons/http.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <rect x="2" y="2" width="20" height="8" rx="2" ry="2"/>
+  <rect x="2" y="14" width="20" height="8" rx="2" ry="2"/>
+  <line x1="6" y1="6" x2="6.01" y2="6"/>
+  <line x1="6" y1="18" x2="6.01" y2="18"/>
+</svg>

--- a/iot-ui/src/assets/icons/software.svg
+++ b/iot-ui/src/assets/icons/software.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <polyline points="8 17 12 21 16 17"/>
+  <line x1="12" y1="12" x2="12" y2="21"/>
+  <path d="M20.88 18.09A5 5 0 0 0 18 9h-1.26A8 8 0 1 0 3 16.29"/>
+</svg>

--- a/iot-ui/src/assets/icons/users.svg
+++ b/iot-ui/src/assets/icons/users.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M17 21v-2a4 4 0 0 0-4-4H5a4 4 0 0 0-4 4v2"/>
+  <circle cx="9" cy="7" r="4"/>
+  <path d="M23 21v-2a4 4 0 0 0-3-3.87"/>
+  <path d="M16 3.13a4 4 0 0 1 0 7.75"/>
+</svg>


### PR DESCRIPTION
## Duplicate sidebar icons
Both UIs reused one SVG for several nav entries:
- **cloud-ui:** HTTP shared `lwm2m.svg`; Users + Software shared `services.svg`.
- **device-ui:** same (HTTP=`lwm2m.svg`; Users+Software=`services.svg`).

Added distinct Feather-style icons to both UIs — `http.svg` (server), `users.svg` (people), `software.svg` (download-cloud) — and pointed HTTP / Users / Software at them. LwM2M and Services keep their own. (Endpoints got `endpoints.svg` in #187.) Every sidebar entry is now unique.

## Firewall form spacing (device-ui)
The "Add Firewall Rule" card had the **Add Rule** button flush against the form inputs. Added `margin-top` for vertical separation.

## Test
- cloud-ui + device-ui build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)