### PR TITLE
feat(wifi): surface DHCP lease (IP/mask/gateway/DNS/lease/domain) in ds + device UI

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -469,6 +469,50 @@ maps `password` → `psk`.
 
 See `apps/docs/tdd-wifi-credentials-seed.md` for the full design.
 
+#### Zero-touch: open the device UI without knowing the IP (mDNS)
+
+With the credential seed above baked in, a flashed image needs **no operator
+interaction**: it boots, joins the AP, gets a DHCP IP, and advertises its web
+UI over mDNS. On a Mac/Linux/Windows machine on the same LAN, open:
+
+```
+http://iot-<serial>.local:8080
+```
+
+`<serial>` is the last 8 hex chars of the RPi serial (so two devices on one LAN
+don't collide). If you don't know it, browse the advertised service — it shows
+up as **"IoT Device UI on iot-<serial>"**:
+
+```sh
+avahi-browse -rt _http._tcp        # Linux
+dns-sd -B _http._tcp               # macOS
+```
+
+How it works on the image:
+
+- **`iot-httpd` auto-starts** (`SYSTEMD_AUTO_ENABLE=enable`), serving the
+  Angular device UI on `0.0.0.0:8080` (`http.listen.port`).
+- **`iot-hostname.service`** runs once at boot (`iot-set-hostname`), deriving
+  `iot-<serial>` from the device-tree serial and applying it before Avahi
+  starts.
+- **Avahi** (`avahi-daemon`, pulled in by `iot-httpd`) advertises
+  `_http._tcp` on port 8080 via `/etc/avahi/services/iot-http.service`, so the
+  device resolves as `iot-<serial>.local`.
+
+> ⚠️ **Security:** auto-starting httpd exposes the UI **and** the `/api/v1/*`
+> REST API on `0.0.0.0:8080` to everyone on the LAN. That's the point for a
+> zero-touch appliance on a trusted home/lab network — but for an untrusted
+> network, restrict `http.listen.ip` (bind to localhost / the VPN iface) or
+> front it with auth.
+
+Notes / limits:
+- The advert hardcodes port **8080**; if you change `http.listen.port` the
+  mDNS record is stale (edit `/etc/avahi/services/iot-http.service` to match).
+- The device's own leased IP is not yet recorded in the data store
+  (`wifi.dhcp.ip` is defined but unpopulated) — mDNS sidesteps needing it.
+
+See `apps/docs/tdd-wifi-zero-touch-mdns.md` for the full design.
+
 `wifi.networks` is a JSON array; each entry is one of:
 
 ```jsonc

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -508,10 +508,29 @@ How it works on the image:
 Notes / limits:
 - The advert hardcodes port **8080**; if you change `http.listen.port` the
   mDNS record is stale (edit `/etc/avahi/services/iot-http.service` to match).
-- The device's own leased IP is not yet recorded in the data store
-  (`wifi.dhcp.ip` is defined but unpopulated) — mDNS sidesteps needing it.
+- mDNS sidesteps needing the device IP at all, but the IP (and the rest of the
+  lease) is now also recorded in ds and shown in the UI — see below.
 
 See `apps/docs/tdd-wifi-zero-touch-mdns.md` for the full design.
+
+#### DHCP lease details in ds + the device UI
+
+The full DHCP lease is mirrored into the data store and rendered on the device
+UI dashboard (IP / mask / gateway / DNS / lease time / domain). A custom
+**udhcpc lease hook** (`/usr/share/iot/udhcpc-ds.script`) — which the
+wifi-client points udhcpc at with `-s` — does the normal interface config and
+then `ds-cli set`s the lease keys:
+
+```sh
+ds-cli --socket=/run/iot/data_store.sock get \
+    wifi.dhcp.state wifi.dhcp.ip wifi.dhcp.mask wifi.dhcp.gateway \
+    wifi.dhcp.dns wifi.dhcp.lease.sec wifi.dhcp.domain
+```
+
+`wifi.dhcp.state` is owned by the daemon (`requesting`/`exited`); the hook adds
+`bound` plus the data keys, and clears them on lease loss. The REST status
+endpoint exposes them as `wifi.dhcp_ip/_mask/_gateway/_dns/_lease_sec/_domain`.
+See `apps/docs/tdd-wifi-dhcp-lease.md`.
 
 `wifi.networks` is a JSON array; each entry is one of:
 

--- a/apps/docs/tdd-wifi-dhcp-lease.md
+++ b/apps/docs/tdd-wifi-dhcp-lease.md
@@ -1,0 +1,112 @@
+# TDD Plan — DHCP Lease → Data Store → device-iot UI
+
+Status: **IN PROGRESS** — design agreed. Surfaces the full DHCP lease (IP,
+mask, gateway, DNS, lease time, domain) in ds so the device UI can render it.
+Mechanism: a custom **udhcpc hook script** writes the lease via `ds-cli`; the
+wifi-client daemon points udhcpc at it with `-s`.
+
+### Implementation progress
+
+| Task | State | Notes |
+| --- | --- | --- |
+| A — ds schema keys | ⬜ TODO | `wifi.lua`: add `wifi.dhcp.mask/gateway/dns/lease.sec/domain/obtained.unix` (Viewer). |
+| B — udhcpc hook script | ⬜ TODO | `udhcpc-ds.script`: delegate networking to the system default.script, then `ds-cli set` the lease fields + `state=bound`; clear data on `deconfig`. |
+| C — daemon `-s` wiring | ⬜ TODO | `process.cpp` `spawn_dhcp` gains optional `script` arg (udhcpc `-s`); `supervisor.cpp` passes the hook path gated on `::access`. Unit test. |
+| D — REST exposure | ⬜ TODO | `handler.cpp`: add the 6 keys to the status `get()` + JSON mappings. |
+| E — device UI | ⬜ TODO | `WifiStatus` interface + dashboard rows (IP / mask / gateway / DNS / lease / domain). |
+| F — recipe + docs | ⬜ TODO | Ship the hook in the wifi-client package; DEPLOY.md. |
+
+## 1. Background / why a hook
+
+udhcpc delivers the full lease ONLY to its `-s` hook script, via environment
+variables — not on stdout, and lease-time/DNS aren't readable back from the
+interface. So the lease writer must be the hook. Today wifi-client runs
+`udhcpc -i wlan0 -f -q` with **no `-s`**, using busybox's built-in
+default.script (configures the interface, never touches ds). Nothing writes the
+lease to ds; even `wifi.dhcp.ip` is unpopulated.
+
+## 2. Key ownership (avoid daemon/hook conflict)
+
+The daemon (`supervisor.cpp`) sets `wifi.dhcp.state` to `"requesting"` (on
+spawn) and `"exited"` (on disconnect), and `wifi.pid.dhcp`. It NEVER sets
+`"bound"` and never writes the IP. Division of labour:
+
+- **Daemon keeps**: `wifi.dhcp.state` ∈ {requesting, exited}, `wifi.pid.dhcp`.
+- **Hook owns**: the lease DATA keys + `wifi.dhcp.state="bound"` (the one state
+  only the hook can know). On `deconfig` the hook clears the data keys but does
+  **not** write `state` (avoids racing the daemon's `"requesting"` — udhcpc
+  fires `deconfig` at startup right around the daemon's spawn).
+
+`ds-cli` writes are not blocked by the schema `access="Viewer"` field (that's
+HTTP-layer metadata; the socket enforces `write_acl`/`read_acl`, and
+`wifi.dhcp.*` declare none — a root-run udhcpc hook can write them).
+
+## 3. New ds keys (`wifi.lua`, Viewer/write keys)
+
+| key | type | meaning |
+| --- | --- | --- |
+| `wifi.dhcp.mask` | string | subnet mask (`$subnet`) |
+| `wifi.dhcp.gateway` | string | default gateway(s) (`$router`) |
+| `wifi.dhcp.dns` | string | nameserver(s) (`$dns`, space-separated) |
+| `wifi.dhcp.lease.sec` | integer | lease time in seconds (`$lease`) |
+| `wifi.dhcp.domain` | string | DNS domain (`$domain`) |
+| `wifi.dhcp.obtained.unix` | integer | unix time the lease was bound (for UI countdown) |
+
+(`wifi.dhcp.ip`, `wifi.dhcp.state` already exist.) These are written by the
+hook and read by the REST status endpoint; the daemon does not read them, so
+they don't join `kReadKeys`/`kWriteKeys`.
+
+## 4. Hook script (`udhcpc-ds.script`)
+
+```sh
+case "$1" in
+  bound|renew)
+    <delegate to /usr/share/udhcpc/default.script for the actual ifconfig>
+    ds-cli set wifi.dhcp.ip "$ip"; mask/gateway/dns/domain/lease.sec/obtained.unix
+    ds-cli set wifi.dhcp.state '"bound"'
+    ;;
+  deconfig)
+    <delegate>
+    clear wifi.dhcp.{ip,mask,gateway,dns,domain}; lease.sec=0   # NOT state
+    ;;
+  leasefail|nak) <delegate>; ;;     # daemon owns state here
+esac
+```
+
+Socket: `--socket=${IOT_DS_SOCK:-/run/iot/data_store.sock}`. Delegating to the
+distro default.script keeps connectivity intact (we only override `-s`).
+
+## 5. Daemon wiring
+
+- `process.cpp` `spawn_dhcp(dhcp_path, iface, script = "")`: for udhcpc, append
+  `-s <script>` when `script` non-empty. dhclient unchanged (out of scope).
+- `supervisor.cpp`: define `kDhcpHookScript = "/usr/share/iot/udhcpc-ds.script"`;
+  pass it to `spawn_dhcp` only when `::access(path, F_OK) == 0`, so dev/test
+  hosts without the script keep today's behaviour.
+
+## 6. REST + UI
+
+- `handler.cpp`: add the 6 keys to the status `get()` list and map them
+  (`wifi.dhcp.mask → wifi.dhcp_mask`, `gateway → dhcp_gateway`, `dns →
+  dhcp_dns`, `lease.sec → dhcp_lease_sec` (int), `domain → dhcp_domain`,
+  `obtained.unix → dhcp_obtained_unix` (int)).
+- `iot-ui` `app-globals.ts` `WifiStatus`: add the optional fields.
+- `dashboard.component.html`: add conditional rows under the WiFi card.
+
+## 7. Test strategy
+
+1. **process_test**: `spawn_dhcp` with a script arg appends `-s <script>` for a
+   udhcpc-basename binary; omits it when empty; dhclient never gets `-s`.
+   (Assert via a thin seam — spawn a `/bin/sh` stand-in named `udhcpc` and
+   confirm behaviour, or factor the argv builder into a testable free function.)
+2. **schema_test**: the new keys are declared with the right types.
+3. Hook script: `sh -n` syntax + a host dry-run with faked env + a stub `ds-cli`
+   on PATH asserting the emitted `set` calls.
+4. C++ suite green in podman; iot-ui production build green in podman.
+
+## 8. Out of scope / caveats
+
+- dhclient hook (different mechanism); only udhcpc covered.
+- The daemon still owns non-bound `wifi.dhcp.state`; brief eventual-consistency
+  windows are acceptable for a status readout.
+- On-device end-to-end (real lease → UI shows it) deferred to the RPi/build env.

--- a/apps/docs/tdd-wifi-zero-touch-mdns.md
+++ b/apps/docs/tdd-wifi-zero-touch-mdns.md
@@ -1,0 +1,109 @@
+# TDD Plan — Zero-Touch Device-UI Discovery via mDNS
+
+Status: **IN PROGRESS** — design agreed. Yocto/image side only. Most of the
+change is recipe + systemd config (not unit-testable without a build); the one
+pure-logic bit (serial → hostname sanitization) is validated with a host shell
+check.
+
+### Implementation progress
+
+| Task | State | Notes |
+| --- | --- | --- |
+| A — auto-start `iot-httpd` | ⬜ TODO | `iot_git.bb`: `SYSTEMD_AUTO_ENABLE:${PN}-httpd` `disable` → `enable`. UI must be up on boot. |
+| B — `iot-set-hostname` (serial → hostname) | ⬜ TODO | Oneshot script: derive `iot-<serial-suffix>` and apply via `hostnamectl`. |
+| C — `iot-hostname.service` | ⬜ TODO | `Type=oneshot`, `Before=avahi-daemon.service`, auto-enabled. |
+| D — Avahi `_http._tcp` advert | ⬜ TODO | `/etc/avahi/services/iot-http.service` advertising port 8080 on `%h`. |
+| E — pull in `avahi-daemon` | ⬜ TODO | `RDEPENDS:${PN}-httpd += "avahi-daemon"`. |
+| F — recipe packaging | ⬜ TODO | SRC_URI + do_install + SYSTEMD_SERVICE + FILES for the new units/files. |
+
+## 1. Goal
+
+Zero touch: flash SD → boot → wifi-client joins the AP (already auto-started) →
+DHCP IP → user opens the device-iot UI in a browser **without knowing the IP**.
+
+The IP is deliberately NOT the discovery mechanism. The device advertises
+itself over mDNS, so the user opens:
+
+```
+http://iot-<serial>.local:8080
+```
+
+`<serial>` is the last 8 chars of the RPi serial — collision-safe when several
+devices share a LAN. A service browser (Bonjour / `avahi-browse` / `dns-sd -B
+_http._tcp`) lists it as **"IoT Device UI on iot-<serial>"**.
+
+## 2. Current gaps (verified)
+
+- `iot-httpd` serves the UI on **0.0.0.0:8080** (`http.lua` defaults) from
+  `/usr/share/iot/www`, but ships **disabled** (`SYSTEMD_AUTO_ENABLE:${PN}-httpd
+  = "disable"`, `iot_git.bb:437`).
+- No mDNS responder in the image (no avahi/nss-mdns anywhere).
+- Hostname defaults to the MACHINE name (`raspberrypi3-64`); not per-device,
+  not advertised.
+
+(Out of scope here: populating `wifi.dhcp.ip` and sending the DHCP hostname
+option — useful but separate; the chosen approach doesn't need the IP at all.)
+
+## 3. Design
+
+### 3.1 httpd auto-start
+Flip `SYSTEMD_AUTO_ENABLE:${PN}-httpd` → `enable`. The unit already orders
+`After=iot-ds.service network-online.target`.
+
+⚠️ **Security note:** this exposes the device UI + REST API on `0.0.0.0:8080`
+to anyone on the LAN by default (previously operator opt-in). That is the
+intent for a zero-touch device, but call it out; lock down via `http.listen.ip`
+/ auth if the deployment is not a trusted LAN.
+
+### 3.2 Hostname from serial (`iot-set-hostname`)
+Read the serial (device-tree `serial-number`, fallback `/proc/cpuinfo`
+`Serial`), lowercase, strip to `[a-z0-9]`, keep the last 8 chars, and set
+`hostname = iot-<suffix>` via `hostnamectl set-hostname` (fallback:
+`/etc/hostname` + `hostname`). Empty serial → `iot-device`.
+
+Run by `iot-hostname.service` (`Type=oneshot`, `RemainAfterExit=yes`,
+`After=local-fs.target`, `Before=avahi-daemon.service`, auto-enabled) so the
+name is set before Avahi advertises. (Avahi also tracks hostname changes, so
+ordering is belt-and-suspenders.)
+
+### 3.3 Avahi advertisement
+Ship `/etc/avahi/services/iot-http.service`:
+
+```xml
+<service-group>
+  <name replace-wildcards="yes">IoT Device UI on %h</name>
+  <service> <type>_http._tcp</type> <port>8080</port> </service>
+</service-group>
+```
+
+`%h` expands to the system hostname → `iot-<serial>.local`. Port hardcoded to
+the httpd default 8080 (note: if an operator changes `http.listen.port`, the
+advert is stale).
+
+### 3.4 Image inclusion
+`RDEPENDS:${PN}-httpd += "avahi-daemon"` pulls the mDNS responder in wherever
+iot-httpd is installed (the full gateway image). `avahi-daemon` is enabled by
+its own recipe.
+
+## 4. Recipe wiring (`iot_git.bb`)
+- `SRC_URI +=` `iot-set-hostname`, `iot-hostname.service`, `iot-http.avahi.service`.
+- `do_install` (systemd branch): install the script to `${bindir}`, the unit to
+  `${systemd_system_unitdir}`, the avahi file to `${sysconfdir}/avahi/services/`.
+- `SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service"`.
+- `SYSTEMD_AUTO_ENABLE:${PN}-httpd = "enable"`.
+- `FILES:${PN}-httpd +=` the avahi service file + the hostname script.
+- `RDEPENDS:${PN}-httpd += "avahi-daemon"`.
+
+## 5. Verification
+- Host shell check of the serial→hostname sanitization (sample serial →
+  `iot-3d1f9c2e`).
+- **Deferred (needs hardware/build):** real RPi boot → `avahi-browse -rt
+  _http._tcp` from a laptop shows `iot-<serial>`, and `http://iot-<serial>.local:8080`
+  loads the UI; `hostnamectl` shows the derived name.
+
+## 6. Out of scope
+- `wifi.dhcp.ip` population + DHCP hostname option (option 12) — separate, not
+  required for mDNS discovery.
+- Port-80 redirect so the `:8080` can be dropped (would need an nft rule).
+- mDNS name collisions if two devices truly share the same 8-char suffix
+  (astronomically unlikely; full serial is available if ever needed).

--- a/iot-ui/src/app/dashboard/dashboard.component.html
+++ b/iot-ui/src/app/dashboard/dashboard.component.html
@@ -31,6 +31,23 @@
             </span>
           </span>
         </div>
+        <!-- DHCP lease detail (written by the udhcpc-ds hook). -->
+        <div class="card-detail" *ngIf="status?.wifi?.dhcp_ip">
+          IP {{ status?.wifi?.dhcp_ip
+          }}<span *ngIf="status?.wifi?.dhcp_mask"> / {{ status?.wifi?.dhcp_mask }}</span>
+        </div>
+        <div class="card-detail" *ngIf="status?.wifi?.dhcp_gateway">
+          GW {{ status?.wifi?.dhcp_gateway }}
+        </div>
+        <div class="card-detail" *ngIf="status?.wifi?.dhcp_dns">
+          DNS {{ status?.wifi?.dhcp_dns }}
+        </div>
+        <div class="card-detail" *ngIf="status?.wifi?.dhcp_domain">
+          Domain {{ status?.wifi?.dhcp_domain }}
+        </div>
+        <div class="card-detail" *ngIf="status?.wifi?.dhcp_lease_sec">
+          Lease {{ status?.wifi?.dhcp_lease_sec }} s
+        </div>
       </div>
     </div>
 

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -52,6 +52,12 @@ export interface WifiStatus {
   rssi?: number;
   dhcp_state?: string;
   dhcp_ip?: string;
+  dhcp_mask?: string;
+  dhcp_gateway?: string;
+  dhcp_dns?: string;
+  dhcp_lease_sec?: number;
+  dhcp_domain?: string;
+  dhcp_obtained_unix?: number;
 }
 
 export interface WanStatus {

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -571,7 +571,9 @@ void install_handlers(Router& router,
                 "vpn.exit_code", "vpn.gate.reason", "vpn.bound.iface",
                 // WiFi
                 "wifi.assoc.state", "wifi.assoc.ssid", "wifi.signal.rssi",
-                "wifi.dhcp.state", "wifi.dhcp.ip",
+                "wifi.dhcp.state", "wifi.dhcp.ip", "wifi.dhcp.mask",
+                "wifi.dhcp.gateway", "wifi.dhcp.dns", "wifi.dhcp.lease.sec",
+                "wifi.dhcp.domain", "wifi.dhcp.obtained.unix",
                 // WAN / net
                 "net.iface.active", "net.state", "net.tun.ip",
                 "net.rules.applied.count", "net.last.apply.unix",
@@ -691,6 +693,12 @@ void install_handlers(Router& router,
                 else if (k == "wifi.signal.rssi")      wifi["rssi"] = iv();
                 else if (k == "wifi.dhcp.state")       wifi["dhcp_state"] = sv();
                 else if (k == "wifi.dhcp.ip")          wifi["dhcp_ip"] = sv();
+                else if (k == "wifi.dhcp.mask")        wifi["dhcp_mask"] = sv();
+                else if (k == "wifi.dhcp.gateway")     wifi["dhcp_gateway"] = sv();
+                else if (k == "wifi.dhcp.dns")         wifi["dhcp_dns"] = sv();
+                else if (k == "wifi.dhcp.lease.sec")   wifi["dhcp_lease_sec"] = iv();
+                else if (k == "wifi.dhcp.domain")      wifi["dhcp_domain"] = sv();
+                else if (k == "wifi.dhcp.obtained.unix") wifi["dhcp_obtained_unix"] = iv();
 
                 else if (k == "net.iface.active")            wan["active_iface"] = sv();
                 else if (k == "net.iface.priority")          wan["iface_priority"] = sv();

--- a/modules/wan/wifi/client/schemas/wifi.lua
+++ b/modules/wan/wifi/client/schemas/wifi.lua
@@ -45,6 +45,15 @@
 --   wifi.dhcp.state         - "idle" / "requesting" / "bound" / "rebinding"
 --                             / "exited"
 --   wifi.dhcp.ip            - IPv4 leased on the iface (empty when not bound)
+--   wifi.dhcp.mask          - subnet mask of the lease (udhcpc $subnet)
+--   wifi.dhcp.gateway       - default gateway(s) (udhcpc $router)
+--   wifi.dhcp.dns           - nameserver(s), space-separated (udhcpc $dns)
+--   wifi.dhcp.lease.sec     - lease time in seconds (udhcpc $lease)
+--   wifi.dhcp.domain        - DNS domain (udhcpc $domain)
+--   wifi.dhcp.obtained.unix - unix time the lease was bound (UI countdown)
+--                             wifi.dhcp.{mask,gateway,dns,lease.sec,domain,
+--                             obtained.unix} are written by the udhcpc hook
+--                             (udhcpc-ds.script) via ds-cli, not the daemon.
 --   wifi.pid.wpa            - live wpa_supplicant pid (0 when not running)
 --   wifi.pid.dhcp           - live DHCP-client pid (0 when not running)
 --   wifi.last.error         - last non-fatal error message (auth reject,
@@ -117,6 +126,21 @@ return {
         access  = "Viewer", type = "string" },
     ["wifi.dhcp.ip"]            = {
         access  = "Viewer", type = "string" },
+    -- Lease detail mirrored from the udhcpc hook (udhcpc-ds.script) so the
+    -- device-iot UI can render the full network config. Written by the hook
+    -- via ds-cli, not by the daemon.
+    ["wifi.dhcp.mask"]          = {
+        access  = "Viewer", type = "string" },
+    ["wifi.dhcp.gateway"]       = {
+        access  = "Viewer", type = "string" },
+    ["wifi.dhcp.dns"]           = {
+        access  = "Viewer", type = "string" },
+    ["wifi.dhcp.lease.sec"]     = {
+        access  = "Viewer", type = "integer", min = 0 },
+    ["wifi.dhcp.domain"]        = {
+        access  = "Viewer", type = "string" },
+    ["wifi.dhcp.obtained.unix"] = {
+        access  = "Viewer", type = "integer", min = 0 },
     ["wifi.pid.wpa"]            = {
         access  = "Viewer", type = "integer", min = 0 },
     ["wifi.pid.dhcp"]           = {

--- a/modules/wan/wifi/client/scripts/test_udhcpc_ds_script.sh
+++ b/modules/wan/wifi/client/scripts/test_udhcpc_ds_script.sh
@@ -1,0 +1,62 @@
+#!/bin/sh
+# Host test for udhcpc-ds.script: stub ds-cli + lease env, assert the emitted
+# `ds-cli set` calls for bound/deconfig. No real udhcpc/ds-server needed.
+#
+# Usage: sh test_udhcpc_ds_script.sh   (exit 0 = pass)
+set -u
+here=$(CDPATH= cd -- "$(dirname -- "$0")" && pwd)
+hook="$here/udhcpc-ds.script"
+
+work="${TMPDIR:-/tmp}/udhcpc-ds-test.$$"
+mkdir -p "$work"
+trap 'rm -rf "$work"' EXIT
+
+# Stub ds-cli: log "key=value" per invocation (args: --socket=.. set KEY VALUE).
+cat > "$work/ds-cli" <<'EOF'
+#!/bin/sh
+key=""; val=""
+for a in "$@"; do
+    case "$a" in --socket=*|set) : ;; *) if [ -z "$key" ]; then key="$a"; else val="$a"; fi ;; esac
+done
+printf '%s=%s\n' "$key" "$val" >> "$DSLOG"
+EOF
+chmod +x "$work/ds-cli"
+
+DSLOG="$work/calls.log"; export DSLOG
+export IOT_DS_CLI="$work/ds-cli"
+
+fail() { echo "FAIL: $1"; exit 1; }
+grep_q() { grep -qF "$1" "$DSLOG" || fail "expected '$1' in ds calls:\n$(cat "$DSLOG")"; }
+
+# ── bound ──
+: > "$DSLOG"
+ip=192.168.1.42 subnet=255.255.255.0 router=192.168.1.1 \
+dns="192.168.1.1 8.8.8.8" domain=lan lease=86400 \
+    sh "$hook" bound
+grep_q 'wifi.dhcp.ip="192.168.1.42"'
+grep_q 'wifi.dhcp.mask="255.255.255.0"'
+grep_q 'wifi.dhcp.gateway="192.168.1.1"'
+grep_q 'wifi.dhcp.dns="192.168.1.1 8.8.8.8"'
+grep_q 'wifi.dhcp.domain="lan"'
+grep_q 'wifi.dhcp.lease.sec=86400'
+grep_q 'wifi.dhcp.state="bound"'
+grep -q 'wifi.dhcp.obtained.unix=' "$DSLOG" || fail "obtained.unix not set"
+
+# ── deconfig clears data, does NOT touch state ──
+: > "$DSLOG"
+sh "$hook" deconfig
+grep_q 'wifi.dhcp.ip=""'
+grep_q 'wifi.dhcp.lease.sec=0'
+grep -q 'wifi.dhcp.state=' "$DSLOG" && fail "deconfig must not write wifi.dhcp.state"
+
+# ── quote-escaping in SSID-ish values (defensive) ──
+: > "$DSLOG"
+ip='1.2.3.4' subnet='' router='' dns='' domain='a"b\c' lease=10 sh "$hook" renew
+grep_q 'wifi.dhcp.domain="a\"b\\c"'
+
+# ── leasefail: no data writes ──
+: > "$DSLOG"
+sh "$hook" leasefail
+[ -s "$DSLOG" ] && fail "leasefail must not write ds keys: $(cat "$DSLOG")"
+
+echo "PASS: udhcpc-ds.script ($(basename "$hook"))"

--- a/modules/wan/wifi/client/scripts/udhcpc-ds.script
+++ b/modules/wan/wifi/client/scripts/udhcpc-ds.script
@@ -1,0 +1,72 @@
+#!/bin/sh
+# udhcpc-ds.script — udhcpc lease hook for wifi-client.
+#
+# udhcpc delivers the full lease ONLY to its -s hook via environment variables
+# (lease time and DNS aren't readable back from the interface). This hook does
+# two things on each lease event:
+#   1. delegates the actual interface configuration to the system default
+#      udhcpc script (so connectivity is unchanged), then
+#   2. mirrors the lease into the data-store via ds-cli so the device-iot UI
+#      can render IP / mask / gateway / DNS / lease-time / domain.
+#
+# The wifi-client daemon points udhcpc at this script with `-s` only when it is
+# installed (see supervisor.cpp). See apps/docs/tdd-wifi-dhcp-lease.md.
+#
+# Key ownership: the daemon owns wifi.dhcp.state ("requesting"/"exited"); this
+# hook adds the one state it alone knows — "bound" — and the lease data keys.
+# On deconfig it clears the data keys but does NOT touch wifi.dhcp.state (udhcpc
+# fires deconfig at startup, racing the daemon's "requesting").
+
+DS_SOCK="${IOT_DS_SOCK:-/run/iot/data_store.sock}"
+DS_CLI="${IOT_DS_CLI:-ds-cli}"
+
+# Locate the distro default udhcpc script to do the real ifconfig.
+DEFAULT_SCRIPT=""
+for c in /usr/share/udhcpc/default.script /etc/udhcpc/default.script; do
+    if [ -x "$c" ]; then DEFAULT_SCRIPT="$c"; break; fi
+done
+
+dsset() {
+    # Best-effort: a ds write must never break DHCP / connectivity.
+    "$DS_CLI" --socket="$DS_SOCK" set "$1" "$2" >/dev/null 2>&1 || true
+}
+
+# JSON-string-quote a value (escape \ and ") for ds-cli string keys.
+jq_str() {
+    printf '"%s"' "$(printf '%s' "$1" | sed -e 's/\\/\\\\/g' -e 's/"/\\"/g')"
+}
+
+# 1) Real networking config (unchanged behaviour).
+if [ -n "$DEFAULT_SCRIPT" ]; then
+    "$DEFAULT_SCRIPT" "$1" || true
+fi
+
+# 2) Mirror the lease to the data-store.
+case "$1" in
+    bound|renew)
+        dsset wifi.dhcp.ip            "$(jq_str "${ip:-}")"
+        dsset wifi.dhcp.mask          "$(jq_str "${subnet:-}")"
+        dsset wifi.dhcp.gateway       "$(jq_str "${router:-}")"
+        dsset wifi.dhcp.dns           "$(jq_str "${dns:-}")"
+        dsset wifi.dhcp.domain        "$(jq_str "${domain:-}")"
+        dsset wifi.dhcp.lease.sec     "${lease:-0}"
+        dsset wifi.dhcp.obtained.unix "$(date +%s 2>/dev/null || echo 0)"
+        dsset wifi.dhcp.state         '"bound"'
+        ;;
+    deconfig)
+        # Lease gone (also fired once at startup). Clear data; leave
+        # wifi.dhcp.state to the daemon to avoid racing "requesting".
+        dsset wifi.dhcp.ip            '""'
+        dsset wifi.dhcp.mask          '""'
+        dsset wifi.dhcp.gateway       '""'
+        dsset wifi.dhcp.dns           '""'
+        dsset wifi.dhcp.domain        '""'
+        dsset wifi.dhcp.lease.sec     0
+        dsset wifi.dhcp.obtained.unix 0
+        ;;
+    leasefail|nak)
+        # Daemon owns the failure state; nothing to mirror.
+        ;;
+esac
+
+exit 0

--- a/modules/wan/wifi/client/src/process.cpp
+++ b/modules/wan/wifi/client/src/process.cpp
@@ -380,8 +380,9 @@ bool Process::spawn_wpa_supplicant(const std::string&             wpa_path,
     return spawn(wpa_path, argv);
 }
 
-bool Process::spawn_dhcp(const std::string& dhcp_path,
-                         const std::string& iface) {
+std::vector<std::string> build_dhcp_argv(const std::string& dhcp_path,
+                                         const std::string& iface,
+                                         const std::string& script) {
     std::vector<std::string> argv;
     argv.push_back(dhcp_path);
     // Detect udhcpc vs dhclient by basename. The picker hands us
@@ -395,12 +396,24 @@ bool Process::spawn_dhcp(const std::string& dhcp_path,
         argv.push_back(iface);
         argv.push_back("-f");
         argv.push_back("-q");
+        // -s <hook> mirrors the lease to the data-store (udhcpc-ds.script).
+        if (!script.empty()) {
+            argv.push_back("-s");
+            argv.push_back(script);
+        }
     } else {
-        // dhclient -d (no daemonise) <iface>
+        // dhclient -d (no daemonise) <iface> — different hook mechanism,
+        // so `script` is intentionally ignored here.
         argv.push_back("-d");
         argv.push_back(iface);
     }
-    return spawn(dhcp_path, argv);
+    return argv;
+}
+
+bool Process::spawn_dhcp(const std::string& dhcp_path,
+                         const std::string& iface,
+                         const std::string& script) {
+    return spawn(dhcp_path, build_dhcp_argv(dhcp_path, iface, script));
 }
 
 bool Process::running() {

--- a/modules/wan/wifi/client/src/process.hpp
+++ b/modules/wan/wifi/client/src/process.hpp
@@ -79,6 +79,16 @@ std::string build_wpa_supplicant_config(const std::string&             iface,
                                         const std::string&             ctrl_dir,
                                         const std::vector<WifiNetwork>& networks);
 
+/// Build the DHCP-client argv for `dhcp_path` against `iface`. Shape is
+/// chosen by the binary basename:
+///   udhcpc:   <path> -i <iface> -f -q [-s <script>]
+///   dhclient: <path> -d <iface>
+/// `script` (udhcpc only, when non-empty) is the `-s` lease hook. Factored
+/// out of spawn_dhcp so the argv shaping is unit-testable without a spawn.
+std::vector<std::string> build_dhcp_argv(const std::string& dhcp_path,
+                                         const std::string& iface,
+                                         const std::string& script = "");
+
 /// Write `body` to a fresh /tmp/wpa-XXXXXX.conf and return the path.
 /// Throws std::runtime_error on mkstemps / write failure. Same
 /// $TMPDIR → /tmp → cwd fallback chain openvpn-client uses.
@@ -126,13 +136,18 @@ public:
     /// Spawn a DHCP client child against `iface`. `dhcp_path` is
     /// the absolute path to udhcpc or dhclient as picked by
     /// pick_dhcp_client(). The argv is shaped per the client:
-    ///   udhcpc:   -i <iface> -f -q
+    ///   udhcpc:   -i <iface> -f -q [-s <script>]
     ///   dhclient: -d <iface>
     /// The picker baseline is the binary's *basename* — anything
     /// containing "udhcpc" gets the udhcpc shape; anything else
     /// falls to dhclient shape.
+    /// `script` (when non-empty AND udhcpc) is passed as `-s <script>`,
+    /// the lease hook that mirrors the lease into the data-store
+    /// (udhcpc-ds.script). Empty = udhcpc's built-in default script.
+    /// dhclient ignores `script` (different hook mechanism).
     bool spawn_dhcp(const std::string& dhcp_path,
-                    const std::string& iface);
+                    const std::string& iface,
+                    const std::string& script = "");
 
     /// Subprocess pid (0 if no spawn yet).
     pid_t pid() const { return m_pid; }

--- a/modules/wan/wifi/client/src/supervisor.cpp
+++ b/modules/wan/wifi/client/src/supervisor.cpp
@@ -7,6 +7,7 @@
 #include <sstream>
 #include <string>
 #include <sys/stat.h>
+#include <unistd.h>
 
 #include <ace/Log_Msg.h>
 #include <nlohmann/json.hpp>
@@ -404,7 +405,14 @@ int Supervisor::run() {
                 m_ds.dhcp_client().value_or("auto"),
                 m_ds.dhcp_path().value_or(""));
             if (!dhcp_path.empty()) {
-                if (m_dhcp.spawn_dhcp(dhcp_path, m_opt.iface)) {
+                // Point udhcpc at the lease hook (mirrors the lease into ds for
+                // the device UI) only when it is installed — dev/test hosts
+                // without it keep udhcpc's built-in default script.
+                static constexpr const char* kDhcpHookScript =
+                    "/usr/share/iot/udhcpc-ds.script";
+                std::string hook;
+                if (::access(kDhcpHookScript, F_OK) == 0) hook = kDhcpHookScript;
+                if (m_dhcp.spawn_dhcp(dhcp_path, m_opt.iface, hook)) {
                     m_ds.set_dhcp_state("requesting");
                     m_ds.set_pid_dhcp(static_cast<std::uint32_t>(m_dhcp.pid()));
                 }

--- a/modules/wan/wifi/client/test/process_test.cpp
+++ b/modules/wan/wifi/client/test/process_test.cpp
@@ -30,6 +30,7 @@
 
 using wifi_client::Process;
 using wifi_client::WifiNetwork;
+using wifi_client::build_dhcp_argv;
 using wifi_client::build_wpa_supplicant_config;
 using wifi_client::parse_wifi_networks;
 using wifi_client::pick_dhcp_client;
@@ -229,6 +230,41 @@ TEST(WIFI_REQ_WIFI_017_dhcp_picker_honours_schema_key,
     // Even when scheme says dhclient, override still wins.
     p = pick_dhcp_client("dhclient", "/opt/local/bin/my-dhcp");
     EXPECT_EQ("/opt/local/bin/my-dhcp", p);
+}
+
+TEST(WIFI_REQ_WIFI_017_dhcp_picker_honours_schema_key,
+     udhcpc_argv_appends_lease_hook_when_script_given) {
+    auto a = build_dhcp_argv("/sbin/udhcpc", "wlan0",
+                             "/usr/share/iot/udhcpc-ds.script");
+    // udhcpc -i wlan0 -f -q -s <script>
+    ASSERT_GE(a.size(), 7u);
+    EXPECT_EQ("/sbin/udhcpc", a[0]);
+    EXPECT_EQ("-i", a[1]);
+    EXPECT_EQ("wlan0", a[2]);
+    EXPECT_EQ("-f", a[3]);
+    EXPECT_EQ("-q", a[4]);
+    EXPECT_EQ("-s", a[5]);
+    EXPECT_EQ("/usr/share/iot/udhcpc-ds.script", a[6]);
+}
+
+TEST(WIFI_REQ_WIFI_017_dhcp_picker_honours_schema_key,
+     udhcpc_argv_omits_hook_when_script_empty) {
+    auto a = build_dhcp_argv("/sbin/udhcpc", "wlan0", "");
+    for (const auto& tok : a)
+        EXPECT_NE("-s", tok) << "no -s expected when script is empty";
+    EXPECT_EQ(5u, a.size());  // path -i wlan0 -f -q
+}
+
+TEST(WIFI_REQ_WIFI_017_dhcp_picker_honours_schema_key,
+     dhclient_ignores_lease_hook_script) {
+    auto a = build_dhcp_argv("/sbin/dhclient", "wlan0",
+                             "/usr/share/iot/udhcpc-ds.script");
+    // dhclient -d wlan0 — never -s.
+    ASSERT_EQ(3u, a.size());
+    EXPECT_EQ("/sbin/dhclient", a[0]);
+    EXPECT_EQ("-d", a[1]);
+    EXPECT_EQ("wlan0", a[2]);
+    for (const auto& tok : a) EXPECT_NE("-s", tok);
 }
 
 TEST(WIFI_REQ_WIFI_017_dhcp_picker_honours_schema_key,

--- a/modules/wan/wifi/client/test/schema_test.cpp
+++ b/modules/wan/wifi/client/test/schema_test.cpp
@@ -169,6 +169,8 @@ TEST_F(WIFI_REQ_WIFI_006_write_keys_typed, integer_keys_typed_integer) {
         "wifi.scan.last.unix",
         "wifi.pid.wpa",
         "wifi.pid.dhcp",
+        "wifi.dhcp.lease.sec",
+        "wifi.dhcp.obtained.unix",
     };
     for (const auto& k : int_keys) {
         auto body = entry_body(schema, k);
@@ -186,6 +188,10 @@ TEST_F(WIFI_REQ_WIFI_006_write_keys_typed, string_keys_typed_string) {
         "wifi.scan.results",
         "wifi.dhcp.state",
         "wifi.dhcp.ip",
+        "wifi.dhcp.mask",
+        "wifi.dhcp.gateway",
+        "wifi.dhcp.dns",
+        "wifi.dhcp.domain",
         "wifi.last.error",
     };
     for (const auto& k : str_keys) {

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-hostname.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-hostname.service
@@ -1,0 +1,17 @@
+[Unit]
+Description=Derive iot-<serial> hostname for mDNS device-UI discovery
+Documentation=https://github.com/naushada/iot
+After=local-fs.target
+# Set the hostname before Avahi advertises so it announces iot-<serial>.local.
+Before=avahi-daemon.service
+ConditionPathExists=/usr/bin/iot-set-hostname
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/iot-set-hostname
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-http.avahi.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-http.avahi.service
@@ -1,0 +1,16 @@
+<?xml version="1.0" standalone='no'?>
+<!DOCTYPE service-group SYSTEM "avahi-service.dtd">
+<!-- Advertises the iot-httpd device UI over mDNS as _http._tcp so a laptop on
+     the same LAN can find it with no IP lookup. Installed to
+     /etc/avahi/services/iot-http.service. %h expands to the system hostname
+     (iot-<serial>, set by iot-set-hostname), so the UI is reachable at
+     http://iot-<serial>.local:8080. Port is the iot-httpd default
+     (http.listen.port); if an operator changes that key this advert is stale.
+     See apps/docs/tdd-wifi-zero-touch-mdns.md. -->
+<service-group>
+  <name replace-wildcards="yes">IoT Device UI on %h</name>
+  <service>
+    <type>_http._tcp</type>
+    <port>8080</port>
+  </service>
+</service-group>

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-set-hostname
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-set-hostname
@@ -1,0 +1,35 @@
+#!/bin/sh
+# iot-set-hostname — derive a stable, collision-safe hostname from the RPi
+# serial and apply it so Avahi advertises <hostname>.local for zero-touch
+# device-UI discovery (http://iot-<serial>.local:8080).
+#
+# Run once at boot by iot-hostname.service, before avahi-daemon. Idempotent:
+# re-running sets the same name. See apps/docs/tdd-wifi-zero-touch-mdns.md.
+set -eu
+
+serial=""
+
+# Preferred: device-tree serial-number (NUL-terminated string).
+if [ -r /sys/firmware/devicetree/base/serial-number ]; then
+    serial=$(tr -d '\000' < /sys/firmware/devicetree/base/serial-number || true)
+fi
+
+# Fallback: /proc/cpuinfo "Serial" line.
+if [ -z "$serial" ] && [ -r /proc/cpuinfo ]; then
+    serial=$(awk -F': ' '/^Serial/ { print $2; exit }' /proc/cpuinfo || true)
+fi
+
+# Sanitize to a valid hostname label: lowercase, keep [a-z0-9], last 8 chars.
+suffix=$(printf '%s' "$serial" | tr 'A-Z' 'a-z' | tr -cd 'a-z0-9' | tail -c 8)
+[ -n "$suffix" ] || suffix="device"
+name="iot-${suffix}"
+
+if command -v hostnamectl >/dev/null 2>&1 && hostnamectl set-hostname "$name" 2>/dev/null; then
+    :
+else
+    # Fallback when hostnamectl/dbus is unavailable.
+    printf '%s\n' "$name" > /etc/hostname
+    hostname "$name" 2>/dev/null || true
+fi
+
+echo "iot-set-hostname: hostname set to ${name}"

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -52,6 +52,9 @@ SRC_URI = "\
     file://migrations/README.md \
     file://migrations/0000-template.sh.example \
     file://gen_wifi_default.py \
+    file://iot-set-hostname \
+    file://iot-hostname.service \
+    file://iot-http.avahi.service \
 "
 
 # Optional, gitignored WiFi credential seed. When an integrator drops
@@ -250,6 +253,14 @@ do_install() {
         install -m 0644 ${WORKDIR}/net-router.env     ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/wifi-client.env    ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/httpd.env          ${D}${sysconfdir}/iot/
+
+        # Zero-touch mDNS device-UI discovery: derive iot-<serial> hostname at
+        # boot and advertise iot-httpd (_http._tcp:8080) via Avahi. See
+        # apps/docs/tdd-wifi-zero-touch-mdns.md.
+        install -m 0755 ${WORKDIR}/iot-set-hostname           ${D}${bindir}/iot-set-hostname
+        install -m 0644 ${WORKDIR}/iot-hostname.service       ${D}${systemd_system_unitdir}/
+        install -d ${D}${sysconfdir}/avahi/services
+        install -m 0644 ${WORKDIR}/iot-http.avahi.service     ${D}${sysconfdir}/avahi/services/iot-http.service
     fi
 }
 
@@ -392,10 +403,15 @@ RRECOMMENDS:${PN}-wifi-client = "\
 # iot-httpd via www-dir. Built by do_build_ui above.
 FILES:${PN}-httpd = "\
     ${bindir}/iot-httpd \
+    ${bindir}/iot-set-hostname \
     ${systemd_system_unitdir}/iot-httpd.service \
+    ${systemd_system_unitdir}/iot-hostname.service \
+    ${sysconfdir}/avahi/services/iot-http.service \
     ${datadir}/iot/www \
 "
-RDEPENDS:${PN}-httpd = "ace-tao"
+# avahi-daemon provides the mDNS responder that advertises the device UI
+# (_http._tcp on iot-<serial>.local) for zero-touch discovery.
+RDEPENDS:${PN}-httpd = "ace-tao avahi-daemon"
 RRECOMMENDS:${PN}-httpd = "\
     ${PN}-ds-server \
     ${PN}-config \
@@ -421,7 +437,9 @@ SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service
 SYSTEMD_SERVICE:${PN}-openvpn-client = "iot-openvpn-client.service iot-vpn-cert.path"
 SYSTEMD_SERVICE:${PN}-net-router = "iot-net-router.service"
 SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
-SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service"
+# httpd also carries the boot-time hostname unit (iot-<serial>) that makes the
+# Avahi advert resolvable — zero-touch device-UI discovery.
+SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service"
 
 # ds-server and wifi-client auto-start. wifi-client comes up on every boot
 # and reads wifi.networks from the data-store (schema default seeds a
@@ -434,7 +452,11 @@ SYSTEMD_AUTO_ENABLE:${PN}-lwm2m = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-openvpn-client = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-net-router = "disable"
 SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "enable"
-SYSTEMD_AUTO_ENABLE:${PN}-httpd = "disable"
+# httpd auto-starts for zero-touch device-UI access (mDNS discovery via Avahi).
+# Enabling this exposes the UI + REST API on 0.0.0.0:8080 to the LAN by default;
+# lock down via http.listen.ip / auth for untrusted networks. Also enables the
+# iot-hostname oneshot (sets iot-<serial> so Avahi advertises a stable name).
+SYSTEMD_AUTO_ENABLE:${PN}-httpd = "enable"
 
 # ── Sanity checks ──────────────────────────────────────────────────
 # Inhibit the "binary already stripped" QA warning — we build with -g

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -222,6 +222,12 @@ do_install() {
     install -m 0644 ${WORKDIR}/migrations/0000-template.sh.example \
         ${D}${datadir}/iot/migrations/0000-template.sh.example
 
+    # udhcpc lease hook — wifi-client points udhcpc at this (-s) to mirror the
+    # DHCP lease (ip/mask/gateway/dns/lease/domain) into ds for the device UI.
+    # See apps/docs/tdd-wifi-dhcp-lease.md.
+    install -m 0755 ${S}/modules/wan/wifi/client/scripts/udhcpc-ds.script \
+        ${D}${datadir}/iot/udhcpc-ds.script
+
     # ── systemd units (overwrite cmake-installed copies) ──────────
     if ${@bb.utils.contains('PACKAGECONFIG', 'systemd', 'true', 'false', d)}; then
         install -d ${D}${systemd_system_unitdir}
@@ -386,11 +392,14 @@ RRECOMMENDS:${PN}-net-router = "\
 # wifi-client — wpa_supplicant + DHCP supervisor
 FILES:${PN}-wifi-client = "\
     ${bindir}/wifi-client \
+    ${datadir}/iot/udhcpc-ds.script \
     ${systemd_system_unitdir}/iot-wifi-client.service \
 "
+# iot-ds-cli: the udhcpc lease hook writes the lease via ds-cli.
 RDEPENDS:${PN}-wifi-client = "\
     ace-tao \
     wpa-supplicant \
+    ${PN}-ds-cli \
 "
 RRECOMMENDS:${PN}-wifi-client = "\
     ${PN}-ds-server \


### PR DESCRIPTION
## Summary

Answers "who writes the DHCP lease to ds so the device-iot UI can render it?" — **a custom udhcpc lease hook**. Once the AP's DHCP server assigns a lease, the hook mirrors it into the data store, the REST status endpoint exposes it, and the dashboard renders it.

Today nothing wrote the lease to ds (udhcpc ran with no `-s`, using the built-in default script that configures the interface but never touches ds; even `wifi.dhcp.ip` was unpopulated).

Design: `apps/docs/tdd-wifi-dhcp-lease.md`.

## Mechanism

udhcpc delivers the full lease **only to its `-s` hook** via env vars (lease time / DNS aren't readable back from the interface), so the writer must be the hook:

- **`scripts/udhcpc-ds.script`** — delegates the real ifconfig to the system `default.script`, then `ds-cli set`s the lease fields on `bound`/`renew` and clears them on `deconfig`.
- **`spawn_dhcp`** gains an optional script arg → appends `-s <hook>` for udhcpc (dhclient ignores it). `supervisor.cpp` passes `/usr/share/iot/udhcpc-ds.script` **only when installed** (`::access` gate), so dev/test hosts keep today's behaviour.

### Key ownership (no daemon/hook conflict)
The daemon keeps owning `wifi.dhcp.state` (`requesting`/`exited`) + `wifi.pid.dhcp`. The hook adds the one state only it knows — `bound` — plus the data keys, and on `deconfig` clears the data but **doesn't** touch `state` (udhcpc fires `deconfig` at startup, racing the daemon's `requesting`).

## Changes

- **Schema** (`wifi.lua`): `wifi.dhcp.{mask,gateway,dns,lease.sec,domain,obtained.unix}` (Viewer write keys).
- **Daemon** (`process.{hpp,cpp}`, `supervisor.cpp`): `build_dhcp_argv()` + `-s` wiring.
- **REST** (`handler.cpp`): 6 keys added to `/api/v1/status` → `wifi.dhcp_mask/_gateway/_dns/_lease_sec/_domain/_obtained_unix`.
- **UI** (`app-globals.ts`, `dashboard.component.html`): `WifiStatus` fields + WiFi-card rows (IP/mask, gateway, DNS, domain, lease).
- **Recipe**: ship the hook to `/usr/share/iot/`, claim in `FILES:${PN}-wifi-client`, `RDEPENDS += ${PN}-ds-cli`.
- **Docs**: DEPLOY.md lease section; corrected the stale "wifi.dhcp.ip unpopulated" note.

## Tests / verification

- `build_dhcp_argv`: appends `-s` for udhcpc with a hook, omits it when empty, dhclient never gets `-s`. Schema type-checks for the new keys. **wifi-client suite 110/110** in podman.
- `scripts/test_udhcpc_ds_script.sh`: host dry-run with a stub `ds-cli` asserts the emitted `set` calls for `bound`/`deconfig`/`leasefail` (+ quote-escaping). **PASS.**
- `http_server_lib` (handler.cpp) **compiles** in podman; **iot-ui production build green** in podman.
- ⚠️ **Deferred:** real on-device end-to-end (actual lease → UI shows it) and the Yocto image build — need the RPi/kas environment.

## Out of scope
- dhclient hook (different mechanism); only udhcpc covered.
- The daemon still owns non-`bound` `wifi.dhcp.state` (brief eventual-consistency windows are fine for a status readout).

🤖 Generated with [Claude Code](https://claude.com/claude-code)