### PR TITLE
fix(device-ui): prefetch http config keys so HTTP Config reads back on cold load

### DIFF
--- a/iot-ui/src/common/datastore.service.ts
+++ b/iot-ui/src/common/datastore.service.ts
@@ -43,6 +43,14 @@ export class DataStoreService {
     // Log levels
     'log.level', 'log.level.httpd', 'log.level.lwm2m',
     'log.level.vpn', 'log.level.dtls',
+    // HTTP server config — the HTTP Config page reads these back on a cold
+    // load. Without them in the prefetch, a fresh page (re-launch) finds no
+    // cached value and falls back to the form defaults — e.g. http.workers
+    // shows 0 even though ds holds the saved value (the value only "stuck"
+    // within the session that wrote it, via write()'s cache mirror).
+    'http.listen.ip', 'http.listen.port', 'http.listen.scheme',
+    'http.workers', 'http.tls.cert', 'http.tls.key', 'http.tls.ca',
+    'http.auth.enabled',
     // HTTP server — remote shell master switch (gates the Terminal page)
     'http.shell.enabled',
   ];


### PR DESCRIPTION
## Problem

On the device-ui **HTTP Config** page, setting **Worker Threads = 4**, saving (green toast), then closing and re-launching the UI shows **0** again.

## Root cause

The page paints from the shared prefetch cache (`DataStoreService.ALL_KEYS`) + `observe()`, which only replay values the prefetch — or a same-session `write()` — seeded into the cache. `ALL_KEYS` listed only `http.shell.enabled`, **omitting** `http.workers`, `http.listen.*`, `http.tls.*`, `http.auth.enabled`.

- In the session that *saved*, `write()` mirrors `http.workers=4` into the cache → form shows 4.
- On a fresh re-launch, the prefetch never loads `http.workers` and `observe()` doesn't lazy-fetch → the form falls back to its default **0**.

⚠️ Not just cosmetic: re-saving from that cold-loaded form would write `0` back, **clobbering** the real value.

ds was always the source of truth — verified live on a device: `ds-cli get http.workers` → `http.workers=4` throughout.

## Fix

Add the HTTP config keys to the device-ui prefetch, matching what `apps/cloud/ui/src/common/datastore.service.ts` **already** lists (the cloud HTTP page was never affected).

## Test

- Set workers=4 in device-ui HTTP Config → save → close → re-launch → field now reads **4**.
- cloud-ui unaffected (already prefetched these keys).

🤖 Generated with [Claude Code](https://claude.com/claude-code)