### PR TITLE
fix(yocto): wired RequiredForOnline=no so WiFi-only NTP syncs (no-RTC clock)

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/10-iot-wired.network
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/10-iot-wired.network
@@ -1,0 +1,27 @@
+# IoT wired (Ethernet) networkd profile.
+#
+# Purpose: keep eth*/en* usable via DHCP when a cable is present, but do NOT
+# let a MISSING cable hold systemd-networkd at "Online state: offline".
+#
+# Why this exists: the device is WiFi-primary. wlan0 is brought up OUTSIDE
+# networkd (wpa_supplicant + udhcpc via iot-wifi-client), so networkd never
+# counts it as an online link. systemd ships a default 80-wired.network that
+# matches eth0 with RequiredForOnline=yes — so on a headless WiFi-only unit the
+# cable-less eth0 pins networkd's GLOBAL online state to "offline". That parks
+# systemd-timesyncd (it only polls NTP once the system is "online"), so on a
+# board with NO battery-backed RTC the clock never leaves its restored-from-
+# save-file value. A stale clock then fails every TLS handshake ("certificate
+# is not yet valid"), which is exactly what broke the OpenVPN tunnel.
+#
+# RequiredForOnline=no lets a cable-less eth0 stay "offline" without dragging
+# the whole system offline, so timesyncd syncs over WiFi within seconds of
+# boot. This filename sorts before 80-wired.network, so it wins the eth*/en*
+# match. See apps/docs/tdd-wifi-autostart.md.
+[Match]
+Name=eth* en*
+
+[Network]
+DHCP=yes
+
+[Link]
+RequiredForOnline=no

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -34,6 +34,7 @@ SRC_URI = "\
     file://iot-vpn-cert.service \
     file://iot-tun.conf \
     file://iot-net-router.service \
+    file://10-iot-wired.network \
     file://iot-wifi-client.service \
     file://iot-httpd.service \
     file://iot.conf \
@@ -255,6 +256,11 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-swupdate.service       ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-ota-confirm.service    ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-net-router.service     ${D}${systemd_system_unitdir}/
+        # networkd wired profile: RequiredForOnline=no so a cable-less eth0 does
+        # not pin the system "offline" and park systemd-timesyncd on a WiFi-only
+        # unit (no-RTC clock would stay stale → TLS/VPN fails). See the file header.
+        install -d ${D}${sysconfdir}/systemd/network
+        install -m 0644 ${WORKDIR}/10-iot-wired.network       ${D}${sysconfdir}/systemd/network/
         # TUN driver autoload for openvpn-client.
         install -d ${D}${sysconfdir}/modules-load.d
         install -m 0644 ${WORKDIR}/iot-tun.conf               ${D}${sysconfdir}/modules-load.d/
@@ -400,6 +406,7 @@ RRECOMMENDS:${PN}-openvpn-client = "\
 FILES:${PN}-net-router = "\
     ${bindir}/net-router \
     ${systemd_system_unitdir}/iot-net-router.service \
+    ${sysconfdir}/systemd/network/10-iot-wired.network \
 "
 RDEPENDS:${PN}-net-router = "\
     ace-tao \


### PR DESCRIPTION
## Symptom

On a headless WiFi-only RPi (no RTC), the OpenVPN tunnel never came up — OpenVPN's TLS failed `certificate is not yet valid: CN=iot-cloud-ca`, and `vpn.state` stuck at `connecting`. The device clock was stuck ~13 months in the past.

## Root cause (not a firewall / not a blocked port)

UDP 123 egress works fine. The real chain:

- `eth0` is managed by systemd's default `80-wired.network` with `RequiredForOnline=yes`, but the unit has **no Ethernet cable**.
- A cable-less `eth0` pins networkd's global **`Online state: offline`**.
- `systemd-timesyncd` only polls NTP once the system is "online", so it **parked forever** — `timedatectl timesync-status` showed `Server: n/a`, `Packet count: 0`. Confirmed via foreground debug: it loads the servers then sits idle, never sending a packet.
- `wlan0` is brought up **outside** networkd (wpa_supplicant + udhcpc), so it never flips the system online.
- No NTP sync + no RTC → clock restored from timesyncd's stale save-file → all certs look "not yet valid" → TLS/VPN fail.

## Fix

Ship `10-iot-wired.network` (sorts before `80-wired.network`, so it wins the `eth*/en*` match) with `RequiredForOnline=no`. A cable-less `eth0` stays offline without dragging the whole system offline, so timesyncd syncs over WiFi within seconds of boot. Wired DHCP still works when a cable is present.

**Durable across reboots, no RTC:** timesyncd's save-file restores a forward-only clock at early boot — now kept fresh because NTP actually syncs — so each boot starts inside cert validity and NTP refines it within seconds. No separate `fake-hwclock` needed.

## Changes (`meta-iot/recipes-iot/lwm2m/`)

- `files/10-iot-wired.network` (new)
- `iot_git.bb`: added to `SRC_URI`, installed to `/etc/systemd/network/`, packaged in `${PN}-net-router`.

## Hardware verification (192.168.1.8)

- Before: `Online state: offline`, timesyncd idle, `Packet count: 0`, clock 2025, VPN down.
- After: `System clock synchronized: yes` (stratum 1, offset +2.5ms), `vpn.state=connected`; `wlan0`/SSH unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)