### PR TITLE
fix(ci): retry ldconfig to survive qemu-arm64 segfault

### DIFF
--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -136,7 +136,10 @@ RUN groupadd --system cloud-svc && \
 
 # ACE shared libraries
 COPY --from=builder /usr/local/ACE_TAO-7.0.0/lib/libACE.so* /usr/local/lib/
-RUN ldconfig
+# ldconfig under qemu-user (multi-arch arm64 emulation in CI) intermittently
+# segfaults (signal 11). Retry a few times so a flaky emulated run doesn't fail
+# the build; on real hardware the first call succeeds.
+RUN ldconfig || ldconfig || ldconfig
 
 # Binaries
 COPY --from=builder /tmp/bds/ds-server /usr/local/bin/

--- a/apps/device/Dockerfile
+++ b/apps/device/Dockerfile
@@ -145,7 +145,10 @@ RUN groupadd --system iot && \
 
 # ACE 7.0.0 shared library.
 COPY --from=builder /usr/local/ACE_TAO-7.0.0/lib/libACE.so* /usr/local/lib/
-RUN ldconfig
+# ldconfig under qemu-user (multi-arch arm64 emulation in CI) intermittently
+# segfaults (signal 11). Retry a few times so a flaky emulated run doesn't fail
+# the build; on real hardware the first call succeeds.
+RUN ldconfig || ldconfig || ldconfig
 
 # Binaries.
 COPY --from=builder /staging/usr/bin/ds-server      /usr/local/bin/


### PR DESCRIPTION
## Failure
cloud-image #190 (and #187) failed on:
```
#75 [linux/arm64 runtime] RUN ldconfig
qemu: uncaught target signal 11 (Segmentation fault) - core dumped
ERROR: process "/bin/sh -c ldconfig" did not complete successfully: exit code: 139
```
The C++ build completed `115/115` (incl. the new `iot.version` bake) — this is a **qemu-user emulation flake** of `ldconfig` during the emulated arm64 runtime stage, not a source issue. It passed on #186/#188/#189 and flaked on #187/#190.

## Fix
`RUN ldconfig || ldconfig || ldconfig` in both the cloud and device runtime stages — a flaky emulated run retries instead of failing the build; on real hardware the first call succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)