### PR TITLE
fix(lwm2m): auto-fill RPi serial before the provisioning park

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1318,6 +1318,26 @@ int main(std::int32_t argc, char *argv[]) {
     dtls_set_log_sink(&iot_dtls_log_sink);   // DTLS (tinydtls) logs → UI
     if (auto* cli = ds.client()) { g_log.apply_level(*cli); g_log.open(*cli, 5, 1); }
 
+    // RPi serial auto-fill — MUST run BEFORE the provisioning park below.
+    // The serial IS the endpoint + BS PSK identity, and the operator reads
+    // it off the device-ui to generate the BS PSK and commission the device.
+    // If this waited until after the park (which blocks on iot.bs.uri + the
+    // BS PSK), iot.serial would still be empty exactly when the operator is
+    // trying to read it — which is why the field showed blank and had to be
+    // typed by hand. Resolve + persist it up front so it is live immediately.
+    const bool rpi = iot::is_rpi();
+    iot::EndpointResolution epres = iot::resolve_endpoint(
+        argValueMap["ep"], ds.serial(), rpi,
+        rpi ? iot::read_rpi_serial() : std::string());
+    if (!epres.serial_to_write.empty()) {
+        if (ds.set_serial(epres.serial_to_write)) {
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l RPi serial auto-filled "
+                                "to data-store: %C\n"),
+                       epres.serial_to_write.c_str()));
+        }
+    }
+
     // Bootstrap URI + BS PSK (client only): ds-driven from iot.bs.uri /
     // iot.bs.psk.* (commissioned via device-ui), with bs=/identity=/secret=
     // CLI fallback. PARK here until commissioned rather than exiting — an
@@ -1347,19 +1367,6 @@ int main(std::int32_t argc, char *argv[]) {
         }
         UDPAdapter::Scheme_t bsScheme;
         parsePeerOption(bsUri, bsScheme, bsHost, bsPort);
-    }
-
-    const bool rpi = iot::is_rpi();
-    iot::EndpointResolution epres = iot::resolve_endpoint(
-        argValueMap["ep"], ds.serial(), rpi,
-        rpi ? iot::read_rpi_serial() : std::string());
-    if (!epres.serial_to_write.empty()) {
-        if (ds.set_serial(epres.serial_to_write)) {
-            ACE_DEBUG((LM_INFO,
-                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l RPi serial auto-filled "
-                                "to data-store: %C\n"),
-                       epres.serial_to_write.c_str()));
-        }
     }
 
     // Endpoint (CLI ep= / data-store serial / RPi auto-detect). Declared here


### PR DESCRIPTION
## Symptom
On a fresh RPi the device-ui **Serial Number** field showed blank, forcing manual entry — even though it's labelled "Auto-detected (Raspberry Pi)".

## Cause
In `apps/src/main.cpp`, the RPi serial auto-fill (`resolve_endpoint` → `ds.set_serial`) ran **just after** the client's *provisioning park* — the `for(;;)` loop that blocks until `iot.bs.uri` + the BS PSK are present.

But the serial **is** the endpoint and the BS PSK identity, so the operator must read it from the device-ui **first** to generate the BS PSK and commission the device. While parked, `iot.serial` was never written → the field was empty exactly when it was needed → manual entry.

(The net.router dependency park is later still, so it isn't the blocker here; the provisioning park is.)

## Fix
Move the serial resolve + persist **above** the provisioning park (right after the data-store / log wiring). On an RPi, `iot.serial` is now written at startup before any park, so the device-ui shows it immediately and the operator can copy it into the cloud-ui provisioning page.

## Notes
- **No change to the value.** `resolve_endpoint()` is unchanged and still treats an already-set `iot.serial` as authoritative — a manually-entered or previously auto-filled serial is never overwritten (only a fresh/empty device gets auto-filled).
- The auto-filled value is the **canonical raw device serial** from device-tree `serial-number` / `/proc/cpuinfo` `Serial` (`read_rpi_serial`), which is what must match on the cloud side — distinct from the `iot-<serial>` hostname. The operator copies whatever the field shows into the cloud, so both sides stay consistent.
- Pure statement reorder within the same scope; `resolve_endpoint` logic is covered by existing `provisioning_policy` unit tests. Not built locally (no host ACE/gtest) — wants a container/CI build before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)