### PR TITLE
feat(wifi): auto-start wifi-client on boot + WPA-Enterprise support

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -421,17 +421,45 @@ NetworkManager MUST be masked on hosts running wifi-client — the
 daemon's startup probe writes `wifi.assoc.state="conflict"` and
 refuses to spawn wpa_supplicant if NM is active.
 
+> **Yocto / RPi image:** wifi-client is **auto-enabled on boot**
+> (`SYSTEMD_AUTO_ENABLE=enable`) and the `wifi.networks` schema
+> default seeds a placeholder PSK network (`ssid="changeme"`), so a
+> fresh image starts the daemon automatically and only needs the
+> `wifi.networks` set below to associate. The `systemctl enable`
+> step is unnecessary on the image; it remains required on bare-metal
+> hosts where the unit ships disabled.
+
+`wifi.networks` is a JSON array; each entry is one of:
+
+```jsonc
+// WPA-PSK (home/personal) — key_mgmt defaults to WPA-PSK when omitted
+{ "ssid": "HomeAP", "psk": "correcthorse", "priority": 10 }
+
+// Open network
+{ "ssid": "GuestAP", "key_mgmt": "NONE" }
+
+// WPA-Enterprise (identity + password). eap defaults "PEAP",
+// phase2 defaults "auth=MSCHAPV2"; ca_cert is optional.
+{ "ssid": "CorpAP", "key_mgmt": "WPA-EAP", "eap": "PEAP",
+  "identity": "user@corp", "password": "secret",
+  "phase2": "auth=MSCHAPV2", "priority": 20 }
+```
+
 ```sh
 sudo systemctl mask NetworkManager   # avoid the conflict gate
 
 ds-cli --socket=/run/iot/data_store.sock set wifi.networks \
     '[{"ssid":"HomeAP","psk":"correcthorse","priority":10}]'
 
+# WPA-Enterprise example:
+# ds-cli ... set wifi.networks \
+#   '[{"ssid":"CorpAP","key_mgmt":"WPA-EAP","identity":"user@corp","password":"secret"}]'
+
 # Optional: pick a different iface or DHCP client.
 ds-cli --socket=/run/iot/data_store.sock set wifi.iface       '"wlan0"'
 ds-cli --socket=/run/iot/data_store.sock set wifi.dhcp.client '"udhcpc"'
 
-sudo systemctl enable --now iot-wifi-client.service
+sudo systemctl enable --now iot-wifi-client.service   # bare-metal only; pre-enabled on the image
 journalctl -u iot-wifi-client.service -f | grep "ctrl attached\|assoc\|connected\|dhcp"
 
 # Observe the published wifi.* keys.

--- a/apps/docs/tdd-wifi-autostart.md
+++ b/apps/docs/tdd-wifi-autostart.md
@@ -89,8 +89,10 @@ overridable at runtime (cloud-UI / `ds-cli`).
 
 Field rules:
 - `ssid` — required, non-empty (unchanged).
-- `key_mgmt` — optional, default `"WPA-PSK"`. Recognised: `WPA-PSK`, `NONE`,
-  `WPA-EAP` (alias `IEEE8021X` accepted, propagated verbatim).
+- `key_mgmt` — optional, default `"WPA-PSK"`. Only the exact value `WPA-EAP`
+  triggers the WPA-Enterprise branch; `NONE` is an open network; any other
+  value (incl. `WPA-PSK`) is PSK-style — `psk` is required and the `key_mgmt`
+  string is propagated verbatim to wpa_supplicant.conf.
 - `psk` — required iff `key_mgmt` is PSK-like (not `NONE`, not `WPA-EAP`).
 - `identity`, `password` — required iff `key_mgmt == WPA-EAP`.
 - `eap` — optional, default `"PEAP"`. (`PEAP` / `TTLS` / `TLS` …)

--- a/apps/docs/tdd-wifi-autostart.md
+++ b/apps/docs/tdd-wifi-autostart.md
@@ -1,25 +1,42 @@
 # TDD Plan — WiFi Client Auto-start on Boot + WPA-Enterprise Support
 
-Status: **IN PROGRESS** — design + scope agreed. Device side only (Yocto
-image + wifi-client daemon); no cloud/UI changes. Build/test via the existing
-host-side gtest harness under `modules/wan/wifi/client/`.
+Status: **COMPLETE** (implementable scope) — device side only (Yocto image +
+wifi-client daemon); no cloud/UI changes. Unit + build verified in podman:
+wifi-client suite **103/103** green. The new WPA-Enterprise surface is tracked
+as **REQ-WIFI-024** (014–023, 026 were already taken).
 
 ### Implementation progress
 
 | Task | State | Notes |
 | --- | --- | --- |
-| A — WifiNetwork struct gains EAP fields | ⬜ TODO | `process.hpp`: `identity`, `password`, `eap`, `phase2`, `ca_cert`. |
-| B — parse_networks parses/validates EAP | ⬜ TODO | `process.cpp`: when `key_mgmt=WPA-EAP`, require `identity`+`password`, parse optional `eap`/`phase2`/`ca_cert`; do **not** require `psk`. |
-| C — build_wpa_supplicant_config emits EAP | ⬜ TODO | `process.cpp`: EAP `network={}` block (no `psk`); PSK/NONE branches unchanged. |
-| D — unit tests | ⬜ TODO | `test/process_test.cpp`: EAP parse OK, missing identity/password rejected, EAP conf-gen, PSK regression. |
-| E — seed default in schema | ⬜ TODO | `schemas/wifi.lua`: `wifi.networks` default `[]` → default network; doc comment extended with EAP shape. |
-| F — auto-enable service | ⬜ TODO | `yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb`: `SYSTEMD_AUTO_ENABLE:${PN}-wifi-client` `disable` → `enable`. |
-| G — docs | ⬜ TODO | `DEPLOY.md` wifi section: both JSON shapes + auto-start note. |
+| A — WifiNetwork struct gains EAP fields | ✅ DONE | `process.hpp`: `eap`, `identity`, `password`, `phase2`, `ca_cert` added after `key_mgmt` (positional aggregate inits stay valid). |
+| B — parse_networks parses/validates EAP | ✅ DONE | `process.cpp`: `key_mgmt=WPA-EAP` requires non-empty `identity`+`password`; `eap` defaults `PEAP`, `phase2` defaults `auth=MSCHAPV2`; `ca_cert` optional; `psk` not required. |
+| C — build_wpa_supplicant_config emits EAP | ✅ DONE | `process.cpp`: shared quote-escape lambda; EAP `network={}` block emits `key_mgmt=WPA-EAP`/`eap`/`identity`/`password`/`phase2`/`ca_cert` and **no** `psk`. PSK/NONE output byte-identical. |
+| D — unit tests | ✅ DONE | `test/process_test.cpp` REQ-WIFI-024: 8 EAP tests (parse OK, missing id/pw rejected, defaults, conf-gen no-psk, ca_cert-only-when-present, quote-escape) + seeded-default round-trip; PSK/NONE regressions green. |
+| E — seed default in schema | ✅ DONE | `schemas/wifi.lua`: `wifi.networks` default `[]` → `[{"ssid":"changeme","key_mgmt":"WPA-PSK","psk":"changeme","priority":10}]`; doc comment extended with EAP shape. `schema_test.cpp` `documented_defaults_match` updated (JSON braces defeat the brace-naive `entry_body` helper → asserted against full schema text). |
+| F — auto-enable service | ✅ DONE | `iot_git.bb`: `SYSTEMD_AUTO_ENABLE:${PN}-wifi-client` `disable` → `enable`. Ships `wifi-client.env`; unit already orders `After=iot-ds.service network-online.target`. |
+| G — docs | ✅ DONE | `DEPLOY.md` wifi section: auto-start-on-image note + all three JSON shapes (PSK / open / WPA-EAP). |
 
-Test cmd (wifi-client): host-side gtest
-`cmake .. -DACE_ROOT=/usr/local/ACE_TAO-7.0.0 && make -j wifi_client_test && ./wifi_client_test`
-(exact target name confirmed at implementation time from the module
-`CMakeLists.txt`).
+Test cmd (wifi-client), podman:
+```sh
+podman run --rm -v "$PWD":/src:Z -w /src/modules/wan/wifi/client \
+  localhost/iot-cloud-builder:authfix bash -lc '
+    apt-get update && apt-get install -y libgtest-dev
+    mkdir -p build && cd build
+    cmake .. -DACE_ROOT=/usr/local/ACE_TAO-7.0.0 -DBUILD_WIFI_CLIENT_TESTS=ON
+    make -j4 wifi-client-tests && ./wifi-client-tests'
+```
+(`libgtest-dev` is not pre-installed in `iot-cloud-builder`; `apt-get update`
+first or `find_package(GTest)` fails. The `:lp` httpd image has it baked in.)
+
+## 6. Deferred / not done
+
+- **On-device boot verification** on real RPi hardware (service comes up,
+  `wifi.assoc.state` → `connected`, `wifi.dhcp.ip` populated). Needs hardware
+  + a real AP; cannot be verified in podman.
+- Cloud-UI / device-UI EAP form fields (keys already flow through ds).
+- Per-device secure WiFi credential provisioning (placeholder default is
+  world-readable in the image — fine for lab, not production).
 
 ## 1. Goal
 

--- a/apps/docs/tdd-wifi-autostart.md
+++ b/apps/docs/tdd-wifi-autostart.md
@@ -1,0 +1,149 @@
+# TDD Plan — WiFi Client Auto-start on Boot + WPA-Enterprise Support
+
+Status: **IN PROGRESS** — design + scope agreed. Device side only (Yocto
+image + wifi-client daemon); no cloud/UI changes. Build/test via the existing
+host-side gtest harness under `modules/wan/wifi/client/`.
+
+### Implementation progress
+
+| Task | State | Notes |
+| --- | --- | --- |
+| A — WifiNetwork struct gains EAP fields | ⬜ TODO | `process.hpp`: `identity`, `password`, `eap`, `phase2`, `ca_cert`. |
+| B — parse_networks parses/validates EAP | ⬜ TODO | `process.cpp`: when `key_mgmt=WPA-EAP`, require `identity`+`password`, parse optional `eap`/`phase2`/`ca_cert`; do **not** require `psk`. |
+| C — build_wpa_supplicant_config emits EAP | ⬜ TODO | `process.cpp`: EAP `network={}` block (no `psk`); PSK/NONE branches unchanged. |
+| D — unit tests | ⬜ TODO | `test/process_test.cpp`: EAP parse OK, missing identity/password rejected, EAP conf-gen, PSK regression. |
+| E — seed default in schema | ⬜ TODO | `schemas/wifi.lua`: `wifi.networks` default `[]` → default network; doc comment extended with EAP shape. |
+| F — auto-enable service | ⬜ TODO | `yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb`: `SYSTEMD_AUTO_ENABLE:${PN}-wifi-client` `disable` → `enable`. |
+| G — docs | ⬜ TODO | `DEPLOY.md` wifi section: both JSON shapes + auto-start note. |
+
+Test cmd (wifi-client): host-side gtest
+`cmake .. -DACE_ROOT=/usr/local/ACE_TAO-7.0.0 && make -j wifi_client_test && ./wifi_client_test`
+(exact target name confirmed at implementation time from the module
+`CMakeLists.txt`).
+
+## 1. Goal
+
+On a fresh Raspberry Pi boot with the `iot` image, the `wifi-client` daemon
+must come up **automatically** and connect using **default credentials seeded
+into the data-store**, supporting **both** modes per-network:
+
+- **WPA-PSK** (home/personal): `{ssid, psk}`
+- **WPA-Enterprise / WPA-EAP** (corporate, identity + password):
+  `{ssid, key_mgmt:"WPA-EAP", eap, identity, password, phase2}`
+
+No operator step is required for the default network; the default is
+overridable at runtime (cloud-UI / `ds-cli`).
+
+## 2. Current state (verified)
+
+- `iot-wifi-client.service` already exists and orders correctly
+  (`After=`/`Wants=network-online.target iot-ds.service`, `Type=simple`,
+  `Restart=on-failure`), but **ships disabled**:
+  `SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "disable"` in `iot_git.bb`.
+- The daemon reads **all** config from ds keys; credentials come solely from
+  `wifi.networks` (default `"[]"` → daemon parks `disconnected`).
+- `modules/wan/wifi/client/src/process.cpp` parses `{ssid, psk, priority,
+  key_mgmt}` and handles `WPA-PSK` + `NONE` only. For any non-`NONE`
+  `key_mgmt` it **requires `psk` and always emits `psk="..."`** — so
+  `WPA-EAP` would produce a malformed `network={}` block today.
+- `WifiNetwork` (`process.hpp:34`) has no EAP fields.
+- wifi-client is in `packagegroup-iot-full` (always installed in the default
+  image); only the systemd auto-enable gate keeps it from starting.
+
+## 3. Design
+
+### 3.1 JSON shapes (`wifi.networks`)
+
+`wifi.networks` stays a JSON **string** (array of objects), schema-typed
+`string`; shape validated in C++ (unchanged contract). Two entry shapes:
+
+```jsonc
+// PSK (default key_mgmt when omitted)
+{ "ssid": "HomeAP", "key_mgmt": "WPA-PSK", "psk": "passphrase", "priority": 10 }
+
+// Open network
+{ "ssid": "GuestAP", "key_mgmt": "NONE" }
+
+// WPA-Enterprise
+{ "ssid": "CorpAP", "key_mgmt": "WPA-EAP", "eap": "PEAP",
+  "identity": "user@corp", "password": "secret",
+  "phase2": "auth=MSCHAPV2", "priority": 20 }
+```
+
+Field rules:
+- `ssid` — required, non-empty (unchanged).
+- `key_mgmt` — optional, default `"WPA-PSK"`. Recognised: `WPA-PSK`, `NONE`,
+  `WPA-EAP` (alias `IEEE8021X` accepted, propagated verbatim).
+- `psk` — required iff `key_mgmt` is PSK-like (not `NONE`, not `WPA-EAP`).
+- `identity`, `password` — required iff `key_mgmt == WPA-EAP`.
+- `eap` — optional, default `"PEAP"`. (`PEAP` / `TTLS` / `TLS` …)
+- `phase2` — optional, default `"auth=MSCHAPV2"` for PEAP/TTLS.
+- `ca_cert` — optional path; emitted only when present.
+- `priority` — optional int, default 0 (unchanged).
+
+### 3.2 wpa_supplicant.conf generation
+
+`build_wpa_supplicant_config` gains an EAP branch. Existing PSK/NONE output is
+byte-for-byte unchanged. EAP block:
+
+```
+network={
+    ssid="CorpAP"
+    key_mgmt=WPA-EAP
+    eap=PEAP
+    identity="user@corp"
+    password="secret"
+    phase2="auth=MSCHAPV2"
+    ca_cert="/etc/iot/certs/corp-ca.pem"   # only if ca_cert present
+    priority=20
+}
+```
+
+All quoted string values reuse the existing `"`/`\` escape helper so a
+mischievous identity/password can't break the conf parser.
+
+### 3.3 Default seeding (schema default)
+
+`wifi.networks` default changes from `"[]"` to a one-network JSON array in
+`schemas/wifi.lua`. Semantics: the schema default applies **only while the key
+is unset**. The moment anything `set`s `wifi.networks`, the persisted value
+wins; the default reappears only on a fresh image / ds reset. This matches the
+"default that an operator can override at runtime" requirement.
+
+⚠️ **Security note:** this bakes a plaintext credential into
+`/etc/iot/ds-schemas/wifi.lua` (world-readable in the image). Acceptable for a
+lab / default AP; production deployments should provision per-device instead
+(out of scope here). The committed default uses a placeholder
+(`ssid="changeme"`, `psk="changeme"`) so no real secret lands in git.
+
+### 3.4 Auto-start
+
+Flip `SYSTEMD_AUTO_ENABLE:${PN}-wifi-client` from `disable` to `enable` in
+`iot_git.bb`. No `.service` edit needed: existing
+`After=/Wants=iot-ds.service network-online.target` guarantees ds-server is up
+(so the schema default for `wifi.networks` resolves) before the daemon's first
+read. The unit is long-running with `Restart=on-failure`, so it re-arms on
+every boot — satisfying "start once after reboot".
+
+## 4. Out of scope
+
+- Cloud-UI / device-UI editing of EAP fields (the keys flow through ds, so the
+  generic key editor already works; bespoke form is future work).
+- Per-device secure provisioning of WiFi credentials (see security note).
+- Certificate management / EAP-TLS client certs beyond an optional `ca_cert`
+  path passthrough.
+
+## 5. Test strategy (TDD)
+
+Write/extend `test/process_test.cpp` **first**, then implement until green:
+
+1. `ParseNetworks_Eap_Valid` — full EAP entry parses into the struct.
+2. `ParseNetworks_Eap_MissingIdentity_Rejected` — sets `err_out`, returns {}.
+3. `ParseNetworks_Eap_MissingPassword_Rejected`.
+4. `ParseNetworks_Eap_DefaultsEapAndPhase2` — omitted `eap`/`phase2` default.
+5. `BuildConfig_Eap_EmitsEapBlockNoPsk` — generated conf has `key_mgmt=WPA-EAP`,
+   `identity=`, `password=`, `eap=`, and **no** `psk=`.
+6. `BuildConfig_Eap_CaCertOnlyWhenPresent`.
+7. Regression: existing PSK/NONE parse + conf-gen tests stay green.
+8. `schema_test.cpp`: assert the new `wifi.networks` default is valid JSON and
+   round-trips through `parse_networks` without error.

--- a/modules/wan/wifi/client/schemas/wifi.lua
+++ b/modules/wan/wifi/client/schemas/wifi.lua
@@ -6,8 +6,17 @@
 --                             (default "/run/wpa_supplicant")
 --   wifi.wpa.path           - path to wpa_supplicant(8)
 --                             (default "/usr/sbin/wpa_supplicant")
---   wifi.networks           - JSON array of {ssid, psk, priority, key_mgmt}
---                             entries (default "[]"; validated in code, not lua)
+--   wifi.networks           - JSON array of network entries (validated in
+--                             code, not lua). Two shapes per entry:
+--                               PSK : {ssid, psk, priority, key_mgmt}
+--                                     key_mgmt "WPA-PSK" (default) or "NONE"
+--                               EAP : {ssid, key_mgmt="WPA-EAP", eap,
+--                                     identity, password, phase2, ca_cert,
+--                                     priority}  (WPA-Enterprise; eap
+--                                     defaults "PEAP", phase2 "auth=MSCHAPV2")
+--                             Default seeds one placeholder PSK network so a
+--                             fresh image auto-associates once provisioned;
+--                             operators override via ds-cli / cloud-ui.
 --   wifi.scan.interval.sec  - periodic background scan cadence in seconds
 --                             (default 60; 0 disables periodic scans)
 --   wifi.scan.max.results   - cap on the length of wifi.scan.results
@@ -68,8 +77,15 @@ return {
     ["wifi.wpa.path"]           = {
         access  = "Admin", type = "string",
                                     default = "/usr/sbin/wpa_supplicant" },
+    -- Default seeds one placeholder PSK network. wifi-client auto-starts
+    -- on boot (SYSTEMD_AUTO_ENABLE=enable) and reads this default until an
+    -- operator overrides wifi.networks. Replace ssid/psk per deployment;
+    -- the placeholder parks the daemon in "disconnected" (no such AP) until
+    -- then. NOTE: this value lives in the world-readable image schema — do
+    -- not commit a real secret here; provision per-device for production.
     ["wifi.networks"]           = {
-        access  = "Admin", type = "string",  default = "[]" },
+        access  = "Admin", type = "string",
+        default = '[{"ssid":"changeme","key_mgmt":"WPA-PSK","psk":"changeme","priority":10}]' },
     ["wifi.scan.interval.sec"]  = {
         access  = "Admin", type = "integer", default = 60,
                                     min = 0, max = 86400 },

--- a/modules/wan/wifi/client/src/ds_bridge.cpp
+++ b/modules/wan/wifi/client/src/ds_bridge.cpp
@@ -88,8 +88,10 @@ DsBridge::DsBridge(std::string socketPath)
     // Prime the snapshot with one initial get. Every read key has a
     // schema default (per schemas/wifi.lua) so the cache is fully
     // populated as soon as ds-server returns. wifi.networks defaults
-    // to "[]" — empty JSON array — which the Supervisor treats as
-    // "no networks configured" (parks in disconnected).
+    // to a placeholder PSK network (ssid "changeme"); the Supervisor
+    // tries to associate and parks in disconnected until that AP is
+    // found or an operator overrides wifi.networks. An operator-set
+    // empty "[]" is treated as "no networks configured".
     const std::vector<std::string> read_keys = {
         kIface, kCtrlDir, kWpaPath, kNetworks,
         kScanIntervalSec, kScanMaxResults, kScanRequest,

--- a/modules/wan/wifi/client/src/process.cpp
+++ b/modules/wan/wifi/client/src/process.cpp
@@ -24,6 +24,21 @@
 
 namespace wifi_client {
 
+namespace {
+
+// wpa_supplicant.conf is line-oriented and has no escape for control
+// characters; a stray '\n' in any emitted value would break the conf
+// or inject a directive (the conf writer's esc() only handles " and \).
+// Reject control characters at parse time instead.
+bool has_control_char(const std::string& s) {
+    for (unsigned char c : s) {
+        if (c < 0x20 || c == 0x7f) return true;
+    }
+    return false;
+}
+
+} // namespace
+
 // ─────────────────────── Pure helpers ───────────────────────────────
 
 std::vector<WifiNetwork>
@@ -79,9 +94,10 @@ parse_wifi_networks(const std::string& json, std::string* err_out) {
                         + " missing non-empty 'identity' for key_mgmt=WPA-EAP");
                 return {};
             }
-            if (!e.contains("password") || !e["password"].is_string()) {
+            if (!e.contains("password") || !e["password"].is_string() ||
+                e["password"].get<std::string>().empty()) {
                 set_err("bad_networks_json: entry " + std::to_string(i)
-                        + " missing 'password' for key_mgmt=WPA-EAP");
+                        + " missing non-empty 'password' for key_mgmt=WPA-EAP");
                 return {};
             }
             n.identity = e["identity"].get<std::string>();
@@ -119,6 +135,17 @@ parse_wifi_networks(const std::string& json, std::string* err_out) {
                 return {};
             }
             n.priority = e["priority"].get<int>();
+        }
+        // Every value below is emitted verbatim into wpa_supplicant.conf;
+        // reject control characters so a newline can't break the conf or
+        // inject a directive.
+        for (const auto* f : {&n.ssid, &n.psk, &n.identity, &n.password,
+                              &n.eap, &n.phase2, &n.ca_cert}) {
+            if (has_control_char(*f)) {
+                set_err("bad_networks_json: entry " + std::to_string(i)
+                        + " field contains control characters");
+                return {};
+            }
         }
         out.push_back(std::move(n));
     }

--- a/modules/wan/wifi/client/src/process.cpp
+++ b/modules/wan/wifi/client/src/process.cpp
@@ -71,8 +71,35 @@ parse_wifi_networks(const std::string& json, std::string* err_out) {
             }
             n.key_mgmt = e["key_mgmt"].get<std::string>();
         }
-        // psk (required unless key_mgmt == NONE)
-        if (n.key_mgmt != "NONE") {
+        if (n.key_mgmt == "WPA-EAP") {
+            // WPA-Enterprise: identity + password instead of psk.
+            if (!e.contains("identity") || !e["identity"].is_string() ||
+                e["identity"].get<std::string>().empty()) {
+                set_err("bad_networks_json: entry " + std::to_string(i)
+                        + " missing non-empty 'identity' for key_mgmt=WPA-EAP");
+                return {};
+            }
+            if (!e.contains("password") || !e["password"].is_string()) {
+                set_err("bad_networks_json: entry " + std::to_string(i)
+                        + " missing 'password' for key_mgmt=WPA-EAP");
+                return {};
+            }
+            n.identity = e["identity"].get<std::string>();
+            n.password = e["password"].get<std::string>();
+            // eap defaults to PEAP, phase2 to MSCHAPV2; ca_cert optional.
+            n.eap    = (e.contains("eap") && e["eap"].is_string() &&
+                        !e["eap"].get<std::string>().empty())
+                           ? e["eap"].get<std::string>()
+                           : "PEAP";
+            n.phase2 = (e.contains("phase2") && e["phase2"].is_string() &&
+                        !e["phase2"].get<std::string>().empty())
+                           ? e["phase2"].get<std::string>()
+                           : "auth=MSCHAPV2";
+            if (e.contains("ca_cert") && e["ca_cert"].is_string()) {
+                n.ca_cert = e["ca_cert"].get<std::string>();
+            }
+        } else if (n.key_mgmt != "NONE") {
+            // psk (required unless key_mgmt == NONE)
             if (!e.contains("psk") || !e["psk"].is_string()) {
                 set_err("bad_networks_json: entry " + std::to_string(i)
                         + " missing 'psk' for key_mgmt=" + n.key_mgmt);
@@ -119,6 +146,18 @@ std::string build_wpa_supplicant_config(const std::string&             iface,
                   return a.priority > b.priority;
               });
 
+    // Quote-escape any literal " or \\ inside a value so a mischievous
+    // passphrase / identity / password can't break the conf parser.
+    auto esc = [](const std::string& in) {
+        std::string out;
+        out.reserve(in.size() + 2);
+        for (char c : in) {
+            if (c == '"' || c == '\\') out.push_back('\\');
+            out.push_back(c);
+        }
+        return out;
+    };
+
     for (const auto& n : sorted) {
         ss << "network={\n";
         // ssid is always quoted; psk may be quoted (passphrase)
@@ -128,16 +167,20 @@ std::string build_wpa_supplicant_config(const std::string&             iface,
         ss << "    ssid=\"" << n.ssid << "\"\n";
         if (n.key_mgmt == "NONE") {
             ss << "    key_mgmt=NONE\n";
-        } else {
-            // Quote-escape any literal " or \\ in the PSK so a
-            // mischievous passphrase can't break the conf parser.
-            std::string esc;
-            esc.reserve(n.psk.size() + 2);
-            for (char c : n.psk) {
-                if (c == '"' || c == '\\') esc.push_back('\\');
-                esc.push_back(c);
+        } else if (n.key_mgmt == "WPA-EAP") {
+            // WPA-Enterprise: no psk — emit EAP method + credentials.
+            ss << "    key_mgmt=WPA-EAP\n";
+            ss << "    eap=" << (n.eap.empty() ? "PEAP" : n.eap) << "\n";
+            ss << "    identity=\"" << esc(n.identity) << "\"\n";
+            ss << "    password=\"" << esc(n.password) << "\"\n";
+            if (!n.phase2.empty()) {
+                ss << "    phase2=\"" << esc(n.phase2) << "\"\n";
             }
-            ss << "    psk=\"" << esc << "\"\n";
+            if (!n.ca_cert.empty()) {
+                ss << "    ca_cert=\"" << esc(n.ca_cert) << "\"\n";
+            }
+        } else {
+            ss << "    psk=\"" << esc(n.psk) << "\"\n";
             if (n.key_mgmt != "WPA-PSK") {
                 ss << "    key_mgmt=" << n.key_mgmt << "\n";
             }

--- a/modules/wan/wifi/client/src/process.cpp
+++ b/modules/wan/wifi/client/src/process.cpp
@@ -190,8 +190,10 @@ std::string build_wpa_supplicant_config(const std::string&             iface,
         // ssid is always quoted; psk may be quoted (passphrase)
         // or a 64-char hex pre-shared key — we always quote here
         // because operators typing PSKs into ds-cli will use the
-        // passphrase form, not pre-computed hex.
-        ss << "    ssid=\"" << n.ssid << "\"\n";
+        // passphrase form, not pre-computed hex. esc() the ssid too:
+        // SSIDs may legitimately contain " or \ which would otherwise
+        // break the conf parser.
+        ss << "    ssid=\"" << esc(n.ssid) << "\"\n";
         if (n.key_mgmt == "NONE") {
             ss << "    key_mgmt=NONE\n";
         } else if (n.key_mgmt == "WPA-EAP") {

--- a/modules/wan/wifi/client/src/process.hpp
+++ b/modules/wan/wifi/client/src/process.hpp
@@ -35,10 +35,20 @@ struct WifiNetwork {
     std::string  ssid;
     std::string  psk;
     int          priority = 0;
-    /// "WPA-PSK" (default) or "NONE" (open network). Anything else
-    /// is propagated verbatim to wpa_supplicant.conf so future key
-    /// management modes don't need a code change here.
+    /// "WPA-PSK" (default), "NONE" (open network), or "WPA-EAP"
+    /// (WPA-Enterprise). Anything else is propagated verbatim to
+    /// wpa_supplicant.conf so future key management modes don't need
+    /// a code change here.
     std::string  key_mgmt = "WPA-PSK";
+
+    // ───── WPA-Enterprise (key_mgmt == "WPA-EAP") fields ─────
+    // Populated by parse_wifi_networks only for EAP entries; ignored
+    // for WPA-PSK / NONE. The config writer emits them in place of psk.
+    std::string  eap;        ///< "PEAP" (default) / "TTLS" / "TLS" / …
+    std::string  identity;   ///< EAP identity (username)
+    std::string  password;   ///< EAP password
+    std::string  phase2;     ///< inner auth, e.g. "auth=MSCHAPV2"
+    std::string  ca_cert;    ///< optional CA-cert path (emitted iff set)
 };
 
 /// Parse a wifi.networks JSON string into a vector of WifiNetwork.
@@ -48,7 +58,11 @@ struct WifiNetwork {
 /// an empty vector. Validates:
 ///   - root must be a JSON array
 ///   - each entry must have "ssid" (non-empty string)
-///   - each entry must have "psk" unless "key_mgmt"=="NONE"
+///   - each entry must have "psk" unless "key_mgmt" is "NONE" or
+///     "WPA-EAP"
+///   - WPA-EAP entries must have "identity" and "password"; "eap"
+///     defaults to "PEAP" and "phase2" to "auth=MSCHAPV2"; "ca_cert"
+///     is optional
 ///   - "priority" is optional, defaults to 0
 ///   - "key_mgmt" is optional, defaults to "WPA-PSK"
 std::vector<WifiNetwork> parse_wifi_networks(const std::string& json,

--- a/modules/wan/wifi/client/test/process_test.cpp
+++ b/modules/wan/wifi/client/test/process_test.cpp
@@ -134,6 +134,18 @@ TEST(WIFI_REQ_WIFI_015_wpa_conf_writer_orders_by_priority,
 }
 
 TEST(WIFI_REQ_WIFI_015_wpa_conf_writer_orders_by_priority,
+     ssid_quote_chars_escaped) {
+    std::vector<WifiNetwork> nets = {
+        { "My\"AP\\x", "psk", 0, "WPA-PSK" },
+    };
+    auto body = build_wpa_supplicant_config(
+        "wlan0", "/run/wpa_supplicant", nets);
+    // " and \\ in the SSID must be backslash-escaped so wpa_supplicant's
+    // parser doesn't see them as terminators.
+    EXPECT_NE(std::string::npos, body.find("ssid=\"My\\\"AP\\\\x\""));
+}
+
+TEST(WIFI_REQ_WIFI_015_wpa_conf_writer_orders_by_priority,
      psk_quote_chars_escaped) {
     std::vector<WifiNetwork> nets = {
         { "Net", "p\"sk\\with\"quotes", 0, "WPA-PSK" },

--- a/modules/wan/wifi/client/test/process_test.cpp
+++ b/modules/wan/wifi/client/test/process_test.cpp
@@ -230,6 +230,148 @@ TEST(WIFI_REQ_WIFI_017_dhcp_picker_honours_schema_key,
     SUCCEED() << "result: '" << p << "'";
 }
 
+// ───────────────────── REQ-WIFI-024 (WPA-Enterprise) ────────────────
+//
+// WPA-EAP networks carry identity + password (and optional eap/phase2/
+// ca_cert) instead of a psk. parse_wifi_networks must accept them and
+// reject entries missing identity/password; build_wpa_supplicant_config
+// must emit an EAP network={} block with NO psk= line.
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_accepts_full_eap_entry) {
+    std::string err;
+    auto nets = parse_wifi_networks(
+        R"([{"ssid":"CorpAP","key_mgmt":"WPA-EAP","eap":"PEAP",)"
+        R"("identity":"user@corp","password":"secret",)"
+        R"("phase2":"auth=MSCHAPV2","priority":20}])", &err);
+    EXPECT_TRUE(err.empty()) << err;
+    ASSERT_EQ(1u, nets.size());
+    EXPECT_EQ("CorpAP",          nets[0].ssid);
+    EXPECT_EQ("WPA-EAP",         nets[0].key_mgmt);
+    EXPECT_EQ("PEAP",            nets[0].eap);
+    EXPECT_EQ("user@corp",       nets[0].identity);
+    EXPECT_EQ("secret",          nets[0].password);
+    EXPECT_EQ("auth=MSCHAPV2",   nets[0].phase2);
+    EXPECT_EQ(20,                nets[0].priority);
+    EXPECT_TRUE(nets[0].psk.empty());
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_eap_defaults_eap_and_phase2) {
+    std::string err;
+    auto nets = parse_wifi_networks(
+        R"([{"ssid":"CorpAP","key_mgmt":"WPA-EAP",)"
+        R"("identity":"u","password":"p"}])", &err);
+    EXPECT_TRUE(err.empty()) << err;
+    ASSERT_EQ(1u, nets.size());
+    EXPECT_EQ("PEAP",          nets[0].eap)    << "eap should default to PEAP";
+    EXPECT_EQ("auth=MSCHAPV2", nets[0].phase2) << "phase2 should default";
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_rejects_eap_missing_identity) {
+    std::string err;
+    auto nets = parse_wifi_networks(
+        R"([{"ssid":"CorpAP","key_mgmt":"WPA-EAP","password":"p"}])", &err);
+    EXPECT_TRUE(nets.empty());
+    EXPECT_NE(std::string::npos, err.find("bad_networks_json"));
+    EXPECT_NE(std::string::npos, err.find("identity"));
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_rejects_eap_missing_password) {
+    std::string err;
+    auto nets = parse_wifi_networks(
+        R"([{"ssid":"CorpAP","key_mgmt":"WPA-EAP","identity":"u"}])", &err);
+    EXPECT_TRUE(nets.empty());
+    EXPECT_NE(std::string::npos, err.find("bad_networks_json"));
+    EXPECT_NE(std::string::npos, err.find("password"));
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_eap_does_not_require_psk) {
+    std::string err;
+    auto nets = parse_wifi_networks(
+        R"([{"ssid":"CorpAP","key_mgmt":"WPA-EAP",)"
+        R"("identity":"u","password":"p"}])", &err);
+    EXPECT_TRUE(err.empty()) << err;
+    ASSERT_EQ(1u, nets.size());
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     build_emits_eap_block_without_psk) {
+    WifiNetwork n;
+    n.ssid     = "CorpAP";
+    n.key_mgmt = "WPA-EAP";
+    n.eap      = "PEAP";
+    n.identity = "user@corp";
+    n.password = "secret";
+    n.phase2   = "auth=MSCHAPV2";
+    n.priority = 20;
+    auto body = build_wpa_supplicant_config(
+        "wlan0", "/run/wpa_supplicant", {n});
+    EXPECT_NE(std::string::npos, body.find("ssid=\"CorpAP\""));
+    EXPECT_NE(std::string::npos, body.find("key_mgmt=WPA-EAP"));
+    EXPECT_NE(std::string::npos, body.find("eap=PEAP"));
+    EXPECT_NE(std::string::npos, body.find("identity=\"user@corp\""));
+    EXPECT_NE(std::string::npos, body.find("password=\"secret\""));
+    EXPECT_NE(std::string::npos, body.find("phase2=\"auth=MSCHAPV2\""));
+    EXPECT_NE(std::string::npos, body.find("priority=20"));
+    EXPECT_EQ(std::string::npos, body.find("psk="))
+        << "EAP network MUST NOT emit psk=, body:\n" << body;
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     build_emits_ca_cert_only_when_present) {
+    WifiNetwork bare;
+    bare.ssid     = "CorpAP";
+    bare.key_mgmt = "WPA-EAP";
+    bare.eap      = "PEAP";
+    bare.identity = "u";
+    bare.password = "p";
+    auto body_bare = build_wpa_supplicant_config(
+        "wlan0", "/run/wpa_supplicant", {bare});
+    EXPECT_EQ(std::string::npos, body_bare.find("ca_cert="));
+
+    WifiNetwork with_ca = bare;
+    with_ca.ca_cert = "/etc/iot/certs/corp-ca.pem";
+    auto body_ca = build_wpa_supplicant_config(
+        "wlan0", "/run/wpa_supplicant", {with_ca});
+    EXPECT_NE(std::string::npos,
+              body_ca.find("ca_cert=\"/etc/iot/certs/corp-ca.pem\""));
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     build_escapes_quotes_in_identity_and_password) {
+    WifiNetwork n;
+    n.ssid     = "CorpAP";
+    n.key_mgmt = "WPA-EAP";
+    n.eap      = "PEAP";
+    n.identity = "us\"er";
+    n.password = "pa\\ss\"wd";
+    auto body = build_wpa_supplicant_config(
+        "wlan0", "/run/wpa_supplicant", {n});
+    EXPECT_NE(std::string::npos, body.find("identity=\"us\\\"er\""));
+    EXPECT_NE(std::string::npos, body.find("password=\"pa\\\\ss\\\"wd\""));
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     seeded_schema_default_parses_cleanly) {
+    // Mirrors the wifi.networks default shipped in schemas/wifi.lua.
+    // A fresh image relies on this parsing into exactly one PSK network
+    // so wifi-client autostart has a valid (placeholder) config to load.
+    const char* kSeededDefault =
+        R"([{"ssid":"changeme","key_mgmt":"WPA-PSK","psk":"changeme","priority":10}])";
+    std::string err;
+    auto nets = parse_wifi_networks(kSeededDefault, &err);
+    EXPECT_TRUE(err.empty()) << err;
+    ASSERT_EQ(1u, nets.size());
+    EXPECT_EQ("changeme", nets[0].ssid);
+    EXPECT_EQ("WPA-PSK",  nets[0].key_mgmt);
+    EXPECT_EQ("changeme", nets[0].psk);
+    EXPECT_EQ(10,         nets[0].priority);
+}
+
 // ─────────────────────────── write_temp_config ──────────────────────
 
 TEST(WIFI_REQ_WIFI_015_wpa_conf_writer_orders_by_priority,

--- a/modules/wan/wifi/client/test/process_test.cpp
+++ b/modules/wan/wifi/client/test/process_test.cpp
@@ -289,6 +289,41 @@ TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
 }
 
 TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_rejects_eap_empty_password) {
+    std::string err;
+    auto nets = parse_wifi_networks(
+        R"([{"ssid":"CorpAP","key_mgmt":"WPA-EAP","identity":"u","password":""}])",
+        &err);
+    EXPECT_TRUE(nets.empty());
+    EXPECT_NE(std::string::npos, err.find("bad_networks_json"));
+    EXPECT_NE(std::string::npos, err.find("password"));
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_rejects_control_chars_in_eap_fields) {
+    // A newline in any emitted field would break wpa_supplicant.conf or
+    // inject a directive; parse must reject it rather than pass it to esc().
+    std::string err;
+    auto nets = parse_wifi_networks(
+        "[{\"ssid\":\"CorpAP\",\"key_mgmt\":\"WPA-EAP\","
+        "\"identity\":\"user\\nkey_mgmt=NONE\",\"password\":\"p\"}]",
+        &err);
+    EXPECT_TRUE(nets.empty());
+    EXPECT_NE(std::string::npos, err.find("bad_networks_json"));
+    EXPECT_NE(std::string::npos, err.find("control characters"));
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
+     parse_rejects_control_chars_in_psk) {
+    // Same guard applies to PSK networks (shared emit path).
+    std::string err;
+    auto nets = parse_wifi_networks(
+        "[{\"ssid\":\"Home\",\"psk\":\"pass\\nword\"}]", &err);
+    EXPECT_TRUE(nets.empty());
+    EXPECT_NE(std::string::npos, err.find("control characters"));
+}
+
+TEST(WIFI_REQ_WIFI_024_wpa_enterprise_eap,
      parse_eap_does_not_require_psk) {
     std::string err;
     auto nets = parse_wifi_networks(

--- a/modules/wan/wifi/client/test/schema_test.cpp
+++ b/modules/wan/wifi/client/test/schema_test.cpp
@@ -116,7 +116,6 @@ TEST_F(WIFI_REQ_WIFI_005_read_keys_have_defaults, documented_defaults_match) {
         {"wifi.iface",             "wlan0"},
         {"wifi.ctrl.dir",          "/run/wpa_supplicant"},
         {"wifi.wpa.path",          "/usr/sbin/wpa_supplicant"},
-        {"wifi.networks",          "\\[\\]"},   // escape brackets for regex
         {"wifi.scan.interval.sec", "60"},
         {"wifi.scan.max.results",  "20"},
         {"wifi.scan.request",      "0"},
@@ -128,6 +127,20 @@ TEST_F(WIFI_REQ_WIFI_005_read_keys_have_defaults, documented_defaults_match) {
         EXPECT_TRUE(has_default(body, p.deflt))
             << p.key << " default expected " << p.deflt << ", body was:\n  " << body;
     }
+
+    // wifi.networks is special-cased: its default is a JSON array whose
+    // embedded { } and quotes defeat the brace-naive entry_body() helper.
+    // Assert against the full schema text instead. The default must seed
+    // one placeholder PSK network (autostart-on-boot, REQ-WIFI-024), NOT
+    // the old empty "[]".
+    EXPECT_EQ(std::string::npos, schema.find(R"(default = "[]")"))
+        << "wifi.networks must no longer default to empty []";
+    EXPECT_NE(std::string::npos,
+              schema.find(R"("ssid":"changeme")"))
+        << "wifi.networks default must seed a placeholder network";
+    EXPECT_NE(std::string::npos,
+              schema.find(R"("key_mgmt":"WPA-PSK")"))
+        << "seeded default network must be a WPA-PSK entry";
 }
 
 // ─────────────────────────── REQ-WIFI-006 ───────────────────────────

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -396,13 +396,17 @@ SYSTEMD_SERVICE:${PN}-net-router = "iot-net-router.service"
 SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
 SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service"
 
-# Only ds-server auto-starts. Role units are enabled by the operator
-# after writing the matching .env file — see DEPLOY.md.
+# ds-server and wifi-client auto-start. wifi-client comes up on every boot
+# and reads wifi.networks from the data-store (schema default seeds a
+# placeholder network); it parks in "disconnected" until provisioned. The
+# unit already orders After=iot-ds.service network-online.target, so the
+# schema default resolves before its first read. Other role units are
+# enabled by the operator after writing the matching .env file — see DEPLOY.md.
 SYSTEMD_AUTO_ENABLE:${PN}-ds-server = "enable"
 SYSTEMD_AUTO_ENABLE:${PN}-lwm2m = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-openvpn-client = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-net-router = "disable"
-SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "disable"
+SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "enable"
 SYSTEMD_AUTO_ENABLE:${PN}-httpd = "disable"
 
 # ── Sanity checks ──────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Device side of the "WiFi up automatically after RPi reboot" feature. On a fresh Yocto image, `wifi-client` now auto-starts on boot and reads its credentials from the data-store, supporting **both** WPA-PSK and WPA-Enterprise (WPA-EAP) networks.

Design + scope captured in `apps/docs/tdd-wifi-autostart.md` (committed first).

## Changes

- **Auto-start on the image** — `iot_git.bb`: `SYSTEMD_AUTO_ENABLE:${PN}-wifi-client` `disable` → `enable`. The unit already orders `After=iot-ds.service network-online.target` and ships `wifi-client.env`, so it comes up cleanly every boot.
- **Default credentials via schema** — `wifi.lua`: `wifi.networks` default `[]` → one placeholder `WPA-PSK` entry. Overridable at runtime (ds-cli / cloud-ui); reappears only on a fresh image / ds reset.
- **WPA-Enterprise (WPA-EAP)** — `WifiNetwork` gains `eap`/`identity`/`password`/`phase2`/`ca_cert`. `parse_wifi_networks` validates EAP entries (require non-empty `identity`+`password`; default `eap=PEAP`, `phase2=auth=MSCHAPV2`; `ca_cert` optional; no `psk`). `build_wpa_supplicant_config` emits a `WPA-EAP` `network={}` block with no `psk`. PSK/NONE output is byte-identical to before.
- **Docs** — `DEPLOY.md` wifi section: auto-start-on-image note + PSK / open / WPA-EAP JSON shapes.

## JSON shapes (`wifi.networks`)

```jsonc
{ "ssid": "HomeAP", "psk": "correcthorse", "priority": 10 }              // WPA-PSK
{ "ssid": "GuestAP", "key_mgmt": "NONE" }                               // open
{ "ssid": "CorpAP", "key_mgmt": "WPA-EAP", "eap": "PEAP",               // WPA-Enterprise
  "identity": "user@corp", "password": "secret", "phase2": "auth=MSCHAPV2" }
```

## Code-review fixes (commits `894493ed`, `ca6e7e11`)

Ran `/code-review` (high effort) on the diff; addressed all 5 findings:

1. **Control-char injection** — `parse_wifi_networks` now rejects control characters in any field emitted into `wpa_supplicant.conf` (`ssid`/`psk`/`identity`/`password`/`eap`/`phase2`/`ca_cert`). The conf is line-oriented with no newline escape, and `esc()` only handled `"`/`\`, so a stray `\n` could break the conf or inject a directive.
2. **Empty `password`** — EAP entries now require a **non-empty** `password` (previously only presence + type were checked, inconsistent with `identity`).
3. **Doc/code mismatch** — corrected the TDD `key_mgmt` rule: only exact `WPA-EAP` triggers the EAP branch; other non-`NONE` values are PSK-style, propagated verbatim (the prior "`IEEE8021X` alias accepted" claim was wrong).
4. **Stale comment** — fixed `ds_bridge.cpp` comment that still said `wifi.networks` defaults to `[]`.
5. **SSID escaping** — `build_wpa_supplicant_config` now routes `ssid` through `esc()` too (SSIDs may legitimately contain `"`/`\`).

## Tests

New requirement **REQ-WIFI-024** (014–023, 026 were taken): EAP parse/build coverage, empty-password rejection, control-char rejection (EAP fields + psk), SSID-escape, and a seeded-default round-trip; plus the `schema_test` default assertion updated for the JSON default. Built and ran the full wifi-client gtest suite in podman (`iot-cloud-builder` + `libgtest-dev`):

```
[==========] 107 tests from 26 test suites ran.
[  PASSED  ] 107 tests.
```

## Not done / deferred

- **On-device boot verification** on real RPi hardware (service up, `wifi.assoc.state=connected`, DHCP IP) — needs hardware + a real AP, cannot be verified in podman.
- Cloud-UI / device-UI EAP form fields (keys already flow through ds).
- Per-device secure WiFi credential provisioning — the placeholder default is **world-readable in the image** (fine for lab, not production).

🤖 Generated with [Claude Code](https://claude.com/claude-code)