### PR TITLE
fix(ui): make device terminal labels truthful — service user, not root

### DIFF
--- a/apps/docs/tdd-device-shell.md
+++ b/apps/docs/tdd-device-shell.md
@@ -102,7 +102,10 @@ ds-cli set http.workers 4        # restart iot-httpd
 
 ## Security
 
-This is a remote **root** shell — the largest attack surface in the device-ui.
+This is a remote shell that runs as the `iot-httpd` service user
+(`DynamicUser=yes` — **not root**, so privileged ops like `ping`/raw sockets,
+`opkg`, and writes under `/etc` are unavailable). It is still the largest attack
+surface in the device-ui.
 Mitigations: off by default; Admin-only; gated per request (instant kill
 switch); idle-reaped; session-capped; audit-logged via `ACE_DEBUG` on
 open/close/reap. It rides the existing session-cookie auth and (where

--- a/iot-ui/src/app/http-config/http-config.component.ts
+++ b/iot-ui/src/app/http-config/http-config.component.ts
@@ -93,10 +93,11 @@ import { DataStoreService } from '../../common/datastore.service';
         <h4 style="margin-top:32px;">Remote Shell
           <span class="hint">(device-ui Terminal page)</span></h4>
         <div class="warn-card">
-          A remote <strong>root shell</strong> on this device — the largest
-          attack surface here. Admin-only, idle-reaped. Leave OFF unless you
-          need it. Each open terminal holds one HTTP worker, so set Worker
-          Threads ≥ 2 (and restart) before enabling.
+          A remote <strong>shell</strong> on this device — runs as the
+          <code>iot-httpd</code> service user (<strong>not root</strong>), but
+          still a remote shell and the largest attack surface here. Admin-only,
+          idle-reaped. Leave OFF unless you need it. Each open terminal holds one
+          HTTP worker, so set Worker Threads ≥ 2 (and restart) before enabling.
         </div>
         <div class="form-grid">
           <clr-checkbox-container>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -49,9 +49,10 @@ export class MainComponent {
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
-  // Terminal is a remote root shell: only surface it to Admins when the
-  // operator has switched on http.shell.enabled. Everything else is always
-  // shown (each page enforces its own access).
+  // Terminal is a remote shell (runs as the iot-httpd service user, not root):
+  // only surface it to Admins when the operator has switched on
+  // http.shell.enabled. Everything else is always shown (each page enforces its
+  // own access).
   get navMenus() {
     return this.menus.filter(m =>
       m.id !== 'shell' || (this.shellEnabled && this.isAdmin));

--- a/iot-ui/src/app/shell/shell.component.ts
+++ b/iot-ui/src/app/shell/shell.component.ts
@@ -37,7 +37,10 @@ function b64ToBytes(b64: string): Uint8Array {
       </div>
       <div #term class="term"></div>
       <p class="hint">
-        Root shell on this device. Session ends on idle or when you leave the page.
+        Shell on this device — runs as the <code>iot-httpd</code> service user,
+        <strong>not root</strong> (so <code>ping</code>, package installs, and
+        writes under <code>/etc</code> lack privilege). Admin-only; session ends
+        on idle or when you leave the page.
       </p>
     </div>
   `,

--- a/modules/http-server/schemas/http.lua
+++ b/modules/http-server/schemas/http.lua
@@ -52,7 +52,8 @@ return {
 
     -- ── Remote shell (device-ui Terminal page) ──────────────────────
     -- Master switch for the forkpty-backed shell at /api/v1/shell/*.
-    -- OFF by default: this is a remote ROOT shell on the device, the
+    -- OFF by default: this is a remote shell on the device — runs as the
+    -- iot-httpd service user (DynamicUser, NOT root), but still the
     -- single largest attack surface here, so an operator must opt in
     -- explicitly. Read on every /api/v1/shell/* request, so flipping it
     -- off kills new sessions immediately and existing ones on next poll.


### PR DESCRIPTION
## Problem

The device-ui Terminal is described as a **root shell** everywhere, but it isn't. `iot-httpd.service` runs `DynamicUser=yes` (+ only `CAP_NET_BIND_SERVICE`), and `shell.cpp` `forkpty`s `/bin/sh` with **no setuid** — so the shell runs as the unprivileged service user. That's why `ping` fails (`are you root?`, needs `CAP_NET_RAW`) and `sudo` isn't present.

## Fix

Make all five labels truthful — the shell runs as the **iot-httpd service user, not root**, with limited privileges:
- `iot-ui/.../shell.component.ts` (terminal hint)
- `iot-ui/.../http-config.component.ts` (enable warning)
- `iot-ui/.../main.component.ts` (comment)
- `apps/docs/tdd-device-shell.md` (security section)
- `modules/http-server/schemas/http.lua` (schema comment)

It's still a remote shell and the largest attack surface, so it stays **off-by-default + Admin-gated** — verified enforced server-side in `handler_shell.cpp` (`http.shell.enabled` + Admin → 403 otherwise), not just hidden in the UI.

Labels/docs only — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)