### PR TITLE
fix(cloud): deprovision matches endpoint by serial/identity/dm.psk.id (Remove now sticks)

### DIFF
--- a/modules/server/lwm2m/inc/cloud_credentials.hpp
+++ b/modules/server/lwm2m/inc/cloud_credentials.hpp
@@ -45,9 +45,10 @@ std::string upsert_credential(const std::string& array_json,
                               const std::string& bs_psk_hex,
                               const std::string& dm_psk_hex);
 
-/// Remove the record for `serial`. No-op if absent. Returns the updated array.
+/// Remove the record matching `key` against any of its identity forms
+/// (serial / identity / dm.psk.id). No-op if absent. Returns the updated array.
 std::string remove_credential(const std::string& array_json,
-                              const std::string& serial);
+                              const std::string& key);
 
 /// Merge a minted VPN client credential family (PEM) into the record for
 /// `serial`, adding/updating the "vpn.ca.cert" + "vpn.client.cert" +

--- a/modules/server/lwm2m/src/cloud_credentials.cpp
+++ b/modules/server/lwm2m/src/cloud_credentials.cpp
@@ -141,11 +141,21 @@ std::optional<VpnCertFamily> vpn_cert_for(const std::string& array_json,
 }
 
 std::string remove_credential(const std::string& array_json,
-                              const std::string& serial) {
+                              const std::string& key) {
     json arr = parse_array(array_json);
     json out = json::array();
     for (auto& e : arr) {
-        if (e.is_object() && e.value("serial", "") == serial) continue;
+        // Match the endpoint the cloud-ui passes (the "Endpoint" column)
+        // against ANY identity form the record carries — raw serial, the
+        // formatted identity (rpi<serial>@cloud.local), or the DM PSK id —
+        // mirroring the UI's credFor() lookup. Matching only `serial` left an
+        // identity-keyed row behind, which rehydrate_registry() then healed
+        // back into the registry on the next iot-cloudd restart, so Remove
+        // "didn't stick".
+        if (e.is_object() &&
+            (e.value("serial", "")    == key ||
+             e.value("identity", "")  == key ||
+             e.value("dm.psk.id", "") == key)) continue;
         out.push_back(e);
     }
     return out.dump();

--- a/modules/server/lwm2m/test/cloud_credentials_test.cpp
+++ b/modules/server/lwm2m/test/cloud_credentials_test.cpp
@@ -57,6 +57,15 @@ TEST(CloudCredentials, RemoveAbsentIsNoop) {
     EXPECT_EQ(1u, json::parse(out).size());
 }
 
+TEST(CloudCredentials, RemoveMatchesIdentityForm) {
+    // The cloud-ui passes the displayed endpoint, which may be the formatted
+    // DM identity (rpi<serial>@cloud.local) rather than the raw serial. Remove
+    // must still drop the record — else it is healed back on the next restart.
+    auto out = upsert_credential("[]", "SER1", "bbbb", "dddd");
+    out = remove_credential(out, "rpiSER1@cloud.local");
+    EXPECT_EQ(0u, json::parse(out).size());
+}
+
 TEST(CloudCredentials, EmptyStringTreatedAsEmptyArray) {
     auto out = upsert_credential("", "SER1", "bbbb", "dddd");
     EXPECT_EQ(1u, json::parse(out).size());


### PR DESCRIPTION
## Symptom
On the cloud-ui **Endpoints** page, clicking **Remove** reported "deleted successfully" but the endpoint reappeared in the list.

## Root cause
`cloud.deprovision.request` carries the **endpoint name** shown in the table. For a DM-registered device that can be the formatted identity `rpi<serial>@cloud.local`, not the raw serial. But `remove_credential()` (modules/server/lwm2m/src/cloud_credentials.cpp) matched **only** the record's `serial` field:

```cpp
if (e.is_object() && e.value("serial", "") == serial) continue;
```

So an identity-keyed endpoint left its `cloud.endpoint.credentials` row in place. `rehydrate_registry()` (apps/cloud/server/src/main.cpp) then **healed that row back** into the EndpointRegistry on the next `iot-cloudd` restart → the endpoint "came back". (The cloud-ui's own `credFor()` already matches on `serial` *or* `identity` — the removal path just didn't.)

## Fix
Match `key` against any identity form the record carries — `serial`, `identity`, or `dm.psk.id` — mirroring `credFor()`. Now Remove clears the credential regardless of which form the operator sees, so the heal can't resurrect it.

## Tests
- New `RemoveMatchesIdentityForm` regression test (removes by `rpi<serial>@cloud.local`).
- Matching logic verified standalone against the nlohmann/json header (remove-by-serial / -identity / -dm.psk.id all match; absent is a no-op). Full cloud gtest suite should run in the container.

## Not in scope (by request)
The "device shows **online** when it's actually offline" behaviour (LwM2M registration stays alive until `cloud.dm.lifetime`, default 24h) is left **as-is** per the maintainer — current semantics retained.

🤖 Generated with [Claude Code](https://claude.com/claude-code)