### PR TITLE
feat(ota): device-ui drag-and-drop .ipk (Phase 1) + A/B image-OTA design (Phase 2)

### DIFF
--- a/apps/docs/tdd-ab-image-ota.md
+++ b/apps/docs/tdd-ab-image-ota.md
@@ -1,0 +1,136 @@
+# TDD — Phase-2 A/B (dual-bank) image OTA with rollback
+
+Status: **DESIGN (for review)** · Target: Yocto/RPi · Author: 2026-06-14
+
+## 1. Why (what Phase 1 can't do)
+
+Phase-1 OTA (`apps/docs/tdd-yocto-swupdate.md`) installs **`.ipk` packages with
+`opkg`, in place, on a single rootfs**. That means:
+
+- **No atomicity** — a power loss mid-`opkg install` can leave a half-written,
+  inconsistent rootfs (partial files + a corrupt package DB).
+- **No rollback** — there is no previous image to fall back to; on reboot the
+  device boots the *same* (possibly broken) rootfs.
+- **No full-image / kernel+rootfs swap** — only userspace package updates.
+
+Phase 2 adds **A/B (dual-bank) image OTA**: write a full image to the *inactive*
+bank, atomically switch the bootloader to it, health-check on first boot, and
+**auto-revert to the previous bank if the new one fails**. This is the
+power-fail-safe, rollback-capable path — and the home for the operator's
+"full bundle" drag-and-drop.
+
+Phase 1 (opkg) and Phase 2 (image) **coexist**: opkg for quick userspace tweaks;
+A/B image for kernel/rootfs/coordinated releases.
+
+## 2. Layout (Raspberry Pi 3B reference)
+
+Dual rootfs banks + shared persistent data, selected by the bootloader:
+
+```
+mmcblk0p1  boot   (FAT) — bootloader + per-bank kernel/dtb, boot-select env
+mmcblk0p2  rootA  (ext4, ro) — bank A rootfs
+mmcblk0p3  rootB  (ext4, ro) — bank B rootfs
+mmcblk0p4  data   (ext4, rw) — /var/lib/iot (ds store), /etc/iot overrides, certs
+```
+
+- Only the **inactive** bank is written during an update; the running bank is
+  never touched → atomic + power-fail-safe (an interrupted write just leaves the
+  inactive bank invalid; the active bank still boots).
+- **Persistent data is a separate partition** so an image swap never loses ds
+  state / credentials / the `iot.config.version` migration marker. The §11
+  config-migration step (Phase-1 doc) still runs after a bank switch when the
+  schema generation changed.
+
+## 3. Update agent — decision needed
+
+| Option | Pros | Cons |
+|--------|------|------|
+| **RAUC** (recommended) | Purpose-built A/B, strong Yocto layer (`meta-rauc`, `meta-rauc-community` RPi), bundle signing (X.509), simple `rauc install <bundle>.raucb`, bootloader-agnostic (u-boot/grub/barebox) | adds u-boot (RPi default uses its own loader) |
+| **Mender** | Full fleet mgmt + server | heavier; server-centric; we already have our own cloud plane |
+| **SWUpdate** (the real one) | Flexible, A/B via `sw-description` | more wiring; overlaps RAUC |
+
+**Recommendation: RAUC.** It's the least-glue A/B engine, signs bundles, and has
+maintained RPi Yocto integration. The "full bundle" = a **`.raucb`** (signed
+squashfs of the rootfs image + manifest). Open decision in §8.
+
+## 4. Boot-select + rollback flow
+
+1. Bootloader reads a small **boot-select env** (u-boot `bootcount` + `BOOT_ORDER`
+   / RAUC's `rauc-grub`/`rauc-uboot` integration): try bank X, increment a
+   per-bank `tries` counter.
+2. If `tries` exceeds the limit (boot looped / never confirmed) → bootloader
+   **switches to the other bank** automatically (rollback).
+3. After a successful boot, a **health check** (systemd
+   `iot-ota-confirm.service`: ds reachable + iot-httpd up + lwm2m registered
+   within N min) marks the bank **good** (`rauc status mark-good`), resetting the
+   try counter. Until confirmed, a reboot reverts.
+
+So a bad/incomplete image **never sticks**: either the write was interrupted
+(inactive bank invalid → active bank keeps running) or the new bank boots badly
+(health check fails → next boot rolls back).
+
+## 5. Bundle delivery (URL + drag-and-drop)
+
+Mirrors Phase-1's two sources, but the artifact is a `.raucb` and the installer
+is `rauc`, not `opkg`:
+
+- **Cloud push** — `iot.update.request` carries a `.raucb` URL; a Phase-2 stager
+  variant pulls + verifies signature, then `rauc install`.
+- **Drag-and-drop (device-ui)** — the operator drops a `.raucb`. Because a full
+  bundle is **tens–hundreds of MB**, this needs a **streaming upload** (the
+  Phase-1 raw-body endpoint buffers in memory, capped at 8 MiB — unsuitable):
+  - `POST /api/v1/update/upload` streams the body **to disk** on the data
+    partition (chunked write, no full-buffer), reporting progress.
+  - Then `rauc install <file>.raucb` (signature-verified) writes the inactive
+    bank; reboot into it; health-check confirms or rolls back.
+
+Streaming upload is a prerequisite and is **out of scope for Phase 1** (which
+keeps the 8 MiB in-memory cap for `.ipk`).
+
+## 6. State / UI
+
+Reuse the OTA ds keys, extended:
+- `iot.update.state`: add `4 writing-bank`, `5 awaiting-confirm`.
+- `iot.update.result`: add `2 rolled-back`.
+- `iot.boot.bank` (A/B), `iot.boot.confirmed` (bool) for the UI to show which
+  bank is running and whether it's confirmed.
+- device-ui: the same software-update page shows bank + confirm status, and the
+  drag-zone accepts `.ipk` (Phase 1, opkg) **or** `.raucb` (Phase 2, A/B) — it
+  routes by extension.
+
+## 7. Yocto work (sketch)
+
+- Add `meta-rauc` (+ RPi community layer); switch RPi to u-boot (or use the
+  RAUC RPi boot integration).
+- `wic` image with the 4-partition layout (2 rootfs banks + boot + data).
+- A RAUC system.conf (slots A/B), bundle signing keys (CI signs `.raucb`).
+- `iot-ota-confirm.service` health-check (mark-good).
+- A Phase-2 stager/installer (`rauc install`) alongside the opkg `iot-swupdate`.
+- CI: build + sign the `.raucb` release artifact (new workflow, like
+  `cloud-image.yml`).
+
+## 8. Open decisions
+
+1. **Agent = RAUC** (recommended) vs Mender vs SWUpdate.
+2. **Bootloader** — move RPi to u-boot (needed by most A/B integrations) vs the
+   RPi native loader + a custom boot-select. (u-boot recommended.)
+3. **Partition sizing** — bank size (2× rootfs) vs SD capacity; data partition
+   size.
+4. **Bundle signing/keys** — where the signing key lives (CI secret) + how the
+   device trusts it (baked CA).
+5. **Coexistence policy** — when to use opkg (Phase 1) vs A/B (Phase 2): e.g.
+   userspace-only → opkg; kernel/base/coordinated → A/B.
+6. **Migration** — does a bank switch re-run the §11 config migrations (yes, on
+   schema-generation change), and how rollback interacts with an already-applied
+   migration (forward-only migrations + a data-partition snapshot?).
+
+## 9. Relationship to Phase 1
+
+| | Phase 1 (shipped) | Phase 2 (this doc) |
+|---|---|---|
+| Artifact | `.ipk` (or multi-`.ipk` bundle) | `.raucb` full image |
+| Installer | `opkg` (in place) | `rauc` (inactive bank) |
+| Atomic / power-fail-safe | ❌ | ✅ |
+| Rollback | ❌ | ✅ (bootloader + health check) |
+| Upload | raw body ≤ 8 MiB | streaming to disk |
+| Scope | userspace daemons | kernel + rootfs |

--- a/apps/docs/tdd-yocto-swupdate.md
+++ b/apps/docs/tdd-yocto-swupdate.md
@@ -179,6 +179,19 @@ today's script, and ds (`/var/lib/iot`) is persistent so the result survives a
 reboot and the relaunched lwm2m client mirrors it back onto Object 5
 (`/5/0/3`, `/5/0/5`, `/5/0/7`).
 
+### 3.5 Local upload (drag-and-drop) — second source
+
+Besides the cloud URL (`iot.update.request` → stager), the device-ui
+**Software Update** page accepts a drag-and-dropped `.ipk` (or small `.tar.gz`
+bundle). iot-httpd's `POST /api/v1/update/upload?name=<f>` (admin-only) writes the
+raw body straight into the spool (`/run/iot/update/<f>`) and trips the trigger —
+the same `iot-swupdate.path` install path, no stager/download. Yocto/systemd only.
+
+Perms: iot-httpd runs `DynamicUser=yes`, so the spool is `0775 root:iot` and the
+unit gets `SupplementaryGroups=iot`; root `iot-swupdate` installs. Bounded by the
+HTTP parser's 8 MiB body cap (`kMaxBody`) — larger / full-image bundles need the
+streaming upload + A/B image OTA in `apps/docs/tdd-ab-image-ota.md`.
+
 ## 4. Reboot-vs-restart decision (requirement 5 — decided here)
 
 **Policy = `auto` by default.** After a successful `opkg install`:

--- a/iot-ui/src/app/software-update/software-update.component.ts
+++ b/iot-ui/src/app/software-update/software-update.component.ts
@@ -51,6 +51,20 @@ import { ToastService } from '../../common/toast.service';
           </div>
         </div>
         <p class="hint">Runs <code>opkg install</code> on the device and restarts the affected daemons. The URL may carry <code>?sha256=</code> &amp; <code>?version=</code>.</p>
+
+        <!-- Drag-and-drop local package -->
+        <h4>Or drop a package</h4>
+        <div class="dropzone" [class.over]="dragOver" [class.busy]="uploading"
+             (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)"
+             (drop)="onDrop($event)" (click)="fileInput.click()">
+          <input #fileInput type="file" accept=".ipk,.tar.gz,.tgz" hidden
+                 (change)="onPick($event)" />
+          <clr-icon shape="upload-cloud" size="28"></clr-icon>
+          <span *ngIf="!uploading">Drag &amp; drop a <code>.ipk</code> (or <code>.tar.gz</code> bundle) here, or click to browse</span>
+          <span *ngIf="uploading">Uploading {{ uploadName }}…</span>
+        </div>
+        <p class="hint">Uploaded to the device and installed via <code>opkg</code>.
+          Max 8&nbsp;MiB per upload — larger / full-image bundles use A/B image OTA (Phase 2).</p>
       </ng-container>
 
       <ng-template #noAccess><p class="hint">You need Admin access to update software.</p></ng-template>
@@ -63,6 +77,11 @@ import { ToastService } from '../../common/toast.service';
     .hint { color: #888; font-size: 12px; margin-top: 8px; }
     .btn-cell { display: flex; align-items: flex-end; }
     .btn-cell .btn-primary { white-space: nowrap; }
+    .dropzone { display: flex; align-items: center; gap: 12px; padding: 18px;
+      border: 2px dashed #b0bec5; border-radius: 8px; color: #607d8b;
+      cursor: pointer; font-size: 13px; transition: all 0.15s; background: #fafcfd; }
+    .dropzone:hover, .dropzone.over { border-color: #0072a3; color: #0072a3; background: #f0f8fc; }
+    .dropzone.busy { opacity: 0.6; pointer-events: none; }
   `]
 })
 export class SoftwareUpdateComponent implements OnInit, OnDestroy {
@@ -71,6 +90,9 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   result = 0;
   url = '';
   busy = false;
+  dragOver = false;
+  uploading = false;
+  uploadName = '';
   private sub = new Subscription();
 
   get isAdmin(): boolean { return this.session.isAdmin; }
@@ -115,6 +137,45 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
         else { this.toast.error(r.err || 'Update failed'); }
       },
       error: () => { this.busy = false; this.toast.error('Update failed'); }
+    });
+  }
+
+  // ── Drag-and-drop upload ──────────────────────────────────────────
+  onDragOver(e: DragEvent): void { e.preventDefault(); this.dragOver = true; }
+  onDragLeave(e: DragEvent): void { e.preventDefault(); this.dragOver = false; }
+  onDrop(e: DragEvent): void {
+    e.preventDefault();
+    this.dragOver = false;
+    const f = e.dataTransfer?.files?.[0];
+    if (f) this.uploadFile(f);
+  }
+  onPick(e: Event): void {
+    const input = e.target as HTMLInputElement;
+    const f = input.files?.[0];
+    if (f) this.uploadFile(f);
+    input.value = '';   // allow re-picking the same file
+  }
+
+  private uploadFile(file: File): void {
+    if (this.uploading) return;
+    if (!/\.(ipk|tar\.gz|tgz)$/i.test(file.name)) {
+      this.toast.error('Pick a .ipk, .tar.gz or .tgz file'); return;
+    }
+    if (file.size > 8 * 1024 * 1024) {
+      this.toast.error('File exceeds the 8 MiB upload limit (use A/B image OTA for larger bundles)');
+      return;
+    }
+    this.uploading = true; this.uploadName = file.name;
+    this.http.uploadUpdate(file).subscribe({
+      next: (r) => {
+        this.uploading = false;
+        if (r.ok) this.toast.success('Uploaded — installing ' + file.name + '…');
+        else this.toast.error(r.err || 'Upload failed');
+      },
+      error: (e) => {
+        this.uploading = false;
+        this.toast.error((e?.error?.err) || 'Upload failed');
+      }
     });
   }
 

--- a/iot-ui/src/common/httpsvc.service.ts
+++ b/iot-ui/src/common/httpsvc.service.ts
@@ -73,6 +73,16 @@ export class HttpsvcService {
       { headers: this.jsonHeaders(), withCredentials: true });
   }
 
+  // Drag-and-drop OTA: post a .ipk (or .tar.gz bundle) as the raw request body;
+  // iot-httpd stages it into the swupdate spool and triggers the install.
+  uploadUpdate(file: File): Observable<{ ok: boolean; err?: string }> {
+    return this.http.post<{ ok: boolean; err?: string }>(
+      `${this.api}/api/v1/update/upload?name=${encodeURIComponent(file.name)}`,
+      file,
+      { headers: new HttpHeaders({ 'Content-Type': 'application/octet-stream' }),
+        withCredentials: true });
+  }
+
   // Long-poll a single key.  Returns as soon as the value changes or
   // the timeout expires (no change → value reflects current state).
   dbGetLongPoll(key: string, timeoutSec = 30): Observable<{

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -8,8 +8,10 @@
 
 #include <ace/Log_Msg.h>
 
+#include <cctype>
 #include <chrono>
 #include <condition_variable>
+#include <fstream>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -386,6 +388,81 @@ void install_handlers(Router& router,
             }
             r.body = R"({"ok":true})";
             r.headers["Set-Cookie"] = make_clear_cookie(cname);
+            return r;
+        });
+
+    // ── POST /api/v1/update/upload?name=<file.ipk> ────────────────
+    // Drag-and-drop OTA: the device-ui posts a .ipk (or small .tar.gz bundle) as
+    // the raw request body. Admin-only. Writes it into the swupdate spool
+    // (/run/iot/update) and trips the inotify trigger; iot-swupdate then installs
+    // it (Yocto/systemd only — the spool + iot-swupdate.path live there). Bounded
+    // by the parser's 8 MiB body cap; larger/full-image bundles use the Phase-2
+    // streaming path (apps/docs/tdd-ab-image-ota.md).
+    router.add("POST", "/api/v1/update/upload",
+        [ds, auth](const HttpParser::Request& req) -> HttpResponse {
+            HttpResponse r;
+            // Admin gate.
+            std::string access_level = "Admin";
+            if (auth && auth->enabled()) {
+                std::string token = extract_session_cookie(req.headers,
+                                                           auth->cookie_name());
+                if (!token.empty()) {
+                    const auto* session = auth->validate(token);
+                    if (session) access_level = session->access;
+                }
+            }
+            if (access_level != "Admin") {
+                r.status = 403;
+                r.body = R"({"ok":false,"err":"admin required"})";
+                return r;
+            }
+            // Sanitise the filename from ?name= (basename, safe charset, known ext).
+            std::string name;
+            if (auto it = req.query.find("name"); it != req.query.end()) name = it->second;
+            if (auto p = name.find_last_of('/'); p != std::string::npos) name = name.substr(p + 1);
+            std::string safe;
+            for (char c : name) {
+                safe.push_back((std::isalnum(static_cast<unsigned char>(c)) ||
+                                c == '.' || c == '_' || c == '-') ? c : '_');
+            }
+            auto ends_with = [&](const char* e) {
+                std::string s(e);
+                return safe.size() >= s.size() &&
+                       safe.compare(safe.size() - s.size(), s.size(), s) == 0;
+            };
+            if (safe.empty() || !(ends_with(".ipk") || ends_with(".tar.gz") || ends_with(".tgz"))) {
+                r.status = 400;
+                r.body = R"({"ok":false,"err":"name must end in .ipk, .tar.gz or .tgz"})";
+                return r;
+            }
+            if (req.body.empty()) {
+                r.status = 400;
+                r.body = R"({"ok":false,"err":"empty upload"})";
+                return r;
+            }
+            const std::string spool = "/run/iot/update";
+            // Write the package, then trip the empty trigger (last, atomic-ish).
+            {
+                std::ofstream f(spool + "/" + safe, std::ios::binary | std::ios::trunc);
+                if (!f) {
+                    r.status = 500;
+                    r.body = R"({"ok":false,"err":"cannot write update spool - perms or non-Yocto host"})";
+                    return r;
+                }
+                f.write(req.body.data(), static_cast<std::streamsize>(req.body.size()));
+                if (!f) {
+                    r.status = 500;
+                    r.body = R"({"ok":false,"err":"spool write failed"})";
+                    return r;
+                }
+            }
+            if (ds) ds->set("iot.update.state", data_store::Value{static_cast<std::int32_t>(2)});
+            { std::ofstream trig(spool + "/update", std::ios::trunc); }  // arm iot-swupdate.path
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D httpd:thread:%t %M %N:%l OTA upload staged %C "
+                                "(%zu bytes); triggered iot-swupdate\n"),
+                       safe.c_str(), req.body.size()));
+            r.body = R"({"ok":true})";
             return r;
         });
 

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-httpd.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-httpd.service
@@ -15,6 +15,10 @@ ExecStart=/usr/bin/iot-httpd $HTTPD_ARGS
 DynamicUser=yes
 RuntimeDirectory=iot
 RuntimeDirectoryMode=0755
+# Join the `iot` group so the dynamic user can write the drag-and-drop OTA spool
+# (/run/iot/update, 0775 root:iot) — iot-httpd drops the uploaded .ipk + trigger,
+# root iot-swupdate installs it. (Also the group that owns the ds socket.)
+SupplementaryGroups=iot
 
 # Lets the dynamic user bind :80/:443 when http.listen.port is set low.
 AmbientCapabilities=CAP_NET_BIND_SERVICE

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
@@ -8,5 +8,7 @@
 #
 # Type Path             Mode UID  GID Age Argument
 d      /run/iot         0755 root root -   -
-d      /run/iot/update  0755 root root -   -
+# 0775 root:iot so the iot-httpd DynamicUser (SupplementaryGroups=iot) can drop a
+# drag-and-drop OTA .ipk + the trigger here; root iot-swupdate then installs it.
+d      /run/iot/update  0775 root iot  -   -
 d      /var/lib/iot     0750 root root -   -


### PR DESCRIPTION
Addresses both asks: drag-and-drop OTA, and the "boot earlier image on interruption" question.

## Phase 1 — drag-and-drop `.ipk` (implemented)
Drop a `.ipk` (or small `.tar.gz`) on the device-ui **Software Update** page → installed locally, no cloud URL.
- **iot-httpd:** `POST /api/v1/update/upload?name=<f>` (admin-only) writes the raw body into the swupdate spool (`/run/iot/update`) and trips `iot-swupdate.path`; root `iot-swupdate` installs. Bounded by the 8 MiB parser body cap.
- **device-ui:** dropzone (drag/drop + browse); `uploadUpdate` posts the `File`; progress via `iot.update.*`.
- **Yocto perms:** spool `0775 root:iot` + `iot-httpd.service` `SupplementaryGroups=iot` (httpd is `DynamicUser`). ⚠️ Needs verification on a real RPi.

## Phase 2 — A/B image OTA (design only)
`apps/docs/tdd-ab-image-ota.md`: dual-bank rootfs + RAUC, bootloader boot-select + health-check **auto-rollback**, the `.raucb` "full bundle" drag-and-drop via **streaming upload**, partition layout, coexistence with opkg.

**This answers the interruption question:** opkg (Phase 1) is in-place → no rollback; an interrupted install can leave a broken rootfs and reboots the *same* image. **A/B (Phase 2)** writes the inactive bank atomically and the bootloader reverts to the previous bank on a failed boot — power-fail-safe + rollback.

## Test
- iot-httpd compiles (115/115); device-ui builds clean. (Found+fixed a raw-string `)"` early-terminator during the build.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)