### PR TITLE
fix(cloud): VpnRegistry::release self-deadlock freezes iot-cloudd on deprovision

### DIFF
--- a/modules/server/openvpn/inc/vpn_registry.hpp
+++ b/modules/server/openvpn/inc/vpn_registry.hpp
@@ -94,6 +94,13 @@ private:
 
     /// Populate the free pool for the given subnet range.
     void init_pool();
+
+    /// Lock-free release helpers — caller MUST already hold m_mutex.
+    /// release() holds the lock for the whole endpoint teardown, so it
+    /// must NOT call the public release_ip()/release_port() (which re-lock
+    /// the non-recursive m_mutex → self-deadlock); it calls these instead.
+    void release_ip_locked(const std::string& ip);
+    void release_port_locked(std::uint16_t port);
 };
 
 } // namespace openvpn

--- a/modules/server/openvpn/src/vpn_registry.cpp
+++ b/modules/server/openvpn/src/vpn_registry.cpp
@@ -131,23 +131,35 @@ void VpnRegistry::release(const std::string& ep) {
     auto it = m_ep_to_alloc.find(ep);
     if (it == m_ep_to_alloc.end()) return;
 
-    release_ip(it->second.tun_ip);
-    release_port(it->second.proxy_port);
+    // Use the lock-free variants — m_mutex is already held here. Calling the
+    // public release_ip()/release_port() would re-lock the non-recursive
+    // m_mutex and self-deadlock the whole iot-cloudd main loop (every
+    // endpoint deprovision goes through here).
+    release_ip_locked(it->second.tun_ip);
+    release_port_locked(it->second.proxy_port);
     m_ep_to_alloc.erase(it);
 }
 
-void VpnRegistry::release_ip(const std::string& ip) {
-    std::lock_guard<std::mutex> lk(m_mutex);
+void VpnRegistry::release_ip_locked(const std::string& ip) {
     if (m_allocated_ips.erase(ip)) {
         m_free_ips.insert(ip);
     }
 }
 
-void VpnRegistry::release_port(std::uint16_t port) {
-    std::lock_guard<std::mutex> lk(m_mutex);
+void VpnRegistry::release_port_locked(std::uint16_t port) {
     if (m_allocated_ports.erase(port)) {
         m_free_ports.insert(port);
     }
+}
+
+void VpnRegistry::release_ip(const std::string& ip) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    release_ip_locked(ip);
+}
+
+void VpnRegistry::release_port(std::uint16_t port) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    release_port_locked(port);
 }
 
 // ── Queries ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

Removing/deprovisioning an endpoint from the cloud **Endpoints** page silently does nothing — the UI toasts "Removed" but the row stays (and comes back on refresh).

## Root cause

`VpnRegistry::release()` locks the non-recursive `m_mutex`, then called the **public** `release_ip()` / `release_port()`, each of which re-locks the same mutex → **self-deadlock**.

Every endpoint deprovision routes through it:
`DELETE /api/v1/cloud/endpoints` → `ds.set("cloud.deprovision.request")` → iot-cloudd watch → `BootstrapProvisioner::deprovision()` → `VpnRegistry::release()`.

So the **first** Remove of any endpoint with a VPN allocation (all of them) wedges iot-cloudd's entire main loop forever. The HTTP handler returns `ok` as soon as it writes the ds key — before iot-cloudd processes it — so the UI reports success regardless, and every subsequent Remove just queues a ds key no one will ever read.

Confirmed on the live Vultr cloud with a gdb backtrace — main thread parked in `futex_wait`:
```
#4 server::openvpn::VpnRegistry::release(...)
#5 server::lwm2m::BootstrapProvisioner::deprovision(...)
#6 main
```
`cloud.deprovision.request` was still set (a completed deprovision clears it) and the 15s DNAT heartbeat had been dead since the first Remove.

## Fix

Extract lock-free `release_ip_locked()` / `release_port_locked()` helpers and call those from `release()` (which already holds the lock). The public `release_ip()`/`release_port()` keep their own locking for external callers (unit tests). `allocate()`/`reserve()` already inline their pool ops, so `release()` was the only offender.

## Why it shipped

Existing test #11 `ReleaseBoth` exercises this exact path, but the `server/openvpn` gtest suite is `BUILD_SERVER_OPENVPN_TESTS=OFF` by default, so it never ran in CI. Worth wiring into CI in a follow-up.

## Verification

Standalone harness driving `allocate("dev-1")` → `release("dev-1")` (the deadlocking path) now completes and exits cleanly; would hang before. Will also verify on the live cloud after redeploy by removing the 3 stuck endpoints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)