### PR TITLE
fix(net-router,ui): make DNAT target optional + fix unreachable DNAT Target UI tab

### DIFF
--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -101,7 +101,7 @@
 
       <!-- Routing -->
       <ng-container *ngIf="selectedMenu==='routing'">
-        <app-port-forward *ngIf="!selectedSubNav || selectedSubNav==='ports' || selectedSubNav==='dnat'"></app-port-forward>
+        <app-port-forward [view]="selectedSubNav==='dnat' ? 'dnat' : 'ports'" *ngIf="!selectedSubNav || selectedSubNav==='ports' || selectedSubNav==='dnat'"></app-port-forward>
         <app-custom-rules *ngIf="selectedSubNav==='rules'"></app-custom-rules>
       </ng-container>
 

--- a/iot-ui/src/app/routing/port-forward/port-forward.component.ts
+++ b/iot-ui/src/app/routing/port-forward/port-forward.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit, OnDestroy, Input } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { SessionService } from '../../../common/session.service';
 import { PubSubService } from '../../../common/pubsubsvc.service';
@@ -75,7 +75,11 @@ import { DataStoreService } from '../../../common/datastore.service';
   `]
 })
 export class PortForwardComponent implements OnInit, OnDestroy {
-  view = 'ports';  // 'ports' | 'dnat'
+  // Driven by the left-nav sub-item (Port Forward vs DNAT Target). Both
+  // tabs render this same component; the binding flips which view shows.
+  // Without the @Input the DNAT Target tab silently showed the Port Forward
+  // view, leaving net.lwm2m.target.ip unreachable from the UI.
+  @Input() view: 'ports' | 'dnat' = 'ports';
   targetIp = ''; targetPort = 5684; forwardPorts = '80,443,5684';
   savingDnat = false; savingPorts = false;
   routeState = ''; rulesApplied = 0; lastApply = '';

--- a/modules/net/router/schemas/net.lua
+++ b/modules/net/router/schemas/net.lua
@@ -2,7 +2,9 @@
 --
 -- Read keys (operator → daemon):
 --   net.tun.dev               - tun interface to monitor (default "tun0")
---   net.lwm2m.target.ip       - DNAT target (required; lwm2m client IP)
+--   net.lwm2m.target.ip       - DNAT target (optional; lwm2m client IP). When
+--                               unset the router still runs — it just skips the
+--                               port-forward/DNAT rules until a target is given.
 --   net.lwm2m.target.port     - DNAT target port (default 5684)
 --   net.iface.priority        - comma-joined outgoing priority list
 --                               (default "eth,wifi,cellular")

--- a/modules/net/router/src/daemon.cpp
+++ b/modules/net/router/src/daemon.cpp
@@ -109,20 +109,11 @@ Status run_daemon(const std::string& socketPath,
         Status s; s.ok = false; s.code = 1;
         s.err = "data-store connect failed"; return s;
     }
-    if (auto missing = ds.missing_required()) {
-        std::ostringstream joined;
-        for (std::size_t i = 0; i < missing->size(); ++i) {
-            if (i) joined << ", ";
-            joined << (*missing)[i];
-        }
-        ACE_ERROR((LM_ERROR,
-                   ACE_TEXT("%D [netr:%t] %M %N:%l refuse to start; "
-                            "required keys missing: %C\n"),
-                   joined.str().c_str()));
-        Status s; s.ok = false; s.code = 2;
-        s.err = "missing required net.* keys"; return s;
-    }
-
+    // No hard config gate: net-router starts on boot regardless of
+    // net.lwm2m.target.ip. It elects the WAN iface, installs the base
+    // firewall + route metrics, and publishes services.net.router.state=
+    // "running" so dependent services (lwm2m/openvpn) come up. The DNAT
+    // target only governs the optional port-forward rules (see Lifecycle).
     install_signals();
 
     // Build sinks. Shell + apply runners use the popen()-backed

--- a/modules/net/router/src/ds_bridge.cpp
+++ b/modules/net/router/src/ds_bridge.cpp
@@ -201,16 +201,6 @@ std::optional<std::uint32_t> DsBridge::poll_interval_sec() const {
     return m_impl->poll_interval_sec;
 }
 
-std::optional<std::vector<std::string>>
-DsBridge::missing_required() const {
-    if (!m_ok) {
-        return std::vector<std::string>{kLwM2MTargetIp};
-    }
-    std::lock_guard<std::mutex> g(m_impl->mtx);
-    if (m_impl->lwm2m_target_ip.has_value()) return std::nullopt;
-    return std::vector<std::string>{kLwM2MTargetIp};
-}
-
 // ───────────────────────── Write side ──────────────────────────────
 
 void DsBridge::set_state(const std::string& s) {

--- a/modules/net/router/src/ds_bridge.hpp
+++ b/modules/net/router/src/ds_bridge.hpp
@@ -18,7 +18,6 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <vector>
 
 namespace data_store { class Client; }   // forward decl
 
@@ -61,12 +60,6 @@ public:
     std::optional<std::string>   forward_ports()        const;
     std::optional<std::string>   custom_rules()         const;
     std::optional<std::uint32_t> poll_interval_sec()    const;
-
-    /// Returns nullopt if net.lwm2m.target_ip is present; otherwise
-    /// returns the one-element list {"net.lwm2m.target_ip"} so the
-    /// caller's missing-required diagnostic is uniform with the
-    /// other DsBridges.
-    std::optional<std::vector<std::string>> missing_required() const;
 
     // ─────────── Write side ───────────
     void set_state(const std::string& s);

--- a/modules/net/router/src/lifecycle.cpp
+++ b/modules/net/router/src/lifecycle.cpp
@@ -19,13 +19,16 @@ void Lifecycle::transition(State next) {
 }
 
 Lifecycle::State Lifecycle::step(const Inputs& in) {
-    // 1) Required-config gate.
-    if (in.lwm2m_target_ip.empty()) {
-        transition(State::NeedConfig);
-        return m_state;
-    }
+    // net.lwm2m.target.ip is OPTIONAL. It only gates the DNAT/forward
+    // rules — build_nft_ruleset() omits that chain when the target (or
+    // the port list) is empty — NOT whether the router runs. The router's
+    // real job (WAN election, base firewall, route metrics) proceeds with
+    // or without a DNAT target, so an unprovisioned device still gets an
+    // uplink and dependent services (lwm2m/openvpn) come up instead of
+    // being wedged behind a config key. State now tracks the WAN uplink:
+    // NeedConfig means "no usable WAN yet", Steady means "uplink up".
 
-    // 2) Build the ruleset. Re-apply only when text actually changed —
+    // 1) Build the ruleset. Re-apply only when text actually changed —
     //    nft -f is idempotent but a no-op apply still incurs the
     //    parser + transaction cost.
     nft::State ns;
@@ -52,14 +55,14 @@ Lifecycle::State Lifecycle::step(const Inputs& in) {
         }
     }
 
-    // 3) Route metrics. Always run — apply_priorities is idempotent
+    // 2) Route metrics. Always run — apply_priorities is idempotent
     //    per-iface (ip route replace is a no-op when target == current).
     bool route_ok = true;
     if (m_sinks.apply_routes) {
         route_ok = m_sinks.apply_routes(in.ifaces_in_priority_order);
     }
 
-    // 4) Emit net.iface.active if the pick changed (empty string when
+    // 3) Emit net.iface.active if the pick changed (empty string when
     //    nothing is up — operator-visible signal that we're offline).
     std::string new_active;
     if (auto idx = iface::pick_active(in.ifaces_in_priority_order)) {
@@ -70,7 +73,13 @@ Lifecycle::State Lifecycle::step(const Inputs& in) {
         if (m_sinks.set_iface_active) m_sinks.set_iface_active(new_active);
     }
 
-    transition((nft_ok && route_ok) ? State::Steady : State::Failed);
+    // 4) State: apply failure dominates; otherwise track the WAN uplink —
+    //    NeedConfig while no iface is usable (waiting for an uplink),
+    //    Steady once one is up.
+    State next = (!nft_ok || !route_ok) ? State::Failed
+               : new_active.empty()     ? State::NeedConfig
+               :                          State::Steady;
+    transition(next);
     return m_state;
 }
 

--- a/modules/net/router/test/ds_bridge_test.cpp
+++ b/modules/net/router/test/ds_bridge_test.cpp
@@ -27,14 +27,6 @@ TEST(DsBridge, AccessorsReturnNulloptWhenDisconnected) {
     EXPECT_FALSE(ds.custom_rules().has_value());
 }
 
-TEST(DsBridge, MissingRequiredReportsTargetIpWhenDisconnected) {
-    DsBridge ds(kBogus);
-    auto missing = ds.missing_required();
-    ASSERT_TRUE(missing.has_value());
-    ASSERT_EQ(1u, missing->size());
-    EXPECT_EQ("net.lwm2m.target.ip", (*missing)[0]);
-}
-
 TEST(DsBridge, SettersAreNoopWhenDisconnected) {
     DsBridge ds(kBogus);
     ds.set_state("monitoring");

--- a/modules/net/router/test/lifecycle_test.cpp
+++ b/modules/net/router/test/lifecycle_test.cpp
@@ -72,7 +72,10 @@ Lifecycle::Inputs configured(std::vector<State> ifaces = {up("eth0")}) {
 
 /* ─────────────── Init / NeedConfig ─────────────── */
 
-TEST(Lifecycle, EmptyTargetIpYieldsNeedConfigAndNoApplyAttempt) {
+TEST(Lifecycle, EmptyTargetIpStillRunsWithBaseRulesetAndNoDnat) {
+    // net.lwm2m.target.ip is optional now: with a usable WAN iface the
+    // router reaches Steady, installs the base ruleset (NO DNAT chain),
+    // applies routes, and elects the uplink — it no longer parks.
     Capture cap;
     Lifecycle lc(cap.make_sinks());
 
@@ -80,12 +83,35 @@ TEST(Lifecycle, EmptyTargetIpYieldsNeedConfigAndNoApplyAttempt) {
     in.tun_dev = "tun0";   // target_ip deliberately empty
     in.ifaces_in_priority_order = {up("eth0")};
 
+    EXPECT_EQ(Lifecycle::State::Steady, lc.step(in));
+    ASSERT_EQ(1u, cap.nft_rulesets.size());
+    EXPECT_EQ(1u, cap.route_calls.size());
+
+    // Base ruleset is present, but with no target there is no DNAT rule.
+    const auto& rs = cap.nft_rulesets[0];
+    EXPECT_NE(std::string::npos, rs.find("flush table inet iot_router"));
+    EXPECT_EQ(std::string::npos, rs.find("dnat to "));
+
+    ASSERT_EQ(1u, cap.iface_writes.size());
+    EXPECT_EQ("eth0", cap.iface_writes[0]);
+    ASSERT_EQ(1u, cap.state_writes.size());
+    EXPECT_EQ("steady", cap.state_writes[0]);
+}
+
+TEST(Lifecycle, NoUsableWanYieldsNeedConfig) {
+    // No iface up → no uplink to elect. The router still applies the base
+    // ruleset but reports need-config (waiting for WAN). The active iface
+    // stays empty (== its initial value) so nothing is published.
+    Capture cap;
+    Lifecycle lc(cap.make_sinks());
+
+    Lifecycle::Inputs in = configured();             // target set…
+    in.ifaces_in_priority_order = {down("eth0")};    // …but nothing is up
+
     EXPECT_EQ(Lifecycle::State::NeedConfig, lc.step(in));
-    EXPECT_TRUE(cap.nft_rulesets.empty());
-    EXPECT_TRUE(cap.route_calls.empty());
-    // Init → NeedConfig emits a state write.
     ASSERT_EQ(1u, cap.state_writes.size());
     EXPECT_EQ("need-config", cap.state_writes[0]);
+    EXPECT_TRUE(cap.iface_writes.empty());           // stays "" → no change
 }
 
 /* ─────────────── First successful apply ─────────────── */


### PR DESCRIPTION
Two related fixes so a freshly-provisioned device comes up on WiFi alone — no manual DNAT target needed — and so that target can actually be set in the UI.

## Background
On an RPi device that is itself the LwM2M client, `net-router` **refused to start** until `net.lwm2m.target.ip` was set, then exited. Because `lwm2m-client` and `openvpn-client` depend on net.router (DepWatch), they parked forever (`disabled`/`stopped`) — even with WiFi up and an IP. And the operator *couldn't* set the target IP from the UI because the **DNAT Target tab was broken** (showed the Port Forward view).

## net-router — `net.lwm2m.target.ip` is now optional
- **Drop the startup refuse-to-start gate** (`daemon.cpp`): net-router boots regardless and publishes `services.net.router.state="running"`, so dependent services unpark.
- **Lifecycle no longer early-returns `NeedConfig` when the target is empty** (`lifecycle.cpp`). It always elects the WAN iface, installs the base firewall, and applies route metrics. `build_nft_ruleset()` already omits the DNAT chain when target/ports are empty. State now tracks the **uplink**: `NeedConfig` while no iface is usable (waiting for WAN), `Steady` once one is up — i.e. "router checks for WAN, comes up, and dependents start."
- Remove the now-unused `DsBridge::missing_required()` + its test; update the `net.lua` schema comment (required → optional).

## device-ui — DNAT Target tab was unreachable
`port-forward.component` serves both the **Port Forward** and **DNAT Target** left-nav items, switching on a `view` flag — but the flag was hardcoded to `'ports'` and `main.component` never bound it. So clicking **DNAT Target** silently re-showed the Port Forward view, and `net.lwm2m.target.ip` could not be set from the UI at all. Fix: make `view` an `@Input` and bind `[view]="selectedSubNav==='dnat' ? 'dnat' : 'ports'"`.

## Verification
The lifecycle redesign was compiled and run against the **real** `lifecycle.cpp` + `nft_rules.cpp` + `iface_monitor.cpp` via a standalone harness:
- empty-target + WAN up → `steady`, base ruleset, **no** DNAT, iface elected;
- no WAN → `need-config`, no iface write;
- target set + WAN up → `steady`, DNAT present.

Unit tests updated to match (`lifecycle_test.cpp`: rewrote the empty-target case + added a no-WAN case; `ds_bridge_test.cpp`: removed the obsolete missing_required test). Full ACE/gtest suite should still run in CI/container.

## Note / follow-up
This removes the footgun for device-as-client. In a true gateway topology you still set a DNAT target (now via the fixed DNAT Target tab) to forward inbound LwM2M to a downstream device. Strict "lwm2m waits for WAN-up" gating (mirroring openvpn-client's `net.iface.active` gate) is a possible later refinement in lwm2m-client; today it unparks when net-router runs and retries until connectivity exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)