### PR TITLE
refactor(ui): route all config pages through the appglobal data store

### DIFF
--- a/apps/cloud/ui/src/app/dashboard/dashboard.component.ts
+++ b/apps/cloud/ui/src/app/dashboard/dashboard.component.ts
@@ -1,5 +1,7 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { HttpsvcService } from '../../common/httpsvc.service';
+import { DataStoreService } from '../../common/datastore.service';
 import { HttpClient } from '@angular/common/http';
 import { environment } from '../../environments/environment';
 
@@ -41,8 +43,9 @@ interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; proxy_por
   styles: [`.page{padding:24px;} h3,h4{color:#333;margin:0 0 16px 0;} h4{font-size:14px;margin-top:20px;}
     .clr-row > [class*="clr-col"]{margin-bottom:1rem;}`]
 })
-export class DashboardComponent implements OnInit {
+export class DashboardComponent implements OnInit, OnDestroy {
   endpoints: EpInfo[] = [];
+  private sub = new Subscription();
   // VPN server's tunnel IP (first host of cloud.vpn.subnet) — the server end of
   // every tunnel; shown in the "Tunnel IP" column.
   serverTunIp = '';
@@ -52,18 +55,14 @@ export class DashboardComponent implements OnInit {
     {label:'Total',value:0,icon:'devices',cls:'starting'},
   ];
 
-  constructor(private http: HttpsvcService) {}
+  constructor(private http: HttpsvcService, private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    this.http.dbGet(['cloud.vpn.subnet']).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const base = String((r.data as Record<string, unknown>)['cloud.vpn.subnet'] || '').split('/')[0];
-          const o = base.split('.');
-          if (o.length === 4) { o[3] = String((Number(o[3]) || 0) + 1); this.serverTunIp = o.join('.'); }
-        }
-      }
-    });
+    // Server tunnel IP is derived from cloud.vpn.subnet — read it from the
+    // shared prefetched cache and stay live off the appglobal store.
+    this.applySubnet(this.ds.getString('cloud.vpn.subnet'));
+    this.sub.add(this.ds.observe('cloud.vpn.subnet')
+      .subscribe(v => this.applySubnet(typeof v === 'string' ? v : '')));
     this.http.getCloudEndpoints().subscribe({
       next: (eps) => {
         this.endpoints = eps;
@@ -72,5 +71,13 @@ export class DashboardComponent implements OnInit {
         this.cards[2].value = eps.length;
       }
     });
+  }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
+
+  private applySubnet(subnet: string): void {
+    const base = String(subnet || '').split('/')[0];
+    const o = base.split('.');
+    if (o.length === 4) { o[3] = String((Number(o[3]) || 0) + 1); this.serverTunIp = o.join('.'); }
   }
 }

--- a/apps/cloud/ui/src/app/http-config/http-config.component.ts
+++ b/apps/cloud/ui/src/app/http-config/http-config.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpsvcService } from '../../common/httpsvc.service';
 import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 import { DataStoreService } from '../../common/datastore.service';
@@ -109,16 +109,21 @@ import { DataStoreService } from '../../common/datastore.service';
     .info-card code { background: #d0e4ff; padding: 1px 4px; border-radius: 2px; font-size: 12px; }
   `]
 })
-export class HttpConfigComponent implements OnInit {
+export class HttpConfigComponent implements OnInit, OnDestroy {
   form: FormGroup;
   loading = true;
   saving = false;
   authEnabled = true;
+  private sub = new Subscription();
+  private readonly KEYS = [
+    'http.listen.ip', 'http.listen.port', 'http.listen.scheme',
+    'http.workers', 'http.tls.cert', 'http.tls.key', 'http.tls.ca',
+    'http.auth.enabled',
+  ];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
   constructor(
-    private http: HttpsvcService,
     fb: FormBuilder,
     private session: SessionService,
     private toast: ToastService,
@@ -142,20 +147,18 @@ export class HttpConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
-    if (this.ds.has('http.listen.ip')) { this.applyData(this.ds.snapshot()); this.loading = false; }
-    this.http.dbGet([
-      'http.listen.ip', 'http.listen.port', 'http.listen.scheme',
-      'http.workers', 'http.tls.cert', 'http.tls.key', 'http.tls.ca',
-      'http.auth.enabled'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>);
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
-    });
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store; re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.form.dirty) this.applyData(this.ds.snapshot());
+      }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     this.form.patchValue({
@@ -172,7 +175,7 @@ export class HttpConfigComponent implements OnInit {
   }
 
   toggleAuth(v: boolean): void {
-    this.http.dbSet([{ key: 'http.auth.enabled', value: v }]).subscribe({
+    this.ds.write([{ key: 'http.auth.enabled', value: v }]).subscribe({
       next: (r) => {
         if (r.ok) { this.authEnabled = v; this.toast.success('Auth ' + (v ? 'enabled' : 'disabled')); }
         else this.toast.error(r.err || 'Toggle failed');
@@ -186,7 +189,7 @@ export class HttpConfigComponent implements OnInit {
     const v = this.form.value;
     // Listener (ip/port/scheme) is deploy-controlled + read-only here, so it
     // is intentionally NOT written — only the safe runtime keys are saved.
-    this.http.dbSet([
+    this.ds.write([
       { key: 'http.workers',       value: v.workers },
       { key: 'http.tls.cert',      value: v.cert },
       { key: 'http.tls.key',       value: v.key },

--- a/apps/cloud/ui/src/app/log-level/log-level.component.ts
+++ b/apps/cloud/ui/src/app/log-level/log-level.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
-import { HttpsvcService } from '../../common/httpsvc.service';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { DataStoreService } from '../../common/datastore.service';
 
 @Component({
   selector: 'app-log-level',
@@ -20,27 +21,32 @@ import { HttpsvcService } from '../../common/httpsvc.service';
     .clr-select:focus { outline: none; border-color: #2e7d32; }
   `]
 })
-export class LogLevelComponent implements OnInit {
+export class LogLevelComponent implements OnInit, OnDestroy {
   level = 'INFO';
   levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR'];
   msg = '';
+  private sub = new Subscription();
 
-  constructor(private http: HttpsvcService) {}
+  constructor(private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    this.http.dbGet(['log.level']).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const v = (r.data['log.level'] as string || 'INFO').toUpperCase();
-          if (this.levels.includes(v)) this.level = v;
-        }
-      }
-    });
+    // Paint from the shared prefetched cache, then stay live off the appglobal
+    // store. log.level is written here and re-seeded into the cache on save.
+    this.applyLevel(this.ds.getString('log.level', 'INFO'));
+    this.sub.add(this.ds.observe('log.level')
+      .subscribe(v => this.applyLevel(typeof v === 'string' ? v : 'INFO')));
+  }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
+
+  private applyLevel(v: string): void {
+    const up = (v || 'INFO').toUpperCase();
+    if (this.levels.includes(up)) this.level = up;
   }
 
   save(): void {
     this.msg = '';
-    this.http.dbSet([{ key: 'log.level', value: this.level }]).subscribe({
+    this.ds.write([{ key: 'log.level', value: this.level }]).subscribe({
       next: (r) => {
         this.msg = r.ok ? 'Set to ' + this.level : 'Error: ' + r.err;
       },

--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
@@ -1,8 +1,9 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
+import { DataStoreService } from '../../../common/datastore.service';
 
 @Component({
   selector: 'app-bs-config',
@@ -15,18 +16,20 @@ import { ToastService } from '../../../common/toast.service';
     .hint { color: #888; font-weight: normal; font-size: 11px; }
   `]
 })
-export class BsConfigComponent implements OnInit {
+export class BsConfigComponent implements OnInit, OnDestroy {
   bsForm: FormGroup;
   loading = true;
   savingBs = false;
+  private sub = new Subscription();
+  private readonly KEYS = ['cloud.bs.uri', 'cloud.dm.uri'];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
   constructor(
-    private http: HttpsvcService,
     fb: FormBuilder,
     private session: SessionService,
-    private toast: ToastService
+    private toast: ToastService,
+    private ds: DataStoreService
   ) {
     // Only the keys the bootstrap server actually consumes at /bs:
     // cloud.bs.uri (Security/0 RID0) and cloud.dm.uri (Security/1 RID0).
@@ -39,27 +42,30 @@ export class BsConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.http.dbGet([
-      'cloud.bs.uri', 'cloud.dm.uri'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const d = r.data as Record<string, unknown>;
-          this.bsForm.patchValue({
-            bs_uri:        d['cloud.bs.uri']           || 'coaps://0.0.0.0:5684',
-            dm_uri:        d['cloud.dm.uri']           || 'coaps://0.0.0.0:5683',
-          });
-        }
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store; re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.bsForm.dirty) this.applyData(this.ds.snapshot());
+      }));
+  }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
+
+  private applyData(d: Record<string, unknown>): void {
+    this.bsForm.patchValue({
+      bs_uri: d['cloud.bs.uri'] || 'coaps://0.0.0.0:5684',
+      dm_uri: d['cloud.dm.uri'] || 'coaps://0.0.0.0:5683',
     });
   }
 
   saveBs(): void {
     this.savingBs = true;
     const v = this.bsForm.value;
-    this.http.dbSet([
+    this.ds.write([
       { key: 'cloud.bs.uri',           value: v.bs_uri },
       { key: 'cloud.dm.uri',           value: v.dm_uri },
     ]).subscribe({

--- a/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -1,25 +1,28 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
+import { DataStoreService } from '../../../common/datastore.service';
 
 @Component({
   selector: 'app-lwm2m-config',
   templateUrl: './lwm2m-config.component.html',
   styleUrls: ['./lwm2m-config.component.scss']
 })
-export class Lwm2mConfigComponent implements OnInit {
+export class Lwm2mConfigComponent implements OnInit, OnDestroy {
   dmForm: FormGroup;
   loading = true; saving = false;
+  private sub = new Subscription();
+  private readonly KEYS = ['cloud.dm.uri', 'cloud.dm.lifetime', 'cloud.dm.binding'];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
   constructor(
-    private http: HttpsvcService,
     fb: FormBuilder,
     private session: SessionService,
-    private toast: ToastService
+    private toast: ToastService,
+    private ds: DataStoreService
   ) {
     // Only the keys the DM server actually consumes when building the
     // Security/Server TLVs at /bs: cloud.dm.uri, cloud.dm.lifetime,
@@ -33,28 +36,31 @@ export class Lwm2mConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.http.dbGet([
-      'cloud.dm.uri', 'cloud.dm.lifetime', 'cloud.dm.binding'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const d = r.data as Record<string, unknown>;
-          this.dmForm.patchValue({
-            dm_uri:        d['cloud.dm.uri']             || 'coaps://0.0.0.0:5683',
-            lifetime:      d['cloud.dm.lifetime']        || 86400,
-            binding:       d['cloud.dm.binding']         || 'U',
-          });
-        }
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store; re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.dmForm.dirty) this.applyData(this.ds.snapshot());
+      }));
+  }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
+
+  private applyData(d: Record<string, unknown>): void {
+    this.dmForm.patchValue({
+      dm_uri:   d['cloud.dm.uri']      || 'coaps://0.0.0.0:5683',
+      lifetime: d['cloud.dm.lifetime'] || 86400,
+      binding:  d['cloud.dm.binding']  || 'U',
     });
   }
 
   save(): void {
     this.saving = true;
     const v = this.dmForm.value;
-    this.http.dbSet([
+    this.ds.write([
       { key: 'cloud.dm.uri',              value: v.dm_uri },
       { key: 'cloud.dm.lifetime',         value: v.lifetime },
       { key: 'cloud.dm.binding',          value: v.binding },

--- a/apps/cloud/ui/src/app/routing/custom-rules/custom-rules.component.ts
+++ b/apps/cloud/ui/src/app/routing/custom-rules/custom-rules.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { HttpsvcService } from '../../../common/httpsvc.service';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 import { DataStoreService } from '../../../common/datastore.service';
@@ -109,9 +109,10 @@ interface CustomRule {
     .bad { color: #c62828; font-size: 12px; margin: 0 0 12px 0; }
   `]
 })
-export class CustomRulesComponent implements OnInit {
+export class CustomRulesComponent implements OnInit, OnDestroy {
   rules: CustomRule[] = [];
   routeState = '';
+  private sub = new Subscription();
 
   // Add-rule form state
   nAction = 'accept';
@@ -126,16 +127,20 @@ export class CustomRulesComponent implements OnInit {
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, private session: SessionService,
+  constructor(private session: SessionService,
               private toast: ToastService, private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
+    // Paint instantly from the shared prefetched cache, then stay live off the
+    // appglobal store. net.custom.rules is edited only here (persisted on each
+    // add/delete) and isn't republished by /status, so it fires once when the
+    // prefetch lands; net.state is the live router-state badge.
     this.applyData(this.ds.snapshot());
-    this.http.dbGet(['net.custom.rules', 'net.state']).subscribe({
-      next: (r) => { if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>); }
-    });
+    this.sub.add(this.ds.observe('net.custom.rules').subscribe(() => this.applyData(this.ds.snapshot())));
+    this.sub.add(this.ds.observe('net.state').subscribe(v => { if (v != null) this.routeState = String(v); }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     if (d['net.custom.rules'] != null) {
@@ -165,7 +170,7 @@ export class CustomRulesComponent implements OnInit {
 
   private persist(next: CustomRule[], okMsg: string): void {
     this.saving = true;
-    this.http.dbSet([{ key: 'net.custom.rules', value: JSON.stringify(next) }]).subscribe({
+    this.ds.write([{ key: 'net.custom.rules', value: JSON.stringify(next) }]).subscribe({
       next: (r) => {
         this.saving = false;
         if (r.ok) { this.rules = next; this.toast.success(okMsg); this.resetForm(); }

--- a/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.ts
+++ b/apps/cloud/ui/src/app/vpn/vpn-config/vpn-config.component.ts
@@ -1,25 +1,36 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
 import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
+import { DataStoreService } from '../../../common/datastore.service';
 
 @Component({
   selector: 'app-vpn-config',
   templateUrl: './vpn-config.component.html',
   styleUrls: ['./vpn-config.component.scss']
 })
-export class VpnConfigComponent implements OnInit {
+export class VpnConfigComponent implements OnInit, OnDestroy {
   form: FormGroup;
   loading = true;
   get isAdmin(): boolean { return this.session.isAdmin; }
   saving = false;
+  private sub = new Subscription();
+  // Cached (prefetched) keys only. cloud.vpn.ca.key / server.key are kept OUT
+  // of the shared cache (secret-adjacent paths) and fetched on demand below.
+  private readonly KEYS = [
+    'cloud.vpn.subnet', 'cloud.vpn.port.next', 'cloud.vpn.listen.port',
+    'cloud.vpn.proto', 'cloud.vpn.cipher', 'cloud.vpn.dev', 'cloud.vpn.mgmt.port',
+    'cloud.vpn.verb', 'cloud.vpn.ca.crt', 'cloud.vpn.server.crt',
+  ];
 
   constructor(
     private http: HttpsvcService,
     fb: FormBuilder,
     private session: SessionService,
-    private toast: ToastService
+    private toast: ToastService,
+    private ds: DataStoreService
   ) {
     this.form = fb.group({
       subnet:      ['10.9.0.0/24'],
@@ -38,41 +49,51 @@ export class VpnConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    this.http.dbGet([
-      'cloud.vpn.subnet', 'cloud.vpn.port.next',
-      'cloud.vpn.listen.port', 'cloud.vpn.proto', 'cloud.vpn.cipher',
-      'cloud.vpn.dev', 'cloud.vpn.mgmt.port', 'cloud.vpn.verb',
-      'cloud.vpn.ca.crt', 'cloud.vpn.ca.key',
-      'cloud.vpn.server.crt', 'cloud.vpn.server.key'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const d = r.data as Record<string, unknown>;
-          this.form.patchValue({
-            subnet:      d['cloud.vpn.subnet']      || '10.9.0.0/24',
-            port_next:   d['cloud.vpn.port.next']   || 5001,
-            listen_port: d['cloud.vpn.listen.port'] || 1194,
-            proto:       d['cloud.vpn.proto']       || 'udp',
-            cipher:      d['cloud.vpn.cipher']      || 'AES-256-GCM',
-            dev:         d['cloud.vpn.dev']         || 'tun',
-            mgmt_port:   d['cloud.vpn.mgmt.port']   || 7506,
-            verb:        d['cloud.vpn.verb']        ?? 3,
-            ca_crt:     d['cloud.vpn.ca.crt']      || '/etc/iot/vpn/ca/ca.crt',
-            ca_key:     d['cloud.vpn.ca.key']      || '/run/secrets/iot-ca-key/ca.key',
-            server_crt: d['cloud.vpn.server.crt']  || '/etc/iot/vpn/server.crt',
-            server_key: d['cloud.vpn.server.key']  || '/etc/iot/vpn/server.key',
-          });
-        }
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store; re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.form.dirty) this.applyData(this.ds.snapshot());
+      }));
+    // ca.key / server.key are deliberately excluded from the prefetch cache
+    // (secret-adjacent key paths), so fetch just those two on demand.
+    this.http.dbGet(['cloud.vpn.ca.key', 'cloud.vpn.server.key']).subscribe({
+      next: (r) => { if (r.ok && r.data && !this.form.dirty) this.applyData(r.data as Record<string, unknown>); }
+    });
+  }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
+
+  private applyData(d: Record<string, unknown>): void {
+    this.form.patchValue({
+      subnet:      d['cloud.vpn.subnet']      ?? this.form.value.subnet,
+      port_next:   d['cloud.vpn.port.next']   ?? this.form.value.port_next,
+      listen_port: d['cloud.vpn.listen.port'] ?? this.form.value.listen_port,
+      proto:       d['cloud.vpn.proto']       ?? this.form.value.proto,
+      cipher:      d['cloud.vpn.cipher']      ?? this.form.value.cipher,
+      dev:         d['cloud.vpn.dev']         ?? this.form.value.dev,
+      mgmt_port:   d['cloud.vpn.mgmt.port']   ?? this.form.value.mgmt_port,
+      verb:        d['cloud.vpn.verb']        ?? this.form.value.verb,
+      ca_crt:      d['cloud.vpn.ca.crt']      ?? this.form.value.ca_crt,
+      ca_key:      d['cloud.vpn.ca.key']      ?? this.form.value.ca_key,
+      server_crt:  d['cloud.vpn.server.crt']  ?? this.form.value.server_crt,
+      server_key:  d['cloud.vpn.server.key']  ?? this.form.value.server_key,
     });
   }
 
   save(): void {
     this.saving = true;
     const v = this.form.value;
+    // Secret-adjacent key paths are kept out of the shared cache → plain dbSet.
     this.http.dbSet([
+      { key: 'cloud.vpn.ca.key',      value: v.ca_key },
+      { key: 'cloud.vpn.server.key',  value: v.server_key },
+    ]).subscribe({ error: () => this.toast.error('Failed to save key paths') });
+    // Cached config keys go through the shared store so the cache stays fresh.
+    this.ds.write([
       { key: 'cloud.vpn.subnet',      value: v.subnet },
       { key: 'cloud.vpn.port.next',   value: v.port_next },
       { key: 'cloud.vpn.listen.port', value: v.listen_port },
@@ -82,9 +103,7 @@ export class VpnConfigComponent implements OnInit {
       { key: 'cloud.vpn.mgmt.port',   value: v.mgmt_port },
       { key: 'cloud.vpn.verb',        value: v.verb },
       { key: 'cloud.vpn.ca.crt',      value: v.ca_crt },
-      { key: 'cloud.vpn.ca.key',      value: v.ca_key },
       { key: 'cloud.vpn.server.crt',  value: v.server_crt },
-      { key: 'cloud.vpn.server.key',  value: v.server_key },
     ]).subscribe({
       next: (r) => {
         this.saving = false;

--- a/apps/cloud/ui/src/app/wan/iface-priority/iface-priority.component.ts
+++ b/apps/cloud/ui/src/app/wan/iface-priority/iface-priority.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { HttpsvcService } from '../../../common/httpsvc.service';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 import { DataStoreService } from '../../../common/datastore.service';
@@ -59,24 +59,34 @@ import { DataStoreService } from '../../../common/datastore.service';
     .active-iface { font-size: 16px; font-weight: 600; color: #2e7d32; display: block; margin-top: 2px; }
   `]
 })
-export class IfacePriorityComponent implements OnInit {
+export class IfacePriorityComponent implements OnInit, OnDestroy {
   priority = 'eth,wifi,cellular'; ethName = 'eth0'; wifiName = 'wlan0';
   cellName = 'wwan0'; pollInterval = 5; activeIface = '';
   saving = false; msg = '';
+  private sub = new Subscription();
+  private readonly CFG_KEYS = [
+    'net.iface.priority', 'net.iface.eth.name', 'net.iface.wifi.name',
+    'net.iface.cellular.name', 'net.poll.interval.sec',
+  ];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, private session: SessionService,
+  constructor(private session: SessionService,
               private toast: ToastService, private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
+    // Paint instantly from the shared prefetched cache, then stay live off the
+    // appglobal store. The editable config keys change only here and aren't
+    // republished by /status (they fire once when the prefetch lands);
+    // net.iface.active is live telemetry off the shared long-poll.
     this.applyData(this.ds.snapshot());
-    this.http.dbGet(['net.iface.priority', 'net.iface.eth.name', 'net.iface.wifi.name',
-      'net.iface.cellular.name', 'net.poll.interval.sec', 'net.iface.active']).subscribe({
-      next: (r) => { if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>); }
-    });
+    for (const k of this.CFG_KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => this.applyData(this.ds.snapshot())));
+    this.sub.add(this.ds.observe('net.iface.active')
+      .subscribe(v => { if (v != null) this.activeIface = String(v); }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     if (d['net.iface.priority'] != null)      this.priority     = String(d['net.iface.priority']);
@@ -89,7 +99,7 @@ export class IfacePriorityComponent implements OnInit {
 
   save(): void {
     this.saving = true; this.msg = '';
-    this.http.dbSet([
+    this.ds.write([
       { key: 'net.iface.priority', value: this.priority },
       { key: 'net.iface.eth.name', value: this.ethName },
       { key: 'net.iface.wifi.name', value: this.wifiName },

--- a/apps/cloud/ui/src/app/wan/wifi-config/wifi-config.component.ts
+++ b/apps/cloud/ui/src/app/wan/wifi-config/wifi-config.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 import { DataStoreService } from '../../../common/datastore.service';
@@ -11,14 +11,20 @@ import { WifiNetwork } from '../../../common/app-globals';
   templateUrl: './wifi-config.component.html',
   styleUrls: ['./wifi-config.component.scss']
 })
-export class WifiConfigComponent implements OnInit {
+export class WifiConfigComponent implements OnInit, OnDestroy {
   form: FormGroup;
   networks: WifiNetwork[] = [];
   loading = true; saving = false; msg = '';
+  private sub = new Subscription();
+  private readonly KEYS = [
+    'wifi.iface', 'wifi.wpa.path', 'wifi.ctrl.dir',
+    'wifi.scan.interval.sec', 'wifi.scan.max.results',
+    'wifi.dhcp.client', 'wifi.networks',
+  ];
 
     get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, fb: FormBuilder, private session: SessionService,
+  constructor(fb: FormBuilder, private session: SessionService,
               private toast: ToastService, private ds: DataStoreService) {
     this.form = fb.group({
       iface:            ['wlan0'],
@@ -32,20 +38,18 @@ export class WifiConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
-    if (this.ds.has('wifi.iface')) { this.applyData(this.ds.snapshot()); this.loading = false; }
-    this.http.dbGet([
-      'wifi.iface', 'wifi.wpa.path', 'wifi.ctrl.dir',
-      'wifi.scan.interval.sec', 'wifi.scan.max.results',
-      'wifi.dhcp.client', 'wifi.networks'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>);
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
-    });
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store. Re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.form.dirty) this.applyData(this.ds.snapshot());
+      }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     this.form.patchValue({
@@ -71,7 +75,7 @@ export class WifiConfigComponent implements OnInit {
     this.saving = true; this.msg = '';
     this.form.patchValue({ networks_json: JSON.stringify(this.networks) });
     const v = this.form.value;
-    this.http.dbSet([
+    this.ds.write([
       { key: 'wifi.iface',               value: v.iface },
       { key: 'wifi.wpa.path',            value: v.wpa_path },
       { key: 'wifi.ctrl.dir',            value: v.ctrl_dir },

--- a/apps/cloud/ui/src/common/datastore.service.ts
+++ b/apps/cloud/ui/src/common/datastore.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, tap } from 'rxjs/operators';
 import { HttpsvcService } from './httpsvc.service';
-import { StatusSnapshot } from './app-globals';
+import { StatusSnapshot, DbSetResponse } from './app-globals';
 
 /// Shared, prefetched view of the data store.
 ///
@@ -93,6 +93,20 @@ export class DataStoreService {
       },
       error: () => { /* pages fall back to their own dbGet */ }
     });
+  }
+
+  /// Write keys through the shared store. Persists to ds-server via the REST
+  /// API and, on success, mirrors the new values into the local cache so
+  /// snapshot()/observe() stay consistent on revisit WITHOUT re-running
+  /// prefetchAll — config keys are written only here and are NOT carried by
+  /// the /status long-poll, so without this a page would show pre-save values
+  /// the next time it mounts. Config pages call this instead of
+  /// HttpsvcService.dbSet for any key they also read back. (Secrets that are
+  /// deliberately excluded from the cache keep using dbSet directly.)
+  write(pairs: { key: string; value: unknown }[]): Observable<DbSetResponse> {
+    return this.http.dbSet(pairs).pipe(
+      tap(r => { if (r && r.ok) for (const p of pairs) this.set(p.key, p.value); })
+    );
   }
 
   /// Keep volatile telemetry fresh via the aggregated /status long-poll.

--- a/iot-ui/src/app/http-config/http-config.component.ts
+++ b/iot-ui/src/app/http-config/http-config.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpsvcService } from '../../common/httpsvc.service';
 import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 import { DataStoreService } from '../../common/datastore.service';
@@ -111,16 +111,21 @@ import { DataStoreService } from '../../common/datastore.service';
     .info-card code { background: #d0e4ff; padding: 1px 4px; border-radius: 2px; font-size: 12px; }
   `]
 })
-export class HttpConfigComponent implements OnInit {
+export class HttpConfigComponent implements OnInit, OnDestroy {
   form: FormGroup;
   loading = true;
   saving = false;
   authEnabled = true;
+  private sub = new Subscription();
+  private readonly KEYS = [
+    'http.listen.ip', 'http.listen.port', 'http.listen.scheme',
+    'http.workers', 'http.tls.cert', 'http.tls.key', 'http.tls.ca',
+    'http.auth.enabled',
+  ];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
   constructor(
-    private http: HttpsvcService,
     fb: FormBuilder,
     private session: SessionService,
     private toast: ToastService,
@@ -143,20 +148,18 @@ export class HttpConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
-    if (this.ds.has('http.listen.ip')) { this.applyData(this.ds.snapshot()); this.loading = false; }
-    this.http.dbGet([
-      'http.listen.ip', 'http.listen.port', 'http.listen.scheme',
-      'http.workers', 'http.tls.cert', 'http.tls.key', 'http.tls.ca',
-      'http.auth.enabled'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>);
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
-    });
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store; re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.form.dirty) this.applyData(this.ds.snapshot());
+      }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     this.form.patchValue({
@@ -173,7 +176,7 @@ export class HttpConfigComponent implements OnInit {
   }
 
   toggleAuth(v: boolean): void {
-    this.http.dbSet([{ key: 'http.auth.enabled', value: v }]).subscribe({
+    this.ds.write([{ key: 'http.auth.enabled', value: v }]).subscribe({
       next: (r) => {
         if (r.ok) { this.authEnabled = v; this.toast.success('Auth ' + (v ? 'enabled' : 'disabled')); }
         else this.toast.error(r.err || 'Toggle failed');
@@ -187,7 +190,7 @@ export class HttpConfigComponent implements OnInit {
     const v = this.form.value;
     // Listener (ip/port/scheme) is deploy-controlled + read-only here, so it
     // is intentionally NOT written — only the safe runtime keys are saved.
-    this.http.dbSet([
+    this.ds.write([
       { key: 'http.workers',       value: v.workers },
       { key: 'http.tls.cert',      value: v.cert },
       { key: 'http.tls.key',       value: v.key },

--- a/iot-ui/src/app/log-level/log-level.component.ts
+++ b/iot-ui/src/app/log-level/log-level.component.ts
@@ -1,5 +1,6 @@
-import { Component, OnInit } from '@angular/core';
-import { HttpsvcService } from '../../common/httpsvc.service';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+import { DataStoreService } from '../../common/datastore.service';
 
 @Component({
   selector: 'app-log-level',
@@ -20,27 +21,32 @@ import { HttpsvcService } from '../../common/httpsvc.service';
     .clr-select:focus { outline: none; border-color: #2e7d32; }
   `]
 })
-export class LogLevelComponent implements OnInit {
+export class LogLevelComponent implements OnInit, OnDestroy {
   level = 'INFO';
   levels = ['DEBUG', 'INFO', 'WARNING', 'ERROR'];
   msg = '';
+  private sub = new Subscription();
 
-  constructor(private http: HttpsvcService) {}
+  constructor(private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    this.http.dbGet(['log.level']).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const v = (r.data['log.level'] as string || 'INFO').toUpperCase();
-          if (this.levels.includes(v)) this.level = v;
-        }
-      }
-    });
+    // Paint from the shared prefetched cache, then stay live off the appglobal
+    // store. log.level is written here and re-seeded into the cache on save.
+    this.applyLevel(this.ds.getString('log.level', 'INFO'));
+    this.sub.add(this.ds.observe('log.level')
+      .subscribe(v => this.applyLevel(typeof v === 'string' ? v : 'INFO')));
+  }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
+
+  private applyLevel(v: string): void {
+    const up = (v || 'INFO').toUpperCase();
+    if (this.levels.includes(up)) this.level = up;
   }
 
   save(): void {
     this.msg = '';
-    this.http.dbSet([{ key: 'log.level', value: this.level }]).subscribe({
+    this.ds.write([{ key: 'log.level', value: this.level }]).subscribe({
       next: (r) => {
         this.msg = r.ok ? 'Set to ' + this.level : 'Error: ' + r.err;
       },

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -27,6 +27,9 @@ export class Lwm2mConfigComponent implements OnInit, OnDestroy {
   generatingPsk = false;
 
   private sub = new Subscription();
+  private readonly CFG_KEYS = [
+    'iot.serial', 'iot.dev.mode', 'iot.bs.uri', 'iot.binding', 'iot.lifetime',
+  ];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
@@ -42,46 +45,47 @@ export class Lwm2mConfigComponent implements OnInit, OnDestroy {
   }
 
   ngOnInit(): void {
-    this.http.dbGet([
-      'iot.serial', 'iot.dev.mode', 'iot.bs.uri',
-      'iot.dm.uri', 'iot.server.uri', 'iot.binding', 'iot.lifetime'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) {
-          const d = r.data as Record<string, unknown>;
-          const serial = (d['iot.serial'] as string) || '';
-          // A serial already in the store means the RPi client auto-filled
-          // it → present it read-only. Empty → installer enters it.
-          this.serialAutoDetected = serial.length > 0;
-          this.devMode = d['iot.dev.mode'] === true;
-          this.serverForm.patchValue({
-            serial:     serial,
-            bs_uri:     d['iot.bs.uri']    || 'coaps://',
-            // DM Server URI: prefer the actual bootstrap-delivered URI the
-            // client persisted (iot.dm.uri); fall back to the legacy
-            // ds-driven server.uri, then to the placeholder when both empty.
-            server_uri: (d['iot.dm.uri'] as string)
-                        || (d['iot.server.uri'] as string)
-                        || '(set by bootstrap)',
-            binding:    d['iot.binding']    || 'U',
-            lifetime:   d['iot.lifetime']   || 86400,
-          });
-        }
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
-    });
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    // The Security tab is an editable form; re-apply the commissioning fields
+    // only while pristine so a late prefetch fills them without clobbering
+    // in-progress edits. These keys aren't republished by /status, so they
+    // fire once when the prefetch lands.
+    for (const k of this.CFG_KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.serverForm.dirty) this.applyData(this.ds.snapshot());
+      }));
 
     // The Server (Device Management) tab is read-only STATUS — the DM URI is
-    // pushed by the bootstrap server after the client registers. Subscribe to
-    // the shared store so it renders live (off the single /status long-poll)
-    // and never shows a stale "(set by bootstrap)" once iot.dm.uri is written.
-    // The Security tab is an editable form, so it stays load-once (no live
-    // subscription that could clobber in-progress edits).
+    // pushed by the bootstrap server after the client registers. Keep it live
+    // off the shared store (single /status long-poll) so it never shows a
+    // stale "(set by bootstrap)" once iot.dm.uri is written.
     if (this.mode === 'server') {
       this.sub.add(this.ds.observe('iot.dm.uri').subscribe(() => this.refreshDmUri()));
       this.sub.add(this.ds.observe('iot.server.uri').subscribe(() => this.refreshDmUri()));
     }
+  }
+
+  private applyData(d: Record<string, unknown>): void {
+    const serial = (d['iot.serial'] as string) || '';
+    // A serial already in the store means the RPi client auto-filled it →
+    // present it read-only. Empty → installer enters it.
+    this.serialAutoDetected = serial.length > 0;
+    this.devMode = d['iot.dev.mode'] === true;
+    this.serverForm.patchValue({
+      serial:     serial,
+      bs_uri:     d['iot.bs.uri']    || 'coaps://',
+      // DM Server URI: prefer the actual bootstrap-delivered URI the client
+      // persisted (iot.dm.uri); fall back to the legacy ds-driven server.uri,
+      // then to the placeholder when both empty.
+      server_uri: (d['iot.dm.uri'] as string)
+                  || (d['iot.server.uri'] as string)
+                  || '(set by bootstrap)',
+      binding:    d['iot.binding']    || 'U',
+      lifetime:   d['iot.lifetime']   || 86400,
+    });
   }
 
   ngOnDestroy(): void { this.sub.unsubscribe(); }
@@ -104,7 +108,7 @@ export class Lwm2mConfigComponent implements OnInit, OnDestroy {
     if (!this.serialAutoDetected && v.serial) {
       pairs.push({ key: 'iot.serial', value: v.serial });
     }
-    this.http.dbSet(pairs).subscribe({
+    this.ds.write(pairs).subscribe({
       next: (r) => { this.saving = false; if(r.ok) this.toast.success('Commissioning saved'); else this.toast.error(r.err||'Save failed'); },
       error: () => { this.saving = false; this.toast.error('Save failed'); }
     });

--- a/iot-ui/src/app/routing/custom-rules/custom-rules.component.ts
+++ b/iot-ui/src/app/routing/custom-rules/custom-rules.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { HttpsvcService } from '../../../common/httpsvc.service';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 import { DataStoreService } from '../../../common/datastore.service';
@@ -113,9 +113,10 @@ interface CustomRule {
     .add-rule-btn { margin-top: 20px; }
   `]
 })
-export class CustomRulesComponent implements OnInit {
+export class CustomRulesComponent implements OnInit, OnDestroy {
   rules: CustomRule[] = [];
   routeState = '';
+  private sub = new Subscription();
 
   // Add-rule form state
   nAction = 'accept';
@@ -130,16 +131,20 @@ export class CustomRulesComponent implements OnInit {
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, private session: SessionService,
+  constructor(private session: SessionService,
               private toast: ToastService, private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
+    // Paint instantly from the shared prefetched cache, then stay live off the
+    // appglobal store. net.custom.rules is edited only here (persisted on each
+    // add/delete) and isn't republished by /status, so it fires once when the
+    // prefetch lands; net.state is the live router-state badge.
     this.applyData(this.ds.snapshot());
-    this.http.dbGet(['net.custom.rules', 'net.state']).subscribe({
-      next: (r) => { if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>); }
-    });
+    this.sub.add(this.ds.observe('net.custom.rules').subscribe(() => this.applyData(this.ds.snapshot())));
+    this.sub.add(this.ds.observe('net.state').subscribe(v => { if (v != null) this.routeState = String(v); }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     if (d['net.custom.rules'] != null) {
@@ -169,7 +174,7 @@ export class CustomRulesComponent implements OnInit {
 
   private persist(next: CustomRule[], okMsg: string): void {
     this.saving = true;
-    this.http.dbSet([{ key: 'net.custom.rules', value: JSON.stringify(next) }]).subscribe({
+    this.ds.write([{ key: 'net.custom.rules', value: JSON.stringify(next) }]).subscribe({
       next: (r) => {
         this.saving = false;
         if (r.ok) { this.rules = next; this.toast.success(okMsg); this.resetForm(); }

--- a/iot-ui/src/app/routing/port-forward/port-forward.component.ts
+++ b/iot-ui/src/app/routing/port-forward/port-forward.component.ts
@@ -1,6 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
-import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { PubSubService } from '../../../common/pubsubsvc.service';
 import { ToastService } from '../../../common/toast.service';
@@ -84,23 +83,34 @@ export class PortForwardComponent implements OnInit, OnDestroy {
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, private session: SessionService,
+  constructor(private session: SessionService,
               private toast: ToastService, private pubsub: PubSubService,
               private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
+    // Paint instantly from the shared prefetched cache, then stay live off the
+    // appglobal store. The DNAT/ports keys are edited only here and aren't
+    // republished by /status (they fire once when the prefetch lands); the
+    // state/rules/last-apply rows are live telemetry off the shared long-poll.
     this.applyData(this.ds.snapshot());
-    this.http.dbGet(['net.lwm2m.target.ip', 'net.lwm2m.target.port', 'net.forward.ports',
-      'net.state', 'net.rules.applied.count', 'net.last.apply.unix']).subscribe({
-      next: (r) => { if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>); }
-    });
+    for (const k of ['net.lwm2m.target.ip', 'net.lwm2m.target.port', 'net.forward.ports'])
+      this.sub.add(this.ds.observe(k).subscribe(() => this.applyEditable(this.ds.snapshot())));
+    for (const k of ['net.state', 'net.rules.applied.count', 'net.last.apply.unix'])
+      this.sub.add(this.ds.observe(k).subscribe(() => this.applyLive(this.ds.snapshot())));
   }
 
   private applyData(d: Record<string, unknown>): void {
+    this.applyEditable(d);
+    this.applyLive(d);
+  }
+
+  private applyEditable(d: Record<string, unknown>): void {
     if (d['net.lwm2m.target.ip'] != null)      this.targetIp     = String(d['net.lwm2m.target.ip']);
     if (d['net.lwm2m.target.port'] != null)    this.targetPort   = Number(d['net.lwm2m.target.port']) || 5684;
     if (d['net.forward.ports'] != null)        this.forwardPorts = String(d['net.forward.ports']);
+  }
+
+  private applyLive(d: Record<string, unknown>): void {
     if (d['net.state'] != null)                this.routeState   = String(d['net.state']);
     if (d['net.rules.applied.count'] != null)  this.rulesApplied = Number(d['net.rules.applied.count']) || 0;
     if (d['net.last.apply.unix'] != null) {
@@ -111,7 +121,7 @@ export class PortForwardComponent implements OnInit, OnDestroy {
 
   saveDnat(): void {
     this.savingDnat = true;
-    this.http.dbSet([
+    this.ds.write([
       { key: 'net.lwm2m.target.ip',   value: this.targetIp },
       { key: 'net.lwm2m.target.port', value: this.targetPort },
     ]).subscribe({
@@ -122,7 +132,7 @@ export class PortForwardComponent implements OnInit, OnDestroy {
 
   savePorts(): void {
     this.savingPorts = true;
-    this.http.dbSet([
+    this.ds.write([
       { key: 'net.forward.ports', value: this.forwardPorts },
     ]).subscribe({
       next: (r) => { this.savingPorts = false; if(r.ok) this.toast.success('Ports saved'); else this.toast.error(r.err||'Port save failed'); },

--- a/iot-ui/src/app/vpn/vpn-config/vpn-config.component.ts
+++ b/iot-ui/src/app/vpn/vpn-config/vpn-config.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 import { DataStoreService } from '../../../common/datastore.service';
@@ -10,14 +10,20 @@ import { DataStoreService } from '../../../common/datastore.service';
   templateUrl: './vpn-config.component.html',
   styleUrls: ['./vpn-config.component.scss']
 })
-export class VpnConfigComponent implements OnInit {
+export class VpnConfigComponent implements OnInit, OnDestroy {
   form: FormGroup;
   loading = true;
   get isAdmin(): boolean { return this.session.isAdmin; }
   saving = false;
   msg = '';
+  private sub = new Subscription();
+  private readonly KEYS = [
+    'vpn.remote.host', 'vpn.remote.port', 'vpn.remote.proto',
+    'vpn.cert.path', 'vpn.key.path', 'vpn.ca.path',
+    'vpn.cipher', 'vpn.dev', 'vpn.mgmt.port',
+  ];
 
-  constructor(private http: HttpsvcService, fb: FormBuilder,
+  constructor(fb: FormBuilder,
     private session: SessionService, private toast: ToastService,
     private ds: DataStoreService) {
     this.form = fb.group({
@@ -34,20 +40,18 @@ export class VpnConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
-    if (this.ds.has('vpn.remote.host')) { this.applyData(this.ds.snapshot()); this.loading = false; }
-    this.http.dbGet([
-      'vpn.remote.host', 'vpn.remote.port', 'vpn.remote.proto',
-      'vpn.cert.path', 'vpn.key.path', 'vpn.ca.path',
-      'vpn.cipher', 'vpn.dev', 'vpn.mgmt.port'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>);
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
-    });
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store; re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.form.dirty) this.applyData(this.ds.snapshot());
+      }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     this.form.patchValue({
@@ -66,7 +70,7 @@ export class VpnConfigComponent implements OnInit {
   save(): void {
     this.saving = true; this.msg = '';
     const v = this.form.value;
-    this.http.dbSet([
+    this.ds.write([
       { key: 'vpn.remote.host',  value: v.remote_host },
       { key: 'vpn.remote.port',  value: v.remote_port },
       { key: 'vpn.remote.proto', value: v.remote_proto },

--- a/iot-ui/src/app/wan/iface-priority/iface-priority.component.ts
+++ b/iot-ui/src/app/wan/iface-priority/iface-priority.component.ts
@@ -1,5 +1,5 @@
-import { Component, OnInit } from '@angular/core';
-import { HttpsvcService } from '../../../common/httpsvc.service';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 import { DataStoreService } from '../../../common/datastore.service';
@@ -59,24 +59,34 @@ import { DataStoreService } from '../../../common/datastore.service';
     .active-iface { font-size: 16px; font-weight: 600; color: #2e7d32; display: block; margin-top: 2px; }
   `]
 })
-export class IfacePriorityComponent implements OnInit {
+export class IfacePriorityComponent implements OnInit, OnDestroy {
   priority = 'eth,wifi,cellular'; ethName = 'eth0'; wifiName = 'wlan0';
   cellName = 'wwan0'; pollInterval = 5; activeIface = '';
   saving = false; msg = '';
+  private sub = new Subscription();
+  private readonly CFG_KEYS = [
+    'net.iface.priority', 'net.iface.eth.name', 'net.iface.wifi.name',
+    'net.iface.cellular.name', 'net.poll.interval.sec',
+  ];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, private session: SessionService,
+  constructor(private session: SessionService,
               private toast: ToastService, private ds: DataStoreService) {}
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
+    // Paint instantly from the shared prefetched cache, then stay live off the
+    // appglobal store. The editable config keys change only here and aren't
+    // republished by /status (they fire once when the prefetch lands);
+    // net.iface.active is live telemetry off the shared long-poll.
     this.applyData(this.ds.snapshot());
-    this.http.dbGet(['net.iface.priority', 'net.iface.eth.name', 'net.iface.wifi.name',
-      'net.iface.cellular.name', 'net.poll.interval.sec', 'net.iface.active']).subscribe({
-      next: (r) => { if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>); }
-    });
+    for (const k of this.CFG_KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => this.applyData(this.ds.snapshot())));
+    this.sub.add(this.ds.observe('net.iface.active')
+      .subscribe(v => { if (v != null) this.activeIface = String(v); }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     if (d['net.iface.priority'] != null)      this.priority     = String(d['net.iface.priority']);
@@ -89,7 +99,7 @@ export class IfacePriorityComponent implements OnInit {
 
   save(): void {
     this.saving = true; this.msg = '';
-    this.http.dbSet([
+    this.ds.write([
       { key: 'net.iface.priority', value: this.priority },
       { key: 'net.iface.eth.name', value: this.ethName },
       { key: 'net.iface.wifi.name', value: this.wifiName },

--- a/iot-ui/src/app/wan/wifi-config/wifi-config.component.ts
+++ b/iot-ui/src/app/wan/wifi-config/wifi-config.component.ts
@@ -1,6 +1,6 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 import { FormBuilder, FormGroup } from '@angular/forms';
-import { HttpsvcService } from '../../../common/httpsvc.service';
 import { SessionService } from '../../../common/session.service';
 import { ToastService } from '../../../common/toast.service';
 import { DataStoreService } from '../../../common/datastore.service';
@@ -11,14 +11,20 @@ import { WifiNetwork } from '../../../common/app-globals';
   templateUrl: './wifi-config.component.html',
   styleUrls: ['./wifi-config.component.scss']
 })
-export class WifiConfigComponent implements OnInit {
+export class WifiConfigComponent implements OnInit, OnDestroy {
   form: FormGroup;
   networks: WifiNetwork[] = [];
   loading = true; saving = false; msg = '';
+  private sub = new Subscription();
+  private readonly KEYS = [
+    'wifi.iface', 'wifi.wpa.path', 'wifi.ctrl.dir',
+    'wifi.scan.interval.sec', 'wifi.scan.max.results',
+    'wifi.dhcp.client', 'wifi.networks',
+  ];
 
     get isAdmin(): boolean { return this.session.isAdmin; }
 
-  constructor(private http: HttpsvcService, fb: FormBuilder, private session: SessionService,
+  constructor(fb: FormBuilder, private session: SessionService,
               private toast: ToastService, private ds: DataStoreService) {
     this.form = fb.group({
       iface:            ['wlan0'],
@@ -32,20 +38,18 @@ export class WifiConfigComponent implements OnInit {
   }
 
   ngOnInit(): void {
-    // Instant paint from the prefetched cache, then refresh from the wire.
-    if (this.ds.has('wifi.iface')) { this.applyData(this.ds.snapshot()); this.loading = false; }
-    this.http.dbGet([
-      'wifi.iface', 'wifi.wpa.path', 'wifi.ctrl.dir',
-      'wifi.scan.interval.sec', 'wifi.scan.max.results',
-      'wifi.dhcp.client', 'wifi.networks'
-    ]).subscribe({
-      next: (r) => {
-        if (r.ok && r.data) this.applyData(r.data as Record<string, unknown>);
-        this.loading = false;
-      },
-      error: () => { this.loading = false; }
-    });
+    // Paint instantly from the shared prefetched cache (no per-page round-trip),
+    // then stay live off the appglobal store. Re-apply only while the form is
+    // pristine so a late prefetch fills the fields without clobbering edits.
+    this.applyData(this.ds.snapshot());
+    this.loading = false;
+    for (const k of this.KEYS)
+      this.sub.add(this.ds.observe(k).subscribe(() => {
+        if (!this.form.dirty) this.applyData(this.ds.snapshot());
+      }));
   }
+
+  ngOnDestroy(): void { this.sub.unsubscribe(); }
 
   private applyData(d: Record<string, unknown>): void {
     this.form.patchValue({
@@ -71,7 +75,7 @@ export class WifiConfigComponent implements OnInit {
     this.saving = true; this.msg = '';
     this.form.patchValue({ networks_json: JSON.stringify(this.networks) });
     const v = this.form.value;
-    this.http.dbSet([
+    this.ds.write([
       { key: 'wifi.iface',               value: v.iface },
       { key: 'wifi.wpa.path',            value: v.wpa_path },
       { key: 'wifi.ctrl.dir',            value: v.ctrl_dir },

--- a/iot-ui/src/common/datastore.service.ts
+++ b/iot-ui/src/common/datastore.service.ts
@@ -1,8 +1,8 @@
 import { Injectable } from '@angular/core';
 import { BehaviorSubject, Observable } from 'rxjs';
-import { filter } from 'rxjs/operators';
+import { filter, tap } from 'rxjs/operators';
 import { HttpsvcService } from './httpsvc.service';
-import { StatusSnapshot } from './app-globals';
+import { StatusSnapshot, DbSetResponse } from './app-globals';
 
 /// Shared, prefetched view of the data store.
 ///
@@ -66,6 +66,20 @@ export class DataStoreService {
       },
       error: () => { /* pages fall back to their own dbGet */ }
     });
+  }
+
+  /// Write keys through the shared store. Persists to ds-server via the REST
+  /// API and, on success, mirrors the new values into the local cache so
+  /// snapshot()/observe() stay consistent on revisit WITHOUT re-running
+  /// prefetchAll — config keys are written only here and are NOT carried by
+  /// the /status long-poll, so without this a page would show pre-save values
+  /// the next time it mounts. Config pages call this instead of
+  /// HttpsvcService.dbSet for any key they also read back. (Secrets that are
+  /// deliberately excluded from the cache keep using dbSet directly.)
+  write(pairs: { key: string; value: unknown }[]): Observable<DbSetResponse> {
+    return this.http.dbSet(pairs).pipe(
+      tap(r => { if (r && r.ok) for (const p of pairs) this.set(p.key, p.value); })
+    );
   }
 
   /// Keep volatile telemetry fresh via the aggregated /status long-poll.


### PR DESCRIPTION
## Why

Config pages bypassed the prefetched `DataStoreService` cache with their own per-page `POST /api/v1/db/get` on every `ngOnInit`. On a busy worker pool that round-trip queues behind the login prefetch + the 30s `/status` long-poll, so pages — notably **WAN → WiFi Configuration** — paint slowly. The appglobal architecture (prefetch all keys + shared long-poll + per-key subscribe) already exists; pages just weren't using it.

## What

- **Reads:** every config page now paints instantly from `ds.snapshot()` and stays live via `ds.observe(key)` — no per-page `dbGet`.
- **Writes (new):** `DataStoreService.write()` persists via `dbSet` and mirrors values back into the cache on success, so revisits aren't stale (config keys aren't carried by the `/status` long-poll).
- **Cleanup:** dropped the now-dead `HttpsvcService` injection from the 14 components that no longer issue any `dbGet`/`dbSet`.

### Per-page nuances
- `iface-priority` / `custom-rules` / `port-forward`: split editable keys (paint once) from live `/status` keys (`net.state`, `net.iface.active`, rules) so live ticks never clobber in-progress edits.
- cloud `vpn-config`: keeps a scoped `dbGet`/`dbSet` for `cloud.vpn.ca.key` / `server.key`, which are deliberately excluded from the prefetch cache.
- device `lwm2m-config`: keeps its existing live server-tab subscriptions; the BS PSK write stays on `dbSet` (secret, uncached).

### Untouched (keys intentionally not cached)
`wifi-scan`, `software-update`, `endpoint-list`, `vpn-status`, cloud `device-forwarding`, `main`.

## Verification
Both UIs type-check clean in a `node:20-alpine` container (`tsc --noEmit`): cloud-ui exit 0, device-ui exit 0. Full `ng build` still worth running as a final gate (container can't run mac-built native esbuild binaries).

🤖 Generated with [Claude Code](https://claude.com/claude-code)