### PR TITLE
feat(ds): data-store throughput/latency benchmark + results

### DIFF
--- a/modules/data-store/CMakeLists.txt
+++ b/modules/data-store/CMakeLists.txt
@@ -91,6 +91,16 @@ target_link_libraries(ds-cli
     pthread)
 
 # --------------------------------------------------------------------
+# ds-bench — throughput/latency benchmark (off by default). Links the client.
+# Build with -DBUILD_DS_BENCH=ON; run against a live ds-server.
+# --------------------------------------------------------------------
+option(BUILD_DS_BENCH "Build the ds throughput/latency benchmark" OFF)
+if(BUILD_DS_BENCH)
+    add_executable(ds-bench bench/ds_bench.cpp)
+    target_link_libraries(ds-bench datastore_client pthread)
+endif()
+
+# --------------------------------------------------------------------
 # Tests — same gtest target as the iot suite. ACE + client lib both
 # in scope because integration tests construct a server in-process.
 # --------------------------------------------------------------------

--- a/modules/data-store/bench/ds_bench.cpp
+++ b/modules/data-store/bench/ds_bench.cpp
@@ -1,0 +1,157 @@
+/// ds_bench — throughput + latency benchmark for the data-store client/server.
+///
+/// Drives a running ds-server over the AF_UNIX socket via the public
+/// data_store::Client API and reports ops/sec + p50/p95/p99 latency for the
+/// hot paths: persistent set (write-through + fsync), volatile set (no fsync),
+/// get, batched set, and watch→notify delivery.
+///
+/// Usage: ds-bench [socket=/run/iot/data_store.sock] [n=20000] [vsize=64] [batch=50]
+///   Build with -DBUILD_DS_BENCH=ON (links libdatastore_client.a).
+
+#include "data_store/client.hpp"
+#include "data_store/value.hpp"
+
+#include <algorithm>
+#include <atomic>
+#include <chrono>
+#include <cmath>
+#include <condition_variable>
+#include <cstdint>
+#include <cstdio>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+using clock_t_ = std::chrono::steady_clock;
+using us = std::chrono::microseconds;
+
+namespace {
+
+std::string arg(int argc, char** argv, const char* key, const std::string& dflt) {
+    const std::size_t kl = std::strlen(key);
+    for (int i = 1; i < argc; ++i)
+        if (std::strncmp(argv[i], key, kl) == 0 && argv[i][kl] == '=')
+            return std::string(argv[i] + kl + 1);
+    return dflt;
+}
+
+double pct(std::vector<double>& v, double p) {
+    if (v.empty()) return 0;
+    auto idx = static_cast<std::size_t>(p / 100.0 * (v.size() - 1) + 0.5);
+    return v[std::min(idx, v.size() - 1)];
+}
+
+void report(const char* name, std::vector<double>& lat_us, double wall_s,
+            long ops) {
+    std::sort(lat_us.begin(), lat_us.end());
+    double sum = 0; for (double x : lat_us) sum += x;
+    std::printf("%-18s %9.0f ops/s | mean %7.1f  p50 %7.1f  p95 %7.1f  "
+                "p99 %7.1f  max %8.1f us\n",
+                name, ops / wall_s, lat_us.empty() ? 0 : sum / lat_us.size(),
+                pct(lat_us, 50), pct(lat_us, 95), pct(lat_us, 99),
+                lat_us.empty() ? 0 : lat_us.back());
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    const std::string sock = arg(argc, argv, "socket", "/run/iot/data_store.sock");
+    const long    N      = std::stol(arg(argc, argv, "n", "20000"));
+    const std::size_t VS = std::stoul(arg(argc, argv, "vsize", "64"));
+    const long    BATCH  = std::stol(arg(argc, argv, "batch", "50"));
+    const std::string val(VS, 'x');
+
+    data_store::Client c;
+    if (auto s = c.connect(sock); !s.ok) {
+        std::fprintf(stderr, "connect(%s) failed: %s\n", sock.c_str(), s.err.c_str());
+        return 1;
+    }
+    std::printf("ds-bench: socket=%s n=%ld vsize=%zu batch=%ld\n\n", sock.c_str(), N, VS, BATCH);
+
+    // Warmup.
+    for (int i = 0; i < 200; ++i) c.set("bench.warm", data_store::Value{val});
+
+    // 1. persistent set (write-through + fsync per call).
+    {
+        std::vector<double> lat; lat.reserve(N);
+        auto t0 = clock_t_::now();
+        for (long i = 0; i < N; ++i) {
+            std::string k = "bench.k" + std::to_string(i % 1000);
+            auto a = clock_t_::now();
+            c.set(k, data_store::Value{val});
+            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
+        }
+        report("set (persist)", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), N);
+    }
+
+    // 2. volatile set (in-memory overlay, no fsync).
+    {
+        std::vector<double> lat; lat.reserve(N);
+        auto t0 = clock_t_::now();
+        for (long i = 0; i < N; ++i) {
+            std::string k = "bench.v" + std::to_string(i % 1000);
+            auto a = clock_t_::now();
+            c.set_volatile(k, data_store::Value{val});
+            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
+        }
+        report("set (volatile)", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), N);
+    }
+
+    // 3. get.
+    {
+        std::vector<double> lat; lat.reserve(N);
+        std::vector<data_store::Client::GetResult> out;
+        auto t0 = clock_t_::now();
+        for (long i = 0; i < N; ++i) {
+            std::string k = "bench.k" + std::to_string(i % 1000);
+            auto a = clock_t_::now();
+            c.get({k}, out);
+            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
+        }
+        report("get", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), N);
+    }
+
+    // 4. batched persistent set (BATCH keys per call) — amortised fsync.
+    {
+        const long iters = N / BATCH;
+        std::vector<double> lat; lat.reserve(iters);
+        auto t0 = clock_t_::now();
+        for (long i = 0; i < iters; ++i) {
+            std::vector<data_store::KV> kv; kv.reserve(BATCH);
+            for (long j = 0; j < BATCH; ++j)
+                kv.emplace_back("bench.b" + std::to_string(j), data_store::Value{val});
+            auto a = clock_t_::now();
+            c.set(kv);
+            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
+        }
+        report("set (batch)", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), iters * BATCH);
+    }
+
+    // 5. watch -> notify delivery latency (set on one client, callback on another).
+    {
+        data_store::Client w;
+        if (w.connect(sock).ok) {
+            std::mutex m; std::condition_variable cv;
+            clock_t_::time_point recv; std::atomic<bool> got{false};
+            w.watch("bench.notify", [&](const data_store::Client::Event&) {
+                recv = clock_t_::now();
+                { std::lock_guard<std::mutex> lk(m); got = true; } cv.notify_one();
+            });
+            const long M = std::min<long>(N, 5000);
+            std::vector<double> lat; lat.reserve(M);
+            for (long i = 0; i < M; ++i) {
+                got = false;
+                auto a = clock_t_::now();
+                c.set("bench.notify", data_store::Value{std::to_string(i)});
+                std::unique_lock<std::mutex> lk(m);
+                if (cv.wait_for(lk, std::chrono::seconds(2), [&]{ return got.load(); }))
+                    lat.push_back(std::chrono::duration_cast<us>(recv - a).count());
+            }
+            report("watch->notify", lat, 1.0, lat.size());  // latency-focused
+        }
+    }
+
+    c.close();
+    return 0;
+}

--- a/modules/data-store/docs/benchmark.md
+++ b/modules/data-store/docs/benchmark.md
@@ -1,0 +1,58 @@
+# data-store benchmark
+
+Throughput + latency of `ds-server` over the AF_UNIX socket, via the public
+`data_store::Client` API. Tool: `modules/data-store/bench/ds_bench.cpp`.
+
+## How to run
+
+```sh
+# In the build env (ACE on the link line). One-liner used for the numbers below:
+g++ -std=c++17 -O2 -Imodules/data-store/inc -I$ACE_ROOT/include \
+    modules/data-store/bench/ds_bench.cpp libdatastore_client.a \
+    -L$ACE_ROOT/lib -lACE -lpthread -o ds-bench
+# or: cmake modules/data-store -DBUILD_DS_BENCH=ON && ninja ds-bench
+
+ds-server --socket=/run/iot/data_store.sock --schema-dir=<dir> --persist-dir=<dir> &
+ds-bench socket=/run/iot/data_store.sock n=20000 vsize=64 batch=50
+```
+
+## Results (indicative)
+
+Environment: containerized Linux (podman VM, 5 vCPU) — **not** target hardware.
+Single client thread; each op is a synchronous request→response round-trip.
+`n=20000`, 64-byte values, batch=50.
+
+| Op | throughput | mean | p50 | p95 | p99 | max |
+|----|-----------:|-----:|----:|----:|----:|----:|
+| `set` (persist + fsync) | 10.1k ops/s | 98 µs | 67 µs | 428 µs | 688 µs | 3.2 ms |
+| `set` (volatile, no fsync) | 14.0k ops/s | 71 µs | 67 µs | 112 µs | 159 µs | 2.0 ms |
+| `get` | 15.6k ops/s | 64 µs | 66 µs | 100 µs | 143 µs | 1.6 ms |
+| `set` (batch ×50) | **248k keys/s** | 198 µs/call | 119 µs | 154 µs | 207 µs | 31 ms |
+| `watch`→notify delivery | — | 761 µs | 728 µs | 1.0 ms | 1.5 ms | 6.4 ms |
+
+## Reading the numbers
+
+- **Single-client throughput is round-trip-bound, not server-bound.** `get` at
+  ~64 µs/op ⇒ ~15.6k ops/s is essentially `1 / round-trip-latency`. The server
+  ceiling is much higher with concurrent clients (see Limitations).
+- **fsync is the write cost.** Persistent `set` (write-through + `fsync` per
+  call) is ~30 % slower than volatile here. On real flash (RPi SD) `fsync` is
+  **far** costlier than in this VM — expect persistent single-`set` throughput to
+  drop sharply on-device.
+- **Batching wins big.** A 50-key `set` lands ~248k keys/s (~2.4 µs/key
+  amortised) — it pays the round-trip + one `fsync` once for the whole batch.
+  **Recommendation:** group multi-key writes into one `set({pairs})` (the daemons
+  already do this in several places); avoid per-key `set` loops on hot paths, and
+  use `set_volatile` for ephemeral state.
+- **Watch/notify latency is sub-ms** (p50 ~0.7 ms) — comfortable for config-change
+  propagation and the UI long-poll wakeups.
+
+## Limitations / follow-ups
+
+- **Not target hardware.** Run on the cloud VM and an RPi for absolute numbers;
+  the SD-card `fsync` profile in particular will differ from this VM.
+- **Single client.** ds_bench drives one connection. A concurrent-client variant
+  (N threads/connections) would measure the *server's* aggregate ceiling rather
+  than per-connection round-trip latency — the more useful number for a fleet.
+- Value size fixed at 64 B; large values (certs/JSON blobs) would show framing +
+  copy cost — add a `vsize` sweep.


### PR DESCRIPTION
`ds_bench` drives `ds-server` over the AF_UNIX socket via the public `data_store::Client` API and reports ops/sec + p50/p95/p99 for **set** (persist + volatile), **get**, **batched set**, and **watch→notify**. New off-by-default CMake target `ds-bench` (`-DBUILD_DS_BENCH=ON`); methodology + results + caveats in `modules/data-store/docs/benchmark.md`.

## Results (containerized VM, single client, sync round-trips, 64 B values)
| Op | throughput | p50 | p99 |
|----|-----------:|----:|----:|
| set (persist+fsync) | 10.1k ops/s | 67 µs | 688 µs |
| set (volatile) | 14.0k ops/s | 67 µs | 159 µs |
| get | 15.6k ops/s | 66 µs | 143 µs |
| set (batch ×50) | **248k keys/s** | 119 µs/batch | 207 µs |
| watch→notify | — | 728 µs | 1.5 ms |

## Takeaways
- Single-client throughput is **round-trip-bound** (`~1/latency`), not server-bound.
- **fsync dominates** persistent writes (and is far costlier on RPi SD than this VM).
- **Batching multi-key writes is ~16×** → group into one `set({pairs})`; use `set_volatile` for ephemeral state.
- Watch/notify is sub-ms.

Caveats: not target hardware; single client (a concurrent-client sweep is the follow-up for the server's aggregate ceiling).

🤖 Generated with [Claude Code](https://claude.com/claude-code)