### PR TITLE
fix(wifi): send wpa ctrl commands without trailing newline (fixes ATTACH)

### DIFF
--- a/modules/wan/wifi/client/src/ctrl.cpp
+++ b/modules/wan/wifi/client/src/ctrl.cpp
@@ -196,12 +196,21 @@ bool Client::connect(const std::string& server_sock_path) {
 bool Client::request(const std::string& cmd, std::string& reply) {
     if (!connected()) return false;
 
-    std::string framed = cmd;
-    if (framed.empty() || framed.back() != '\n') framed.push_back('\n');
+    // Send the command verbatim — NO trailing terminator. wpa_supplicant's
+    // control protocol matches verbs with an exact os_strcmp() (ATTACH,
+    // PING, SCAN, DETACH, …), and wpa_ctrl(3) puts no newline on the wire.
+    // A trailing '\n' makes the exact match miss and wpa replies
+    // "UNKNOWN COMMAND" — which silently broke ATTACH against real
+    // wpa_supplicant (the smoke fake rstrip'd it, so the bug hid until
+    // hardware). Defensively strip any caller-supplied EOL.
+    std::string wire = cmd;
+    while (!wire.empty() && (wire.back() == '\n' || wire.back() == '\r')) {
+        wire.pop_back();
+    }
 
-    ssize_t n = m_impl->sock.send(framed.data(), framed.size(),
+    ssize_t n = m_impl->sock.send(wire.data(), wire.size(),
                                   m_impl->peer);
-    if (n != static_cast<ssize_t>(framed.size())) {
+    if (n != static_cast<ssize_t>(wire.size())) {
         ACE_ERROR((LM_WARNING,
                    ACE_TEXT("%D [wifi:%t] %M %N:%l send('%C') n=%d errno=%d\n"),
                    cmd.c_str(), static_cast<int>(n), errno));

--- a/modules/wan/wifi/client/src/supervisor.cpp
+++ b/modules/wan/wifi/client/src/supervisor.cpp
@@ -196,7 +196,11 @@ bool wpa_ctrl_socket_is_live(const std::string& server_path) {
 
     bool live = false;
     ACE_UNIX_Addr peer(server_path.c_str());
-    static const char kPing[] = "PING\n";
+    // No trailing newline — wpa matches "PING" with exact os_strcmp; a
+    // "PING\n" comes back "UNKNOWN COMMAND", which would make a LIVE wpa
+    // look dead and get its socket wrongly reclaimed. Same wire rule as
+    // ctrl::Client::request().
+    static const char kPing[] = "PING";
     ssize_t sent = sock.send(kPing, sizeof(kPing) - 1, peer);
     if (sent == static_cast<ssize_t>(sizeof(kPing) - 1)) {
         char buf[64];

--- a/modules/wan/wifi/client/test/ctrl_test.cpp
+++ b/modules/wan/wifi/client/test/ctrl_test.cpp
@@ -21,9 +21,16 @@
 #include <fstream>
 #include <sstream>
 #include <string>
+#include <thread>
+
+#include <cstring>
+#include <sys/socket.h>
+#include <sys/un.h>
+#include <unistd.h>
 
 #include "ctrl.hpp"
 
+using wifi_client::ctrl::Client;
 using wifi_client::ctrl::CtrlEvent;
 using wifi_client::ctrl::Parser;
 
@@ -214,4 +221,51 @@ TEST(WIFI_NFR_WIFI_005_parser_bounded_per_line,
     auto ev = Parser::classify(huge);
     EXPECT_EQ(CtrlEvent::Kind::Unknown, ev.kind);
     EXPECT_GT(ev.raw.size(), 1000u);  // priority stripped, body kept
+}
+
+// ─────────────────────────── REQ-WIFI-010 ───────────────────────────
+// Wire-level: connect() must put "ATTACH" on the socket with NO trailing
+// terminator. Real wpa_supplicant matches control verbs with an exact
+// os_strcmp(), so a trailing '\n' comes back "UNKNOWN COMMAND" and the
+// daemon never attaches (the bug that wedged WiFi on hardware; the
+// line-based smoke fake rstrip'd the newline so it never surfaced there).
+
+TEST(WIFI_REQ_WIFI_010_ctrl_attach_wire,
+     attach_sent_without_trailing_newline) {
+    char dir[] = "/tmp/wpa_ctrl_wire_XXXXXX";
+    ASSERT_NE(nullptr, ::mkdtemp(dir));
+    const std::string srv_path = std::string(dir) + "/wlan0";
+
+    int srv = ::socket(AF_UNIX, SOCK_DGRAM, 0);
+    ASSERT_GE(srv, 0);
+    sockaddr_un addr{};
+    addr.sun_family = AF_UNIX;
+    ::strncpy(addr.sun_path, srv_path.c_str(), sizeof(addr.sun_path) - 1);
+    ASSERT_EQ(0, ::bind(srv, reinterpret_cast<sockaddr*>(&addr), sizeof(addr)));
+
+    // Fake wpa: recv the ATTACH datagram verbatim, reply "OK".
+    std::string got;
+    std::thread wpa([&] {
+        char buf[256];
+        sockaddr_un from{};
+        socklen_t   fl = sizeof(from);
+        ssize_t n = ::recvfrom(srv, buf, sizeof(buf), 0,
+                               reinterpret_cast<sockaddr*>(&from), &fl);
+        if (n > 0) {
+            got.assign(buf, static_cast<std::size_t>(n));
+            ::sendto(srv, "OK\n", 3, 0,
+                     reinterpret_cast<sockaddr*>(&from), fl);
+        }
+    });
+
+    Client c;
+    const bool attached = c.connect(srv_path);
+    wpa.join();
+    ::close(srv);
+    ::unlink(srv_path.c_str());
+    ::rmdir(dir);
+
+    EXPECT_TRUE(attached) << "connect() must accept an OK reply to ATTACH";
+    EXPECT_EQ("ATTACH", got)
+        << "ATTACH must hit the wire with no trailing newline";
 }


### PR DESCRIPTION
## Symptom (RPi3B hardware)

`iot-wifi-client` restart-looped until systemd gave up. Each run:

```
wifi-client[...]: Successfully initialized wpa_supplicant
wifi-client[...]: ctrl.cpp:184 ATTACH failed; reply='UNKNOWN COMMAND'
... CTRL-EVENT-TERMINATING ...
iot-wifi-client.service: Main process exited, code=exited, status=1/FAILURE
```

`wlan0` exists, the `brcmfmac` driver is loaded (`iw dev` shows `phy#0`), and a real `wifi.networks` is set — so this was purely the control-channel `ATTACH` being rejected.

## Root cause

`ctrl::Client::request()` appended `'\n'` to every command before sending. Real `wpa_supplicant` matches control verbs with an **exact** `os_strcmp` (`ATTACH`, `PING`, `SCAN`, `DETACH`, …) and `wpa_ctrl(3)` puts **no terminator on the wire**. So `"ATTACH\n"` never matched and wpa replied `UNKNOWN COMMAND`; `connect()` returned false, `initialize()` reaped wpa, the daemon exited 1, and systemd looped.

Why it hid until hardware: the D8 smoke fake (`log/L15/fake-wpa.py:115`) does `cmd = data.decode(...).rstrip("\r\n")` before matching, so it accepted the malformed frame.

## Fix

- `ctrl.cpp` — send the command **verbatim**, defensively stripping any caller-supplied EOL. No `\n` on the wire.
- `supervisor.cpp` — same latent bug in PR #222's reclaim probe (`wpa_ctrl_socket_is_live` sent `"PING\n"`); against real wpa that would make a **live** wpa look dead and wrongly reclaim its socket. Now `"PING"`.

## Test

- New wire-level regression test `attach_sent_without_trailing_newline` (`ctrl_test.cpp`): stands up a fake `AF_UNIX` DGRAM wpa socket, runs `Client::connect()`, and asserts the bytes received are exactly `"ATTACH"` with **no** terminator — the assertion the line-based smoke fake could not make.
- `fake-wpa.py` `rstrip`s `\r\n`, so the existing D8 smoke path stays green with the newline removed.

## Verification

No host ACE/gtest, so this was not built locally — please run the wifi-client gtest suite + `log/L15/smoke.sh` in the verify container before merge. The change is a one-line wire-protocol correction backed by hardware logs and the new regression test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)