### PR TITLE
fix(yocto): create /run/wpa_supplicant via tmpfiles for wifi-client

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
@@ -16,8 +16,13 @@
 # owns it. Pre-creating it as a "public" dir made systemd migrate it to
 # /var/lib/private/iot on every boot (DynamicUser state churn).
 #
-# Type Path             Mode UID  GID Age Argument
-d      /run/iot         2775 root iot  -   -
+# Type Path                Mode UID  GID Age Argument
+d      /run/iot            2775 root iot  -   -
 # 0775 root:iot so the iot-httpd DynamicUser (SupplementaryGroups=iot) can drop a
 # drag-and-drop OTA .ipk + the trigger here; root iot-swupdate then installs it.
-d      /run/iot/update  0775 root iot  -   -
+d      /run/iot/update     0775 root iot  -   -
+# wpa_supplicant control-socket dir for wifi-client (--ctrl-dir=/run/wpa_supplicant).
+# wifi-client runs as a DynamicUser and can't mkdir under root-owned /run, so
+# wpa_supplicant fails to create its ctrl socket and never associates. Create it
+# here (2775 root:iot) so the iot-group DynamicUser can drop the socket.
+d      /run/wpa_supplicant 2775 root iot  -   -


### PR DESCRIPTION
wifi-client passes `--ctrl-dir=/run/wpa_supplicant` and writes `ctrl_interface=DIR=/run/wpa_supplicant` into the wpa_supplicant config. wpa_supplicant then tries to create that dir, but runs as wifi-client's `DynamicUser` and **can't mkdir under root-owned `/run`** — so the control socket is never created and wifi-client can't drive wpa_supplicant (no association). The dir doesn't exist on a fresh image.

Adds a tmpfiles entry (`2775 root:iot`, same pattern as `/run/iot`) so systemd-tmpfiles creates it at boot and the iot-group DynamicUser can drop its socket there.

Pairs with #217 (wifi-client net.router dependency removal) — both are needed for zero-touch WiFi on a fresh flash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)