### PR TITLE
fix(wifi): reclaim stale wpa ctrl socket + add iot-dump key dumper

### DIFF
--- a/modules/wan/wifi/client/src/supervisor.cpp
+++ b/modules/wan/wifi/client/src/supervisor.cpp
@@ -3,6 +3,7 @@
 #include <algorithm>
 #include <cstdio>
 #include <cstdlib>
+#include <cstring>
 #include <ctime>
 #include <sstream>
 #include <string>
@@ -10,6 +11,9 @@
 #include <unistd.h>
 
 #include <ace/Log_Msg.h>
+#include <ace/LSOCK_Dgram.h>
+#include <ace/Time_Value.h>
+#include <ace/UNIX_Addr.h>
 #include <nlohmann/json.hpp>
 
 #include "data_store/service_gate.hpp"
@@ -160,6 +164,56 @@ select_best_network(const std::vector<WifiNetwork>& parsed_networks,
     return best_idx;
 }
 
+// Probe a wpa_supplicant control socket for a LIVE peer, using the same
+// ACE local-DGRAM primitive ctrl::Client speaks (ACE_LSOCK_Dgram +
+// ACE_UNIX_Addr) and wpa_supplicant's own liveness command: send "PING",
+// expect "PONG". A live wpa answers within milliseconds; a STALE leftover
+// node (wpa crashed / was SIGKILLed / exited without unlinking its socket)
+// has no receiver, so the send fails with ECONNREFUSED (or the recv times
+// out). That is exactly what tells a real conflict from a dead socket.
+//
+// Conservative on its own setup errors: if we can't stand up the probe
+// socket we assume "live" so we never unlink a socket that might be in use.
+// REQ-WIFI-022.
+bool wpa_ctrl_socket_is_live(const std::string& server_path) {
+    // ACE_LSOCK needs a bound local rendezvous path to send/recv a reply
+    // — same throwaway-name idiom ctrl::Client::connect() uses.
+    char tmpl[64];
+    std::snprintf(tmpl, sizeof(tmpl),
+                  "/tmp/wpa_probe_iot_%d_XXXXXX",
+                  static_cast<int>(::getpid()));
+    int fd = ::mkstemp(tmpl);
+    if (fd < 0) return true;                        // can't probe → assume live
+    ::close(fd);
+    ::unlink(tmpl);                                 // need a socket node, not a file
+
+    ACE_UNIX_Addr   local(tmpl);
+    ACE_LSOCK_Dgram sock;
+    if (sock.open(local) != 0) {
+        ::unlink(tmpl);
+        return true;                                // can't probe → assume live
+    }
+
+    bool live = false;
+    ACE_UNIX_Addr peer(server_path.c_str());
+    static const char kPing[] = "PING\n";
+    ssize_t sent = sock.send(kPing, sizeof(kPing) - 1, peer);
+    if (sent == static_cast<ssize_t>(sizeof(kPing) - 1)) {
+        char buf[64];
+        ACE_UNIX_Addr  src;
+        ACE_Time_Value tv(0, 300 * 1000);           // 300 ms is ample locally
+        ssize_t got = sock.recv(buf, sizeof(buf) - 1, src, 0, &tv);
+        if (got > 0) {
+            buf[got] = '\0';
+            live = std::strncmp(buf, "PONG", 4) == 0;
+        }
+    }
+    // sent < 0 (ECONNREFUSED on a dead node) → live stays false.
+    sock.close();
+    ::unlink(tmpl);
+    return live;
+}
+
 bool nm_conflict_detected(const std::string& iface,
                           const std::string& ctrl_dir) {
     // (1) systemctl is-active NetworkManager → "active" means yes.
@@ -173,12 +227,26 @@ bool nm_conflict_detected(const std::string& iface,
         ::pclose(fp);
         if (n >= 6 && std::string(buf, 6) == "active") return true;
     }
-    // (2) Existing ctrl socket at <ctrl_dir>/<iface> → conflict.
+    // (2) Existing ctrl socket at <ctrl_dir>/<iface>. A LIVE
+    // wpa_supplicant there is a genuine conflict — refuse to start a
+    // second one on the same iface. But a STALE leftover (wpa crashed,
+    // was SIGKILLed, or exited uncleanly without unlinking its socket)
+    // is NOT a conflict, and treating it as one permanently wedges every
+    // restart into "conflict" — the daemon never recovers without manual
+    // `rm`. So probe the socket: reclaim (unlink) a dead one and proceed.
     std::string path = ctrl_dir;
     if (!path.empty() && path.back() != '/') path.push_back('/');
     path += iface;
     struct ::stat st;
-    if (::stat(path.c_str(), &st) == 0) return true;
+    if (::stat(path.c_str(), &st) == 0) {
+        if (wpa_ctrl_socket_is_live(path)) return true;   // live peer → conflict
+        // Orphaned node: clear it so spawn_wpa_supplicant can re-bind.
+        ::unlink(path.c_str());
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D [wifi:%t] %M %N:%l reclaimed stale wpa ctrl "
+                            "socket %C (no live peer; not a conflict)\n"),
+                   path.c_str()));
+    }
     return false;
 }
 
@@ -295,6 +363,13 @@ bool Supervisor::initialize() {
         ::usleep(50 * 1000);
     }
     if (!m_ctrl.connect(sock_path)) {
+        // Reap the wpa_supplicant we just spawned instead of orphaning it.
+        // An orphaned wpa keeps its ctrl socket bound, which would make the
+        // next start trip nm_conflict_detected() — the exact deadlock the
+        // stale-socket reclaim above guards against. terminate() SIGTERMs
+        // wpa, which unlinks its own ctrl socket on the way out.
+        m_wpa.terminate();
+        m_ds.set_pid_wpa(0u);
         m_ds.set_assoc_state("exited");
         m_ds.set_last_error("ctrl connect/ATTACH failed");
         return false;

--- a/modules/wan/wifi/client/test/supervisor_test.cpp
+++ b/modules/wan/wifi/client/test/supervisor_test.cpp
@@ -6,8 +6,14 @@
 #include <gtest/gtest.h>
 
 #include <chrono>
+#include <cstdlib>
 #include <string>
+#include <sys/stat.h>
+#include <unistd.h>
 #include <vector>
+
+#include <ace/LSOCK_Dgram.h>
+#include <ace/UNIX_Addr.h>
 
 #include "supervisor.hpp"
 
@@ -207,6 +213,39 @@ TEST(WIFI_REQ_WIFI_022_nm_active_or_socket_exists_yields_conflict,
     // completes and returns a boolean.
     bool r = nm_conflict_detected("wlan-nonexistent", "/run/no-such");
     EXPECT_TRUE(r == true || r == false);  // tautology by type
+}
+
+TEST(WIFI_REQ_WIFI_022_nm_active_or_socket_exists_yields_conflict,
+     stale_ctrl_socket_is_reclaimed_not_a_conflict) {
+    // A LEFTOVER ctrl socket with no live wpa_supplicant behind it must
+    // NOT count as a conflict: nm_conflict_detected probes it, finds no
+    // peer, unlinks the dead node, and returns false so the daemon can
+    // re-spawn. Regression for the "stale socket wedges every restart into
+    // conflict" deadlock. (Assumes NetworkManager isn't active in the test
+    // env — same caveat as the sibling test above; if it were, the NM
+    // branch would short-circuit before the socket probe.)
+    char dir_tmpl[] = "/tmp/wifi_ctrl_test_XXXXXX";
+    ASSERT_NE(::mkdtemp(dir_tmpl), nullptr);
+    const std::string iface     = "wlan-test";
+    const std::string sock_path = std::string(dir_tmpl) + "/" + iface;
+
+    // Bind an ACE local DGRAM socket then close WITHOUT removing it → a node
+    // on disk with no receiver, exactly what an unclean wpa exit leaves
+    // behind (ACE_LSOCK_Dgram::close() shuts the handle but does not unlink
+    // the rendezvous — same reason ctrl.cpp unlinks its bind path by hand).
+    {
+        ACE_UNIX_Addr   bind_addr(sock_path.c_str());
+        ACE_LSOCK_Dgram dead;
+        ASSERT_EQ(dead.open(bind_addr), 0);
+        dead.close();
+    }
+    struct ::stat st;
+    ASSERT_EQ(::stat(sock_path.c_str(), &st), 0);     // dead node present
+
+    EXPECT_FALSE(nm_conflict_detected(iface, dir_tmpl));   // reclaimed, not conflict
+    EXPECT_NE(::stat(sock_path.c_str(), &st), 0);          // dead node unlinked
+
+    ::rmdir(dir_tmpl);
 }
 
 // ─────────────────────── NFR-WIFI-002 ────────────────────────

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-dump
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-dump
@@ -1,0 +1,94 @@
+#!/bin/sh
+# iot-dump — dump every data-store key + value for an iot module/daemon.
+#
+# Usage:
+#   iot-dump <module>          e.g.  iot-dump iot-wifi-client
+#   iot-dump all               dump every key in every schema
+#   iot-dump --list            list the known modules
+#
+# Resolves the module to its data-store key prefix(es), enumerates the
+# matching keys straight from the installed schema files
+# (/etc/iot/ds-schemas/*.lua — the on-device source of truth, so the key
+# list can never drift from the daemons), and prints each via `ds-cli get`.
+# Read-only; safe to run anytime.
+#
+# Env overrides: IOT_SCHEMA_DIR, IOT_DS_SOCKET, DS_CLI.
+
+set -eu
+
+SCHEMA_DIR="${IOT_SCHEMA_DIR:-/etc/iot/ds-schemas}"
+DS_CLI="${DS_CLI:-ds-cli}"
+SOCKET="${IOT_DS_SOCKET:-}"
+
+dscli() {
+    if [ -n "$SOCKET" ]; then "$DS_CLI" --socket="$SOCKET" "$@"
+    else                      "$DS_CLI" "$@"; fi
+}
+
+usage() {
+    cat >&2 <<EOF
+Usage: iot-dump <module>
+Dump all data-store keys + values for an iot module. Read-only.
+
+  iot-wifi-client | wifi        ->  wifi.*  + services.wifi.client.*
+  iot-net-router  | net-router  ->  net.*   + services.net.router.*
+  iot-openvpn-client | openvpn  ->  vpn.*   + services.openvpn.client.*
+  iot-lwm2m-client | lwm2m       ->  iot.* lwm2m.* cloud.* + services.lwm2m.*
+  iot-httpd | httpd             ->  http.* auth.* + services.httpd.*
+  iot-ds | ds | all             ->  every key
+EOF
+}
+
+[ $# -ge 1 ] || { usage; exit 2; }
+
+case "$1" in
+    -h|--help|--list) usage; exit 0 ;;
+esac
+
+module="$1"
+case "$module" in
+    *wifi*)               prefixes="wifi. services.wifi.client." ;;
+    *net*router*|net-router|net)
+                          prefixes="net. services.net.router." ;;
+    *openvpn*|*vpn*)      prefixes="vpn. services.openvpn.client." ;;
+    *lwm2m*)              prefixes="iot. lwm2m. cloud. services.lwm2m." ;;
+    *http*)               prefixes="http. auth. services.httpd." ;;
+    all|ds|iot-ds)        prefixes="" ;;   # everything
+    *) echo "iot-dump: unknown module '$module'" >&2; usage; exit 2 ;;
+esac
+
+[ -d "$SCHEMA_DIR" ] || {
+    echo "iot-dump: schema dir not found: $SCHEMA_DIR" >&2; exit 1; }
+
+# Every key is declared in a schema as a line like:  ["wifi.iface"] = {
+# Pull the quoted names out of all schema files at once.
+all_keys=$(grep -hoE '\["[^"]+"\]' "$SCHEMA_DIR"/*.lua 2>/dev/null \
+           | sed 's/^\["//; s/"\]$//' | sort -u)
+
+[ -n "$all_keys" ] || {
+    echo "iot-dump: no keys found under $SCHEMA_DIR" >&2; exit 1; }
+
+# Filter by the module's prefixes (empty => keep all keys).
+if [ -z "$prefixes" ]; then
+    keys="$all_keys"
+else
+    keys=$(for k in $all_keys; do
+               for p in $prefixes; do
+                   # ${k#$p} strips prefix $p; if it changed, k starts with p.
+                   if [ "${k#$p}" != "$k" ]; then echo "$k"; break; fi
+               done
+           done)
+fi
+
+[ -n "$keys" ] || {
+    echo "iot-dump: no keys match module '$module'" >&2; exit 1; }
+
+# One ds-cli get per key so a single write-only / unreadable key can't
+# abort the whole dump (and the output stays in schema-sorted order).
+for k in $keys; do
+    if v=$(dscli get "$k" 2>/dev/null); then
+        echo "$v"
+    else
+        echo "$k=<unreadable>"
+    fi
+done

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -56,6 +56,7 @@ SRC_URI = "\
     file://iot-set-hostname \
     file://iot-hostname.service \
     file://iot-http.avahi.service \
+    file://iot-dump \
 "
 
 # Optional, gitignored WiFi credential seed. When an integrator drops
@@ -216,6 +217,10 @@ do_install() {
     install -m 0755 ${WORKDIR}/iot-swupdate     ${D}${bindir}/iot-swupdate
     install -m 0755 ${WORKDIR}/iot-ota-confirm  ${D}${bindir}/iot-ota-confirm
 
+    # iot-dump: operator/debug tool — dumps all data-store keys + values for
+    # a module (e.g. `iot-dump iot-wifi-client`). Ships with ds-cli.
+    install -m 0755 ${WORKDIR}/iot-dump         ${D}${bindir}/iot-dump
+
     # Config/schema migration scripts (§11), run by iot-swupdate after opkg.
     install -d ${D}${datadir}/iot/migrations
     install -m 0644 ${WORKDIR}/migrations/README.md \
@@ -330,9 +335,10 @@ RDEPENDS:${PN}-ds-server = "\
     lua \
 "
 
-# ds-cli — operator debug/admin CLI
+# ds-cli — operator debug/admin CLI (+ iot-dump key-dump helper)
 FILES:${PN}-ds-cli = "\
     ${bindir}/ds-cli \
+    ${bindir}/iot-dump \
 "
 RDEPENDS:${PN}-ds-cli = "ace-tao"
 


### PR DESCRIPTION
## Background
On the RPi3B, wifi-client kept parking in `wifi.assoc.state=conflict` and never brought wlan0 up. Root cause: `nm_conflict_detected()` treated **any** existing `/run/wpa_supplicant/<iface>` socket as a conflict. A wpa instance that exits uncleanly (crash, SIGKILL, or a stray detached `wpa_supplicant -B`) leaves its ctrl socket behind with no live peer — and every subsequent start then deadlocked on "conflict" forever, recoverable only with a manual `rm`.

## Fixes
1. **Reclaim stale ctrl sockets.** The existing socket is now *probed* for a live peer using the same ACE local-DGRAM primitive `ctrl::Client` uses (`ACE_LSOCK_Dgram` + `ACE_UNIX_Addr`) and wpa's own `PING`/`PONG`. A live wpa → genuine conflict; a dead leftover → unlink and proceed. Self-heals across crashes/reflashes.
2. **Don't orphan wpa on failed init.** On a ctrl connect/ATTACH failure, `initialize()` now `terminate()`s the wpa it just spawned (SIGTERM → wpa unlinks its own socket) instead of leaking it — an orphaned wpa was what re-created the stale socket in the first place.
3. **`iot-dump <module>`** — operator tool that dumps every data-store key + value for a module (e.g. `iot-dump iot-wifi-client`). Data-driven from the installed `/etc/iot/ds-schemas/*.lua` so the key list never drifts; read-only; ships with `ds-cli`.

## Verification
- `wifi_client_lib` compiles clean against ACE 7.0 in the `iot-device-cpp-verify` container.
- The reclaim path was exercised **at runtime** there: a fabricated dead `ACE_LSOCK_Dgram` node → `nm_conflict_detected` returns false and unlinks it (`node_before=1 conflict=0 node_after=0`).
- Adds regression test `stale_ctrl_socket_is_reclaimed_not_a_conflict`.
- `iot-dump` functionally tested against the repo schemas (per-module filtering, `all`, unknown-module error, unreadable-key resilience).

All socket I/O (production probe + test fixture) uses the ACE API — no raw POSIX sockets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)