### PR TITLE
fix(device): populate VPN gateway/netmask/DNS from the openvpn log PUSH_REPLY

### DIFF
--- a/modules/openvpn/client/src/lifecycle.cpp
+++ b/modules/openvpn/client/src/lifecycle.cpp
@@ -37,6 +37,18 @@ std::string join_csv(const std::vector<std::string>& v) {
     return out;
 }
 
+/// Split `s` on commas (PUSH_REPLY option list from a log line).
+std::vector<std::string> comma_split(const std::string& s) {
+    std::vector<std::string> out;
+    std::string cur;
+    for (char c : s) {
+        if (c == ',') { out.push_back(cur); cur.clear(); }
+        else          { cur.push_back(c); }
+    }
+    out.push_back(cur);
+    return out;
+}
+
 } // namespace
 
 std::string Lifecycle::normalise_state(const std::string& s) {
@@ -71,45 +83,67 @@ void Lifecycle::step(const mgmt::Event& ev) {
         return;
     }
 
+    // A real >PUSH_REPLY: mgmt notification (kept for completeness — most
+    // openvpn builds don't emit it; the >LOG path below is what fires live).
     if (ev.kind == K::PushReply) {
-        // Each field is "name [value...]"; dispatch each known one.
-        std::vector<std::string> dns;
-        for (const auto& opt : ev.fields) {
-            auto [name, val] = mgmt::split_push_option(opt);
-            if (name == "ifconfig") {
-                // "10.8.0.6 255.255.255.0" → ip + netmask
-                auto toks = ws_split(val);
-                if (toks.size() >= 1 && m_sinks.set_assigned_ip) {
-                    m_sinks.set_assigned_ip(toks[0]);
-                }
-                if (toks.size() >= 2 && m_sinks.set_assigned_netmask) {
-                    m_sinks.set_assigned_netmask(toks[1]);
-                }
-            } else if (name == "route-gateway") {
-                if (m_sinks.set_assigned_gateway) {
-                    m_sinks.set_assigned_gateway(val);
-                }
-            } else if (name == "dhcp-option") {
-                // "DNS 1.1.1.1" — strip the "DNS " prefix, collect.
-                auto toks = ws_split(val);
-                if (toks.size() >= 2 && toks[0] == "DNS") {
-                    dns.push_back(toks[1]);
-                }
-            }
-        }
-        if (!dns.empty() && m_sinks.set_assigned_dns) {
-            m_sinks.set_assigned_dns(join_csv(dns));
-        }
-        if (!m_saw_push_reply) {
-            m_saw_push_reply = true;
-            if (m_sinks.on_first_push_reply) m_sinks.on_first_push_reply();
+        apply_push_options(ev.fields);
+        return;
+    }
+
+    // openvpn surfaces the pushed config in its log, not a PUSH_REPLY mgmt
+    // event: ">LOG:<time>,<flags>,PUSH: Received control message:
+    // 'PUSH_REPLY,route-gateway 10.9.0.1,...,ifconfig 10.9.0.2 255.255.255.0,
+    // dhcp-option DNS 1.1.1.1,...'". Parse it so gateway/netmask/DNS populate
+    // (the assigned IP also comes via the CONNECTED state line above). Requires
+    // the supervisor to have sent `log on`.
+    if (ev.kind == K::Log) {
+        auto pos = ev.raw.find("PUSH_REPLY,");
+        if (pos != std::string::npos) {
+            std::string sub = ev.raw.substr(pos + 11);  // after "PUSH_REPLY,"
+            auto q = sub.find('\'');   // closing quote of the log message
+            if (q != std::string::npos) sub = sub.substr(0, q);
+            apply_push_options(comma_split(sub));
         }
         return;
     }
 
-    // Other event kinds (Banner, Hold, Log, ByteCount, Fatal, ...)
-    // are observed but not acted on by v1. The reactor wrapper logs
-    // them via ACE_DEBUG.
+    // Other event kinds (Banner, Hold, ByteCount, Fatal, ...) are observed but
+    // not acted on by v1. The reactor wrapper logs them via ACE_DEBUG.
+}
+
+void Lifecycle::apply_push_options(const std::vector<std::string>& opts) {
+    // Each option is "name [value...]"; dispatch the known ones.
+    std::vector<std::string> dns;
+    for (const auto& opt : opts) {
+        auto [name, val] = mgmt::split_push_option(opt);
+        if (name == "ifconfig") {
+            // "10.9.0.2 255.255.255.0" → ip + netmask (topology subnet).
+            auto toks = ws_split(val);
+            if (toks.size() >= 1 && m_sinks.set_assigned_ip) {
+                m_sinks.set_assigned_ip(toks[0]);
+            }
+            if (toks.size() >= 2 && m_sinks.set_assigned_netmask) {
+                m_sinks.set_assigned_netmask(toks[1]);
+            }
+        } else if (name == "route-gateway") {
+            if (m_sinks.set_assigned_gateway) {
+                m_sinks.set_assigned_gateway(val);
+            }
+        } else if (name == "dhcp-option") {
+            // "DNS 1.1.1.1" — strip the "DNS " prefix, collect.
+            auto toks = ws_split(val);
+            if (toks.size() >= 2 && toks[0] == "DNS") {
+                dns.push_back(toks[1]);
+            }
+        }
+    }
+    if (!dns.empty() && m_sinks.set_assigned_dns) {
+        m_sinks.set_assigned_dns(join_csv(dns));
+    }
+    if (!m_saw_push_reply) {
+        m_saw_push_reply = true;
+        if (m_sinks.on_first_push_reply) m_sinks.on_first_push_reply();
+    }
 }
 
 } // namespace openvpn_client

--- a/modules/openvpn/client/src/lifecycle.hpp
+++ b/modules/openvpn/client/src/lifecycle.hpp
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <vector>
 
 #include "mgmt_protocol.hpp"
 
@@ -44,9 +45,12 @@ private:
     /// pass through verbatim.
     static std::string normalise_state(const std::string& openvpn_state);
 
-    /// Parse a PUSH_REPLY option into name/value, then dispatch
-    /// known options (ifconfig / route-gateway / dhcp-option DNS).
-    void apply_push_option(const std::string& option);
+    /// Apply a list of PUSH_REPLY options (each "name value..."), dispatching
+    /// the known ones (ifconfig → ip+netmask, route-gateway, dhcp-option DNS) to
+    /// the sinks. Shared by the >PUSH_REPLY event path and the >LOG "PUSH:
+    /// Received control message: 'PUSH_REPLY,...'" path (real openvpn surfaces
+    /// the pushed config via the log, not a PUSH_REPLY mgmt notification).
+    void apply_push_options(const std::vector<std::string>& opts);
 };
 
 } // namespace openvpn_client

--- a/modules/openvpn/client/src/supervisor.cpp
+++ b/modules/openvpn/client/src/supervisor.cpp
@@ -210,6 +210,19 @@ bool Supervisor::serve_one_session(const std::string& iface) {
                                 "connecting\n"),
                        errno));
         }
+        // Subscribe to the log too: the pushed config (route-gateway, ifconfig
+        // ip+netmask, dhcp-option DNS) is NOT delivered as a >PUSH_REPLY mgmt
+        // event — it only appears in openvpn's log ("PUSH: Received control
+        // message: 'PUSH_REPLY,...'"). Without `log on`, vpn.assigned.gateway/
+        // netmask/dns never populate (only the IP, from the CONNECTED state).
+        static const char kLogOn[] = "log on\r\n";
+        if (stream.send_n(kLogOn, sizeof(kLogOn) - 1) < 0) {
+            ACE_ERROR((LM_WARNING,
+                       ACE_TEXT("%D [ovpn:%t] %M %N:%l mgmt 'log on' send failed "
+                                "errno=%d; vpn.assigned.gateway/netmask/dns may "
+                                "stay empty\n"),
+                       errno));
+        }
         // openvpn was spawned with `management-hold`, so it is paused until we
         // release it. Now that real-time state notifications are enabled, let
         // it connect — the CONNECTED state + PUSH_REPLY (assigned

--- a/modules/openvpn/client/test/lifecycle_test.cpp
+++ b/modules/openvpn/client/test/lifecycle_test.cpp
@@ -79,6 +79,33 @@ TEST(Lifecycle, PushReplyFillsIfconfigGatewayAndDns) {
     EXPECT_TRUE(s.first_push_seen);
 }
 
+TEST(Lifecycle, LogPushReplyFillsIfconfigGatewayAndDns) {
+    // Real openvpn delivers the pushed config via the LOG, not a >PUSH_REPLY
+    // mgmt event: ">LOG:<time>,<flags>,PUSH: Received control message:
+    // 'PUSH_REPLY,...'". The lifecycle must parse it (requires `log on`).
+    Spy s;
+    Lifecycle l(sinks_for(s));
+    Parser p; p.feed(">LOG:1718,I,PUSH: Received control message: "
+                     "'PUSH_REPLY,route-gateway 10.9.0.1,topology subnet,"
+                     "ifconfig 10.9.0.2 255.255.255.0,dhcp-option DNS 1.1.1.1,"
+                     "peer-id 0'\n");
+    while (auto ev = p.next()) l.step(*ev);
+    EXPECT_EQ("10.9.0.2",      s.ip);
+    EXPECT_EQ("255.255.255.0", s.netmask);
+    EXPECT_EQ("10.9.0.1",      s.gateway);
+    EXPECT_EQ("1.1.1.1",       s.dns);
+    EXPECT_TRUE(s.first_push_seen);
+}
+
+TEST(Lifecycle, LogWithoutPushReplyIgnored) {
+    Spy s;
+    Lifecycle l(sinks_for(s));
+    Parser p; p.feed(">LOG:1718,I,OpenVPN 2.6 starting\n");
+    while (auto ev = p.next()) l.step(*ev);
+    EXPECT_EQ("", s.gateway);
+    EXPECT_FALSE(s.first_push_seen);
+}
+
 TEST(Lifecycle, PushReplyJoinsMultipleDnsCommaSeparated) {
     Spy s;
     Lifecycle l(sinks_for(s));


### PR DESCRIPTION
## Problem
Device VPN status showed **Assigned IP** (`10.9.0.2`) but **Gateway / Netmask / DNS = "—"**.

The client's `Lifecycle` only parsed a `>PUSH_REPLY:` management event — which **real openvpn does not emit**. The assigned IP came solely from the `>STATE:CONNECTED` line (field 4); the pushed config (`route-gateway`, `ifconfig ip+netmask`, `dhcp-option DNS`) was never seen. The cloud server already pushes all of it (`topology subnet` auto-pushes route-gateway + ifconfig; `push "dhcp-option DNS"`) — it just arrives in openvpn's **log**, not a mgmt notification.

## Fix
- **supervisor:** send `log on` alongside `state on`, so the client receives `>LOG:...,PUSH: Received control message: 'PUSH_REPLY,...'`.
- **lifecycle:** parse `PUSH_REPLY` out of `>LOG` events and apply the options; factored the dispatch into `apply_push_options()`, shared with the (kept) `>PUSH_REPLY` path. `vpn.assigned.gateway/netmask/dns` now populate.
- **tests:** `LogPushReplyFillsIfconfigGatewayAndDns` + `LogWithoutPushReplyIgnored`.

## Test
- openvpn-client compiles; existing PushReply lifecycle tests unchanged + 2 new LOG tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)