### PR TITLE
feat(ota): A/B Phase-2 increment 2 — RAUC runtime hooks + bring-up scaffold

### DIFF
--- a/iot-ui/src/app/software-update/software-update.component.ts
+++ b/iot-ui/src/app/software-update/software-update.component.ts
@@ -33,6 +33,12 @@ import { ToastService } from '../../common/toast.service';
             <clr-dg-cell><app-status-badge [label]="resultLabel"
               [state]="result===1 ? 'connected' : (result>=5 ? 'exited' : 'idle')"></app-status-badge></clr-dg-cell>
           </clr-dg-row>
+          <clr-dg-row *ngIf="bank">
+            <clr-dg-cell>Running Bank <span class="hint">(A/B image)</span>
+              <app-ds-hint *dsDebug key="iot.boot.bank"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell><app-status-badge [label]="bank + (confirmed ? ' · confirmed' : ' · unconfirmed')"
+              [state]="confirmed ? 'connected' : 'starting'"></app-status-badge></clr-dg-cell>
+          </clr-dg-row>
         </clr-datagrid>
 
         <!-- Self-update trigger -->
@@ -89,6 +95,8 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   version = '';
   state = 0;
   result = 0;
+  bank = '';          // iot.boot.bank — running A/B rootfs bank (empty = single-rootfs)
+  confirmed = false;  // iot.boot.confirmed — this boot marked good
   url = '';
   busy = false;
   dragOver = false;
@@ -126,6 +134,14 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     }));
     this.sub.add(this.ds.observe('iot.update.result').subscribe(v => {
       this.result = Number(v) || 0;
+    }));
+    // A/B boot status changes only once per boot — read it once.
+    this.sub.add(this.http.dbGet(['iot.boot.bank', 'iot.boot.confirmed']).subscribe(r => {
+      if (r.ok && r.data) {
+        const d = r.data as Record<string, unknown>;
+        this.bank = d['iot.boot.bank'] != null ? String(d['iot.boot.bank']) : '';
+        this.confirmed = d['iot.boot.confirmed'] === true;
+      }
     }));
   }
 

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -156,15 +156,30 @@ return {
     -- Apply progress, written by iot-ota-apply, read by device-ui and
     -- mirrored into Object 5 (/5/0/3, /5/0/5) on client (re)start so a
     -- post-restart server readback reflects the outcome.
-    ["iot.update.state"] = {        -- 0 idle,1 downloading,2 downloaded,3 updating
-        access  = "Admin",
+    ["iot.update.state"] = {        -- 0 idle,1 downloading,2 downloaded,3 updating,
+        access  = "Admin",          -- 4 writing-bank,5 awaiting-confirm (A/B, Phase 2)
         type    = "integer",
         default = 0,
     },
-    ["iot.update.result"] = {       -- 0 initial,1 success,5 integrity,8 uri,9 install
-        access  = "Admin",
+    ["iot.update.result"] = {       -- 0 initial,1 success,2 rolled-back (A/B),
+        access  = "Admin",          -- 5 integrity,8 uri,9 install
         type    = "integer",
         default = 0,
+    },
+
+    -- A/B image OTA (Phase 2). Which rootfs bank is running, and whether this
+    -- boot has been health-checked + confirmed good (else the bootloader rolls
+    -- back to the other bank on the next boot). Written by iot-ota-confirm.
+    -- See apps/docs/tdd-ab-image-ota.md.
+    ["iot.boot.bank"] = {           -- "A" | "B" | "" (single-rootfs / non-RAUC)
+        access  = "Admin",
+        type    = "string",
+        default = "",
+    },
+    ["iot.boot.confirmed"] = {      -- this boot marked good (mark-good done)
+        access  = "Admin",
+        type    = "boolean",
+        default = false,
     },
     ["iot.update.version"] = {      -- installed package version after apply
         access  = "Admin",

--- a/yocto/meta-iot/docs/rauc-bringup.md
+++ b/yocto/meta-iot/docs/rauc-bringup.md
@@ -1,0 +1,56 @@
+# RAUC A/B image OTA — device bring-up checklist
+
+Status: **scaffold — not yet validated on hardware.** This lists the Yocto/boot
+work to turn the Phase-2 design (`apps/docs/tdd-ab-image-ota.md`) into a booting
+A/B image. The runtime hooks (chunked `.raucb` upload, `iot-swupdate` → `rauc
+install` routing, `iot-ota-confirm` mark-good/rollback, the `iot.boot.*` ds keys,
+device-ui bank status) are already in the tree; the items below are the
+build/bootloader pieces that need a Yocto build + an RPi to validate.
+
+## 1. Layers
+- Add **`meta-rauc`** and **`meta-rauc-community`** (RPi support) to `bblayers`
+  (kas-iot.yml / the build container).
+
+## 2. Bootloader (u-boot)
+- Switch the RPi to **u-boot** (`PREFERRED_PROVIDER_virtual/bootloader = "u-boot"`,
+  `RPI_USE_U_BOOT = "1"`).
+- Enable the RAUC u-boot boot-select integration (`rauc-uboot` / the community
+  layer's `BOOT_ORDER` + `bootcount` env), with `boot-attempts` matching
+  `system.conf`.
+
+## 3. Image
+- `WKS_FILE = "iot-ab.wks.in"` (the 4-partition layout in `yocto/meta-iot/wic/`).
+- `IMAGE_FSTYPES += "wic.bz2"` for the SD image, and the RAUC **bundle** image
+  type for the `.raucb` (`IMAGE_CLASSES += "rauc"` / a `bundle.bb`).
+- Mount the data partition at `/var/lib/iot` (fstab/systemd mount); keep ds
+  state + certs there so an image swap never loses them.
+
+## 4. RAUC config + keys
+- Install `recipes-core/rauc/files/system.conf` → `/etc/rauc/system.conf`
+  (slot devices must match the wks partitions).
+- Generate a signing keypair; bake the **cert** into the image at
+  `/etc/rauc/keyring.pem`; keep the **key** as a CI secret.
+- `set compatible=iot-rpi` to match the bundle manifest.
+
+## 5. Bundle (.raucb)
+- A `rauc-bundle` recipe producing the signed `.raucb` (rootfs image + manifest,
+  `compatible=iot-rpi`).
+- The operator drops the `.raucb` on the device-ui (already chunk-uploads) or the
+  cloud pushes its URL; `iot-swupdate` runs `rauc install` (already routed).
+
+## 6. Confirm / rollback
+- `iot-ota-confirm.service` (already in the recipe) health-checks the boot and
+  `rauc status mark-good`s it; an unhealthy boot is left un-confirmed so the
+  bootloader reverts. Verify the boot-attempts/bootcount round-trip on HW.
+
+## 7. CI
+- A workflow (like `cloud-image.yml`) to build + **sign** the `.raucb` release
+  artifact on tag, using the CI signing-key secret.
+
+## Acceptance (on hardware)
+1. Flash A/B image; boots bank A; `rauc status` shows A good.
+2. `rauc install` a B bundle (or drop it in the UI) → writes bank B → reboot → B.
+3. `iot-ota-confirm` marks B good; `iot.boot.bank=B`, `iot.boot.confirmed=true`.
+4. Install a deliberately-broken bundle → boot fails health check → next boot
+   **rolls back to A** automatically.
+5. Power-cut mid-`rauc install` → A still boots (inactive-bank write was atomic).

--- a/yocto/meta-iot/recipes-core/rauc/files/system.conf
+++ b/yocto/meta-iot/recipes-core/rauc/files/system.conf
@@ -1,0 +1,30 @@
+# RAUC system configuration — A/B (dual-bank) rootfs for the IoT RPi image.
+# Installed to /etc/rauc/system.conf. See apps/docs/tdd-ab-image-ota.md.
+#
+# NOTE: device-bring-up scaffold — validate on hardware (slot devices depend on
+# the wic partition layout in yocto/meta-iot/wic/iot-ab.wks.in, and `bootloader`
+# requires u-boot with the rauc boot-select integration).
+
+[system]
+compatible=iot-rpi
+bootloader=uboot
+# Max boot attempts before the bootloader reverts to the other bank. The booted
+# bank is marked good by iot-ota-confirm once healthy (see that service).
+boot-attempts=3
+mountprefix=/run/rauc
+
+[keyring]
+# Trust anchor for bundle signatures. The matching signing key lives in CI
+# (a secret); the cert is baked into the image. Bundles that don't verify are
+# rejected by `rauc install`.
+path=/etc/rauc/keyring.pem
+
+[slot.rootfs.0]
+device=/dev/mmcblk0p2
+type=ext4
+bootname=A
+
+[slot.rootfs.1]
+device=/dev/mmcblk0p3
+type=ext4
+bootname=B

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm
@@ -1,0 +1,58 @@
+#!/bin/sh
+# iot-ota-confirm — A/B (RAUC) boot confirmation + rollback gate (Phase 2).
+#
+# Runs once per boot. After a RAUC update the bootloader boots the new bank with
+# a try-counter; this service health-checks the running system and, if healthy,
+# `rauc status mark-good` (clears the counter → the bank sticks). If it does NOT
+# confirm within the window, the bank stays "tried" and the bootloader rolls
+# back to the previous bank on the next boot. Publishes iot.boot.bank /
+# iot.boot.confirmed for the device-ui. No-op on a non-RAUC (single-rootfs) image.
+#
+# See apps/docs/tdd-ab-image-ota.md.
+
+set -u
+
+SOCK="/run/iot/data_store.sock"
+DSCLI="ds-cli --socket=${SOCK}"
+log()    { logger -t iot-ota-confirm "$*" 2>/dev/null; echo "iot-ota-confirm: $*"; }
+set_ds() { $DSCLI set "$1" "$2" >/dev/null 2>&1 || true; }
+
+if ! command -v rauc >/dev/null 2>&1; then
+    log "rauc absent — non-A/B image, nothing to confirm"
+    exit 0
+fi
+
+# Which rootfs bank booted (e.g. "rootfs.0"/"A"). Publish for the UI.
+BANK="$(rauc status --output-format=shell 2>/dev/null \
+        | sed -n 's/^RAUC_SYSTEM_BOOTED_SLOT=\(.*\)/\1/p' | tr -d "\"'")"
+[ -n "$BANK" ] && set_ds iot.boot.bank "\"$BANK\""
+
+# Healthy = ds answers AND the core daemons are active. (Deliberately NOT gating
+# on LwM2M registration — a transient cloud outage must not trigger a rollback
+# of an otherwise-good image; daemon liveness is what proves the new bank boots.)
+healthy() {
+    $DSCLI get log.version >/dev/null 2>&1 || return 1
+    for u in iot-ds iot-httpd iot-lwm2m-client; do
+        systemctl is-active --quiet "${u}.service" || return 1
+    done
+    return 0
+}
+
+i=0
+while [ "$i" -lt 90 ]; do          # up to ~90 s for the stack to come up
+    if healthy; then
+        rauc status mark-good >/dev/null 2>&1 || true
+        set_ds iot.boot.confirmed true
+        set_ds iot.update.result 1     # success
+        set_ds iot.update.state  0     # idle
+        log "boot ${BANK:-?} confirmed good (marked good)"
+        exit 0
+    fi
+    i=$((i + 1)); sleep 1
+done
+
+# Not confirmed: leave the try-counter set so the bootloader reverts on next boot.
+set_ds iot.boot.confirmed false
+set_ds iot.update.result 2             # rolled-back (pending next boot)
+log "boot ${BANK:-?} NOT confirmed within window — bootloader will roll back on next boot"
+exit 1

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm.service
@@ -1,0 +1,16 @@
+[Unit]
+Description=Confirm the A/B (RAUC) boot once healthy, else allow rollback
+Documentation=https://github.com/naushada/iot
+After=iot-ds.service iot-httpd.service iot-lwm2m-client.service network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/iot-ota-confirm
+# Runs as root (rauc mark-good + systemctl). Bounded by the script's own ~90 s
+# health-check loop.
+TimeoutStartSec=180
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -47,6 +47,8 @@ SRC_URI = "\
     file://iot-swupdate \
     file://iot-swupdate.path \
     file://iot-swupdate.service \
+    file://iot-ota-confirm \
+    file://iot-ota-confirm.service \
     file://migrations/README.md \
     file://migrations/0000-template.sh.example \
 "
@@ -195,8 +197,9 @@ do_install() {
     # systemd-run by the lwm2m client) and iot-swupdate (the inotify-triggered
     # installer, run by iot-swupdate.service). See apps/docs/tdd-yocto-swupdate.md.
     install -d ${D}${bindir}
-    install -m 0755 ${WORKDIR}/iot-ota-stage ${D}${bindir}/iot-ota-stage
-    install -m 0755 ${WORKDIR}/iot-swupdate  ${D}${bindir}/iot-swupdate
+    install -m 0755 ${WORKDIR}/iot-ota-stage    ${D}${bindir}/iot-ota-stage
+    install -m 0755 ${WORKDIR}/iot-swupdate     ${D}${bindir}/iot-swupdate
+    install -m 0755 ${WORKDIR}/iot-ota-confirm  ${D}${bindir}/iot-ota-confirm
 
     # Config/schema migration scripts (§11), run by iot-swupdate after opkg.
     install -d ${D}${datadir}/iot/migrations
@@ -216,6 +219,7 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-vpn-cert.service       ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-swupdate.path          ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-swupdate.service       ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-ota-confirm.service    ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-net-router.service     ${D}${systemd_system_unitdir}/
         # TUN driver autoload for openvpn-client.
         install -d ${D}${sysconfdir}/modules-load.d
@@ -286,11 +290,13 @@ FILES:${PN}-lwm2m = "\
     ${bindir}/lwm2m \
     ${bindir}/iot-ota-stage \
     ${bindir}/iot-swupdate \
+    ${bindir}/iot-ota-confirm \
     ${datadir}/iot/migrations \
     ${systemd_system_unitdir}/iot-lwm2m-client.service \
     ${systemd_system_unitdir}/iot-lwm2m-server.service \
     ${systemd_system_unitdir}/iot-swupdate.path \
     ${systemd_system_unitdir}/iot-swupdate.service \
+    ${systemd_system_unitdir}/iot-ota-confirm.service \
 "
 RDEPENDS:${PN}-lwm2m = "\
     ace-tao \
@@ -382,7 +388,7 @@ FILES:${PN}-config = "\
 SYSTEMD_SERVICE:${PN}-ds-server = "iot-ds.service"
 # iot-swupdate.path is enabled (watches the OTA spool trigger); iot-swupdate.service
 # is activated by the path unit, not enabled directly (it has no [Install]).
-SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service iot-swupdate.path"
+SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service iot-swupdate.path iot-ota-confirm.service"
 # iot-vpn-cert.path is enabled (watches the cert); iot-vpn-cert.service is
 # activated by the path unit, not enabled directly (it has no [Install]).
 SYSTEMD_SERVICE:${PN}-openvpn-client = "iot-openvpn-client.service iot-vpn-cert.path"

--- a/yocto/meta-iot/wic/iot-ab.wks.in
+++ b/yocto/meta-iot/wic/iot-ab.wks.in
@@ -1,0 +1,16 @@
+# A/B (dual-bank) partition layout for the IoT RPi image (RAUC, Phase 2).
+# See apps/docs/tdd-ab-image-ota.md §2.  device-bring-up scaffold — validate on HW.
+#
+#   p1 boot   (FAT)  bootloader + per-bank kernel/dtb + boot-select env
+#   p2 rootA  (ext4) rootfs bank A   ─┐ only the INACTIVE bank is written on update
+#   p3 rootB  (ext4) rootfs bank B   ─┘ (atomic + power-fail-safe; active keeps running)
+#   p4 data   (ext4) persistent: /var/lib/iot (ds store), certs, /etc/iot overrides
+#
+# Build with: WKS_FILE = "iot-ab.wks.in" (and IMAGE_FSTYPES += "wic.bz2").
+
+part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4096 --size 64M
+part /     --source rootfs --fstype=ext4 --label rootA --align 4096 --size 768M
+part /     --source rootfs --fstype=ext4 --label rootB --align 4096 --size 768M
+part /var/lib/iot --fstype=ext4 --label data --align 4096 --size 256M
+
+bootloader --ptable msdos


### PR DESCRIPTION
Second Phase-2 increment.

## Runtime hooks (verifiable here)
- **ds keys:** `iot.boot.bank`, `iot.boot.confirmed`; `iot.update.state` +4 writing-bank/+5 awaiting-confirm; `iot.update.result` +2 rolled-back.
- **`iot-ota-confirm`** (service + script): per-boot health check (ds answers + `iot-ds`/`iot-httpd`/`iot-lwm2m-client` active) → `rauc status mark-good`; an unhealthy boot is left unconfirmed so the bootloader **rolls back**. Publishes `iot.boot.*`. No-op without `rauc`.
- **device-ui:** Software Update shows **Running Bank** + confirmed/unconfirmed.
- recipe wiring for the confirm service.

## Bring-up scaffold (device-bring-up — standard patterns, untested off-hardware)
- `recipes-core/rauc/files/system.conf` (A/B slots, u-boot, signed bundles)
- `wic/iot-ab.wks.in` (boot + rootA + rootB + data)
- `docs/rauc-bringup.md` — the Yocto/bootloader checklist + on-hardware acceptance tests

## Test
- `iot-ota-confirm` passes `sh -n`; device-ui builds; `iot.lua` parses (`luac5.3`).

Next: the actual meta-rauc/u-boot/wic build + `.raucb` bundle recipe + CI signing (needs a Yocto build + RPi).

🤖 Generated with [Claude Code](https://claude.com/claude-code)