### PR TITLE
fix(ui): version line icon (cloud + device sidebar)

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -16,7 +16,9 @@
       <img src="assets/icons/debug.svg" class="nav-icon" alt="" /><span>{{debug.on ? 'Debug Off' : 'Debug'}}</span>
     </a>
     <a class="nav-item nav-logout" (click)="onLogout()"><img src="assets/icons/logout.svg" class="nav-icon" alt="" /><span>Sign out</span></a>
-    <div class="nav-version" *ngIf="version" title="Running release">v{{ version }}</div>
+    <div class="nav-version" *ngIf="version" title="Running release">
+      <img src="assets/icons/version.svg" class="nav-icon" alt="" /><span>v{{ version }}</span>
+    </div>
   </nav>
   <div class="main-area">
     <div class="live-strip">

--- a/apps/cloud/ui/src/app/main/main.component.scss
+++ b/apps/cloud/ui/src/app/main/main.component.scss
@@ -12,7 +12,8 @@
 .sidebar-spacer { flex:1; }
 .nav-logout { border-top:1px solid #e0e0e0; margin-top:4px; color:#888; }
 .nav-logout:hover { color:#c62828; background:rgba(198,40,40,0.05); }
-.nav-version { padding:6px 16px 10px; font-size:11px; color:#9a9a9a; }
+.nav-version { display:flex; align-items:center; gap:12px; padding:8px 16px 12px; font-size:11px; color:#9a9a9a; }
+.nav-version .nav-icon { opacity:0.5; }
 .main-area { flex:1; display:flex; flex-direction:column; overflow:hidden; }
 .live-strip { display:flex; align-items:center; padding:0 16px; height:42px; background:#fff; border-bottom:1px solid #e0e0e0; font-size:12px; flex-shrink:0; }
 .live-tag { display:flex; align-items:center; gap:5px; }

--- a/apps/cloud/ui/src/assets/icons/version.svg
+++ b/apps/cloud/ui/src/assets/icons/version.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
+  <line x1="7" y1="7" x2="7.01" y2="7"/>
+</svg>

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -50,7 +50,9 @@
       <img src="assets/icons/logout.svg" class="nav-icon" alt="" />
       <span>Sign out</span>
     </a>
-    <div class="nav-version" *ngIf="version" title="Running release">v{{ version }}</div>
+    <div class="nav-version" *ngIf="version" title="Running release">
+      <img src="assets/icons/version.svg" class="nav-icon" alt="" /><span>v{{ version }}</span>
+    </div>
   </nav>
 
   <!-- ── Main area ──────────────────────────────────────────────── -->

--- a/iot-ui/src/app/main/main.component.scss
+++ b/iot-ui/src/app/main/main.component.scss
@@ -141,7 +141,11 @@
   color: #888;
   &:hover { color: #c62828; background: rgba(198,40,40,0.05); }
 }
-.nav-version { padding: 6px 16px 10px; font-size: 11px; color: #9a9a9a; }
+.nav-version {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 16px 12px; font-size: 11px; color: #9a9a9a;
+  .nav-icon { opacity: 0.5; }
+}
 
 // ── Main area ─────────────────────────────────────────────────────
 

--- a/iot-ui/src/assets/icons/version.svg
+++ b/iot-ui/src/assets/icons/version.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M20.59 13.41l-7.17 7.17a2 2 0 0 1-2.83 0L2 12V2h10l8.59 8.59a2 2 0 0 1 0 2.82z"/>
+  <line x1="7" y1="7" x2="7.01" y2="7"/>
+</svg>


### PR DESCRIPTION
The sidebar version footer (`v1.1.0`) had no icon while every other row does. Added a `version.svg` (tag) rendered with the shared `.nav-icon`, aligned with Dark/Debug/Sign out. Both UIs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)