### PR TITLE
feat(wifi): build-time WiFi credential seed via wifi_credentials.lua

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,11 @@ build/
 
 # Image export tarballs
 iot-cloud.tar.gz
+
+# Real WiFi credential seed baked into the image at build time — never commit.
+# Commit wifi_credentials.lua.sample instead. See apps/docs/tdd-wifi-credentials-seed.md
+yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua
+
+# Python bytecode cache (e.g. from the gen_wifi_default.py tests)
+__pycache__/
+*.pyc

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -429,6 +429,46 @@ refuses to spawn wpa_supplicant if NM is active.
 > step is unnecessary on the image; it remains required on bare-metal
 > hosts where the unit ships disabled.
 
+#### Bake WiFi credentials into the image at build time (optional)
+
+Instead of running `ds-cli set wifi.networks …` on every device, you can
+seed the credentials at **build time** so a freshly-flashed image associates
+to your AP with no runtime step. Drop a `wifi_credentials.lua` into the
+recipe's `files/` directory **before building**:
+
+```
+yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua
+```
+
+Copy the committed template and edit it:
+
+```sh
+cd <repo-root>
+cp yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua.sample \
+   yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua
+# edit, e.g.:  return { ssid = "cordoba_2G", password = "whatever" }
+```
+
+The build (`iot_git.bb` → `gen_wifi_default.py`) converts it to the
+`wifi.networks` JSON below and bakes it into the shipped
+`/etc/iot/ds-schemas/wifi.lua` default. Accepted shapes (PSK / open /
+WPA-EAP) are documented in `wifi_credentials.lua.sample`. The simple form
+maps `password` → `psk`.
+
+- **Optional & safe:** the file is **gitignored** — real passwords never land
+  in source control (only the `.sample` is tracked). Absent file ⇒ build is a
+  no-op and the `changeme` placeholder default stands.
+- **Rebuild on change:** it is wired into `SRC_URI` only when present, so
+  editing it triggers a recipe rebuild (no stale sstate).
+- **Caveats:** the credential is still **plaintext on the device image**
+  (this keeps it out of *git*, not off the *device*), and one build = the
+  same credential for every device flashed from that image (fine for a shared
+  default AP; per-device provisioning is separate).
+- **Verify on device:** `ds-cli get wifi.networks` should show your seeded
+  value. Operators can still override it at runtime with `ds-cli set`.
+
+See `apps/docs/tdd-wifi-credentials-seed.md` for the full design.
+
 `wifi.networks` is a JSON array; each entry is one of:
 
 ```jsonc

--- a/apps/docs/tdd-wifi-credentials-seed.md
+++ b/apps/docs/tdd-wifi-credentials-seed.md
@@ -1,0 +1,130 @@
+# TDD Plan — Build-time WiFi Credential Seed (`wifi_credentials.lua`)
+
+Status: **IN PROGRESS** — design agreed. Builds on the auto-start/EAP work
+(PR #204, merged). Device/Yocto side only. The new logic is a small build-time
+generator, unit-tested in pure Python (no ACE/podman needed).
+
+### Implementation progress
+
+| Task | State | Notes |
+| --- | --- | --- |
+| A — `gen_wifi_default.py` generator | ⬜ TODO | Parse the lua credential file → `wifi.networks` JSON → rewrite the default in the staged `wifi.lua`. |
+| B — Python unit tests | ⬜ TODO | `test_gen_wifi_default.py`: parse PSK/EAP, single/list, `password`→`psk`, malformed→error, schema rewrite, escaping. |
+| C — recipe wiring | ⬜ TODO | `iot_git.bb`: conditional `SRC_URI` + `do_install:append` running the generator on the staged `wifi.lua` iff the file exists. |
+| D — gitignore + sample | ⬜ TODO | `.gitignore` the real file; commit `wifi_credentials.lua.sample`. |
+
+Test cmd: `python3 -m unittest discover -s yocto/meta-iot/recipes-iot/lwm2m/files -p 'test_gen_wifi_default.py'` (host-side, no toolchain).
+
+## 1. Goal
+
+Let a build integrator drop a **gitignored** `wifi_credentials.lua` into the
+recipe's designated dir; the Yocto build reads it and bakes the credentials
+into the `wifi.networks` schema default so a freshly-flashed image associates
+to the operator's AP with no runtime step. If the file is absent, the build is
+a no-op and the committed `changeme` placeholder default stands ("don't care").
+
+This keeps real WiFi credentials **out of source control** — the committed
+`wifi.lua` always carries only the placeholder.
+
+## 2. Designated dir + file
+
+- `yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua` — the real
+  file, **gitignored**.
+- `…/files/wifi_credentials.lua.sample` — committed template.
+- `…/files/gen_wifi_default.py` — committed generator (build tool).
+
+## 3. Credential file format (lua)
+
+Two accepted shapes (matching the operator's mental model):
+
+```lua
+-- (a) single network, simplest form. "password" maps to psk for WPA-PSK.
+return { ssid = "cordoba_2G", password = "whatever" }
+
+-- (b) explicit list (PSK / open / WPA-EAP), one table per network.
+return {
+  { ssid = "cordoba_2G", key_mgmt = "WPA-PSK", psk = "whatever", priority = 10 },
+  { ssid = "Guest",      key_mgmt = "NONE" },
+  { ssid = "Corp",       key_mgmt = "WPA-EAP",
+    identity = "u@corp", password = "secret", eap = "PEAP" },
+}
+```
+
+Field handling (mirrors `parse_wifi_networks` in the daemon):
+- `ssid` — required, non-empty.
+- `key_mgmt` — optional, default `"WPA-PSK"`.
+- For PSK (default / non-EAP, non-NONE): credential comes from `psk`, or from
+  `password` if `psk` is absent (the simple form). One of the two required.
+- For `WPA-EAP`: `identity` + `password` required; `eap`/`phase2`/`ca_cert`
+  optional (generator omits them so the daemon applies its own defaults —
+  `eap=PEAP`, `phase2=auth=MSCHAPV2`).
+- For `NONE`: no credential.
+- `priority` — optional int, default `10` (matches the placeholder default).
+
+The generator parses a **constrained lua subset** (table literals with
+identifier keys, single/double-quoted string values, integer values, `--`
+comments). It is NOT a full lua interpreter; anything outside the documented
+shape is a hard error (fails the build loudly rather than shipping wrong creds).
+
+## 4. Output + schema rewrite
+
+The generator emits a compact JSON array identical in shape to what the daemon
+consumes, e.g.:
+
+```json
+[{"ssid":"cordoba_2G","key_mgmt":"WPA-PSK","psk":"whatever","priority":10}]
+```
+
+then replaces the `wifi.networks` `default = '…'` line in the staged
+`wifi.lua`. The JSON is embedded as a **single-quoted lua string** with `\` and
+`'` escaped, so an SSID/PSK containing those characters round-trips byte-exact
+through ds-server back to the daemon. Only the `${D}` (staged) copy is changed;
+the committed source `wifi.lua` is untouched.
+
+## 5. Recipe wiring (build-time, no-op when absent)
+
+```python
+# Conditional — keeps the file optional AND part of the recipe signature so a
+# credential change triggers a rebuild.
+SRC_URI += "${@'file://wifi_credentials.lua' if os.path.exists(d.getVar('THISDIR') + '/files/wifi_credentials.lua') else ''}"
+SRC_URI += " file://gen_wifi_default.py"
+
+do_install:append() {
+    if [ -f ${WORKDIR}/wifi_credentials.lua ]; then
+        python3 ${WORKDIR}/gen_wifi_default.py \
+            ${WORKDIR}/wifi_credentials.lua \
+            ${D}${sysconfdir}/iot/ds-schemas/wifi.lua
+        bbnote "wifi-client: seeded wifi.networks default from wifi_credentials.lua"
+    fi
+}
+```
+
+`cmake_do_install` has already placed `wifi.lua` at
+`${D}${sysconfdir}/iot/ds-schemas/wifi.lua`; the append rewrites it in place.
+
+## 6. Test strategy (TDD)
+
+`test_gen_wifi_default.py` (pure Python, no toolchain), write first:
+
+1. `parse_simple_psk` — `{ssid, password}` → one WPA-PSK network, `password`
+   mapped to `psk`, `priority` defaulted to 10.
+2. `parse_explicit_psk_psk_field` — `psk` field used directly.
+3. `parse_list_multi` — array of tables preserves order + fields.
+4. `parse_open_none` — `key_mgmt="NONE"` → no psk.
+5. `parse_eap` — identity+password retained; eap omitted unless given.
+6. `reject_missing_ssid`, `reject_psk_without_credential`,
+   `reject_eap_without_identity` — hard errors.
+7. `ignores_lua_comments`.
+8. `json_output_is_valid_and_compact`.
+9. `escaping` — ssid/psk with `'`, `\`, `"` round-trips through the
+   single-quoted lua literal (parse the rewritten schema's default back out).
+10. `rewrite_targets_only_wifi_networks` — other keys' `default =` lines
+    untouched; rewritten file still contains exactly one wifi.networks default.
+
+## 7. Out of scope / caveats
+
+- Credential remains **plaintext on the device image** — this moves it out of
+  git, not off the device.
+- One build = one credential set for every device flashed from that image
+  (fine for a shared/default AP; per-device provisioning is separate).
+- Not a general lua interpreter — only the documented credential shapes.

--- a/apps/docs/tdd-wifi-credentials-seed.md
+++ b/apps/docs/tdd-wifi-credentials-seed.md
@@ -1,17 +1,19 @@
 # TDD Plan — Build-time WiFi Credential Seed (`wifi_credentials.lua`)
 
-Status: **IN PROGRESS** — design agreed. Builds on the auto-start/EAP work
-(PR #204, merged). Device/Yocto side only. The new logic is a small build-time
-generator, unit-tested in pure Python (no ACE/podman needed).
+Status: **COMPLETE** (implementable scope) — design + impl done. Builds on the
+auto-start/EAP work (PR #204, merged). Device/Yocto side only. The new logic is
+a small build-time generator, unit-tested in pure Python — **20/20 green**.
+On-target verification (a real Yocto build with a dropped-in
+`wifi_credentials.lua`) is deferred (needs the kas/RPi build environment).
 
 ### Implementation progress
 
 | Task | State | Notes |
 | --- | --- | --- |
-| A — `gen_wifi_default.py` generator | ⬜ TODO | Parse the lua credential file → `wifi.networks` JSON → rewrite the default in the staged `wifi.lua`. |
-| B — Python unit tests | ⬜ TODO | `test_gen_wifi_default.py`: parse PSK/EAP, single/list, `password`→`psk`, malformed→error, schema rewrite, escaping. |
-| C — recipe wiring | ⬜ TODO | `iot_git.bb`: conditional `SRC_URI` + `do_install:append` running the generator on the staged `wifi.lua` iff the file exists. |
-| D — gitignore + sample | ⬜ TODO | `.gitignore` the real file; commit `wifi_credentials.lua.sample`. |
+| A — `gen_wifi_default.py` generator | ✅ DONE | Tokenizer + parser for the lua subset → `wifi.networks` JSON (`password`→`psk`; EAP passthrough) → in-place rewrite of the staged `wifi.lua` default. Safe single-quoted-lua escaping (round-trips `\`, `'`, `"`). |
+| B — Python unit tests | ✅ DONE | `test_gen_wifi_default.py`, 20 tests: PSK/EAP/open, single/list, mapping, hard-error cases, comments, control-char rejection, schema rewrite isolates wifi.networks, escaping round-trip. |
+| C — recipe wiring | ✅ DONE | `iot_git.bb`: `gen_wifi_default.py` in `SRC_URI`; conditional `file://wifi_credentials.lua` (present-only, so it's both optional and signature-tracked); `do_install:append` runs the generator on the staged `wifi.lua`; `do_install[depends] += python3-native`. |
+| D — gitignore + sample | ✅ DONE | `.gitignore` the real file (+ `__pycache__/`); committed `wifi_credentials.lua.sample`. |
 
 Test cmd: `python3 -m unittest discover -s yocto/meta-iot/recipes-iot/lwm2m/files -p 'test_gen_wifi_default.py'` (host-side, no toolchain).
 

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/gen_wifi_default.py
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/gen_wifi_default.py
@@ -1,0 +1,289 @@
+#!/usr/bin/env python3
+"""Build-time generator: bake a wifi_credentials.lua file into the wifi.networks
+schema default.
+
+Invoked from the iot recipe's do_install when an (optional, gitignored)
+wifi_credentials.lua is present. Parses a constrained lua subset describing one
+or more WiFi networks, converts it to the JSON shape the wifi-client daemon
+consumes (parse_wifi_networks), and rewrites the `wifi.networks` `default = '…'`
+line of the already-installed schemas/wifi.lua in place.
+
+This is NOT a full lua interpreter — only the documented credential shapes are
+accepted; anything else is a hard error so a bad file fails the build loudly
+rather than shipping wrong credentials.
+
+Usage:  gen_wifi_default.py <wifi_credentials.lua> <installed wifi.lua>
+
+Credential file shapes:
+    return { ssid = "cordoba_2G", password = "whatever" }       -- simple PSK
+    return {                                                     -- explicit list
+      { ssid = "A", key_mgmt = "WPA-PSK", psk = "p", priority = 10 },
+      { ssid = "Guest", key_mgmt = "NONE" },
+      { ssid = "Corp", key_mgmt = "WPA-EAP", identity = "u", password = "s" },
+    }
+"""
+
+import json
+import re
+import sys
+
+DEFAULT_PRIORITY = 10
+
+# ───────────────────────────── lua subset parser ────────────────────────────
+
+_TOKEN_RE = re.compile(r"""
+      (?P<ws>\s+)
+    | (?P<comment>--[^\n]*)
+    | (?P<string>"(?:\\.|[^"\\])*" | '(?:\\.|[^'\\])*')
+    | (?P<number>-?\d+)
+    | (?P<name>[A-Za-z_][A-Za-z0-9_]*)
+    | (?P<punct>[{}=,;])
+""", re.VERBOSE)
+
+_LUA_ESCAPES = {
+    "n": "\n", "t": "\t", "r": "\r", "a": "\a", "b": "\b",
+    "f": "\f", "v": "\v", "\\": "\\", '"': '"', "'": "'", "\n": "\n",
+}
+
+
+def _decode_lua_string(tok):
+    """Strip the surrounding quotes and decode escapes; reject control chars."""
+    body = tok[1:-1]
+    out = []
+    i = 0
+    while i < len(body):
+        c = body[i]
+        if c == "\\" and i + 1 < len(body):
+            nxt = body[i + 1]
+            out.append(_LUA_ESCAPES.get(nxt, nxt))
+            i += 2
+        else:
+            out.append(c)
+            i += 1
+    s = "".join(out)
+    if any(ord(ch) < 0x20 or ord(ch) == 0x7F for ch in s):
+        raise ValueError("control character in string value %r" % s)
+    return s
+
+
+def _tokenize(text):
+    toks = []
+    pos = 0
+    while pos < len(text):
+        m = _TOKEN_RE.match(text, pos)
+        if not m:
+            raise ValueError("unexpected character at offset %d: %r"
+                             % (pos, text[pos:pos + 16]))
+        pos = m.end()
+        kind = m.lastgroup
+        if kind in ("ws", "comment"):
+            continue
+        toks.append((kind, m.group()))
+    return toks
+
+
+class _Parser:
+    def __init__(self, toks):
+        self.toks = toks
+        self.i = 0
+
+    def _peek(self):
+        return self.toks[self.i] if self.i < len(self.toks) else (None, None)
+
+    def _next(self):
+        t = self._peek()
+        self.i += 1
+        return t
+
+    def _expect(self, value):
+        kind, v = self._next()
+        if v != value:
+            raise ValueError("expected %r, got %r" % (value, v))
+
+    def parse_program(self):
+        kind, v = self._next()
+        if v != "return":
+            raise ValueError("credential file must start with 'return'")
+        val = self._parse_value()
+        return val
+
+    def _parse_value(self):
+        kind, v = self._peek()
+        if kind == "string":
+            self._next()
+            return _decode_lua_string(v)
+        if kind == "number":
+            self._next()
+            return int(v)
+        if v == "{":
+            return self._parse_table()
+        raise ValueError("unexpected token %r" % (v,))
+
+    def _parse_table(self):
+        """Return {'fields': {name: value}, 'items': [value, ...]}."""
+        self._expect("{")
+        fields, items = {}, []
+        while True:
+            kind, v = self._peek()
+            if v == "}":
+                self._next()
+                break
+            if v is None:
+                raise ValueError("unterminated table (missing '}')")
+            if kind == "name" and self._lookahead_is_assign():
+                self._next()              # name
+                self._expect("=")
+                fields[v] = self._parse_value()
+            else:
+                items.append(self._parse_value())
+            kind, v = self._peek()
+            if v in (",", ";"):
+                self._next()
+        return {"fields": fields, "items": items}
+
+    def _lookahead_is_assign(self):
+        return (self.i + 1 < len(self.toks)
+                and self.toks[self.i + 1][1] == "=")
+
+
+# ───────────────────────────── credential mapping ───────────────────────────
+
+def _table_to_network(tbl, idx):
+    if not isinstance(tbl, dict) or tbl.get("items"):
+        raise ValueError("network entry %d is not a field table" % idx)
+    f = tbl["fields"]
+
+    ssid = f.get("ssid")
+    if not isinstance(ssid, str) or not ssid:
+        raise ValueError("network entry %d missing non-empty 'ssid'" % idx)
+
+    key_mgmt = f.get("key_mgmt", "WPA-PSK")
+    if not isinstance(key_mgmt, str):
+        raise ValueError("network entry %d 'key_mgmt' must be a string" % idx)
+
+    net = {"ssid": ssid, "key_mgmt": key_mgmt}
+
+    if key_mgmt == "NONE":
+        pass
+    elif key_mgmt == "WPA-EAP":
+        identity = f.get("identity")
+        password = f.get("password")
+        if not isinstance(identity, str) or not identity:
+            raise ValueError("network entry %d (WPA-EAP) needs 'identity'" % idx)
+        if not isinstance(password, str) or not password:
+            raise ValueError("network entry %d (WPA-EAP) needs 'password'" % idx)
+        net["identity"] = identity
+        net["password"] = password
+        for opt in ("eap", "phase2", "ca_cert"):
+            if opt in f:
+                if not isinstance(f[opt], str):
+                    raise ValueError("network entry %d '%s' must be a string"
+                                     % (idx, opt))
+                net[opt] = f[opt]
+    else:
+        # PSK-like: credential from 'psk', or 'password' as a friendly alias.
+        cred = f.get("psk", f.get("password"))
+        if not isinstance(cred, str) or not cred:
+            raise ValueError("network entry %d (key_mgmt=%s) needs 'psk' "
+                             "or 'password'" % (idx, key_mgmt))
+        net["psk"] = cred
+
+    prio = f.get("priority", DEFAULT_PRIORITY)
+    if not isinstance(prio, int):
+        raise ValueError("network entry %d 'priority' must be an integer" % idx)
+    net["priority"] = prio
+    return net
+
+
+def parse_credentials(text):
+    """Parse wifi_credentials.lua text into a list of network dicts.
+
+    Accepts either a single field table (one network) or a list of field
+    tables. Raises ValueError on any shape outside the documented forms.
+    """
+    root = _Parser(_tokenize(text)).parse_program()
+    if not isinstance(root, dict):
+        raise ValueError("credential file must return a table")
+    if root["items"]:
+        if root["fields"]:
+            raise ValueError("table mixes list entries and named fields")
+        return [_table_to_network(item, i) for i, item in enumerate(root["items"])]
+    if root["fields"]:
+        return [_table_to_network(root, 0)]
+    raise ValueError("credential table is empty")
+
+
+def networks_to_json(networks):
+    """Compact JSON array in the daemon's expected key order."""
+    return json.dumps(networks, separators=(",", ":"), ensure_ascii=False)
+
+
+# ──────────────────────────── schema rewriting ──────────────────────────────
+
+# Anchor on the wifi.networks key, then its single-quoted default literal.
+_DEFAULT_RE = re.compile(
+    r"(\[\"wifi\.networks\"\]\s*=\s*\{.*?default\s*=\s*)'((?:\\.|[^'\\])*)'",
+    re.DOTALL)
+
+
+def _lua_sq_literal(s):
+    """Embed s into a single-quoted lua string literal (escape \\ and ')."""
+    return "'" + s.replace("\\", "\\\\").replace("'", "\\'") + "'"
+
+
+def _lua_sq_unescape(s):
+    out = []
+    i = 0
+    while i < len(s):
+        if s[i] == "\\" and i + 1 < len(s):
+            out.append(s[i + 1])
+            i += 2
+        else:
+            out.append(s[i])
+            i += 1
+    return "".join(out)
+
+
+def rewrite_wifi_networks_default(schema_text, json_text):
+    """Return schema_text with the wifi.networks default replaced by json_text."""
+    if not _DEFAULT_RE.search(schema_text):
+        raise ValueError("wifi.networks default not found in schema")
+    literal = _lua_sq_literal(json_text)
+    return _DEFAULT_RE.sub(lambda m: m.group(1) + literal, schema_text, count=1)
+
+
+def extract_wifi_networks_default(schema_text):
+    """Return the (un-escaped) wifi.networks default string from a schema."""
+    m = _DEFAULT_RE.search(schema_text)
+    if not m:
+        raise ValueError("wifi.networks default not found in schema")
+    return _lua_sq_unescape(m.group(2))
+
+
+# ───────────────────────────────── CLI ──────────────────────────────────────
+
+def main(argv):
+    if len(argv) != 3:
+        sys.stderr.write("usage: gen_wifi_default.py "
+                         "<wifi_credentials.lua> <installed wifi.lua>\n")
+        return 2
+    cred_path, schema_path = argv[1], argv[2]
+    try:
+        with open(cred_path, encoding="utf-8") as fh:
+            nets = parse_credentials(fh.read())
+        json_text = networks_to_json(nets)
+        with open(schema_path, encoding="utf-8") as fh:
+            schema = fh.read()
+        out = rewrite_wifi_networks_default(schema, json_text)
+        with open(schema_path, "w", encoding="utf-8") as fh:
+            fh.write(out)
+    except (ValueError, OSError) as exc:
+        sys.stderr.write("gen_wifi_default: %s\n" % exc)
+        return 2
+    sys.stderr.write("gen_wifi_default: seeded wifi.networks from %s -> %s\n"
+                     % (cred_path, json_text))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/test_gen_wifi_default.py
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/test_gen_wifi_default.py
@@ -1,0 +1,162 @@
+#!/usr/bin/env python3
+"""Unit tests for gen_wifi_default.py — the build-time generator that turns a
+wifi_credentials.lua file into the wifi.networks schema default.
+
+Pure-Python, no toolchain: run with
+    python3 -m unittest discover -s <this dir> -p 'test_gen_wifi_default.py'
+"""
+
+import json
+import unittest
+
+import gen_wifi_default as g
+
+
+# A minimal stand-in for schemas/wifi.lua with the wifi.networks default plus
+# two sibling keys whose `default =` lines MUST stay untouched by the rewrite.
+SCHEMA = '''return {
+  namespace = "wifi",
+  keys = {
+    ["wifi.iface"]    = { access = "Admin", type = "string", default = "wlan0" },
+    ["wifi.networks"] = {
+        access  = "Admin", type = "string",
+        default = '[{"ssid":"changeme","key_mgmt":"WPA-PSK","psk":"changeme","priority":10}]' },
+    ["wifi.dhcp.path"] = { access = "Admin", type = "string", default = "" },
+  },
+}
+'''
+
+
+class ParseCredentials(unittest.TestCase):
+    def test_simple_psk_password_maps_to_psk(self):
+        nets = g.parse_credentials(
+            'return { ssid = "cordoba_2G", password = "whatever" }')
+        self.assertEqual(nets, [{
+            "ssid": "cordoba_2G", "key_mgmt": "WPA-PSK",
+            "psk": "whatever", "priority": 10,
+        }])
+
+    def test_explicit_psk_field(self):
+        nets = g.parse_credentials(
+            'return { ssid = "AP", key_mgmt = "WPA-PSK", psk = "p", priority = 3 }')
+        self.assertEqual(nets[0]["psk"], "p")
+        self.assertEqual(nets[0]["priority"], 3)
+
+    def test_list_of_networks_preserves_order(self):
+        nets = g.parse_credentials('''return {
+            { ssid = "A", psk = "a", priority = 5 },
+            { ssid = "B", psk = "b" },
+        }''')
+        self.assertEqual([n["ssid"] for n in nets], ["A", "B"])
+        self.assertEqual(nets[0]["priority"], 5)
+        self.assertEqual(nets[1]["priority"], 10)  # defaulted
+
+    def test_open_network_none(self):
+        nets = g.parse_credentials('return { ssid = "Guest", key_mgmt = "NONE" }')
+        self.assertEqual(nets[0]["key_mgmt"], "NONE")
+        self.assertNotIn("psk", nets[0])
+        self.assertNotIn("password", nets[0])
+
+    def test_eap_retains_identity_password(self):
+        nets = g.parse_credentials('''return {
+            ssid = "Corp", key_mgmt = "WPA-EAP",
+            identity = "u@corp", password = "secret", eap = "PEAP" }''')
+        n = nets[0]
+        self.assertEqual(n["key_mgmt"], "WPA-EAP")
+        self.assertEqual(n["identity"], "u@corp")
+        self.assertEqual(n["password"], "secret")
+        self.assertEqual(n["eap"], "PEAP")
+        self.assertNotIn("psk", n)
+
+    def test_eap_omits_eap_when_absent(self):
+        nets = g.parse_credentials('''return {
+            ssid = "Corp", key_mgmt = "WPA-EAP",
+            identity = "u", password = "p" }''')
+        self.assertNotIn("eap", nets[0])
+        self.assertNotIn("phase2", nets[0])
+
+    def test_ignores_comments(self):
+        nets = g.parse_credentials('''-- my home AP
+            return { ssid = "Home", password = "pw" }  -- trailing comment
+        ''')
+        self.assertEqual(nets[0]["ssid"], "Home")
+
+    def test_double_quoted_and_single_quoted_values(self):
+        nets = g.parse_credentials("return { ssid = 'A', psk = \"b\" }")
+        self.assertEqual(nets[0]["ssid"], "A")
+        self.assertEqual(nets[0]["psk"], "b")
+
+    # ── hard errors (fail the build loudly) ──
+    def test_reject_missing_ssid(self):
+        with self.assertRaises(ValueError):
+            g.parse_credentials('return { psk = "x" }')
+
+    def test_reject_empty_ssid(self):
+        with self.assertRaises(ValueError):
+            g.parse_credentials('return { ssid = "", psk = "x" }')
+
+    def test_reject_psk_without_credential(self):
+        with self.assertRaises(ValueError):
+            g.parse_credentials('return { ssid = "A" }')
+
+    def test_reject_eap_without_identity(self):
+        with self.assertRaises(ValueError):
+            g.parse_credentials(
+                'return { ssid = "C", key_mgmt = "WPA-EAP", password = "p" }')
+
+    def test_reject_eap_without_password(self):
+        with self.assertRaises(ValueError):
+            g.parse_credentials(
+                'return { ssid = "C", key_mgmt = "WPA-EAP", identity = "u" }')
+
+    def test_reject_no_return(self):
+        with self.assertRaises(ValueError):
+            g.parse_credentials('{ ssid = "A", psk = "b" }')
+
+    def test_reject_control_char_in_value(self):
+        with self.assertRaises(ValueError):
+            g.parse_credentials('return { ssid = "A\\npsk", psk = "b" }')
+
+
+class NetworksToJson(unittest.TestCase):
+    def test_compact_and_valid(self):
+        nets = g.parse_credentials('return { ssid = "A", password = "b" }')
+        s = g.networks_to_json(nets)
+        self.assertNotIn(" ", s)            # compact
+        self.assertEqual(json.loads(s), nets)
+
+    def test_field_order_matches_daemon(self):
+        nets = g.parse_credentials('return { ssid = "A", password = "b" }')
+        s = g.networks_to_json(nets)
+        self.assertTrue(s.startswith('[{"ssid":"A","key_mgmt":"WPA-PSK","psk":"b"'))
+
+
+class RewriteSchema(unittest.TestCase):
+    def test_replaces_only_wifi_networks(self):
+        new_json = g.networks_to_json(
+            g.parse_credentials('return { ssid = "cordoba_2G", password = "pw" }'))
+        out = g.rewrite_wifi_networks_default(SCHEMA, new_json)
+        # sibling keys untouched
+        self.assertIn('default = "wlan0"', out)
+        self.assertIn('default = "" }', out)
+        # exactly one wifi.networks default, and it's the new one
+        self.assertNotIn("changeme", out)
+        self.assertEqual(g.extract_wifi_networks_default(out), new_json)
+
+    def test_escaping_roundtrip(self):
+        # ssid/psk with backslash, single quote, double quote must survive the
+        # single-quoted lua literal byte-exact.
+        nets = [{"ssid": "A'B\\C", "key_mgmt": "WPA-PSK",
+                 "psk": 'p"q', "priority": 10}]
+        new_json = g.networks_to_json(nets)
+        out = g.rewrite_wifi_networks_default(SCHEMA, new_json)
+        self.assertEqual(g.extract_wifi_networks_default(out), new_json)
+        self.assertEqual(json.loads(g.extract_wifi_networks_default(out)), nets)
+
+    def test_rewrite_missing_key_raises(self):
+        with self.assertRaises(ValueError):
+            g.rewrite_wifi_networks_default('return { keys = {} }', "[]")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua.sample
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua.sample
@@ -1,0 +1,36 @@
+-- wifi_credentials.lua — OPTIONAL build-time WiFi credential seed.
+--
+-- Copy this file to `wifi_credentials.lua` (same directory) and fill in your
+-- AP details. During the Yocto build the iot recipe bakes it into the
+-- wifi.networks schema default, so a freshly-flashed image associates to your
+-- AP with no runtime step. If `wifi_credentials.lua` is absent the build is a
+-- no-op and the committed "changeme" placeholder default stands.
+--
+-- `wifi_credentials.lua` is gitignored — keep real passwords out of git.
+-- A real credential is still plaintext on the device image, and one build
+-- yields one credential set for every device flashed from it.
+--
+-- See apps/docs/tdd-wifi-credentials-seed.md for the full design.
+
+-- Simplest form — a single WPA-PSK network. "password" maps to psk.
+return { ssid = "cordoba_2G", password = "whatever" }
+
+-- ── Other accepted shapes ───────────────────────────────────────────────────
+-- Explicit list (PSK / open / WPA-Enterprise), one table per network:
+--
+-- return {
+--   { ssid = "cordoba_2G", key_mgmt = "WPA-PSK", psk = "whatever", priority = 10 },
+--   { ssid = "Guest",      key_mgmt = "NONE" },
+--   { ssid = "Corp",       key_mgmt = "WPA-EAP",
+--     identity = "user@corp", password = "secret", eap = "PEAP" },
+-- }
+--
+-- Field rules (mirror the wifi-client daemon):
+--   ssid      required, non-empty
+--   key_mgmt  optional, default "WPA-PSK"  ("WPA-PSK" | "NONE" | "WPA-EAP")
+--   psk       PSK credential; "password" accepted as an alias for the simple form
+--   identity  WPA-EAP only, required
+--   password  WPA-EAP credential (required); alias for psk on PSK networks
+--   eap/phase2/ca_cert  WPA-EAP only, optional (daemon defaults eap=PEAP,
+--                       phase2=auth=MSCHAPV2 when omitted)
+--   priority  optional integer, default 10

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -51,7 +51,18 @@ SRC_URI = "\
     file://iot-ota-confirm.service \
     file://migrations/README.md \
     file://migrations/0000-template.sh.example \
+    file://gen_wifi_default.py \
 "
+
+# Optional, gitignored WiFi credential seed. When an integrator drops
+# files/wifi_credentials.lua into this layer, bake it into the wifi.networks
+# schema default at build time (see do_install:append + apps/docs/
+# tdd-wifi-credentials-seed.md). Adding it to SRC_URI only when present keeps
+# it optional AND part of the recipe signature, so changing the credentials
+# triggers a rebuild. Absent => no-op, the committed "changeme" placeholder
+# stands.
+SRC_URI += "${@'file://wifi_credentials.lua' if os.path.exists(d.getVar('THISDIR') + '/files/wifi_credentials.lua') else ''}"
+
 SRCREV = "${AUTOREV}"
 
 # Package version. Keep the leading semver in sync with the repo-root /VERSION
@@ -239,6 +250,22 @@ do_install() {
         install -m 0644 ${WORKDIR}/net-router.env     ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/wifi-client.env    ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/httpd.env          ${D}${sysconfdir}/iot/
+    fi
+}
+
+# Bake an optional WiFi credential seed into the wifi.networks schema default.
+# cmake_do_install has already placed wifi.lua under ds-schemas/; rewrite it in
+# place from files/wifi_credentials.lua when that file was fetched. No-op (and
+# the "changeme" placeholder default stands) when it is absent.
+# python3-native gives the do_install task a python3 on PATH for the generator.
+do_install[depends] += "python3-native:do_populate_sysroot"
+do_install:append() {
+    if [ -f ${WORKDIR}/wifi_credentials.lua ]; then
+        python3 ${WORKDIR}/gen_wifi_default.py \
+            ${WORKDIR}/wifi_credentials.lua \
+            ${D}${sysconfdir}/iot/ds-schemas/wifi.lua \
+            || bbfatal "gen_wifi_default.py failed on wifi_credentials.lua"
+        bbnote "wifi-client: seeded wifi.networks default from wifi_credentials.lua"
     fi
 }
 


### PR DESCRIPTION
## Summary

Lets a build integrator drop an **optional, gitignored** `wifi_credentials.lua` into the recipe's `files/` dir; the Yocto build bakes it into the `wifi.networks` schema default so a freshly-flashed image auto-associates to the operator's AP with no runtime step. If the file is absent the build is a **no-op** and the committed `changeme` placeholder default stands.

The point is to keep **real WiFi credentials out of source control** — the tracked `wifi.lua` only ever carries the placeholder. Follows the auto-start/WPA-EAP work merged in #204.

Design: `apps/docs/tdd-wifi-credentials-seed.md`.

## Credential file format (lua)

```lua
-- simplest: one WPA-PSK network, "password" maps to psk
return { ssid = "cordoba_2G", password = "whatever" }

-- or an explicit list (PSK / open / WPA-EAP):
return {
  { ssid = "cordoba_2G", key_mgmt = "WPA-PSK", psk = "whatever", priority = 10 },
  { ssid = "Guest",      key_mgmt = "NONE" },
  { ssid = "Corp",       key_mgmt = "WPA-EAP", identity = "u@corp", password = "secret" },
}
```

## How it works

- **`gen_wifi_default.py`** — tokenizes a constrained lua subset (table literals, identifier keys, quoted strings, ints, `--` comments), maps to the `wifi.networks` JSON the daemon already consumes (`password`→`psk` for PSK; `identity`/`password` for EAP; defaults `key_mgmt=WPA-PSK`, `priority=10`), and rewrites the `wifi.networks` `default = '…'` line of the **staged** `wifi.lua` in place. Safe single-quoted-lua escaping (round-trips `\`, `'`, `"`); rejects control chars and any shape outside the documented forms (fails the build loudly).
- **`iot_git.bb`** — `gen_wifi_default.py` added to `SRC_URI`; `file://wifi_credentials.lua` added **only when present** (keeps it optional *and* part of the recipe signature, so changing creds triggers a rebuild); `do_install:append` runs the generator on the staged schema; `do_install[depends] += python3-native`.
- **`.gitignore`** the real `wifi_credentials.lua` (+ `__pycache__/`); committed `wifi_credentials.lua.sample`.

## Tests

20 pure-Python unit tests (no toolchain needed):

```
python3 -m unittest discover -s yocto/meta-iot/recipes-iot/lwm2m/files -p 'test_gen_wifi_default.py'
Ran 20 tests ... OK
```

Covers PSK/open/EAP parsing, single-vs-list, `password`→`psk` mapping, hard-error cases (missing ssid/credential/identity, control chars, no `return`), comment handling, schema-rewrite isolation (only `wifi.networks` touched), and the escaping round-trip. Also smoke-verified end-to-end against the real `modules/wan/wifi/client/schemas/wifi.lua` (produces `[{"ssid":"cordoba_2G","key_mgmt":"WPA-PSK","psk":"whatever","priority":10}]`, the exact shape the daemon's `seeded_schema_default_parses_cleanly` test already covers).

## Not done / deferred

- **On-target Yocto build verification** (drop a real `wifi_credentials.lua`, build the RPi image, confirm `ds-cli get wifi.networks` shows the seeded value) — needs the kas/RPi build environment.
- Credential remains **plaintext on the device image** (this moves it out of *git*, not off the *image*); one build = one credential set for every device flashed from it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)