### PR TITLE
feat(ds): ds-bench memory measurement + ds.bench.summary key

### DIFF
--- a/modules/data-store/bench/ds_bench.cpp
+++ b/modules/data-store/bench/ds_bench.cpp
@@ -1,11 +1,13 @@
-/// ds_bench — throughput + latency benchmark for the data-store client/server.
+/// ds_bench — throughput + latency + memory benchmark for the data-store.
 ///
 /// Drives a running ds-server over the AF_UNIX socket via the public
-/// data_store::Client API and reports ops/sec + p50/p95/p99 latency for the
-/// hot paths: persistent set (write-through + fsync), volatile set (no fsync),
-/// get, batched set, and watch→notify delivery.
+/// data_store::Client API and reports ops/sec + p50/p95/p99 latency for the hot
+/// paths (persistent/volatile set, get, batched set, watch→notify), plus the
+/// server's resident memory (RSS) when its pid is given. Writes a JSON summary
+/// to the ds key `ds.bench.summary` so the result is queryable / UI-surfaceable.
 ///
-/// Usage: ds-bench [socket=/run/iot/data_store.sock] [n=20000] [vsize=64] [batch=50]
+/// Usage: ds-bench [socket=/run/iot/data_store.sock] [n=20000] [vsize=64]
+///                 [batch=50] [pid=<ds-server-pid>]
 ///   Build with -DBUILD_DS_BENCH=ON (links libdatastore_client.a).
 
 #include "data_store/client.hpp"
@@ -14,19 +16,21 @@
 #include <algorithm>
 #include <atomic>
 #include <chrono>
-#include <cmath>
 #include <condition_variable>
 #include <cstdint>
 #include <cstdio>
 #include <cstring>
+#include <fstream>
 #include <mutex>
 #include <string>
 #include <vector>
 
-using clock_t_ = std::chrono::steady_clock;
+using bclock = std::chrono::steady_clock;
 using us = std::chrono::microseconds;
 
 namespace {
+
+std::string g_summary;   // JSON fragments, joined into ds.bench.summary
 
 std::string arg(int argc, char** argv, const char* key, const std::string& dflt) {
     const std::size_t kl = std::strlen(key);
@@ -36,21 +40,41 @@ std::string arg(int argc, char** argv, const char* key, const std::string& dflt)
     return dflt;
 }
 
-double pct(std::vector<double>& v, double p) {
+double pct(const std::vector<double>& v, double p) {
     if (v.empty()) return 0;
     auto idx = static_cast<std::size_t>(p / 100.0 * (v.size() - 1) + 0.5);
     return v[std::min(idx, v.size() - 1)];
 }
 
-void report(const char* name, std::vector<double>& lat_us, double wall_s,
-            long ops) {
+/// Read a /proc/<pid>/status field (kB). Returns 0 when unavailable.
+long proc_kb(long pid, const char* field) {
+    if (pid <= 0) return 0;
+    std::ifstream f("/proc/" + std::to_string(pid) + "/status");
+    std::string line;
+    while (std::getline(f, line))
+        if (line.rfind(field, 0) == 0) {
+            long kb = 0; std::sscanf(line.c_str() + std::strlen(field), " %ld", &kb);
+            return kb;
+        }
+    return 0;
+}
+
+void report(const char* name, const char* jkey, std::vector<double>& lat_us,
+            double wall_s, long ops, bool throughput) {
     std::sort(lat_us.begin(), lat_us.end());
     double sum = 0; for (double x : lat_us) sum += x;
+    double opsps = (throughput && wall_s > 0) ? ops / wall_s : 0;
     std::printf("%-18s %9.0f ops/s | mean %7.1f  p50 %7.1f  p95 %7.1f  "
                 "p99 %7.1f  max %8.1f us\n",
-                name, ops / wall_s, lat_us.empty() ? 0 : sum / lat_us.size(),
+                name, opsps, lat_us.empty() ? 0 : sum / lat_us.size(),
                 pct(lat_us, 50), pct(lat_us, 95), pct(lat_us, 99),
                 lat_us.empty() ? 0 : lat_us.back());
+    char buf[256];
+    std::snprintf(buf, sizeof(buf),
+                  "%s\"%s\":{\"ops\":%.0f,\"p50\":%.0f,\"p95\":%.0f,\"p99\":%.0f}",
+                  g_summary.empty() ? "" : ",", jkey, opsps,
+                  pct(lat_us, 50), pct(lat_us, 95), pct(lat_us, 99));
+    g_summary += buf;
 }
 
 } // namespace
@@ -60,6 +84,7 @@ int main(int argc, char** argv) {
     const long    N      = std::stol(arg(argc, argv, "n", "20000"));
     const std::size_t VS = std::stoul(arg(argc, argv, "vsize", "64"));
     const long    BATCH  = std::stol(arg(argc, argv, "batch", "50"));
+    const long    PID    = std::stol(arg(argc, argv, "pid", "0"));
     const std::string val(VS, 'x');
 
     data_store::Client c;
@@ -67,90 +92,93 @@ int main(int argc, char** argv) {
         std::fprintf(stderr, "connect(%s) failed: %s\n", sock.c_str(), s.err.c_str());
         return 1;
     }
-    std::printf("ds-bench: socket=%s n=%ld vsize=%zu batch=%ld\n\n", sock.c_str(), N, VS, BATCH);
+    std::printf("ds-bench: socket=%s n=%ld vsize=%zu batch=%ld pid=%ld\n\n",
+                sock.c_str(), N, VS, BATCH, PID);
 
-    // Warmup.
+    const long rss0 = proc_kb(PID, "VmRSS:");
+
     for (int i = 0; i < 200; ++i) c.set("bench.warm", data_store::Value{val});
 
-    // 1. persistent set (write-through + fsync per call).
-    {
+    {   // persistent set (write-through + fsync per call)
         std::vector<double> lat; lat.reserve(N);
-        auto t0 = clock_t_::now();
-        for (long i = 0; i < N; ++i) {
-            std::string k = "bench.k" + std::to_string(i % 1000);
-            auto a = clock_t_::now();
-            c.set(k, data_store::Value{val});
-            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
-        }
-        report("set (persist)", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), N);
+        auto t0 = bclock::now();
+        for (long i = 0; i < N; ++i) { auto a = bclock::now();
+            c.set("bench.k" + std::to_string(i % 1000), data_store::Value{val});
+            lat.push_back(std::chrono::duration_cast<us>(bclock::now() - a).count()); }
+        report("set (persist)", "set_persist", lat,
+               std::chrono::duration<double>(bclock::now() - t0).count(), N, true);
     }
-
-    // 2. volatile set (in-memory overlay, no fsync).
-    {
+    {   // volatile set (in-memory overlay, no fsync)
         std::vector<double> lat; lat.reserve(N);
-        auto t0 = clock_t_::now();
-        for (long i = 0; i < N; ++i) {
-            std::string k = "bench.v" + std::to_string(i % 1000);
-            auto a = clock_t_::now();
-            c.set_volatile(k, data_store::Value{val});
-            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
-        }
-        report("set (volatile)", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), N);
+        auto t0 = bclock::now();
+        for (long i = 0; i < N; ++i) { auto a = bclock::now();
+            c.set_volatile("bench.v" + std::to_string(i % 1000), data_store::Value{val});
+            lat.push_back(std::chrono::duration_cast<us>(bclock::now() - a).count()); }
+        report("set (volatile)", "set_volatile", lat,
+               std::chrono::duration<double>(bclock::now() - t0).count(), N, true);
     }
-
-    // 3. get.
-    {
+    {   // get
         std::vector<double> lat; lat.reserve(N);
         std::vector<data_store::Client::GetResult> out;
-        auto t0 = clock_t_::now();
-        for (long i = 0; i < N; ++i) {
-            std::string k = "bench.k" + std::to_string(i % 1000);
-            auto a = clock_t_::now();
-            c.get({k}, out);
-            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
-        }
-        report("get", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), N);
+        auto t0 = bclock::now();
+        for (long i = 0; i < N; ++i) { auto a = bclock::now();
+            c.get({"bench.k" + std::to_string(i % 1000)}, out);
+            lat.push_back(std::chrono::duration_cast<us>(bclock::now() - a).count()); }
+        report("get", "get", lat,
+               std::chrono::duration<double>(bclock::now() - t0).count(), N, true);
     }
-
-    // 4. batched persistent set (BATCH keys per call) — amortised fsync.
-    {
+    {   // batched persistent set (BATCH keys / call) — amortised fsync
         const long iters = N / BATCH;
         std::vector<double> lat; lat.reserve(iters);
-        auto t0 = clock_t_::now();
+        auto t0 = bclock::now();
         for (long i = 0; i < iters; ++i) {
             std::vector<data_store::KV> kv; kv.reserve(BATCH);
             for (long j = 0; j < BATCH; ++j)
                 kv.emplace_back("bench.b" + std::to_string(j), data_store::Value{val});
-            auto a = clock_t_::now();
-            c.set(kv);
-            lat.push_back(std::chrono::duration_cast<us>(clock_t_::now() - a).count());
-        }
-        report("set (batch)", lat, std::chrono::duration<double>(clock_t_::now() - t0).count(), iters * BATCH);
+            auto a = bclock::now(); c.set(kv);
+            lat.push_back(std::chrono::duration_cast<us>(bclock::now() - a).count()); }
+        report("set (batch)", "set_batch", lat,
+               std::chrono::duration<double>(bclock::now() - t0).count(), iters * BATCH, true);
     }
-
-    // 5. watch -> notify delivery latency (set on one client, callback on another).
-    {
+    {   // watch -> notify delivery latency
         data_store::Client w;
         if (w.connect(sock).ok) {
             std::mutex m; std::condition_variable cv;
-            clock_t_::time_point recv; std::atomic<bool> got{false};
+            bclock::time_point recv; std::atomic<bool> got{false};
             w.watch("bench.notify", [&](const data_store::Client::Event&) {
-                recv = clock_t_::now();
-                { std::lock_guard<std::mutex> lk(m); got = true; } cv.notify_one();
-            });
+                recv = bclock::now();
+                { std::lock_guard<std::mutex> lk(m); got = true; } cv.notify_one(); });
             const long M = std::min<long>(N, 5000);
             std::vector<double> lat; lat.reserve(M);
             for (long i = 0; i < M; ++i) {
-                got = false;
-                auto a = clock_t_::now();
+                got = false; auto a = bclock::now();
                 c.set("bench.notify", data_store::Value{std::to_string(i)});
                 std::unique_lock<std::mutex> lk(m);
                 if (cv.wait_for(lk, std::chrono::seconds(2), [&]{ return got.load(); }))
-                    lat.push_back(std::chrono::duration_cast<us>(recv - a).count());
-            }
-            report("watch->notify", lat, 1.0, lat.size());  // latency-focused
+                    lat.push_back(std::chrono::duration_cast<us>(recv - a).count()); }
+            report("watch->notify", "notify", lat, 1.0, lat.size(), false);
         }
     }
+
+    // Memory: ds-server resident set after the run + its peak (VmHWM).
+    const long rss1 = proc_kb(PID, "VmRSS:");
+    const long hwm  = proc_kb(PID, "VmHWM:");
+    if (PID > 0) {
+        std::printf("%-18s rss %ld KB -> %ld KB (delta %+ld) | peak(VmHWM) %ld KB\n",
+                    "ds-server mem", rss0, rss1, rss1 - rss0, hwm);
+    }
+
+    // Write the summary into ds for at-a-glance reporting / UI.
+    char cfg[160];
+    std::snprintf(cfg, sizeof(cfg),
+                  "{\"config\":{\"n\":%ld,\"vsize\":%zu,\"batch\":%ld},"
+                  "\"mem\":{\"rss_kb\":%ld,\"hwm_kb\":%ld},",
+                  N, VS, BATCH, rss1, hwm);
+    std::string json = std::string(cfg) + g_summary + "}";
+    if (auto s = c.set("ds.bench.summary", data_store::Value{json}); s.ok)
+        std::printf("\nwrote ds.bench.summary (%zu bytes)\n", json.size());
+    else
+        std::printf("\nds.bench.summary set failed: %s\n", s.err.c_str());
 
     c.close();
     return 0;

--- a/modules/data-store/docs/benchmark.md
+++ b/modules/data-store/docs/benchmark.md
@@ -13,8 +13,13 @@ g++ -std=c++17 -O2 -Imodules/data-store/inc -I$ACE_ROOT/include \
 # or: cmake modules/data-store -DBUILD_DS_BENCH=ON && ninja ds-bench
 
 ds-server --socket=/run/iot/data_store.sock --schema-dir=<dir> --persist-dir=<dir> &
-ds-bench socket=/run/iot/data_store.sock n=20000 vsize=64 batch=50
+ds-bench socket=/run/iot/data_store.sock n=20000 vsize=64 batch=50 pid=$!
 ```
+
+`pid=<ds-server-pid>` lets the bench read the server's `/proc/<pid>/status`
+(RSS + peak `VmHWM`). At the end the bench writes a JSON summary to the ds key
+**`ds.bench.summary`** (`config`, `mem`, and per-op `{ops,p50,p95,p99}`), so the
+latest result is queryable: `ds-cli get ds.bench.summary` (or surfaced in the UI).
 
 ## Results (indicative)
 
@@ -28,7 +33,10 @@ Single client thread; each op is a synchronous request→response round-trip.
 | `set` (volatile, no fsync) | 14.0k ops/s | 71 µs | 67 µs | 112 µs | 159 µs | 2.0 ms |
 | `get` | 15.6k ops/s | 64 µs | 66 µs | 100 µs | 143 µs | 1.6 ms |
 | `set` (batch ×50) | **248k keys/s** | 198 µs/call | 119 µs | 154 µs | 207 µs | 31 ms |
-| `watch`→notify delivery | — | 761 µs | 728 µs | 1.0 ms | 1.5 ms | 6.4 ms |
+| `watch`→notify delivery | — | 737 µs | 732 µs | 774 µs | 847 µs | 4.8 ms |
+
+**ds-server memory:** RSS **~5.2 MB → ~6.7 MB** after the run (≈ +1.5 MB holding
+~1000+ keys), peak `VmHWM` ~6.7 MB. A small, flat footprint — fine for an RPi.
 
 ## Reading the numbers
 

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -181,6 +181,16 @@ return {
         type    = "boolean",
         default = false,
     },
+
+    -- data-store self-benchmark summary (JSON), written by ds-bench at the end
+    -- of a run: { config, mem:{rss_kb,hwm_kb}, per-op {ops,p50,p95,p99} }.
+    -- Read via `ds-cli get ds.bench.summary` or surfaced in the UI.
+    -- See modules/data-store/docs/benchmark.md.
+    ["ds.bench.summary"] = {
+        access  = "Admin",
+        type    = "string",
+        default = "",
+    },
     ["iot.update.version"] = {      -- installed package version after apply
         access  = "Admin",
         type    = "string",


### PR DESCRIPTION
Follow-up to the ds benchmark.

- **Memory:** `ds-bench pid=<ds-server-pid>` reads the server's RSS + peak `VmHWM` from `/proc/<pid>/status` and adds it to the results. Measured (containerized VM): **~5.2 MB → ~6.7 MB** after the run (+~1.5 MB holding ~1000+ keys), peak ~6.7 MB — small, flat footprint, fine for an RPi.
- **Summary in ds:** at the end of a run the bench writes a JSON summary (config, mem, per-op `{ops,p50,p95,p99}`) to the new ds key **`ds.bench.summary`** — queryable via `ds-cli get ds.bench.summary` or surfaceable in the UI. Defined in `iot.lua` (keys are by full name; namespace is informational).
- doc updated (memory line + summary-key note).

Verified: ds-server loads the updated schema and accepts the typed `ds.bench.summary` write; full bench run round-trips the summary back via ds-cli.

🤖 Generated with [Claude Code](https://claude.com/claude-code)