### PR TITLE
fix(cloud): stream ds-server state live in /status so Services page shows running

### DIFF
--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -709,7 +709,15 @@ void install_handlers(Router& router,
                 else if (k == "net.rules.applied.count")     routing["rules_applied"] = iv();
                 else if (k == "net.last.apply.unix")         routing["last_apply_unix"] = iv();
 
-                else if (k == "services.ds.state")                services["ds"]["state"] = sv();
+                // ds-server keys feed BOTH the nested `services` block (device-ui
+                // reads s.services.ds) AND the flat `cloud` passthrough (cloud-ui
+                // reads the flat d['services.ds.state']). The services.ds.* keys
+                // are matched by these explicit branches BEFORE the generic
+                // services.cloud.* passthrough below, so without dual-emitting into
+                // `cloud` here the cloud Services page never streams ds-server live
+                // off /status — it then relies only on the one-shot prefetch, loses
+                // the race, and shows a stale "stopped" + "—" telemetry.
+                else if (k == "services.ds.state")                { services["ds"]["state"] = sv(); cloud[k] = sv(); }
                 else if (k == "services.ds.uptime.sec")           services["ds"]["uptime_sec"] = iv();
                 else if (k == "services.net.router.enable")       services["net_router"]["enable"] = bv(true);
                 else if (k == "services.net.router.state")        services["net_router"]["state"] = sv();
@@ -723,11 +731,11 @@ void install_handlers(Router& router,
                 else if (k == "services.wifi.client.state")       services["wifi_client"]["state"] = sv();
 
                 // L22 — resource telemetry per service.
-                else if (k == "services.ds.cpu.permille")             services["ds"]["cpu_permille"] = iv();
-                else if (k == "services.ds.cpu.count")                services["ds"]["cpu_count"] = iv();
-                else if (k == "services.ds.mem.rss.kb")               services["ds"]["mem_kb"] = iv();
-                else if (k == "services.ds.fd.count")                 services["ds"]["fd_count"] = iv();
-                else if (k == "services.ds.threads")                  services["ds"]["threads"] = iv();
+                else if (k == "services.ds.cpu.permille")             { services["ds"]["cpu_permille"] = iv(); cloud[k] = iv(); }
+                else if (k == "services.ds.cpu.count")                { services["ds"]["cpu_count"] = iv(); cloud[k] = iv(); }
+                else if (k == "services.ds.mem.rss.kb")               { services["ds"]["mem_kb"] = iv(); cloud[k] = iv(); }
+                else if (k == "services.ds.fd.count")                 { services["ds"]["fd_count"] = iv(); cloud[k] = iv(); }
+                else if (k == "services.ds.threads")                  { services["ds"]["threads"] = iv(); cloud[k] = iv(); }
                 else if (k == "services.net.router.cpu.permille")     services["net_router"]["cpu_permille"] = iv();
                 else if (k == "services.net.router.cpu.count")        services["net_router"]["cpu_count"] = iv();
                 else if (k == "services.net.router.mem.rss.kb")       services["net_router"]["mem_kb"] = iv();


### PR DESCRIPTION
## Symptom

Cloud **Services** page shows `ds-server` as **stopped** with `—` for all telemetry, while every other daemon (iot-cloudd, iot-httpd, lwm2m-bs/dm, openvpn-server) shows **running**.

## Root cause (data was correct, backend bug)

Verified live on the cloud: `services.ds.state = "running"`, and `/status` even returns a correct nested `services.ds` block. The bug is in the **flat `cloud` passthrough** the cloud-ui reads.

`/status` (`modules/http-server/src/handler.cpp`) builds two things:
- a **nested `services`** block — device-ui reads `s.services.ds`
- a **flat `cloud`** passthrough — cloud-ui reads the flat `d['services.ds.state']`

The flat `cloud` block is filled by a generic branch matching only `services.cloud.*` (+ `services.stats.version` / `log.version`). The `services.ds.*` keys are matched by their **own earlier `else-if` branches** that write **only** into the nested `services` block — so they never fall through to the `cloud` passthrough.

Net: every `services.cloud.*` daemon streams live state via `/status`; ds-server's flat key comes **only** from the one-shot prefetch, which the Services page races → it falls back to the schema default `stopped` (and `—` telemetry). That's why ds-server uniquely showed both wrong.

## Fix

Dual-emit the ds keys (`state` + `cpu.permille`/`cpu.count`/`mem.rss.kb`/`fd.count`/`threads`) into the `cloud` block as well, so ds-server streams live off `/status` like every other service. Device-ui unaffected (nested block unchanged).

## Deploy note

C++ httpd change — needs the **cloud image rebuilt + redeployed** to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)