### PR TITLE
fix(device): create /etc/iot/vpn for bootstrap certs + let openvpn read them

### DIFF
--- a/apps/src/lwm2m_object_cert.cpp
+++ b/apps/src/lwm2m_object_cert.cpp
@@ -49,7 +49,10 @@ const char* default_filename(const std::string& type) {
 }
 
 /// Default store_artifact: atomically write <certDir>/<file> (temp + rename),
-/// 0600 for the private key, 0644 otherwise.
+/// 0640 for the private key, 0644 otherwise. The key is group-readable (not
+/// 0600) so openvpn-client — a separate DynamicUser sharing group `iot` via the
+/// 2750 engineer:iot certDir — can read it; the writer (lwm2m client, `engineer`)
+/// owns it. World still has no access to the key.
 int default_store(const std::string& certDir,
                   const std::string& type,
                   const std::string& pem) {
@@ -63,7 +66,7 @@ int default_store(const std::string& certDir,
     if (!dir.empty() && dir.back() != '/') dir.push_back('/');
     const std::string path = dir + file;
     const std::string tmp  = path + ".tmp";
-    const mode_t mode = (type == "key") ? 0600 : 0644;
+    const mode_t mode = (type == "key") ? 0640 : 0644;
 
     int fd = ::open(tmp.c_str(), O_WRONLY | O_CREAT | O_TRUNC, mode);
     if (fd < 0) {

--- a/packaging/systemd/iot-openvpn-client.service
+++ b/packaging/systemd/iot-openvpn-client.service
@@ -22,6 +22,10 @@ DynamicUser=yes
 AmbientCapabilities=CAP_NET_ADMIN
 CapabilityBoundingSet=CAP_NET_ADMIN
 DeviceAllow=/dev/net/tun rw
+# Join the `iot` group so the DynamicUser can read the VPN credentials the
+# lwm2m client (engineer) drops in /etc/iot/vpn (2750 engineer:iot, key 0640).
+# ca.crt/client.crt/client.key are vpn.{ca,cert,key}.path.
+SupplementaryGroups=iot
 
 # Same RuntimeDirectory=iot as iot-ds.service so the daemon sees
 # the same /run/iot/data_store.sock socket file.

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
@@ -26,3 +26,10 @@ d      /run/iot/update     0775 root iot  -   -
 # wpa_supplicant fails to create its ctrl socket and never associates. Create it
 # here (2775 root:iot) so the iot-group DynamicUser can drop the socket.
 d      /run/wpa_supplicant 2775 root iot  -   -
+# VPN credential dir. The lwm2m client (runs as `engineer`) writes the
+# bootstrap-delivered CA + client cert/key here via LwM2M Object 2048; without
+# this dir the write fails ENOENT and the device never gets VPN certs. The
+# openvpn-client (DynamicUser + SupplementaryGroups=iot) reads them. 2750
+# engineer:iot — engineer owns + writes, setgid so files inherit group iot, and
+# group r-x lets openvpn traverse + read (the key is written group-readable).
+d      /etc/iot/vpn        2750 engineer iot - -


### PR DESCRIPTION
## Symptom (RPi, from the device journal)
LwM2M bootstrap **works** — DTLS handshakes, and the device receives the VPN credential family over Object 2048 (`reassembled ca (1870 bytes)`, `cert (1428)`, `key (1704)`). It fails at the final persist step:

```
[cert-obj] lwm2m_object_cert.cpp:70 open(/etc/iot/vpn/ca.crt.tmp) failed errno=2   # ENOENT
```

## Cause
`/etc/iot/vpn` doesn't exist on the **device** image — only the cloud image's Dockerfile creates it. The lwm2m client runs as the unprivileged `engineer` account and can't `mkdir` under root-owned `/etc/iot`. So the bootstrap certs are never stored → `openvpn-client` has nothing to load → VPN (and the rest of the DM chain) never come up, and the device shows `LwM2M idle` / `OpenVPN stopped`.

## Fix (engineer → openvpn cert handoff, end to end)
1. **tmpfiles** (`iot.conf`): create `/etc/iot/vpn` as **`2750 engineer:iot`** — engineer owns + writes; setgid so written files inherit group `iot`; group `r-x` so openvpn can traverse + read. Paths match the `vpn.{ca,cert,key}.path` defaults (`/etc/iot/vpn/{ca.crt,client.crt,client.key}`).
2. **cert writer** (`lwm2m_object_cert.cpp`): write the private key **`0640`** (was `0600`) so the `iot` group — i.e. openvpn — can read it. Owner stays `engineer`; still no world access.
3. **`iot-openvpn-client.service`**: add **`SupplementaryGroups=iot`** so the DynamicUser is in group `iot` and can read the group-readable certs. (`iot-ds.service` already uses the same `DynamicUser` + `SupplementaryGroups=iot` combo, so it's a proven pattern.)

## Expected result after reflash
Bootstrap's cert writes succeed → cert family stored under `/etc/iot/vpn` → openvpn-client reads ca/cert/key → tunnel comes up → LwM2M registration completes (`LwM2M idle` → registered, `OpenVPN running`).

## Verification
Image/permission change — not unit-testable here; no cert-mode test exists to update. The cpp change is a one-bit mode constant. Wants a verify-container/CI build + an on-device reflash to confirm the full DM/VPN chain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)