### PR TITLE
feat(yocto): auto-enable lwm2m/openvpn/net-router for zero-touch boot

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -428,6 +428,18 @@ refuses to spawn wpa_supplicant if NM is active.
 > `wifi.networks` set below to associate. The `systemctl enable`
 > step is unnecessary on the image; it remains required on bare-metal
 > hosts where the unit ships disabled.
+>
+> **As of the zero-touch image, `lwm2m-client`, `openvpn-client` and
+> `net-router` are also auto-enabled** (`SYSTEMD_AUTO_ENABLE=enable`),
+> so the full DM/VPN chain comes up on first boot with no SSH. Each
+> daemon self-gates on its `services.<name>.enable` data-store key and
+> parks until provisioned, so the device-UI **Services** page can
+> pause/resume them without touching systemd. Until certs
+> (`/etc/iot/vpn/*`), the DM PSK and `vpn.remote.port`/`proto` are
+> provisioned, `openvpn-client`/`lwm2m-client` will `Restart=on-failure`
+> loop — expected on an un-provisioned boot. The `systemctl enable`
+> commands below remain required only on bare-metal hosts where the
+> units ship disabled.
 
 #### Bake WiFi credentials into the image at build time (optional)
 

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -454,12 +454,19 @@ SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service"
 # and reads wifi.networks from the data-store (schema default seeds a
 # placeholder network); it parks in "disconnected" until provisioned. The
 # unit already orders After=iot-ds.service network-online.target, so the
-# schema default resolves before its first read. Other role units are
-# enabled by the operator after writing the matching .env file — see DEPLOY.md.
+# schema default resolves before its first read.
+#
+# lwm2m, openvpn-client and net-router also auto-start so a freshly flashed
+# device brings up the full DM/VPN chain with zero SSH. Each daemon self-gates
+# on its `services.<name>.enable` data-store key and parks (rather than doing
+# work) until provisioned, so the device-UI Services page can pause/resume them
+# without touching systemd. Caveat: until certs (/etc/iot/vpn/*), PSK and
+# vpn.remote.port/proto are provisioned, openvpn-client/lwm2m may Restart=on-
+# failure loop; that is expected on an un-provisioned boot. See DEPLOY.md.
 SYSTEMD_AUTO_ENABLE:${PN}-ds-server = "enable"
-SYSTEMD_AUTO_ENABLE:${PN}-lwm2m = "disable"
-SYSTEMD_AUTO_ENABLE:${PN}-openvpn-client = "disable"
-SYSTEMD_AUTO_ENABLE:${PN}-net-router = "disable"
+SYSTEMD_AUTO_ENABLE:${PN}-lwm2m = "enable"
+SYSTEMD_AUTO_ENABLE:${PN}-openvpn-client = "enable"
+SYSTEMD_AUTO_ENABLE:${PN}-net-router = "enable"
 SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "enable"
 # httpd auto-starts for zero-touch device-UI access (mDNS discovery via Avahi).
 # Enabling this exposes the UI + REST API on 0.0.0.0:8080 to the LAN by default;


### PR DESCRIPTION
## What

Flip `SYSTEMD_AUTO_ENABLE` to `enable` for `lwm2m`, `openvpn-client` and `net-router` so a freshly flashed device brings up the full DM/VPN chain on first boot with **zero SSH**.

## Why it's safe

Each daemon self-gates on its `services.<name>.enable` data-store key and **parks** (rather than doing work) until provisioned, so the device-UI **Services** page can pause/resume them without touching systemd.

## Caveat (documented)

Until certs (`/etc/iot/vpn/*`), the DM PSK and `vpn.remote.port`/`proto` are provisioned, `openvpn-client`/`lwm2m` will `Restart=on-failure` loop — expected on an un-provisioned boot. Noted in both `DEPLOY.md` and the recipe comment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)