### PR TITLE
feat(yocto): seed http.workers=2 on first boot for device-ui long-polls

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
@@ -11,6 +11,7 @@
 # Order matters: the first matching rule wins. Keep this list in sync with the
 # SYSTEMD_AUTO_ENABLE:* assignments in iot_git.bb.
 enable iot-ds.service
+enable iot-ds-seed.service
 enable iot-httpd.service
 enable iot-hostname.service
 enable iot-wifi-client.service

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
@@ -1,0 +1,47 @@
+#!/bin/sh
+# iot-ds-seed — first-boot data-store seed for device-only defaults.
+#
+# Writes ds values that must differ from the shared schema defaults on a
+# device, ONCE, before iot-httpd starts (ordered After=iot-ds, Before=iot-httpd
+# in iot-ds-seed.service). Guarded by a flag file kept alongside the ds persist
+# file (/var/lib/iot), so it runs exactly once per device lifetime and never
+# re-clobbers operator changes made later via the UI / ds-cli — including across
+# an OS update (the flag lives with the persisted state, not in the rootfs).
+#
+# Current seed:
+#   http.workers = 2
+#     The schema default is 0 (handlers run inline on the reactor thread). The
+#     device-ui relies on blocking long-polls (the shared /status poll, and the
+#     Terminal shell's /api/v1/shell/output) which would stall an inline server,
+#     so a fresh device needs a worker pool. 2 is enough for the status poll +
+#     one shell session; bump via the HTTP Config page (restart required —
+#     http.workers is not hot-reloaded).
+set -eu
+
+SOCK="${IOT_DS_SOCK:-/run/iot/data_store.sock}"
+STATE="${IOT_DS_STATE:-/var/lib/iot}"
+FLAG="$STATE/.seeded"
+DSCLI="ds-cli --socket=$SOCK"
+
+# Already seeded → nothing to do (idempotent, preserves operator changes).
+[ -f "$FLAG" ] && exit 0
+
+# After=iot-ds orders start, not readiness — wait for the socket to appear.
+i=0
+while [ ! -S "$SOCK" ] && [ "$i" -lt 30 ]; do
+    sleep 1
+    i=$((i + 1))
+done
+if [ ! -S "$SOCK" ]; then
+    echo "iot-ds-seed: ds socket $SOCK not ready after ${i}s; will retry next boot" >&2
+    exit 0   # don't fail the boot; no flag written, so it retries
+fi
+
+if $DSCLI set http.workers 2; then
+    mkdir -p "$STATE"
+    : > "$FLAG"
+    echo "iot-ds-seed: set http.workers=2 (first boot)"
+else
+    echo "iot-ds-seed: failed to set http.workers; will retry next boot" >&2
+    exit 0   # leave the flag unwritten so the next boot retries
+fi

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=Seed first-boot device-only data-store defaults (http.workers)
+Documentation=https://github.com/naushada/iot
+# Run after ds-server is up so ds-cli can connect, and BEFORE iot-httpd so the
+# server reads the seeded http.workers at startup (it is not hot-reloaded).
+After=iot-ds.service
+Requires=iot-ds.service
+Before=iot-httpd.service
+# Fast skip once seeded; the script also self-guards with the same flag.
+ConditionPathExists=!/var/lib/iot/.seeded
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# root: reach the 0660 root:iot ds socket and write the flag into ds state.
+ExecStart=/usr/bin/iot-ds-seed
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -57,6 +57,8 @@ SRC_URI = "\
     file://iot-hostname.service \
     file://iot-http.avahi.service \
     file://iot-dump \
+    file://iot-ds-seed \
+    file://iot-ds-seed.service \
 "
 
 # Optional, gitignored WiFi credential seed. When an integrator drops
@@ -221,6 +223,12 @@ do_install() {
     # a module (e.g. `iot-dump iot-wifi-client`). Ships with ds-cli.
     install -m 0755 ${WORKDIR}/iot-dump         ${D}${bindir}/iot-dump
 
+    # iot-ds-seed: first-boot ds seed (http.workers=2 so the device-ui
+    # long-poll endpoints — /status and the Terminal shell — have worker
+    # threads instead of stalling the inline reactor). Runs once, before
+    # iot-httpd. Needs ds-cli at runtime (RDEPENDS below).
+    install -m 0755 ${WORKDIR}/iot-ds-seed      ${D}${bindir}/iot-ds-seed
+
     # Config/schema migration scripts (§11), run by iot-swupdate after opkg.
     install -d ${D}${datadir}/iot/migrations
     install -m 0644 ${WORKDIR}/migrations/README.md \
@@ -252,6 +260,7 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-tun.conf               ${D}${sysconfdir}/modules-load.d/
         install -m 0644 ${WORKDIR}/iot-wifi-client.service    ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-httpd.service          ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-ds-seed.service        ${D}${systemd_system_unitdir}/
 
         # tmpfiles.d: sole owner of /run/iot (units no longer use RuntimeDirectory=iot)
         install -d ${D}${nonarch_libdir}/tmpfiles.d
@@ -426,14 +435,17 @@ RRECOMMENDS:${PN}-wifi-client = "\
 FILES:${PN}-httpd = "\
     ${bindir}/iot-httpd \
     ${bindir}/iot-set-hostname \
+    ${bindir}/iot-ds-seed \
     ${systemd_system_unitdir}/iot-httpd.service \
     ${systemd_system_unitdir}/iot-hostname.service \
+    ${systemd_system_unitdir}/iot-ds-seed.service \
     ${sysconfdir}/avahi/services/iot-http.service \
     ${datadir}/iot/www \
 "
 # avahi-daemon provides the mDNS responder that advertises the device UI
 # (_http._tcp on iot-<serial>.local) for zero-touch discovery.
-RDEPENDS:${PN}-httpd = "ace-tao avahi-daemon"
+# ${PN}-ds-cli supplies ds-cli, used by iot-ds-seed.service at first boot.
+RDEPENDS:${PN}-httpd = "ace-tao avahi-daemon ${PN}-ds-cli"
 RRECOMMENDS:${PN}-httpd = "\
     ${PN}-ds-server \
     ${PN}-config \
@@ -462,7 +474,7 @@ SYSTEMD_SERVICE:${PN}-net-router = "iot-net-router.service"
 SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
 # httpd also carries the boot-time hostname unit (iot-<serial>) that makes the
 # Avahi advert resolvable — zero-touch device-UI discovery.
-SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service"
+SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service iot-ds-seed.service"
 
 # ds-server and wifi-client auto-start. wifi-client comes up on every boot
 # and reads wifi.networks from the data-store (schema default seeds a


### PR DESCRIPTION
## Why
Follow-up to the device-ui Terminal (#234). The device ships `iot-httpd` at the schema default `http.workers=0` (handlers run inline on the reactor thread). The device-ui depends on blocking long-polls — the shared `/status` poll and the Terminal shell's `/api/v1/shell/output` — which stall an inline server. A fresh device needs a worker pool.

## What
A **once-only first-boot ds seed** that sets `http.workers=2`:
- `files/iot-ds-seed` — waits for the ds socket, `ds-cli set http.workers 2`, then drops a flag in `/var/lib/iot` (same lifecycle as the ds persist file) so it never re-clobbers operator changes, **including across an OS update**.
- `files/iot-ds-seed.service` — oneshot, `After=iot-ds` / `Before=iot-httpd` so the server reads the seeded value at startup (`http.workers` is not hot-reloaded), `ConditionPathExists` self-guard.
- Recipe: install both, add to `FILES`/`SYSTEMD_SERVICE` for `${PN}-httpd`, `RDEPENDS` on `${PN}-ds-cli`, enable in `90-iot.preset`.

Operators can still raise `http.workers` later via the HTTP Config page (restart required); the seed only sets the first-boot default. Cloud is unaffected (separate image; it sets workers itself).

## Notes
- No `SRCREV` bump needed for #234 itself — the recipe tracks `branch=${IOT_BRANCH}` with `SRCREV=${AUTOREV}`, and `do_build_ui` (`npm ci`) pulls the new `xterm` dep from the committed lockfile; the `http.shell.enabled` schema ships via CMake install. This PR only adds the worker seed.
- Shell-syntax checked; install placement mirrors `iot-dump` (script) and `iot-httpd.service` (unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)