### PR TITLE
fix(yocto): repair systemd unit set so the stack comes up zero-touch

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
@@ -1,0 +1,22 @@
+# systemd preset policy for the iot gateway stack.
+#
+# Why this exists: SYSTEMD_AUTO_ENABLE creates the WantedBy symlinks at image
+# build time, but the image runs `systemctl preset-all` on first boot, which
+# resets every unit to its preset policy. With no matching preset the built-in
+# default is "disable", so the build-time enables were silently undone — units
+# came up `disabled` with `preset: disabled` and the whole stack stayed dead
+# until hand-enabled. Shipping this preset makes the enablement stick across
+# preset-all.
+#
+# Order matters: the first matching rule wins. Keep this list in sync with the
+# SYSTEMD_AUTO_ENABLE:* assignments in iot_git.bb.
+enable iot-ds.service
+enable iot-httpd.service
+enable iot-hostname.service
+enable iot-wifi-client.service
+enable iot-lwm2m-client.service
+enable iot-openvpn-client.service
+enable iot-net-router.service
+enable iot-swupdate.path
+enable iot-vpn-cert.path
+enable iot-ota-confirm.service

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds.service
@@ -18,8 +18,12 @@ DynamicUser=yes
 # chgrp its 0660 socket to `iot` (ds-socket-group= above); the static
 # `engineer` client is also in `iot` and can then connect.
 SupplementaryGroups=iot
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# /run/iot is created once by tmpfiles.d/iot.conf (2775 root:iot) — deliberately
+# NOT via RuntimeDirectory=iot. systemd removes a RuntimeDirectory= when the unit
+# (or any other unit that also declared the same name) stops, which would delete
+# the live socket out from under running clients and break ds-server's own
+# restart (pre-exec dir setup churn). The setgid tmpfiles dir lets this
+# DynamicUser (in group iot) create the 0660 group-iot socket.
 StateDirectory=iot
 StateDirectoryMode=0750
 

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-httpd.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-httpd.service
@@ -13,11 +13,12 @@ EnvironmentFile=-/etc/iot/httpd.env
 ExecStart=/usr/bin/iot-httpd $HTTPD_ARGS
 
 DynamicUser=yes
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
 # Join the `iot` group so the dynamic user can write the drag-and-drop OTA spool
 # (/run/iot/update, 0775 root:iot) — iot-httpd drops the uploaded .ipk + trigger,
 # root iot-swupdate installs it. (Also the group that owns the ds socket.)
+# /run/iot itself is created by tmpfiles.d/iot.conf, not RuntimeDirectory=iot:
+# a RuntimeDirectory= here is removed on stop/restart, taking the shared dir
+# (ds socket + OTA spool) with it.
 SupplementaryGroups=iot
 
 # Lets the dynamic user bind :80/:443 when http.listen.port is set low.

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-lwm2m-server.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-lwm2m-server.service
@@ -12,8 +12,11 @@ EnvironmentFile=/etc/iot/lwm2m-server.env
 ExecStart=/usr/bin/lwm2m $LWM2M_ARGS
 
 DynamicUser=yes
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# Join the `iot` group to open ds-server's 0660 group-iot socket.
+SupplementaryGroups=iot
+
+# No RuntimeDirectory=iot: /run/iot is owned by tmpfiles.d/iot.conf. Declaring
+# it here would delete the shared dir (and ds-server's socket) on stop/restart.
 
 Restart=on-failure
 RestartSec=5s

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-net-router.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-net-router.service
@@ -12,11 +12,13 @@ EnvironmentFile=/etc/iot/net-router.env
 ExecStart=/usr/bin/net-router $NET_ROUTER_ARGS
 
 DynamicUser=yes
+# Join the `iot` group to open ds-server's 0660 group-iot socket.
+SupplementaryGroups=iot
 AmbientCapabilities=CAP_NET_ADMIN
 CapabilityBoundingSet=CAP_NET_ADMIN
 
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# No RuntimeDirectory=iot: /run/iot is owned by tmpfiles.d/iot.conf. Declaring
+# it here would delete the shared dir (and ds-server's socket) on stop/restart.
 
 Restart=on-failure
 RestartSec=5s

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-openvpn-client.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-openvpn-client.service
@@ -12,12 +12,14 @@ EnvironmentFile=/etc/iot/openvpn-client.env
 ExecStart=/usr/bin/openvpn-client $OPENVPN_CLIENT_ARGS
 
 DynamicUser=yes
+# Join the `iot` group to open ds-server's 0660 group-iot socket.
+SupplementaryGroups=iot
 AmbientCapabilities=CAP_NET_ADMIN
 CapabilityBoundingSet=CAP_NET_ADMIN
 DeviceAllow=/dev/net/tun rw
 
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# No RuntimeDirectory=iot: /run/iot is owned by tmpfiles.d/iot.conf. Declaring
+# it here would delete the shared dir (and ds-server's socket) on stop/restart.
 
 Restart=on-failure
 RestartSec=5s

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-wifi-client.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-wifi-client.service
@@ -12,13 +12,17 @@ EnvironmentFile=/etc/iot/wifi-client.env
 ExecStart=/usr/bin/wifi-client $WIFI_CLIENT_ARGS
 
 DynamicUser=yes
+# Join the `iot` group to open ds-server's 0660 group-iot socket
+# (/run/iot/data_store.sock).
+SupplementaryGroups=iot
 AmbientCapabilities=CAP_NET_ADMIN CAP_NET_RAW
 CapabilityBoundingSet=CAP_NET_ADMIN CAP_NET_RAW
 
 DeviceAllow=/dev/rfkill rw
 
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# No RuntimeDirectory=iot: /run/iot is owned by tmpfiles.d/iot.conf. Declaring
+# it here would delete the shared dir (and ds-server's socket) on every
+# stop/restart of this unit.
 
 Restart=on-failure
 RestartSec=5s

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
@@ -1,14 +1,23 @@
-# tmpfiles.d entry for the iot socket and state directories.
+# tmpfiles.d entry for the iot runtime directory.
 #
-# Belt-and-braces: the systemd units use RuntimeDirectory=iot and
-# StateDirectory=iot which already create and chown /run/iot/ and
-# /var/lib/iot/. This file exists as a fallback for hosts where
-# systemd-tmpfiles runs before the service starts (rare) and for
-# sysvinit shims where RuntimeDirectory= is not honoured.
+# This is the SOLE owner of /run/iot. The systemd units deliberately do NOT use
+# RuntimeDirectory=iot: multiple DynamicUser units sharing one RuntimeDirectory=
+# caused /run/iot (and ds-server's live socket) to be removed whenever any of
+# them stopped or crash-looped, and broke ds-server's own restart. systemd-
+# tmpfiles creates this once at boot (sysinit, before any iot service starts)
+# and never removes it.
+#
+# /run/iot is 2775 root:iot: setgid so files created inside inherit group `iot`,
+# and group-writable so the ds-server / wifi / openvpn / net-router / httpd
+# DynamicUsers (all SupplementaryGroups=iot) can create the 0660 group-iot
+# socket and the OTA spool.
+#
+# /var/lib/iot is intentionally NOT created here — ds-server's StateDirectory=iot
+# owns it. Pre-creating it as a "public" dir made systemd migrate it to
+# /var/lib/private/iot on every boot (DynamicUser state churn).
 #
 # Type Path             Mode UID  GID Age Argument
-d      /run/iot         0755 root root -   -
+d      /run/iot         2775 root iot  -   -
 # 0775 root:iot so the iot-httpd DynamicUser (SupplementaryGroups=iot) can drop a
 # drag-and-drop OTA .ipk + the trigger here; root iot-swupdate then installs it.
 d      /run/iot/update  0775 root iot  -   -
-d      /var/lib/iot     0750 root root -   -

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -37,6 +37,7 @@ SRC_URI = "\
     file://iot-wifi-client.service \
     file://iot-httpd.service \
     file://iot.conf \
+    file://90-iot.preset \
     file://lwm2m-client.env \
     file://lwm2m-server.env \
     file://openvpn-client.env \
@@ -247,9 +248,15 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-wifi-client.service    ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-httpd.service          ${D}${systemd_system_unitdir}/
 
-        # tmpfiles.d fallback
+        # tmpfiles.d: sole owner of /run/iot (units no longer use RuntimeDirectory=iot)
         install -d ${D}${nonarch_libdir}/tmpfiles.d
         install -m 0644 ${WORKDIR}/iot.conf ${D}${nonarch_libdir}/tmpfiles.d/
+
+        # systemd preset: keep SYSTEMD_AUTO_ENABLE enables across `preset-all`
+        # (which the image runs on first boot — without this they get reset to
+        # the default "disable" policy).
+        install -d ${D}${nonarch_libdir}/systemd/system-preset
+        install -m 0644 ${WORKDIR}/90-iot.preset ${D}${nonarch_libdir}/systemd/system-preset/
 
         # EnvironmentFile for each daemon
         install -d ${D}${sysconfdir}/iot
@@ -434,6 +441,7 @@ RRECOMMENDS:${PN}-httpd = "\
 FILES:${PN}-config = "\
     ${sysconfdir}/iot \
     ${nonarch_libdir}/tmpfiles.d/iot.conf \
+    ${nonarch_libdir}/systemd/system-preset/90-iot.preset \
 "
 
 # ── systemd ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Context

Bringing up a freshly flashed RPi3B from this image, the entire daemon stack stayed dead until services were hand-enabled and unit files hand-patched on the device. Root-caused to **four** distinct bugs in the systemd units.

## Bugs fixed

1. **`RuntimeDirectory=iot` collision.** `ds`, `httpd`, `wifi-client`, `openvpn-client`, `net-router` and `lwm2m-server` all declared `RuntimeDirectory=iot`. systemd removes a unit's `RuntimeDirectory` when it stops, so any client crash-loop wiped `/run/iot` — **deleting ds-server's live socket** — and ds-server's own restart died in pre-exec dir setup. Removed `RuntimeDirectory=iot` from every unit; `/run/iot` is now owned **solely** by `tmpfiles.d/iot.conf` (created once at boot, never removed).

2. **`/run/iot` not group-writable.** tmpfiles made it `0755 root:root`, so the `DynamicUser`s couldn't create the socket (which is *why* the units added the `RuntimeDirectory=` workaround). Now `2775 root:iot` — setgid + group-writable so every `iot`-group service can create the `0660` group-iot socket and the OTA spool.

3. **Missing `SupplementaryGroups=iot`** on `wifi-client`, `openvpn-client`, `net-router`, `lwm2m-server` → couldn't open the `0660` group-iot socket (`connect failed`, exit 1, crash loop). Added it (ds + httpd already had it).

4. **`SYSTEMD_AUTO_ENABLE` undone by `preset-all`.** The image runs `systemctl preset-all` on first boot, resetting units to the default *disable* policy (units shipped `preset: disabled`; stack never started). Added `90-iot.preset` so the enablement sticks.

Also dropped the `/var/lib/iot` line from tmpfiles — pre-creating it as a public dir made ds-server's `StateDirectory=iot` migrate it to `/var/lib/private/iot` on every boot.

## Validation

Verified the corresponding fixes by hand on a running RPi3B (drop-ins + `tmpfiles`/group changes), which got `ds-server` stable and clients able to connect. This PR moves those fixes into the recipe. **Requires a rebuild + reflash to validate end-to-end.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)