### PR TITLE
fix(wifi): drop net.router dependency so WiFi uplink isn't deadlocked

### DIFF
--- a/modules/data-store/schemas/services.lua
+++ b/modules/data-store/schemas/services.lua
@@ -60,10 +60,12 @@ local keys = {
     ["services.lwm2m.server.state"]        = {
         access  = "Viewer", type = "string",  default = "stopped" },
 
-    -- wifi-client
+    -- wifi-client — the WAN uplink, so NO dependency on net.router (routing
+    -- layers on top of the uplink; the inverse dep deadlocked WiFi whenever
+    -- net-router was down). Matches the (lack of) DepWatch in supervisor.cpp.
     ["services.wifi.client.enable"]        = {
         access  = "Admin", type = "boolean", default = true,
-                                               depends_on = {"net.router"},
+                                               depends_on = {},
                                                write_acl = {"uid:0"} },
     ["services.wifi.client.state"]         = {
         access  = "Viewer", type = "string",  default = "stopped" },

--- a/modules/wan/wifi/client/src/supervisor.cpp
+++ b/modules/wan/wifi/client/src/supervisor.cpp
@@ -235,9 +235,15 @@ Supervisor::Supervisor(DsBridge& ds, SupervisorOptions opt)
         m_svc = std::make_unique<data_store::ServiceGate>(*cli, "wifi.client");
         m_svc->publish_state("running");
 
-        // L17a/D4 — dependency watch for net.router.
-        m_dep = std::make_unique<data_store::DepWatch>(
-            *cli, std::vector<std::string>{"net.router"});
+        // wifi-client is the WAN uplink — it must NOT depend on net.router.
+        // Routing (net-router) layers ON TOP of the uplink, not before it, so
+        // the inverse dependency deadlocked WiFi whenever net-router wasn't
+        // healthy: on an un-provisioned device net-router refuses to start
+        // until net.lwm2m.target.ip is set, so it never publishes
+        // services.net.router.state="running", and wifi-client parked here
+        // forever (assoc.state=disconnected, wpa_supplicant never spawned).
+        // m_dep stays null → the run-loop dep checks are skipped and
+        // wifi-client associates + DHCPs independently.
     }
 }
 


### PR DESCRIPTION
## Symptom (root-caused on RPi3B hardware)

On an un-provisioned device, `wlan0` never gets an IP. `wifi.pid.wpa=null`, `wifi.assoc.state=disconnected` — wifi-client is running but never spawns wpa_supplicant.

## Root cause (the deadlock)

1. wifi-client hard-depends on `net.router` (`DepWatch{"net.router"}` in `supervisor.cpp` + `depends_on={"net.router"}` in the services schema).
2. net-router **refuses to start** until `net.lwm2m.target.ip` is set (`daemon.cpp`: *"refuse to start; required keys missing"*), so on an un-provisioned device it crash-loops and never publishes `services.net.router.state="running"`.
3. `DepWatch` treats a dep healthy only when its state is `running`/`starting`. `services.net.router.state` is the schema default `stopped`.
4. So wifi-client's dep gate (highest priority in `Supervisor::run()`) parks forever — silently, no wpa_supplicant, `assoc.state=disconnected`.

## Fix

The dependency is **backwards**: WiFi is the WAN uplink; routing layers *on top of* the uplink, not before it. wifi-client no longer constructs a `DepWatch` (`m_dep` stays null; run-loop dep checks skipped), and `services.wifi.client.enable` now declares `depends_on={}`. WiFi associates + DHCPs independently.

## Scope / follow-up

`openvpn-client` and `lwm2m-client` legitimately depend on `net.router`. The separate net-router "refuse to start when unconfigured" behavior (which blocks *them* until provisioned, against the documented "park until provisioned" design) is a recommended follow-up.

Requires rebuild + reflash to validate on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)