### PR TITLE
fix(device-ui): Installed Version reads iot.version, not the OTA target

### DIFF
--- a/iot-ui/src/app/software-update/software-update.component.ts
+++ b/iot-ui/src/app/software-update/software-update.component.ts
@@ -18,7 +18,7 @@ import { ToastService } from '../../common/toast.service';
           <clr-dg-column>Value</clr-dg-column>
           <clr-dg-row>
             <clr-dg-cell>Installed Version
-              <app-ds-hint *dsDebug key="iot.update.version"></app-ds-hint></clr-dg-cell>
+              <app-ds-hint *dsDebug key="iot.version"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell>{{ version || '—' }}</clr-dg-cell>
           </clr-dg-row>
           <clr-dg-row>
@@ -92,7 +92,7 @@ import { ToastService } from '../../common/toast.service';
   `]
 })
 export class SoftwareUpdateComponent implements OnInit, OnDestroy {
-  version = '';
+  version = '';       // iot.version — the running/installed release (footer value)
   state = 0;
   result = 0;
   bank = '';          // iot.boot.bank — running A/B rootfs bank (empty = single-rootfs)
@@ -126,8 +126,14 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     // Read OTA progress live off the single shared /status stream — no
     // per-page 5s self-poll. The long-poll wakes on iot.update.state changes,
     // so download/install progress renders promptly without missing updates.
-    this.sub.add(this.ds.observe('iot.update.version').subscribe(v => {
-      if (v != null) this.version = String(v);
+    // Installed Version = the running release iot-httpd records at startup
+    // (iot.version — the same value the sidebar footer shows). That is what is
+    // actually installed/booted now. Do NOT read iot.update.version here: that
+    // is only the last OTA *target* and is empty on a device that has never
+    // been pushed, so it rendered "—" even though a real version is running.
+    this.sub.add(this.http.dbGet(['iot.version']).subscribe(r => {
+      if (r.ok && r.data)
+        this.version = String((r.data as Record<string, unknown>)['iot.version'] || '');
     }));
     this.sub.add(this.ds.observe('iot.update.state').subscribe(v => {
       this.state = Number(v) || 0;


### PR DESCRIPTION
## Symptom

Device-ui **Software Update** page shows **Installed Version: —**, even though the device is clearly running a release (sidebar footer shows `v1.1.0+23fdb23`).

## Root cause

The "Installed Version" row read **`iot.update.version`** — the last OTA *target* — which is empty on a device that has never had a package pushed. So it rendered `—`, and even when populated it would echo the *pushed* version, not the running one. (Same bug class the `tdd-installed-version.md` doc calls out for the cloud side.)

The footer already shows the correct value from **`iot.version`** — the running release `iot-httpd` records at startup.

## Fix

Point the "Installed Version" row at `iot.version` via a one-shot `dbGet`, exactly like the footer. OTA State/Result rows unchanged.

## Verification (live, 192.168.1.8)

```
iot.version        = 1.1.0+23fdb23   ← now shown
iot.update.version =                 ← was being read → "—"
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)