### PR TITLE
chore(yocto): align .ipk PV to /VERSION + overridable build branch

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -16,8 +16,12 @@ SECTION = "net"
 # fetch it from nlohmann/json. git:// fetches the committed files directly:
 #   apps/3rdparty/json/single_include  → nlohmann/json (used by the build)
 #   tinydtls headers + .a come from the separate tinydtls recipe (sysroot).
+# Branch/ref to build. Defaults to `main` (rolling dev image). For a frozen
+# release image, override (here on a release branch, or in local.conf):
+#   IOT_BRANCH = "release/v1.1.0"
+IOT_BRANCH ?= "main"
 SRC_URI = "\
-    git://github.com/naushada/iot.git;protocol=https;branch=main \
+    git://github.com/naushada/iot.git;protocol=https;branch=${IOT_BRANCH} \
     file://0001-cmake-use-yocto-sysroot-paths.patch \
     file://iot-ds.service \
     file://iot-lwm2m-client.service \
@@ -44,6 +48,13 @@ SRC_URI = "\
     file://migrations/0000-template.sh.example \
 "
 SRCREV = "${AUTOREV}"
+
+# Package version. Keep the leading semver in sync with the repo-root /VERSION
+# file (the single source of truth that iot-httpd also bakes into iot.version).
+# PV can't read the fetched VERSION at parse time (source isn't unpacked yet),
+# so it's set here manually. The +git${SRCPV} suffix gives opkg per-commit
+# upgrade ordering (AUTOINC+sha) for the _git recipe.
+PV = "1.1.0+git${SRCPV}"
 
 S = "${WORKDIR}/git"
 B = "${WORKDIR}/build"


### PR DESCRIPTION
Follow-up to the `iot.version` work — how the Yocto build picks up the version, and how to build a frozen release.

- **PV aligned to `/VERSION`:** `PV = "1.1.0+git${SRCPV}"` — leading semver kept in sync with the repo-root `VERSION` file (the same source `iot-httpd` bakes into `iot.version`). PV can't read the fetched file at parse time, so it's set manually; `+git${SRCPV}` preserves opkg per-commit upgrade ordering for the `_git` recipe.
- **Overridable branch:** `IOT_BRANCH ?= "main"` + `branch=${IOT_BRANCH}`. Default builds rolling `main` (dev). For a frozen release image, override with `IOT_BRANCH = "release/v1.1.0"` (set on the release branch's recipe, or in `local.conf`).

Recipe-only; no image-build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)