### PR TITLE
fix(httpd): auth gate must use configured cookie name (cloud login broken)

### DIFF
--- a/modules/http-server/src/session.cpp
+++ b/modules/http-server/src/session.cpp
@@ -102,7 +102,11 @@ int HttpSession::handle_input(ACE_HANDLE /*fd*/) {
     // 401 responses are short-lived and sent inline even when a worker pool is
     // configured — no point off-loading them.
     if (m_auth && m_auth->enabled() && !is_public_route(req.path)) {
-        std::string token = extract_session_cookie(req.headers);
+        // Use the configured cookie name (e.g. the cloud's "iot-cloud-session"),
+        // not the default — else the gate looks for the wrong cookie and 401s
+        // every /api/* request even with a valid session.
+        std::string token = extract_session_cookie(req.headers,
+                                                    m_auth->cookie_name());
         if (token.empty() || !m_auth->validate(token)) {
             HttpResponse unauth;
             unauth.status = 401;


### PR DESCRIPTION
## Bug
After redeploying, **cloud-ui login fails** — you log in, but the UI immediately bounces back to login (logs show repeated "session created for admin").

## Root cause
The per-request auth gate in `HttpSession` (`session.cpp:105`) extracted the session cookie with the **default** name `iot-session`, not `m_auth->cookie_name()`. The cloud's cookie is **`iot-cloud-session`** (per-instance name, #183), so the gate never found it → **401 on every `/api/*`** even with a valid session. #183 updated the `handler.cpp`/`auth.cpp` call sites but missed this gate — latent until the cloud actually ran with the non-default cookie name (this redeploy). Device httpd (default `iot-session`) was unaffected.

Verified live: `login → cookie → /api/v1/status` returned **401**; server-side login itself was fine (`200`).

## Fix
Gate uses `m_auth->cookie_name()`.

## Test
- iot-httpd compiles (115/115).

🤖 Generated with [Claude Code](https://claude.com/claude-code)