### PR TITLE
fix(cloud): truthful + self-healing endpoint deprovision

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -718,6 +718,57 @@ int main(int argc, char** argv) {
         []() -> long { return g_ovpn_pid.load(); });
     g_ovpn_stats.open();
 
+    // Deprovision handler — shared by the watch loop and the startup sweep
+    // below. Factored out so a request left pending in ds by a previous
+    // instance that crashed or wedged mid-request (the old VpnRegistry
+    // self-deadlock did exactly this) is still honored. The watch is
+    // edge-triggered, so it never replays an unchanged value on restart — the
+    // request would sit forever and the cloud-ui "Remove" would silently no-op
+    // (re-writing the same value produces no watch event).
+    auto handle_deprovision = [&](const std::string& ep) {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l deprovision request '%C'\n"),
+                   ep.c_str()));
+        bool ok = provisioner.deprovision(ep);
+        // Also drop the per-endpoint credential record so the BS/DM stop
+        // accepting it and the row disappears from cloud.endpoint.credentials.
+        // Done independently of the registry result so a stale credential-only
+        // entry can still be cleaned (counts as a successful removal).
+        try {
+            const std::string cur =
+                ds_str(ds, "cloud.endpoint.credentials", "[]");
+            const std::string next =
+                server::lwm2m::remove_credential(cur, ep);
+            if (next != cur) {
+                ds.set("cloud.endpoint.credentials", data_store::Value{next});
+                ok = true;
+            }
+        } catch (const std::exception& e) {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D cloudd:thread:%t %M %N:%l remove credential "
+                                "for %C failed: %C\n"), ep.c_str(), e.what()));
+        }
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l deprovision %C '%C'\n"),
+                   (ok ? "ok" : "failed (not found)"), ep.c_str()));
+        // One-shot: clear both triggers so a watch replay on restart doesn't
+        // re-deprovision, and a stale provision.request can't resurrect what we
+        // just removed.
+        ds.set("cloud.deprovision.request", data_store::Value{std::string("")});
+        ds.set("cloud.provision.request",   data_store::Value{std::string("")});
+    };
+
+    // Startup self-heal: honor a deprovision request left pending in ds (the
+    // edge-triggered watch won't replay it), then sync so cloud.endpoints
+    // reflects the removal immediately instead of after the first periodic tick.
+    if (auto pending = ds_str(ds, "cloud.deprovision.request", ""); !pending.empty()) {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l honoring pending deprovision "
+                            "request '%C' from ds at startup\n"), pending.c_str()));
+        handle_deprovision(pending);
+        sync_endpoints_to_ds(ds, ep_reg);
+    }
+
     // ── Main loop ─────────────────────────────────────────────────
     // Block on recv_event() up to sync_interval seconds.  A provision
     // or deprovision request from iot-httpd wakes us immediately; a
@@ -826,43 +877,8 @@ int main(int argc, char** argv) {
                            data_store::Value{std::string("")});
                 }
             } else if (ev.key == "cloud.deprovision.request") {
-                if (auto ep = data_store::to_string(ev.value); ep && !ep->empty()) {
-                    ACE_DEBUG((LM_INFO,
-                               ACE_TEXT("%D cloudd:thread:%t %M %N:%l deprovision request '%C'\n"),
-                               ep->c_str()));
-                    bool ok = provisioner.deprovision(*ep);
-                    // Also drop the per-endpoint credential record so the BS/DM
-                    // stop accepting it and the row disappears from
-                    // cloud.endpoint.credentials. Done independently of the
-                    // registry result so a stale credential-only entry can
-                    // still be cleaned (counts as a successful removal).
-                    try {
-                        const std::string cur =
-                            ds_str(ds, "cloud.endpoint.credentials", "[]");
-                        const std::string next =
-                            server::lwm2m::remove_credential(cur, *ep);
-                        if (next != cur) {
-                            ds.set("cloud.endpoint.credentials",
-                                   data_store::Value{next});
-                            ok = true;
-                        }
-                    } catch (const std::exception& e) {
-                        ACE_ERROR((LM_ERROR,
-                                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l remove "
-                                            "credential for %C failed: %C\n"),
-                                   ep->c_str(), e.what()));
-                    }
-                    ACE_DEBUG((LM_INFO,
-                               ACE_TEXT("%D cloudd:thread:%t %M %N:%l deprovision %C '%C'\n"),
-                               (ok ? "ok" : "failed (not found)"), ep->c_str()));
-                    // One-shot: clear both triggers so a watch replay on restart
-                    // doesn't re-deprovision, and a stale provision.request can't
-                    // resurrect what we just removed.
-                    ds.set("cloud.deprovision.request",
-                           data_store::Value{std::string("")});
-                    ds.set("cloud.provision.request",
-                           data_store::Value{std::string("")});
-                }
+                if (auto ep = data_store::to_string(ev.value); ep && !ep->empty())
+                    handle_deprovision(*ep);
             } else if (ev.key == "log.level") {
                 g_log.apply_level(ds);
                 ACE_DEBUG((LM_INFO,

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -7,6 +7,8 @@
 #include <nlohmann/json.hpp>
 
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
+#include <ace/Time_Value.h>
 
 #include <cctype>
 #include <chrono>
@@ -1026,11 +1028,48 @@ void install_handlers(Router& router,
             auto sr = ds->set("cloud.deprovision.request",
                               data_store::Value{ep});
             json resp;
-            resp["ok"]       = sr.ok;
             resp["endpoint"] = ep;
             if (!sr.ok) {
+                resp["ok"]  = false;
                 resp["err"] = sr.err;
-                r.status = 500;
+                r.status    = 500;
+                r.body      = resp.dump();
+                return r;
+            }
+
+            // Don't report success on the mere trigger write — that lied when a
+            // stale/duplicate request or a wedged iot-cloudd left the endpoint in
+            // place (the UI showed a green toast, then the row repopulated from
+            // iot-cloudd's in-memory registry on the next sync). Poll cloud.endpoints
+            // until the endpoint is actually gone (iot-cloudd processed the
+            // deprovision and removed the in-memory row → sync rewrote the key), or
+            // time out and report failure honestly.
+            auto endpoint_present = [&](const std::string& want) -> bool {
+                std::vector<data_store::Client::GetResult> got;
+                if (!ds->get({"cloud.endpoints"}, got).ok || got.empty() ||
+                    !got[0].has_value)
+                    return false;
+                auto s = data_store::to_string(got[0].value);
+                if (!s) return false;
+                try {
+                    auto arr = json::parse(*s);
+                    if (arr.is_array())
+                        for (const auto& e : arr)
+                            if (e.value("endpoint", std::string()) == want)
+                                return true;
+                } catch (const std::exception&) {}
+                return false;
+            };
+            bool removed = false;
+            for (int i = 0; i < 50; ++i) {           // ~5s (50 × 100ms)
+                if (!endpoint_present(ep)) { removed = true; break; }
+                ACE_OS::sleep(ACE_Time_Value(0, 100 * 1000));  // 100ms
+            }
+            resp["ok"] = removed;
+            if (!removed) {
+                resp["err"] = "deprovision not confirmed (iot-cloudd did not "
+                              "remove the endpoint within timeout)";
+                r.status = 504;
             }
             r.body = resp.dump();
             return r;


### PR DESCRIPTION
## Why

Follow-up to the VpnRegistry deadlock fix (#236). During that incident, the cloud-ui **Remove** showed a green "success" toast while the endpoint **repopulated** — because the Endpoints table is a projection of iot-cloudd's in-memory `EndpointRegistry` (rewritten each sync), and the removal never actually reached `ep_reg.remove()`. Two root weaknesses made it confusing and unrecoverable without manual `ds-cli` surgery.

## Fixes

**1. Truthful DELETE (`handler.cpp`).** The `DELETE /api/v1/cloud/endpoints` handler returned `ok` the instant it wrote `cloud.deprovision.request` — before iot-cloudd processed anything. So the toast lied whenever the request didn't take. It now **polls `cloud.endpoints` (~5s) and returns `ok:true` only once the endpoint is actually gone**, else `504` with an explicit error. No more green-toast-then-reappear.

**2. Self-healing startup (`main.cpp`).** `cloud.deprovision.request` is edge-triggered. A request left pending in ds by a previous instance that crashed/wedged mid-request (exactly what the old self-deadlock caused) was **never replayed** on restart — it sat forever, and re-clicking Remove on that same endpoint re-wrote the same value → no watch event → silent no-op (this is what required the manual `ds-cli set … '""'` to unstick). The deprovision is now factored into a handler and **run once at startup for any pending request**, then synced. Self-healing — no manual cleanup.

## Convention
New poll uses the **ACE API** (`ACE_OS::sleep` / `ACE_Time_Value`), not `std::this_thread`, per project standard.

## Verification
- Reproduced the exact incident: stale `cloud.deprovision.request=iot-6556e041` + green toast + repopulation. The live trace (after the deadlock fix + manual clear) confirmed the actual removal path works: `deprovision request → deprovision ok → row gone`. These two fixes make that the *only* outcome the operator can observe (truthful toast) and make the stale-trigger state self-recover (startup sweep).
- Build/runtime verification pending CI (`cloud-image.yml`) on merge.

## Deliberately NOT here
- **Drop the in-memory registry, make ds the single source of truth** (requested): a core refactor of iot-cloudd — `VpnRegistry` IP/port allocation atomicity, the DNAT builder, and `reconcile_registrations` all use the in-memory maps as their working set. Needs its own design pass; tracked as a follow-up rather than rushed into a hardening PR for the live control plane.
- A pre-existing `std::this_thread::sleep_for` at `handler.cpp:860` (unrelated to this change) — left as-is to keep scope tight; can be swept to ACE separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)