### PR TITLE
feat(wifi): zero-touch device-UI discovery via mDNS (http://iot-<serial>.local)

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -469,6 +469,50 @@ maps `password` → `psk`.
 
 See `apps/docs/tdd-wifi-credentials-seed.md` for the full design.
 
+#### Zero-touch: open the device UI without knowing the IP (mDNS)
+
+With the credential seed above baked in, a flashed image needs **no operator
+interaction**: it boots, joins the AP, gets a DHCP IP, and advertises its web
+UI over mDNS. On a Mac/Linux/Windows machine on the same LAN, open:
+
+```
+http://iot-<serial>.local:8080
+```
+
+`<serial>` is the last 8 hex chars of the RPi serial (so two devices on one LAN
+don't collide). If you don't know it, browse the advertised service — it shows
+up as **"IoT Device UI on iot-<serial>"**:
+
+```sh
+avahi-browse -rt _http._tcp        # Linux
+dns-sd -B _http._tcp               # macOS
+```
+
+How it works on the image:
+
+- **`iot-httpd` auto-starts** (`SYSTEMD_AUTO_ENABLE=enable`), serving the
+  Angular device UI on `0.0.0.0:8080` (`http.listen.port`).
+- **`iot-hostname.service`** runs once at boot (`iot-set-hostname`), deriving
+  `iot-<serial>` from the device-tree serial and applying it before Avahi
+  starts.
+- **Avahi** (`avahi-daemon`, pulled in by `iot-httpd`) advertises
+  `_http._tcp` on port 8080 via `/etc/avahi/services/iot-http.service`, so the
+  device resolves as `iot-<serial>.local`.
+
+> ⚠️ **Security:** auto-starting httpd exposes the UI **and** the `/api/v1/*`
+> REST API on `0.0.0.0:8080` to everyone on the LAN. That's the point for a
+> zero-touch appliance on a trusted home/lab network — but for an untrusted
+> network, restrict `http.listen.ip` (bind to localhost / the VPN iface) or
+> front it with auth.
+
+Notes / limits:
+- The advert hardcodes port **8080**; if you change `http.listen.port` the
+  mDNS record is stale (edit `/etc/avahi/services/iot-http.service` to match).
+- The device's own leased IP is not yet recorded in the data store
+  (`wifi.dhcp.ip` is defined but unpopulated) — mDNS sidesteps needing it.
+
+See `apps/docs/tdd-wifi-zero-touch-mdns.md` for the full design.
+
 `wifi.networks` is a JSON array; each entry is one of:
 
 ```jsonc

--- a/apps/docs/tdd-wifi-zero-touch-mdns.md
+++ b/apps/docs/tdd-wifi-zero-touch-mdns.md
@@ -1,0 +1,109 @@
+# TDD Plan — Zero-Touch Device-UI Discovery via mDNS
+
+Status: **IN PROGRESS** — design agreed. Yocto/image side only. Most of the
+change is recipe + systemd config (not unit-testable without a build); the one
+pure-logic bit (serial → hostname sanitization) is validated with a host shell
+check.
+
+### Implementation progress
+
+| Task | State | Notes |
+| --- | --- | --- |
+| A — auto-start `iot-httpd` | ⬜ TODO | `iot_git.bb`: `SYSTEMD_AUTO_ENABLE:${PN}-httpd` `disable` → `enable`. UI must be up on boot. |
+| B — `iot-set-hostname` (serial → hostname) | ⬜ TODO | Oneshot script: derive `iot-<serial-suffix>` and apply via `hostnamectl`. |
+| C — `iot-hostname.service` | ⬜ TODO | `Type=oneshot`, `Before=avahi-daemon.service`, auto-enabled. |
+| D — Avahi `_http._tcp` advert | ⬜ TODO | `/etc/avahi/services/iot-http.service` advertising port 8080 on `%h`. |
+| E — pull in `avahi-daemon` | ⬜ TODO | `RDEPENDS:${PN}-httpd += "avahi-daemon"`. |
+| F — recipe packaging | ⬜ TODO | SRC_URI + do_install + SYSTEMD_SERVICE + FILES for the new units/files. |
+
+## 1. Goal
+
+Zero touch: flash SD → boot → wifi-client joins the AP (already auto-started) →
+DHCP IP → user opens the device-iot UI in a browser **without knowing the IP**.
+
+The IP is deliberately NOT the discovery mechanism. The device advertises
+itself over mDNS, so the user opens:
+
+```
+http://iot-<serial>.local:8080
+```
+
+`<serial>` is the last 8 chars of the RPi serial — collision-safe when several
+devices share a LAN. A service browser (Bonjour / `avahi-browse` / `dns-sd -B
+_http._tcp`) lists it as **"IoT Device UI on iot-<serial>"**.
+
+## 2. Current gaps (verified)
+
+- `iot-httpd` serves the UI on **0.0.0.0:8080** (`http.lua` defaults) from
+  `/usr/share/iot/www`, but ships **disabled** (`SYSTEMD_AUTO_ENABLE:${PN}-httpd
+  = "disable"`, `iot_git.bb:437`).
+- No mDNS responder in the image (no avahi/nss-mdns anywhere).
+- Hostname defaults to the MACHINE name (`raspberrypi3-64`); not per-device,
+  not advertised.
+
+(Out of scope here: populating `wifi.dhcp.ip` and sending the DHCP hostname
+option — useful but separate; the chosen approach doesn't need the IP at all.)
+
+## 3. Design
+
+### 3.1 httpd auto-start
+Flip `SYSTEMD_AUTO_ENABLE:${PN}-httpd` → `enable`. The unit already orders
+`After=iot-ds.service network-online.target`.
+
+⚠️ **Security note:** this exposes the device UI + REST API on `0.0.0.0:8080`
+to anyone on the LAN by default (previously operator opt-in). That is the
+intent for a zero-touch device, but call it out; lock down via `http.listen.ip`
+/ auth if the deployment is not a trusted LAN.
+
+### 3.2 Hostname from serial (`iot-set-hostname`)
+Read the serial (device-tree `serial-number`, fallback `/proc/cpuinfo`
+`Serial`), lowercase, strip to `[a-z0-9]`, keep the last 8 chars, and set
+`hostname = iot-<suffix>` via `hostnamectl set-hostname` (fallback:
+`/etc/hostname` + `hostname`). Empty serial → `iot-device`.
+
+Run by `iot-hostname.service` (`Type=oneshot`, `RemainAfterExit=yes`,
+`After=local-fs.target`, `Before=avahi-daemon.service`, auto-enabled) so the
+name is set before Avahi advertises. (Avahi also tracks hostname changes, so
+ordering is belt-and-suspenders.)
+
+### 3.3 Avahi advertisement
+Ship `/etc/avahi/services/iot-http.service`:
+
+```xml
+<service-group>
+  <name replace-wildcards="yes">IoT Device UI on %h</name>
+  <service> <type>_http._tcp</type> <port>8080</port> </service>
+</service-group>
+```
+
+`%h` expands to the system hostname → `iot-<serial>.local`. Port hardcoded to
+the httpd default 8080 (note: if an operator changes `http.listen.port`, the
+advert is stale).
+
+### 3.4 Image inclusion
+`RDEPENDS:${PN}-httpd += "avahi-daemon"` pulls the mDNS responder in wherever
+iot-httpd is installed (the full gateway image). `avahi-daemon` is enabled by
+its own recipe.
+
+## 4. Recipe wiring (`iot_git.bb`)
+- `SRC_URI +=` `iot-set-hostname`, `iot-hostname.service`, `iot-http.avahi.service`.
+- `do_install` (systemd branch): install the script to `${bindir}`, the unit to
+  `${systemd_system_unitdir}`, the avahi file to `${sysconfdir}/avahi/services/`.
+- `SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service"`.
+- `SYSTEMD_AUTO_ENABLE:${PN}-httpd = "enable"`.
+- `FILES:${PN}-httpd +=` the avahi service file + the hostname script.
+- `RDEPENDS:${PN}-httpd += "avahi-daemon"`.
+
+## 5. Verification
+- Host shell check of the serial→hostname sanitization (sample serial →
+  `iot-3d1f9c2e`).
+- **Deferred (needs hardware/build):** real RPi boot → `avahi-browse -rt
+  _http._tcp` from a laptop shows `iot-<serial>`, and `http://iot-<serial>.local:8080`
+  loads the UI; `hostnamectl` shows the derived name.
+
+## 6. Out of scope
+- `wifi.dhcp.ip` population + DHCP hostname option (option 12) — separate, not
+  required for mDNS discovery.
+- Port-80 redirect so the `:8080` can be dropped (would need an nft rule).
+- mDNS name collisions if two devices truly share the same 8-char suffix
+  (astronomically unlikely; full serial is available if ever needed).

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-hostname.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-hostname.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Derive iot-<serial> hostname for mDNS device-UI discovery
+Documentation=https://github.com/naushada/iot
+After=local-fs.target
+# Set the hostname before Avahi advertises so it announces iot-<serial>.local.
+Before=avahi-daemon.service
+ConditionPathExists=/usr/bin/iot-set-hostname
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/iot-set-hostname
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-http.avahi.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-http.avahi.service
@@ -1,0 +1,16 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<!-- Advertises the iot-httpd device UI over mDNS as _http._tcp so a laptop on
+     the same LAN can find it with no IP lookup. Installed to
+     /etc/avahi/services/iot-http.service. %h expands to the system hostname
+     (iot-<serial>, set by iot-set-hostname), so the UI is reachable at
+     http://iot-<serial>.local:8080. Port is the iot-httpd default
+     (http.listen.port); if an operator changes that key this advert is stale.
+     See apps/docs/tdd-wifi-zero-touch-mdns.md. -->
+<service-group>
+  <name replace-wildcards="yes">IoT Device UI on %h</name>
+  <service>
+    <type>_http._tcp</type>
+    <port>8080</port>
+  </service>
+</service-group>

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-set-hostname
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-set-hostname
@@ -1,0 +1,35 @@
+#!/bin/sh
+# iot-set-hostname — derive a stable, collision-safe hostname from the RPi
+# serial and apply it so Avahi advertises <hostname>.local for zero-touch
+# device-UI discovery (http://iot-<serial>.local:8080).
+#
+# Run once at boot by iot-hostname.service, before avahi-daemon. Idempotent:
+# re-running sets the same name. See apps/docs/tdd-wifi-zero-touch-mdns.md.
+set -eu
+
+serial=""
+
+# Preferred: device-tree serial-number (NUL-terminated string).
+if [ -r /sys/firmware/devicetree/base/serial-number ]; then
+    serial=$(tr -d '\000' < /sys/firmware/devicetree/base/serial-number || true)
+fi
+
+# Fallback: /proc/cpuinfo "Serial" line.
+if [ -z "$serial" ] && [ -r /proc/cpuinfo ]; then
+    serial=$(awk -F': ' '/^Serial/ { print $2; exit }' /proc/cpuinfo || true)
+fi
+
+# Sanitize to a valid hostname label: lowercase, keep [a-z0-9], last 8 chars.
+suffix=$(printf '%s' "$serial" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9' | tail -c 8)
+[ -n "$suffix" ] || suffix="device"
+name="iot-${suffix}"
+
+if command -v hostnamectl >/dev/null 2>&1 && hostnamectl set-hostname "$name" 2>/dev/null; then
+    :
+else
+    # Fallback when hostnamectl/dbus is unavailable.
+    printf '%s\n' "$name" > /etc/hostname
+    hostname "$name" 2>/dev/null || true
+fi
+
+echo "iot-set-hostname: hostname set to ${name}"

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -52,6 +52,9 @@ SRC_URI = "\
     file://migrations/README.md \
     file://migrations/0000-template.sh.example \
     file://gen_wifi_default.py \
+    file://iot-set-hostname \
+    file://iot-hostname.service \
+    file://iot-http.avahi.service \
 "
 
 # Optional, gitignored WiFi credential seed. When an integrator drops
@@ -250,6 +253,14 @@ do_install() {
         install -m 0644 ${WORKDIR}/net-router.env     ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/wifi-client.env    ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/httpd.env          ${D}${sysconfdir}/iot/
+
+        # Zero-touch mDNS device-UI discovery: derive iot-<serial> hostname at
+        # boot and advertise iot-httpd (_http._tcp:8080) via Avahi. See
+        # apps/docs/tdd-wifi-zero-touch-mdns.md.
+        install -m 0755 ${WORKDIR}/iot-set-hostname           ${D}${bindir}/iot-set-hostname
+        install -m 0644 ${WORKDIR}/iot-hostname.service       ${D}${systemd_system_unitdir}/
+        install -d ${D}${sysconfdir}/avahi/services
+        install -m 0644 ${WORKDIR}/iot-http.avahi.service     ${D}${sysconfdir}/avahi/services/iot-http.service
     fi
 }
 
@@ -392,10 +403,15 @@ RRECOMMENDS:${PN}-wifi-client = "\
 # iot-httpd via www-dir. Built by do_build_ui above.
 FILES:${PN}-httpd = "\
     ${bindir}/iot-httpd \
+    ${bindir}/iot-set-hostname \
     ${systemd_system_unitdir}/iot-httpd.service \
+    ${systemd_system_unitdir}/iot-hostname.service \
+    ${sysconfdir}/avahi/services/iot-http.service \
     ${datadir}/iot/www \
 "
-RDEPENDS:${PN}-httpd = "ace-tao"
+# avahi-daemon provides the mDNS responder that advertises the device UI
+# (_http._tcp on iot-<serial>.local) for zero-touch discovery.
+RDEPENDS:${PN}-httpd = "ace-tao avahi-daemon"
 RRECOMMENDS:${PN}-httpd = "\
     ${PN}-ds-server \
     ${PN}-config \
@@ -421,7 +437,9 @@ SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service
 SYSTEMD_SERVICE:${PN}-openvpn-client = "iot-openvpn-client.service iot-vpn-cert.path"
 SYSTEMD_SERVICE:${PN}-net-router = "iot-net-router.service"
 SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
-SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service"
+# httpd also carries the boot-time hostname unit (iot-<serial>) that makes the
+# Avahi advert resolvable — zero-touch device-UI discovery.
+SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service"
 
 # ds-server and wifi-client auto-start. wifi-client comes up on every boot
 # and reads wifi.networks from the data-store (schema default seeds a
@@ -434,7 +452,11 @@ SYSTEMD_AUTO_ENABLE:${PN}-lwm2m = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-openvpn-client = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-net-router = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "enable"
-SYSTEMD_AUTO_ENABLE:${PN}-httpd = "disable"
+# httpd auto-starts for zero-touch device-UI access (mDNS discovery via Avahi).
+# Enabling this exposes the UI + REST API on 0.0.0.0:8080 to the LAN by default;
+# lock down via http.listen.ip / auth for untrusted networks. Also enables the
+# iot-hostname oneshot (sets iot-<serial> so Avahi advertises a stable name).
+SYSTEMD_AUTO_ENABLE:${PN}-httpd = "enable"
 
 # ── Sanity checks ──────────────────────────────────────────────────
 # Inhibit the "binary already stripped" QA warning — we build with -g


### PR DESCRIPTION
## Summary

Completes the zero-touch story: flash SD → boot → wifi-client joins the AP (auto-started, #204) using the baked-in credentials (#205) → DHCP IP → **open the device-iot UI with no IP lookup**:

```
http://iot-<serial>.local:8080
```

The device advertises its web UI over mDNS, so you never have to find its IP. `<serial>` is the last 8 hex chars of the RPi serial (collision-safe across multiple devices on one LAN). Design: `apps/docs/tdd-wifi-zero-touch-mdns.md`.

## What it adds

- **`iot-httpd` auto-starts** — `SYSTEMD_AUTO_ENABLE:${PN}-httpd` `disable` → `enable` (serves the Angular UI on `0.0.0.0:8080`).
- **`iot-set-hostname`** — boot script deriving `iot-<serial>` from the device-tree serial (fallback `/proc/cpuinfo`), sanitized to a valid label, applied via `hostnamectl` (fallback `/etc/hostname`).
- **`iot-hostname.service`** — `Type=oneshot`, `Before=avahi-daemon.service`, auto-enabled (carried on the httpd package).
- **`iot-http.avahi.service`** — advertises `_http._tcp:8080` on `%h`, so the device resolves as `iot-<serial>.local` and shows up as "IoT Device UI on iot-<serial>" in any service browser.
- **`avahi-daemon`** pulled in via `RDEPENDS:${PN}-httpd`.

## How you find it

```sh
avahi-browse -rt _http._tcp     # Linux
dns-sd -B _http._tcp            # macOS
# or just open http://iot-<serial>.local:8080
```

## Verification

- Serial→hostname sanitization host-verified: `100000003d1f9c2e → iot-3d1f9c2e`, `"" → iot-device`, `ABCD-EF99xyz → iot-def99xyz`; `sh -n` clean.
- Avahi service XML well-formed (`xml.dom.minidom`).
- ⚠️ **Full Yocto build + on-device mDNS browse not run** (needs the kas/RPi environment). Recipe wiring (SRC_URI/do_install/FILES/RDEPENDS/SYSTEMD_*) verified by inspection. Also assumes `avahi-daemon` is provided by the configured layers (it's in oe-core).

## Security caveat (called out in code + DEPLOY.md)

Auto-starting httpd exposes the UI **and** `/api/v1/*` on `0.0.0.0:8080` to the whole LAN by default — intended for a zero-touch appliance on a trusted network. For untrusted nets, restrict `http.listen.ip` or front with auth.

## Not done / deferred

- Populating `wifi.dhcp.ip` + sending the DHCP hostname option (option 12) — separate; mDNS doesn't need the IP.
- Port-80 redirect so the `:8080` can be dropped (would need an nft rule).
- The Avahi advert hardcodes 8080; changing `http.listen.port` makes it stale.

🤖 Generated with [Claude Code](https://claude.com/claude-code)