### PR TITLE
fix(yocto): add IOT_FRESH to force fresh iot recipe fetch + rebuild

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -13,6 +13,12 @@
 # Default target is the full bootable distribution `iot-image`. Override:
 #   TARGET=packagegroup-iot ./build.sh   # build just the .ipk feed
 #
+# Guarantee the image carries the latest commit on IOT_BRANCH (main). The iot
+# recipe is AUTOREV, but a cached git mirror / sstate can serve a stale checkout
+# so a reflash ships old code. Force a fresh re-clone + recompile of just the
+# iot recipe (deps still restore from sstate, so it stays fast):
+#   IOT_FRESH=1 ./build.sh
+#
 # Output per machine:
 #   yocto/build/<machine>/images/<machine>/*.wic.bz2   flashable SD image
 #   yocto/build/<machine>/ipk/                          *.ipk feed (opkg)
@@ -165,6 +171,7 @@ build_machine() {
     # recipe fix only applies after `podman build` re-COPYs meta-iot.)
     $CR run --name "$container" \
         -e "MACHINE=$machine" \
+        -e "IOT_FRESH=${IOT_FRESH:-}" \
         -v "$SCRIPT_DIR/meta-iot:/home/builduser/yocto/meta-iot:ro" \
         -v "${DOWNLOADS_VOLUME}:/home/builduser/yocto/build/downloads:U" \
         -v "${SSTATE_VOLUME}:/home/builduser/yocto/build/sstate-cache:U" \

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -125,6 +125,20 @@ fi
 echo 'SSTATE_MIRRORS += "file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"' \
     >> conf/local.conf
 
+# ── 4b. Force-refresh the iot recipe (opt-in: IOT_FRESH=1) ─────────
+# SRCREV = "${AUTOREV}" on IOT_BRANCH is meant to track the branch tip, but a
+# cached git mirror / the recipe's sstate (and the baked own-mirrors dl-mirror
+# used by IOT_USE_CACHE builds) can serve a STALE iot checkout — so a reflash
+# silently ships pre-fix code. IOT_FRESH=1 runs `cleanall` on just the iot
+# recipe: it wipes that recipe's downloads + sstate + WORKDIR so do_fetch
+# re-clones the real tip of $IOT_BRANCH from GitHub and the C++/Angular build
+# recompiles. Only the iot recipe is affected; every dependency still restores
+# from sstate, so the extra cost is one small clone + the iot rebuild.
+if [ -n "${IOT_FRESH:-}" ]; then
+    echo "→ IOT_FRESH set: forcing fresh fetch + rebuild of the iot recipe ..."
+    bitbake -c cleanall iot
+fi
+
 # ── 5. Run bitbake ─────────────────────────────────────────────────
 echo ""
 echo "→ Starting bitbake for $MACHINE: $@ ..."


### PR DESCRIPTION
## Problem
The `iot` recipe is `SRCREV = "${AUTOREV}"` on `IOT_BRANCH` (main), so it should track the branch tip. In practice a cached git mirror / the recipe's sstate — and especially the baked `own-mirrors` dl-mirror used by `IOT_USE_CACHE` builds — can serve a **stale iot checkout**, so a reflash silently ships pre-fix code.

This is exactly how the `wifi-client` `ctrl_interface_group=0` fix (PR #220) failed to appear on the RPi3B after a rebuild+reflash: the flashed binary still contained the old code, and wpa_supplicant kept dying on `lchown(... gid=0): Operation not permitted`.

## Fix
Add an opt-in `IOT_FRESH=1` flag:
- `entrypoint.sh` — when set, runs `bitbake -c cleanall iot` before the main build, wiping **only** the iot recipe's downloads + sstate + WORKDIR so `do_fetch` re-clones the real tip of `IOT_BRANCH` and the C++/Angular build recompiles.
- `build.sh` — passes `-e IOT_FRESH` into the build container and documents the flag in the usage header.

Every dependency still restores from sstate, so the extra cost is one small clone + the iot rebuild. Unset → unchanged fast incremental behaviour.

## Usage
```sh
IOT_FRESH=1 ./build.sh
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)