### PR TITLE
feat(cloud): Endpoints table — Next Heart Beat in (HH:MM:SS) + Location columns

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -114,6 +114,8 @@ void sync_endpoints_to_ds(data_store::Client& ds,
         item["registered"]    = ep.registered;
         item["last_seen_unix"] = ep.last_seen_unix;
         item["installed_version"] = ep.installed_version;  // device /3/0/3
+        item["lifetime"]      = ep.lifetime;     // heartbeat interval (s)
+        item["location"]      = ep.location;     // /rd/<id> registration path
         arr.push_back(item);
     }
     ds.set("cloud.endpoints", data_store::Value{arr.dump()});
@@ -180,6 +182,8 @@ bool reconcile_registrations(data_store::Client& ds,
     const std::string js = ds_str(ds, "cloud.lwm2m.registrations", "[]");
     std::unordered_map<std::string, std::int64_t> online;  // ep → last_seen_unix
     std::unordered_map<std::string, std::string>  versions;  // ep → /3/0/3
+    std::unordered_map<std::string, std::uint32_t> lifetimes; // ep → lifetime(s)
+    std::unordered_map<std::string, std::string>  locations;  // ep → /rd/<id>
     try {
         auto arr = nlohmann::json::parse(js);
         if (arr.is_array()) {
@@ -190,6 +194,10 @@ bool reconcile_registrations(data_store::Client& ds,
                 if (ep.empty()) continue;
                 auto ver = e.value("version", std::string());
                 if (!ver.empty()) versions[ep] = std::move(ver);
+                if (auto lt = e.value("lifetime", std::uint32_t{0}); lt != 0)
+                    lifetimes[ep] = lt;
+                if (auto loc = e.value("location", std::string()); !loc.empty())
+                    locations[ep] = std::move(loc);
                 online[std::move(ep)] = e.value("last_seen_unix",
                                                 std::int64_t{0});
             }
@@ -208,6 +216,14 @@ bool reconcile_registrations(data_store::Client& ds,
         auto vit = versions.find(ep.ep);
         if (vit != versions.end() && reg.update_version(ep.ep, vit->second))
             changed = true;
+        // Heartbeat interval + /rd location (Endpoints table columns).
+        {
+            std::uint32_t lt = 0; std::string loc;
+            if (auto lit = lifetimes.find(ep.ep); lit != lifetimes.end()) lt = lit->second;
+            if (auto qit = locations.find(ep.ep); qit != locations.end()) loc = qit->second;
+            if ((lt != 0 || !loc.empty()) && reg.update_reg_meta(ep.ep, lt, loc))
+                changed = true;
+        }
         auto it = online.find(ep.ep);
         if (it != online.end()) {
             // Online — refresh the registered flag + last-seen timestamp.

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -3,8 +3,10 @@ import { Subscription } from 'rxjs';
 import { HttpsvcService } from '../../common/httpsvc.service';
 import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
+import { DebugService } from '../../common/debug.service';
 
-interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; proxy_port:number; registered:boolean; }
+interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; proxy_port:number; registered:boolean;
+                   last_seen_unix?:number; lifetime?:number; location?:string; }
 
 /** Per-endpoint credential record, as minted by iot-cloudd into the
  *  cloud.endpoint.credentials ds key (JSON array). Field names follow the
@@ -64,6 +66,8 @@ interface EpCred {
         <clr-dg-column>Tunnel IP</clr-dg-column>
         <clr-dg-column>Device Tunnel IP</clr-dg-column>
         <clr-dg-column>Proxy Port</clr-dg-column>
+        <clr-dg-column>Next Heart Beat in</clr-dg-column>
+        <clr-dg-column>Location</clr-dg-column>
         <clr-dg-column>Device UI</clr-dg-column>
         <clr-dg-column *ngIf="isAdmin">Actions</clr-dg-column>
 
@@ -76,6 +80,18 @@ interface EpCred {
           <clr-dg-cell><code>{{ serverTunIp || '—' }}</code></clr-dg-cell>
           <clr-dg-cell><code>{{ e.dev_tun_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
+          <clr-dg-cell>
+            <code>{{ nextHeartbeat(e) }}</code>
+            <!-- Debug mode: reveal the raw ds values the countdown derives from
+                 (cloud.endpoints[].lifetime + .last_seen_unix), mirroring the
+                 *dsDebug hint convention used on the config forms. -->
+            <span *ngIf="debug.on" class="hint">
+              (lt {{ e.lifetime || 0 }}s · seen {{ e.last_seen_unix || 0 }})
+            </span>
+          </clr-dg-cell>
+          <clr-dg-cell>
+            <code>{{ e.location || '—' }}</code>
+          </clr-dg-cell>
           <clr-dg-cell>
             <!-- Launch UI only when the device's VPN tunnel is up (dev_tun_ip).
                  Same-origin path-scoped reverse proxy: iot-httpd proxies
@@ -147,6 +163,10 @@ interface EpCred {
 export class EndpointListComponent implements OnInit, OnDestroy {
   endpoints: EpInfo[] = [];
   creds: EpCred[] = [];
+  // Live wall-clock (unix s), ticked every second so the "Next Heart Beat in"
+  // countdown re-renders without re-fetching the endpoint list.
+  now = Math.floor(Date.now() / 1000);
+  private ticker?: ReturnType<typeof setInterval>;
   windowHost = window.location.hostname;
   // Device UI port reached over the VPN (cloud.proxy.device.ui.port,
   // default 80). Shown in the per-endpoint "VPN forwarding rule" line.
@@ -175,9 +195,29 @@ export class EndpointListComponent implements OnInit, OnDestroy {
     return o.join('.');
   }
 
-  constructor(private http: HttpsvcService, private session: SessionService, private toast: ToastService) {}
+  constructor(private http: HttpsvcService, private session: SessionService,
+              private toast: ToastService, public debug: DebugService) {}
+
+  /** Format a non-negative second count as HH:MM:SS (hours uncapped). */
+  private hhmmss(total: number): string {
+    const s = Math.max(0, Math.floor(total));
+    const h = Math.floor(s / 3600);
+    const m = Math.floor((s % 3600) / 60);
+    const sec = s % 60;
+    const p = (n: number) => String(n).padStart(2, '0');
+    return `${p(h)}:${p(m)}:${p(sec)}`;
+  }
+
+  /** Time until the device's next expected registration refresh, HH:MM:SS:
+   *  (last_seen + lifetime) - now. '—' when we have no lifetime yet;
+   *  '00:00:00' once overdue (the registration has lapsed). */
+  nextHeartbeat(e: EpInfo): string {
+    if (!e.lifetime || !e.last_seen_unix) return '—';
+    return this.hhmmss(e.last_seen_unix + e.lifetime - this.now);
+  }
 
   ngOnInit(): void {
+    this.ticker = setInterval(() => { this.now = Math.floor(Date.now() / 1000); }, 1000);
     this.startLongPoll();
     this.http.dbGet(['cloud.dev.mode', 'cloud.endpoint.credentials',
                      'cloud.proxy.device.ui.port', 'cloud.vpn.subnet']).subscribe({
@@ -257,5 +297,9 @@ export class EndpointListComponent implements OnInit, OnDestroy {
     });
   }
 
-  ngOnDestroy(): void { this.active = false; this.sub.unsubscribe(); }
+  ngOnDestroy(): void {
+    this.active = false;
+    if (this.ticker) clearInterval(this.ticker);
+    this.sub.unsubscribe();
+  }
 }

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -393,7 +393,13 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                     kept[ep] = ls;
                     nlohmann::json row = {{"endpoint", ep},
                                           {"registered", true},
-                                          {"last_seen_unix", ls}};
+                                          {"last_seen_unix", ls},
+                                          // Heartbeat interval (registration
+                                          // lifetime, seconds) + the assigned
+                                          // /rd/<id> location — surfaced in the
+                                          // cloud-UI Endpoints table.
+                                          {"lifetime", kv.second.lifetime},
+                                          {"location", kv.second.location}};
                     // Carry the last-read installed version, if any.
                     {
                         std::lock_guard<std::mutex> lk(*verMtx);

--- a/modules/server/lwm2m/inc/endpoint_registry.hpp
+++ b/modules/server/lwm2m/inc/endpoint_registry.hpp
@@ -28,6 +28,10 @@ struct EndpointInfo {
     std::string installed_version;    // device's running firmware (LwM2M
                                       // /3/0/3 = iot.version), learned from
                                       // lwm2m-dm; empty until first read
+    std::uint32_t lifetime = 0;       // LwM2M registration lifetime (s) = the
+                                      // heartbeat interval; next heartbeat is
+                                      // due by last_seen_unix + lifetime
+    std::string location;             // assigned /rd/<id> registration path
 
     EndpointInfo() = default;
     EndpointInfo(std::string ep_, std::string tun_ip_,
@@ -56,6 +60,12 @@ public:
     /// endpoint is not in the registry.
     bool update_state(const std::string& ep, bool registered,
                       std::int64_t last_seen_unix);
+
+    /// Record the registration heartbeat metadata (lifetime + /rd/<id>
+    /// location) learned from cloud.lwm2m.registrations. Returns true only
+    /// if a value changed; false when the endpoint is absent or unchanged.
+    bool update_reg_meta(const std::string& ep, std::uint32_t lifetime,
+                         const std::string& location);
 
     /// Record the address openvpn actually assigned an endpoint (learned from
     /// the server's management interface). Stored separately from the

--- a/modules/server/lwm2m/src/endpoint_registry.cpp
+++ b/modules/server/lwm2m/src/endpoint_registry.cpp
@@ -72,6 +72,25 @@ bool EndpointRegistry::update_version(const std::string& ep,
     return true;
 }
 
+bool EndpointRegistry::update_reg_meta(const std::string& ep,
+                                       std::uint32_t lifetime,
+                                       const std::string& location) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+
+    auto it = m_by_ep.find(ep);
+    if (it == m_by_ep.end()) return false;                  // unknown endpoint
+    bool changed = false;
+    if (lifetime != 0 && it->second.lifetime != lifetime) {
+        it->second.lifetime = lifetime;
+        changed = true;
+    }
+    if (!location.empty() && it->second.location != location) {
+        it->second.location = location;
+        changed = true;
+    }
+    return changed;
+}
+
 const EndpointInfo* EndpointRegistry::lookup_by_ep(const std::string& ep) const {
     std::lock_guard<std::mutex> lk(m_mutex);
     auto it = m_by_ep.find(ep);


### PR DESCRIPTION
Adds two columns to the cloud-ui **Endpoints** table.

## Columns
- **Next Heart Beat in** — time until the device's next expected registration refresh = `(last_seen_unix + lifetime) - now`, rendered **HH:MM:SS** and ticking down once a second (no re-fetch). Shows `—` until a lifetime is known and `00:00:00` once overdue (registration lapsed).
- **Location** — the LwM2M `/rd/<id>` registration path the DM assigns on Register (per the maintainer's choice over GPS/operator-label).

## Plumbing (end to end)
- **lwm2m-dm** `publish_regs` (`apps/src/main.cpp`) adds `lifetime` + `location` to each `cloud.lwm2m.registrations` row (from `ServerRegistration`).
- **EndpointInfo** gains `lifetime` + `location`; new `EndpointRegistry::update_reg_meta()` sets them. **iot-cloudd** `reconcile_registrations` parses the two fields and applies them; `sync_endpoints_to_ds` emits them into `cloud.endpoints`.
- **cloud-ui** `endpoint-list` renders the two columns; a 1 Hz ticker drives the countdown via a live `now`, cleared in `ngOnDestroy`.

## Debug mode
When the sidebar **Debug** toggle is on, the heartbeat cell reveals the raw ds values it derives from (`lifetime` seconds + `last_seen_unix`), mirroring the `*dsDebug` hint convention used on the config forms.

## Scope / verification
Cloud-only (lwm2m-dm + iot-cloudd + cloud-ui) — **no device reflash**, picked up on the next `apps/cloud` image rebuild. cloud-ui production build is green in podman (node:18); the `EndpointRegistry` change is verified against the real lib via a standalone harness (set/unchanged/lifetime-change/unknown-ep). Full cloud C++ gtest build should run in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)