### PR TITLE
chore: ignore ad-hoc module build dirs (build-chk, build-test)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -70,6 +70,10 @@ apps/test/build/
 yocto/build/
 build/
 
+# Ad-hoc CMake build dirs under modules (e.g. build-chk, build-test)
+modules/**/build-chk/
+modules/**/build-test/
+
 # Image export tarballs
 iot-cloud.tar.gz
 


### PR DESCRIPTION
Ignore `modules/**/build-chk/` and `modules/**/build-test/` — local CMake build output that was showing up as untracked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)