### PR TITLE
fix(yocto): auto-detect SD cards in the built-in reader

### DIFF
--- a/yocto/flash-sd.sh
+++ b/yocto/flash-sd.sh
@@ -47,18 +47,42 @@ usage() { awk 'NR==1{next} /^#/{sub(/^# ?/,""); print; next} {exit}' "$0"; }
 OS="$(uname -s)"
 
 # ── List removable disks (read-only) ─────────────────────────────────
+# macOS: a card in the built-in SD reader is reported with Device Location
+# "Internal" even though its media is Removable, so filtering on "external"
+# alone misses it. Instead walk every physical disk and keep those that are
+# External OR have Removable media — the same rule the write-time check uses.
+darwin_sd_disks() {
+    diskutil list physical 2>/dev/null \
+        | awk '/^\/dev\/disk[0-9]+ \(/{print $1}' \
+        | while read -r d; do
+            info="$(diskutil info "$d" 2>/dev/null)" || continue
+            loc="$(echo "$info" | awk -F: '/Device Location/{print $2; exit}' | xargs)"
+            rem="$(echo "$info" | awk -F: '/Removable Media/{print $2; exit}' | xargs)"
+            if [ "$loc" = "External" ] || [ "$rem" = "Removable" ]; then
+                echo "$d"
+            fi
+        done
+}
+
 list_disks() {
     log_section "Candidate removable disks"
-    local out
+    local out=""
     if [ "$OS" = "Darwin" ]; then
-        out="$(diskutil list external physical 2>/dev/null || true)"
+        local d info size name
+        while read -r d; do
+            [ -n "$d" ] || continue
+            info="$(diskutil info "$d" 2>/dev/null || true)"
+            size="$(echo "$info" | awk -F: '/Disk Size/{print $2; exit}' | xargs)"
+            name="$(echo "$info" | awk -F: '/Device \/ Media Name/{print $2; exit}' | xargs)"
+            out+="  $d  ${size}  ${name}"$'\n'
+        done < <(darwin_sd_disks)
     else
         # RM=1 → removable. Show size/model so the right one is obvious.
         out="$(lsblk -dno NAME,SIZE,RM,TYPE,MODEL 2>/dev/null \
             | awk '$3==1{printf "  /dev/%s  %s  %s\n",$1,$2,$5}')"
     fi
     if [ -n "$out" ]; then
-        echo "$out"
+        printf '%s\n' "${out%$'\n'}"
     else
         log_info "No removable disks detected. Insert the SD card and retry."
     fi
@@ -67,9 +91,7 @@ list_disks() {
 # Print the device path(s) of removable/external whole disks, one per line.
 detect_sd() {
     if [ "$OS" = "Darwin" ]; then
-        # Section headers look like: "/dev/disk4 (external, physical):"
-        diskutil list external physical 2>/dev/null \
-            | awk '/^\/dev\/disk[0-9]+ \(external/{print $1}'
+        darwin_sd_disks
     else
         lsblk -dno NAME,RM,TYPE 2>/dev/null \
             | awk '$2==1 && $3=="disk"{print "/dev/"$1}'


### PR DESCRIPTION
## What

Make `flash-sd.sh` detect SD cards inserted in the Mac's **built-in SDXC reader**.

## Why

macOS reports a card in the built-in reader with `Device Location: Internal` (only the *media* is `Removable`). The old detection filtered solely on `external`, so such cards were invisible to both `--list` and auto-detect — even though the script's *write-time* safety check already accepted them (it allows External **or** Removable). You had to pass `/dev/diskN` explicitly every time.

## Change

`darwin_sd_disks()` now walks every **physical** disk and keeps those that are `External` **or** have `Removable` media — the same rule the write-time check uses, so detection and the safety gate are consistent. The internal SSD (`Internal` + `Fixed`) is still correctly excluded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)