### PR TITLE
fix(stats): Memory/Threads show 0 on RPi — fall back to /proc/self when cgroup unaccounted

### DIFF
--- a/modules/data-store/src/stats_publisher.cpp
+++ b/modules/data-store/src/stats_publisher.cpp
@@ -354,6 +354,21 @@ StatsSample StatsPublisher::sample() {
     StatsSample s;
     s.mem_rss_kb = stats_detail::read_mem_kb(m_roots, m_cg);
     s.threads    = stats_detail::read_pids(m_roots, m_cg);
+    // Fall back to the daemon's own /proc/self when the cgroup memory/pids
+    // controllers aren't accounted for this unit. cgroups aren't a container
+    // thing — systemd puts every service in its own cgroup on bare metal too —
+    // but CPU is accounted by default while memory+pids often are not, and on
+    // Raspberry Pi the kernel memory cgroup is disabled unless cgroup_enable=
+    // memory is on the boot cmdline. The cgroup figure would also fold in child
+    // procs (e.g. wifi-client's wpa_supplicant), so this self-only number is a
+    // slight under-count — but far better than reporting 0.
+    if (s.mem_rss_kb == 0)
+        s.mem_rss_kb = stats_detail::read_proc_mem_kb(m_roots.proc_self);
+    if (s.threads == 0) {
+        unsigned long long j = 0; std::int32_t th = 0;
+        if (stats_detail::read_proc_stat(m_roots.proc_self, j, th))
+            s.threads = th;
+    }
     s.fd_count   = stats_detail::count_fds(m_roots);
     s.cpu_count  = stats_detail::read_ncpu(m_roots, m_cg);
 

--- a/modules/data-store/test/stats_publisher_test.cpp
+++ b/modules/data-store/test/stats_publisher_test.cpp
@@ -196,6 +196,19 @@ TEST(StatsSample, none_cgroup_all_zero) {
     EXPECT_EQ(s.fd_count, 0);
 }
 
+TEST(StatsSample, cgroup_absent_mem_threads_fall_back_to_proc_self) {
+    // No cgroup memory/pids accounting (empty cgroup dir) but proc_self points
+    // at the real /proc/self — the bare-metal-RPi case where the kernel memory
+    // cgroup is off. mem + threads must come from /proc/self, not report 0.
+    ds::StatsRoots r;
+    r.cgroup_root = make_tmpdir();   // no memory.current / pids.current
+    r.proc_self   = "/proc/self";
+    ds::StatsPublisher pub("services.test", nullptr, r);
+    auto s = pub.sample();
+    EXPECT_GT(s.mem_rss_kb, 0);
+    EXPECT_GE(s.threads, 1);
+}
+
 // ── publish (sink — no server, no reactor) ──────────────────────────
 TEST(StatsPublish, sink_receives_four_metrics_plus_version) {
     auto dir = make_tmpdir();


### PR DESCRIPTION
## Symptom
On the device **Services** page, every running daemon showed **Memory = 0 KB** and **Threads = 0**, while CPU % and FDs were correct.

## Why (answering "RPi isn't a container, so why cgroup?")
cgroups aren't a container thing — **systemd puts every service in its own cgroup on bare metal too** (`/sys/fs/cgroup/system.slice/<unit>/`), which is the right place to read per-service stats. `StatsPublisher` reads:
- CPU ← `cpu.stat` ✓ (CPUAccounting is on by default)
- FDs ← `/proc/self/fd` ✓
- **Memory ← `memory.current` / `memory.usage_in_bytes`** ✗
- **Threads ← `pids.current`** ✗

Memory + pids come back empty because those controllers aren't accounted for the units (MemoryAccounting/TasksAccounting off), and on **Raspberry Pi the kernel memory cgroup is disabled unless `cgroup_enable=memory` is on the boot cmdline**. Either way → `read_uint_file` returns nullopt → 0.

## Fix
In cgroup-mode `sample()`, when the cgroup memory/pids read yields 0, fall back to the daemon's own `/proc/self` (`read_proc_mem_kb` via `statm`, `read_proc_stat` for `num_threads`). No kernel-cmdline or systemd-accounting change required; works on any host.

Trade-off: the cgroup figure would also fold in child processes (e.g. wifi-client's `wpa_supplicant`), so the self-only number is a slight under-count — but far better than reporting 0. (If exact cgroup totals are wanted later, enabling `cgroup_enable=memory` + `MemoryAccounting=yes`/`TasksAccounting=yes` would make the primary cgroup path light up; the fallback stays as a safety net.)

## Tests
Added `cgroup_absent_mem_threads_fall_back_to_proc_self` (empty cgroup dir, real `/proc/self` → mem>0, threads≥1). Existing `none_cgroup_all_zero` still passes (its fake `proc_self` is an empty dir, so the fallback also yields 0). Compiled by both device + cloud image CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)