### PR TITLE
fix(cloud-ui): Launch UI back to port-based DNAT (path proxy blocked on netns)

### DIFF
--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -77,14 +77,15 @@ interface EpCred {
           <clr-dg-cell><code>{{ e.dev_tun_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
           <clr-dg-cell>
-            <!-- Launch UI only when the device's VPN tunnel is actually up
-                 (dev_tun_ip present). Same-origin path-scoped reverse proxy:
-                 the cloud httpd proxies /dev/<ep>/ over the tun to the device UI
-                 (one TLS origin, per-device cookie isolation, no published port).
-                 See apps/docs/tdd-device-ui-path-proxy.md. -->
+            <!-- Launch UI only when the device's VPN tunnel is up (dev_tun_ip).
+                 Port-based: iot-cloudd publishes <proxy_port> and DNATs it to
+                 dev_tun_ip:<ui_port> over tun0 (all in the cloudd netns that owns
+                 the tun). The path-scoped /dev/<ep>/ proxy is the intended future
+                 path but needs iot-httpd to share the tun netns first — see
+                 apps/docs/tdd-device-ui-path-proxy.md §"netns". -->
             <a class="btn btn-sm" target="_blank" rel="noopener"
-               [href]="launchUrl(e.endpoint)"
-               *ngIf="e.registered && e.dev_tun_ip">
+               [href]="'http://' + windowHost + ':' + e.proxy_port + '/'"
+               *ngIf="e.registered && e.proxy_port && e.dev_tun_ip">
               Launch UI <clr-icon shape="pop-out" size="12"></clr-icon>
             </a>
             <span *ngIf="!e.registered" class="hint">offline</span>
@@ -156,11 +157,6 @@ export class EndpointListComponent implements OnInit, OnDestroy {
   private sub = new Subscription(); private active = true;
 
   get isAdmin(): boolean { return this.session.isAdmin; }
-
-  /** Same-origin path-scoped device-UI URL (reverse-proxied by the cloud httpd
-   *  over the VPN tun). The endpoint is URL-encoded so urn:dev:* names are
-   *  path-safe. See apps/docs/tdd-device-ui-path-proxy.md. */
-  launchUrl(ep: string): string { return '/dev/' + encodeURIComponent(ep) + '/'; }
 
   constructor(private http: HttpsvcService, private session: SessionService, private toast: ToastService) {}
 

--- a/apps/docs/tdd-device-ui-path-proxy.md
+++ b/apps/docs/tdd-device-ui-path-proxy.md
@@ -1,7 +1,35 @@
 # TDD — Per-device path-scoped reverse proxy for the device UI
 
-Status: **DESIGN (for review)** · Target: cloud (`iot-httpd`) + device UI (`iot-ui`)
-· Author: 2026-06-14
+Status: **PARTIAL — blocked on netns (see §netns)** · Target: cloud (`iot-httpd`)
++ device UI (`iot-ui`) · Author: 2026-06-14
+
+## ⚠️ §netns — the proxy can't reach the tun from the httpd container (BLOCKER)
+
+Shipped in #186, but **disabled in the cloud** as of the Launch-UI revert: the
+proxy runs inside `iot-httpd`, but in the cloud's multi-container topology the
+OpenVPN `tun0` (10.9.0.1) lives **only in the `iot-cloudd` container**.
+`iot-httpd` is a separate container on the docker bridge with **no tun and no
+route to 10.9.0.0/24**, so the proxy's `ACE_SOCK_Connector` to `dev_tun_ip:8080`
+fails → **504**. (The old port-based Launch UI works because the DNAT + the
+published `proxy_port` are in `iot-cloudd`, which owns the tun.)
+
+**Fix options (pick before re-enabling `/dev/<ep>/` Launch UI):**
+1. **Share the netns** — `iot-httpd` joins `iot-cloudd`'s network namespace
+   (`network_mode: "service:iot-cloudd"` in `apps/cloud/docker-compose.yml`),
+   mirroring the device stack's httpd↔openvpn-client sharing (#175). Then httpd
+   sees `tun0` and reaches `10.9.0.x`. Requires moving httpd's published `443`
+   (and `80`) onto `iot-cloudd` (the netns owner). **Recommended.**
+2. Route `10.9.0.0/24` from the httpd container via `iot-cloudd` (bridge IP) with
+   `iot-cloudd` forwarding — more moving parts.
+3. Move the proxy into `iot-cloudd` (would need an HTTP listener there).
+
+Until one of these lands, **Launch UI uses the port-based DNAT** (works today;
+cookie collision already solved by the per-instance cookie name in #183). The
+device↔device cookie isolation that this proxy adds is therefore still pending.
+
+---
+
+(original design follows)
 
 ## 1. Goal
 


### PR DESCRIPTION
## Bug
"Launch UI launches the Cloud UI instead of the Device UI."

## Root cause (architectural)
The path-scoped `/dev/<ep>/` proxy (#186) runs inside **iot-httpd**, but the OpenVPN **`tun0` (10.9.0.1) lives only in the `iot-cloudd` container**. `iot-httpd` is a separate bridge container with **no tun and no route to `10.9.0.0/24`**, so:
- with a cloud cookie → proxy `connect(dev_tun_ip:8080)` fails → **504**;
- without a cookie → proxy auth gate **302 → `/webui/`** → the **Cloud UI** (what was observed).

Verified on the live cloud: `tun0` only in `iot-cloudd`; `iot-httpd` has no tun.

## Fix (now)
Revert Launch UI to the **port-based** link `http://<host>:<proxy_port>/`. `iot-cloudd` publishes `proxy_port` and DNATs it to `dev_tun_ip:<ui_port>` over `tun0` — all in the netns that owns the tun, so it works. The cookie collision that motivated the proxy is already solved by the per-instance cookie name (#183), so port-based is clean.

## Follow-up (to re-enable the proxy)
`iot-httpd` must share `iot-cloudd`'s netns (`network_mode: service:iot-cloudd`, moving `443`/`80` onto cloudd) — documented as **§netns** in `apps/docs/tdd-device-ui-path-proxy.md`. Path-proxy code stays in the tree, just not wired to Launch UI until then.

🤖 Generated with [Claude Code](https://claude.com/claude-code)