### PR TITLE
fix(ui): WiFi config page breaks when a network is saved (ngModel-in-formGroup)

### DIFF
--- a/apps/cloud/ui/src/app/wan/wifi-config/wifi-config.component.html
+++ b/apps/cloud/ui/src/app/wan/wifi-config/wifi-config.component.html
@@ -46,10 +46,10 @@
       <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
 
       <clr-dg-row *clrDgItems="let n of networks; let i=index">
-        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" [(ngModel)]="n.ssid" [name]="'ssid-'+i" placeholder="MyWiFi" /></clr-dg-cell>
-        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="password" [(ngModel)]="n.psk" [name]="'psk-'+i" placeholder="passphrase" /></clr-dg-cell>
-        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="number" [(ngModel)]="n.priority" [name]="'pri-'+i" style="width:80px;" /></clr-dg-cell>
-        <clr-dg-cell><select class="clr-select" [disabled]="!isAdmin" [(ngModel)]="n.key_mgmt" [name]="'km-'+i">
+        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" [(ngModel)]="n.ssid" [ngModelOptions]="{standalone: true}" [name]="'ssid-'+i" placeholder="MyWiFi" /></clr-dg-cell>
+        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="password" [(ngModel)]="n.psk" [ngModelOptions]="{standalone: true}" [name]="'psk-'+i" placeholder="passphrase" /></clr-dg-cell>
+        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="number" [(ngModel)]="n.priority" [ngModelOptions]="{standalone: true}" [name]="'pri-'+i" style="width:80px;" /></clr-dg-cell>
+        <clr-dg-cell><select class="clr-select" [disabled]="!isAdmin" [(ngModel)]="n.key_mgmt" [ngModelOptions]="{standalone: true}" [name]="'km-'+i">
           <option value="WPA2-PSK">WPA2-PSK</option><option value="WPA-PSK">WPA-PSK</option><option value="NONE">Open</option>
         </select></clr-dg-cell>
         <clr-dg-cell *ngIf="isAdmin"><button type="button" class="btn btn-sm btn-danger" (click)="removeNetwork(i)">Remove</button></clr-dg-cell>

--- a/iot-ui/src/app/wan/wifi-config/wifi-config.component.html
+++ b/iot-ui/src/app/wan/wifi-config/wifi-config.component.html
@@ -46,10 +46,10 @@
       <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
 
       <clr-dg-row *clrDgItems="let n of networks; let i=index">
-        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" [(ngModel)]="n.ssid" [name]="'ssid-'+i" placeholder="MyWiFi" /></clr-dg-cell>
-        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="password" [(ngModel)]="n.psk" [name]="'psk-'+i" placeholder="passphrase" /></clr-dg-cell>
-        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="number" [(ngModel)]="n.priority" [name]="'pri-'+i" style="width:80px;" /></clr-dg-cell>
-        <clr-dg-cell><select class="clr-select" [disabled]="!isAdmin" [(ngModel)]="n.key_mgmt" [name]="'km-'+i">
+        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" [(ngModel)]="n.ssid" [ngModelOptions]="{standalone: true}" [name]="'ssid-'+i" placeholder="MyWiFi" /></clr-dg-cell>
+        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="password" [(ngModel)]="n.psk" [ngModelOptions]="{standalone: true}" [name]="'psk-'+i" placeholder="passphrase" /></clr-dg-cell>
+        <clr-dg-cell><input class="clr-input" [disabled]="!isAdmin" type="number" [(ngModel)]="n.priority" [ngModelOptions]="{standalone: true}" [name]="'pri-'+i" style="width:80px;" /></clr-dg-cell>
+        <clr-dg-cell><select class="clr-select" [disabled]="!isAdmin" [(ngModel)]="n.key_mgmt" [ngModelOptions]="{standalone: true}" [name]="'km-'+i">
           <option value="WPA2-PSK">WPA2-PSK</option><option value="WPA-PSK">WPA-PSK</option><option value="NONE">Open</option>
         </select></clr-dg-cell>
         <clr-dg-cell *ngIf="isAdmin"><button type="button" class="btn btn-sm btn-danger" (click)="removeNetwork(i)">Remove</button></clr-dg-cell>


### PR DESCRIPTION
## Symptom
The **WiFi Configuration** page rendered broken — the **Saved Networks** datagrid was missing, the **Save** button had no label, and the layout was half-painted — **but only on a device that already has a saved network**. With zero networks the page looked fine, which is why it wasn't caught.

## Cause
The Saved Networks datagrid rows bind each cell with `[(ngModel)]` (ssid/psk/priority/key_mgmt), but the whole form is a **reactive** form (`<form [formGroup]="form">`). A template-driven `ngModel` inside a `formGroup` **without** `[ngModelOptions]="{standalone: true}"` throws Angular's **NG01352** — *"ngModel cannot be used to register form controls with a parent formGroup directive"* — the moment a row is instantiated. That thrown error breaks change detection for the datagrid and everything after it (the Save button), so the page only half-renders.

A device with a configured network (e.g. `cordoba_2G`) hits this immediately; an empty list renders no rows → no `ngModel` → no error.

These row controls are intentionally **not** part of the reactive form — the form carries `networks_json`, serialized from the `networks` array on save — so `standalone` is the correct contract.

## Fix
Add `[ngModelOptions]="{standalone: true}"` to all four row controls. Applied to **both** the device UI (`iot-ui`) and the duplicated cloud UI copy (`apps/cloud/ui`).

## Verification
Production build is clean — `podman run --rm node:18 ng build --configuration production` succeeds with only pre-existing benign warnings (CommonJS `@clr/icons`, bundle-budget +32 KB). Clarity CSS is bundled in `styles.css` as expected; the issue was never CSS/serving.

🤖 Generated with [Claude Code](https://claude.com/claude-code)