### PR TITLE
fix(net-router): require routable IPv4 before electing active WAN iface

### DIFF
--- a/modules/net/router/src/iface_monitor.cpp
+++ b/modules/net/router/src/iface_monitor.cpp
@@ -37,6 +37,35 @@ void parse_link_show(const std::string& body, State& out) {
     }
 }
 
+// True for an address that can carry WAN traffic: not loopback and not
+// an IPv4 link-local (169.254.0.0/16, auto-assigned when DHCP fails —
+// the very case where the iface is "up" but unusable).
+bool is_routable_v4(const std::string& ip) {
+    if (ip.rfind("127.", 0) == 0)     return false;
+    if (ip.rfind("169.254.", 0) == 0) return false;
+    return !ip.empty();
+}
+
+void parse_addr_show(const std::string& body, State& out) {
+    if (body.empty()) return;
+    try {
+        auto j = json::parse(body);
+        if (!j.is_array() || j.empty()) return;
+        const auto& e = j[0];
+        if (!e.contains("addr_info") || !e["addr_info"].is_array()) return;
+        for (const auto& a : e["addr_info"]) {
+            if (!a.contains("family") || a["family"] != "inet") continue;
+            if (!a.contains("local") || !a["local"].is_string()) continue;
+            if (is_routable_v4(a["local"].get<std::string>())) {
+                out.addr = true;
+                return;
+            }
+        }
+    } catch (const std::exception&) {
+        // Leave defaults; caller treats as not-usable.
+    }
+}
+
 void parse_route_default(const std::string& body, State& out) {
     if (body.empty()) return;
     try {
@@ -63,6 +92,9 @@ State probe(const std::string& name, shell::Runner runner) {
     if (rc != 0) return s;          // iface absent
     parse_link_show(link, s);
 
+    auto addr = runner({"ip", "-j", "addr", "show", name}, nullptr);
+    parse_addr_show(addr, s);
+
     auto route = runner({"ip", "-j", "route", "show", "default", "dev", name},
                         nullptr);
     parse_route_default(route, s);
@@ -79,7 +111,10 @@ std::vector<State> probe_all(const std::vector<std::string>& names,
 
 std::optional<std::size_t> pick_active(const std::vector<State>& states) {
     for (std::size_t i = 0; i < states.size(); ++i) {
-        if (states[i].present && states[i].up) return i;
+        // A link that's OPER-UP but has no routable IPv4 (e.g. eth0 with
+        // the cable in but no DHCP lease) can't carry WAN traffic — skip
+        // it so net.iface.active reflects a genuinely usable path.
+        if (states[i].present && states[i].up && states[i].addr) return i;
     }
     return std::nullopt;
 }

--- a/modules/net/router/src/iface_monitor.hpp
+++ b/modules/net/router/src/iface_monitor.hpp
@@ -2,10 +2,10 @@
 #define __net_router_iface_monitor_hpp__
 
 /// Stateless prober for a Linux network interface — shells out to
-/// `ip -j link show <name>` (oper state) and `ip -j route show
-/// default dev <name>` (gateway). All shell calls go through a
-/// `shell::Runner` so tests can inject canned JSON without touching
-/// the host.
+/// `ip -j link show <name>` (oper state), `ip -j addr show <name>`
+/// (routable IPv4) and `ip -j route show default dev <name>`
+/// (gateway). All shell calls go through a `shell::Runner` so tests
+/// can inject canned JSON without touching the host.
 
 #include <optional>
 #include <string>
@@ -19,6 +19,7 @@ struct State {
     std::string name;       ///< e.g. "eth0"
     bool        present = false;  ///< iface exists in the kernel
     bool        up      = false;  ///< OPER state == "UP"
+    bool        addr    = false;  ///< has a routable (non-link-local) IPv4 addr
     std::string gateway;    ///< default route's `via`, empty if none
 };
 
@@ -32,7 +33,9 @@ State probe(const std::string& name,
 std::vector<State> probe_all(const std::vector<std::string>& names,
                              shell::Runner runner = shell::default_runner());
 
-/// Pick the highest-priority interface that is BOTH present and up.
+/// Pick the highest-priority interface that is present, OPER-up AND
+/// holds a routable IPv4 address — an up link with no usable address
+/// (cable in, DHCP not leased) doesn't qualify as the active WAN path.
 /// Returns the index into `states` or std::nullopt if none qualify.
 std::optional<std::size_t> pick_active(const std::vector<State>& states);
 

--- a/modules/net/router/test/iface_monitor_test.cpp
+++ b/modules/net/router/test/iface_monitor_test.cpp
@@ -79,6 +79,31 @@ const char* kDefRouteEth0 = R"([{
   "dev": "eth0", "protocol": "dhcp"
 }])";
 
+// `ip -j addr show eth0` with a leased global IPv4.
+const char* kAddrEth0Routable = R"([{
+  "ifindex": 2, "ifname": "eth0",
+  "addr_info": [
+    {"family": "inet", "local": "192.168.1.50", "prefixlen": 24, "scope": "global"},
+    {"family": "inet6", "local": "fe80::1", "prefixlen": 64, "scope": "link"}
+  ]
+}])";
+
+// Cable in but DHCP never leased — kernel auto-assigns a 169.254 link-local.
+const char* kAddrEth0LinkLocalOnly = R"([{
+  "ifindex": 2, "ifname": "eth0",
+  "addr_info": [
+    {"family": "inet", "local": "169.254.7.3", "prefixlen": 16, "scope": "link"}
+  ]
+}])";
+
+// No IPv4 at all — only the link-local IPv6.
+const char* kAddrEth0NoV4 = R"([{
+  "ifindex": 2, "ifname": "eth0",
+  "addr_info": [
+    {"family": "inet6", "local": "fe80::1", "prefixlen": 64, "scope": "link"}
+  ]
+}])";
+
 } // namespace
 
 /* ─────────────────────── probe() ─────────────────────────────── */
@@ -95,13 +120,36 @@ TEST(IfaceProbe, ReturnsZeroInitForEmptyName) {
 TEST(IfaceProbe, UpInterfaceWithGatewayPopulated) {
     FakeRunner fr;
     fr.on({"ip","-j","link","show","eth0"}, kEth0Up);
+    fr.on({"ip","-j","addr","show","eth0"}, kAddrEth0Routable);
     fr.on({"ip","-j","route","show","default","dev","eth0"}, kDefRouteEth0);
     auto s = probe("eth0", fr.make());
     EXPECT_TRUE(s.present);
     EXPECT_TRUE(s.up);
+    EXPECT_TRUE(s.addr);
     EXPECT_EQ("192.168.1.1", s.gateway);
     EXPECT_EQ("eth0", s.name);
-    ASSERT_EQ(2u, fr.calls.size());     // link + route
+    ASSERT_EQ(3u, fr.calls.size());     // link + addr + route
+}
+
+TEST(IfaceProbe, UpInterfaceWithOnlyLinkLocalV4HasNoAddr) {
+    // Cable in, OPER-UP, but DHCP never leased: only a 169.254 address.
+    FakeRunner fr;
+    fr.on({"ip","-j","link","show","eth0"}, kEth0Up);
+    fr.on({"ip","-j","addr","show","eth0"}, kAddrEth0LinkLocalOnly);
+    fr.on({"ip","-j","route","show","default","dev","eth0"}, "[]");
+    auto s = probe("eth0", fr.make());
+    EXPECT_TRUE(s.up);
+    EXPECT_FALSE(s.addr);
+}
+
+TEST(IfaceProbe, UpInterfaceWithNoV4HasNoAddr) {
+    FakeRunner fr;
+    fr.on({"ip","-j","link","show","eth0"}, kEth0Up);
+    fr.on({"ip","-j","addr","show","eth0"}, kAddrEth0NoV4);
+    fr.on({"ip","-j","route","show","default","dev","eth0"}, "[]");
+    auto s = probe("eth0", fr.make());
+    EXPECT_TRUE(s.up);
+    EXPECT_FALSE(s.addr);
 }
 
 TEST(IfaceProbe, DownInterfaceMarkedNotUp) {
@@ -146,11 +194,11 @@ TEST(IfaceProbe, GarbageJsonLeavesStateUntouched) {
 
 /* ─────────────────────── probe_all + pick_active ─────────────── */
 
-TEST(PickActive, FirstUpInterfaceWins) {
+TEST(PickActive, FirstUpInterfaceWithAddrWins) {
     std::vector<State> ss(3);
-    ss[0].name = "eth0";     ss[0].present = true; ss[0].up = false;
-    ss[1].name = "wlan0";    ss[1].present = true; ss[1].up = true;
-    ss[2].name = "wwan0";    ss[2].present = true; ss[2].up = true;
+    ss[0].name = "eth0";  ss[0].present = true; ss[0].up = false;
+    ss[1].name = "wlan0"; ss[1].present = true; ss[1].up = true; ss[1].addr = true;
+    ss[2].name = "wwan0"; ss[2].present = true; ss[2].up = true; ss[2].addr = true;
     auto idx = pick_active(ss);
     ASSERT_TRUE(idx.has_value());
     EXPECT_EQ(1u, *idx);
@@ -163,10 +211,26 @@ TEST(PickActive, NoneUpReturnsNullopt) {
     EXPECT_FALSE(pick_active(ss).has_value());
 }
 
+TEST(PickActive, UpWithoutAddrIsSkipped) {
+    // eth0 OPER-UP but no routable IPv4 (cable in, no DHCP lease) must be
+    // skipped in favour of the next iface that actually holds an address.
+    std::vector<State> ss(2);
+    ss[0].name = "eth0";  ss[0].present = true; ss[0].up = true; ss[0].addr = false;
+    ss[1].name = "wlan0"; ss[1].present = true; ss[1].up = true; ss[1].addr = true;
+    EXPECT_EQ(1u, *pick_active(ss));
+}
+
+TEST(PickActive, AllUpButNoneAddrReturnsNullopt) {
+    std::vector<State> ss(2);
+    ss[0].present = true; ss[0].up = true; ss[0].addr = false;
+    ss[1].present = true; ss[1].up = true; ss[1].addr = false;
+    EXPECT_FALSE(pick_active(ss).has_value());
+}
+
 TEST(PickActive, AbsentInterfaceIgnoredEvenIfUpFieldSet) {
     std::vector<State> ss(2);
-    ss[0].present = false; ss[0].up = true;   // can't happen in practice
-    ss[1].present = true;  ss[1].up = true;
+    ss[0].present = false; ss[0].up = true; ss[0].addr = true;  // can't happen
+    ss[1].present = true;  ss[1].up = true; ss[1].addr = true;
     EXPECT_EQ(1u, *pick_active(ss));
 }
 

--- a/modules/net/router/test/lifecycle_test.cpp
+++ b/modules/net/router/test/lifecycle_test.cpp
@@ -49,7 +49,8 @@ struct Capture {
 };
 
 State up(const std::string& n, const std::string& gw = "10.0.0.1") {
-    State s; s.name = n; s.present = true; s.up = true; s.gateway = gw;
+    State s; s.name = n; s.present = true; s.up = true; s.addr = true;
+    s.gateway = gw;
     return s;
 }
 State down(const std::string& n) {

--- a/modules/net/router/test/supervisor_test.cpp
+++ b/modules/net/router/test/supervisor_test.cpp
@@ -57,7 +57,8 @@ struct GateCapture {
 };
 
 State up(const std::string& n, const std::string& gw = "10.0.0.1") {
-    State s; s.name = n; s.present = true; s.up = true; s.gateway = gw;
+    State s; s.name = n; s.present = true; s.up = true; s.addr = true;
+    s.gateway = gw;
     return s;
 }
 State down(const std::string& n) {


### PR DESCRIPTION
## Problem

The device-ui Dashboard "Active WAN Interface" card showed `eth0` as the connected interface even though eth0 had **no IP** (cable plugged in, no DHCP lease).

Root cause: `pick_active()` in `modules/net/router/src/iface_monitor.cpp` elected any interface that was `present && up`, where `up` reflects only the **kernel link state** (`operstate=UP`). An interface with the cable in but no DHCP lease still reports `operstate=UP`, so it was published as `net.iface.active` and shown as connected despite being unusable for WAN traffic.

## Fix

An interface now qualifies as the active WAN path only if it also holds a **routable IPv4 address** — excluding loopback and `169.254.x` link-local (which the kernel auto-assigns precisely when DHCP fails).

- `iface_monitor.hpp` — add `bool addr` to `State`; update doc comments.
- `iface_monitor.cpp` — `probe()` now runs `ip -j addr show <name>` and sets `addr` via `parse_addr_show()` / `is_routable_v4()`; `pick_active()` requires `present && up && addr`.
- `up` semantics are unchanged — `ip_route.cpp` still uses link-state for route-metric application (correct there).

With this, when eth0 is up but unleased and nothing else is usable, `net.iface.active` goes empty → the UI card shows "none"/disconnected, matching reality.

## Tests

- `iface_monitor_test.cpp` — registered the new addr probe call; added routable / link-local-only / no-IPv4 cases and a `pick_active` case proving an up-but-no-addr iface is skipped for one with an address.
- Updated the `up()` helpers in `lifecycle_test.cpp` / `supervisor_test.cpp` to set `addr=true` (their "up" iface means fully usable).

## Verification

No host ACE/gtest available, so I compiled the **real** `iface_monitor.cpp` against a standalone harness exercising `probe()` + `pick_active()` — all cases pass (routable→addr, link-local→no addr, no-v4→no addr, eth0-up-no-addr skipped for wlan0, all-no-addr→none). The full gtest suite should still run in the container/CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)