### PR TITLE
docs: optional net-router DNAT, zero-touch VPN certs, serial autofill

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -395,10 +395,13 @@ bound iface in `vpn.bound.iface`. See
 § "WAN gate" for the state machine.
 
 For the **net-router** unit (L13: nftables DNAT + iface priority),
-seed the only required key and enable:
+just enable it — **`net.lwm2m.target.ip` is optional**:
 
 ```sh
-ds-cli --socket=/run/iot/data_store.sock set net.lwm2m.target.ip '"192.168.10.5"'
+# Optional: a DNAT target only matters for a GATEWAY that forwards inbound
+# LwM2M to a DOWNSTREAM device. A device that is its OWN LwM2M client needs
+# none — leave it unset and net-router still runs.
+ds-cli --socket=/run/iot/data_store.sock set net.lwm2m.target.ip '"192.168.10.5"'  # gateway topology only
 # Optional: rename per-class iface keys to match your host
 ds-cli --socket=/run/iot/data_store.sock set net.iface.eth.name      '"eth0"'
 ds-cli --socket=/run/iot/data_store.sock set net.iface.wifi.name     '"wlan0"'
@@ -408,12 +411,21 @@ sudo systemctl enable --now iot-net-router.service
 journalctl -u iot-net-router.service -f | grep "ruleset applied\|metric\|active"
 ```
 
-The unit ships with `AmbientCapabilities=CAP_NET_ADMIN`; that's
-enough for `nft -f` and `ip route replace` under DynamicUser. Default
-forwarded ports are `80,443,5684` (HTTP/HTTPS + LwM2M/CoAP-over-DTLS)
-DNAT'd to `net.lwm2m.target.ip`. Override via `net.forward.ports`
-and add operator drops/forwards via the JSON `net.custom.rules`
-schema key (see `/etc/iot/ds-schemas/net.lua`).
+net-router starts on boot regardless of config: it elects the
+highest-priority OPER-up WAN iface (publishes `net.iface.active`),
+installs the base firewall + route metrics, and publishes
+`services.net.router.state="running"` so dependent services
+(`openvpn-client`, `lwm2m-client`) unpark. Its lifecycle state
+(`net.state`) tracks the uplink — `need-config` while no usable WAN
+iface is present, `steady` once one is up. The DNAT/port-forward rules
+are installed **only** when `net.lwm2m.target.ip` is set (default
+forwarded ports `80,443,5684`, HTTP/HTTPS + LwM2M/CoAP-over-DTLS,
+overridable via `net.forward.ports`); set them in the device-UI under
+**Routing → DNAT Target / Port Forward**, or via the keys directly. Add
+operator drops/forwards via the JSON `net.custom.rules` schema key (see
+`/etc/iot/ds-schemas/net.lua`). The unit ships with
+`AmbientCapabilities=CAP_NET_ADMIN` — enough for `nft -f` and
+`ip route replace` under DynamicUser.
 
 For the **wifi-client** unit (L15: wpa_supplicant + DHCP-client
 supervisor; publishes `wifi.*`), seed the network list and enable.
@@ -433,15 +445,23 @@ refuses to spawn wpa_supplicant if NM is active.
 >
 > **As of the zero-touch image, `lwm2m-client`, `openvpn-client` and
 > `net-router` are also auto-enabled** (`SYSTEMD_AUTO_ENABLE=enable`),
-> so the full DM/VPN chain comes up on first boot with no SSH. Each
-> daemon self-gates on its `services.<name>.enable` data-store key and
-> parks until provisioned, so the device-UI **Services** page can
-> pause/resume them without touching systemd. Until certs
-> (`/etc/iot/vpn/*`), the DM PSK and `vpn.remote.port`/`proto` are
-> provisioned, `openvpn-client`/`lwm2m-client` will `Restart=on-failure`
-> loop — expected on an un-provisioned boot. The `systemctl enable`
-> commands below remain required only on bare-metal hosts where the
-> units ship disabled.
+> so the full DM/VPN chain comes up on first boot with no SSH.
+> `net-router` runs immediately (no `net.lwm2m.target.ip` needed) and
+> publishes the WAN iface; `lwm2m-client` and `openvpn-client` unpark
+> once it is `running`. The operator's only step is **commissioning the
+> LwM2M bootstrap** (device-UI **LwM2M → Security**: set the Bootstrap
+> Server URI + **Generate BS PSK**, then paste the serial + key into the
+> cloud-UI Endpoints page). After that the VPN credentials (CA + client
+> cert/key) are **delivered automatically over LwM2M bootstrap**
+> (Object 2048) and persisted to `/etc/iot/vpn/` — the image creates
+> that dir (`2750 engineer:iot`, via tmpfiles) so the `engineer`-run
+> lwm2m client can write it and the `openvpn-client` DynamicUser
+> (SupplementaryGroups=iot) can read it; no manual cert placement. Until
+> the bootstrap PSK is commissioned, `lwm2m-client` parks in its
+> provisioning wait-loop (shows `services.lwm2m.client.state="stopped"`
+> with no CPU/FD stats — it is alive, just pre-ServiceGate) and
+> `openvpn-client` stays down. The `systemctl enable` commands below
+> remain required only on bare-metal hosts where the units ship disabled.
 >
 > **Troubleshooting (older images / regressions).** If the stack is dead
 > on boot, check these three invariants (all fixed in PR #212):

--- a/apps/docs/tdd-psk-provisioning.md
+++ b/apps/docs/tdd-psk-provisioning.md
@@ -51,9 +51,15 @@ Move DTLS PSK credentials and the LwM2M endpoint out of CLI args / Lua
 config and into the data-store, with the following behaviour:
 
 1. On a Raspberry Pi, the lwm2m client reads the hardware serial number at
-   startup and writes it to the serial/endpoint key (auto-fill). On non-RPi
-   the client leaves it empty and the **installer** types it in the device-ui
-   Configuration page. The serial is the LwM2M **endpoint** and the DTLS PSK
+   startup and writes it to the serial/endpoint key (auto-fill). This runs
+   **before the client's provisioning park** (the wait-loop for `iot.bs.uri` +
+   BS PSK): the serial is what the operator reads from the device-ui to
+   generate the BS PSK and commission the device, so it must be live *before*
+   commissioning, not after. On non-RPi the client leaves it empty and the
+   **installer** types it in the device-ui Configuration page. The auto-filled
+   value is the **raw** device serial (`read_rpi_serial`, device-tree/cpuinfo),
+   not the `iot-<serial>` hostname, and `resolve_endpoint` never overwrites an
+   already-set serial. The serial is the LwM2M **endpoint** and the DTLS PSK
    **identity (raw, on the wire)** for the Bootstrap (BS) handshake.
 2. **device-ui** generates a 32-byte BS PSK key, shows it in an input field
    (so the engineer can copy it), and stores it in the data-store

--- a/modules/net/router/docs/design.md
+++ b/modules/net/router/docs/design.md
@@ -60,10 +60,15 @@ An iptables fallback is FUP only if a target without nftables surfaces.
 ## Schema layout
 
 `schemas/net.lua` (installed to `/etc/iot/ds-schemas/net.lua` by D7's
-install rule). 9 read keys + 6 write keys; the only required read
-key is `net.lwm2m.target_ip`. Custom rules ship as a JSON-encoded
-string in `net.custom.rules`; shape is validated at the JSON-parse
-step in the daemon (the schema can't json-parse).
+install rule). 9 read keys + 6 write keys; **all are optional** — the
+daemon starts on boot regardless of config. `net.lwm2m.target.ip` (once
+required) now only gates the optional DNAT/port-forward chain
+(`build_nft_ruleset` omits it when the target/ports are empty); the
+lifecycle reaches `steady` as soon as a WAN iface is up and `need-config`
+while none is, so dependent services (lwm2m/openvpn) come up without it.
+Custom rules ship as a JSON-encoded string in `net.custom.rules`; shape
+is validated at the JSON-parse step in the daemon (the schema can't
+json-parse).
 
 See [L13 plan §2.D1](../../../../log/L13/plan.md) for the full
 key list; the schema file itself is the canonical reference.

--- a/modules/openvpn/client/docs/design.md
+++ b/modules/openvpn/client/docs/design.md
@@ -168,7 +168,13 @@ watching `/etc/iot/vpn`:
    (instances 0/1/2 = ca/cert/key) and EXECUTEs RID 3 (Apply).
 2. On the device, `install_cert` (`apps/src/lwm2m_object_stubs.cpp`)
    materialises `/etc/iot/vpn/{ca.crt,client.crt,client.key}`, then
-   calls its `CertHooks::apply`.
+   calls its `CertHooks::apply`. The image **must** ship `/etc/iot/vpn`
+   (created by tmpfiles, `2750 engineer:iot`) — the lwm2m client runs as
+   `engineer` and can't `mkdir` under root-owned `/etc/iot`, so without
+   it the write fails `ENOENT` and no certs land. The key is written
+   `0640` (group `iot`) so the `openvpn-client` DynamicUser
+   (`SupplementaryGroups=iot`) can read it; `ca.crt`/`client.crt` are
+   `0644`.
 3. The client wiring (`apps/src/main.cpp`) supplies that hook as a
    **ds gate-flip**: it `set`s `services.openvpn.client.enable`
    `false` then `true`. ds watches fire on *change*, so the deliberate


### PR DESCRIPTION
Sync the docs with the device bring-up behavior changes merged this session (#226 net-router optional DNAT + DNAT UI tab, #227 serial autofill ordering, #229 /etc/iot/vpn cert dir + perms).

## Changes
- **DEPLOY.md**
  - net-router section: `net.lwm2m.target.ip` is **optional** (gateway-topology only); net-router starts on boot, elects the WAN iface, and unparks lwm2m/openvpn on its own. State tracks the uplink (`need-config`→`steady`).
  - zero-touch note: VPN certs are **delivered automatically over LwM2M bootstrap (Object 2048)** into `/etc/iot/vpn/` (image-created `2750 engineer:iot`) — no manual cert placement. Documented the `lwm2m-client stopped + no CPU/FD stats = parked pre-ServiceGate` diagnostic.
- **modules/net/router/docs/design.md** — all `net.*` keys optional now; `net.lwm2m.target.ip` only gates the DNAT chain.
- **modules/openvpn/client/docs/design.md** — `/etc/iot/vpn` must ship in the image (engineer can't mkdir under root `/etc/iot`); key `0640` + openvpn `SupplementaryGroups=iot` so the DynamicUser can read engineer-written certs.
- **apps/docs/tdd-psk-provisioning.md** — RPi serial auto-fill runs **before** the provisioning park (so it's live for commissioning); auto-filled value is the raw device serial and never overwrites an existing one.

Docs-only — no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)