### PR TITLE
feat(ui): dashboard & top-bar connectivity details — VPN info, uptimes, live WiFi RSSI

### DIFF
--- a/iot-ui/src/app/dashboard/dashboard.component.html
+++ b/iot-ui/src/app/dashboard/dashboard.component.html
@@ -10,7 +10,17 @@
         <div class="card-value">{{ vpnLabel() }}</div>
         <div class="card-label">OpenVPN Client</div>
         <div class="card-detail" *ngIf="status?.vpn?.ip">
-          {{ status?.vpn?.ip }}
+          IP {{ status?.vpn?.ip
+          }}<span *ngIf="status?.vpn?.netmask"> / {{ status?.vpn?.netmask }}</span>
+        </div>
+        <div class="card-detail" *ngIf="status?.vpn?.gateway">
+          GW {{ status?.vpn?.gateway }}
+        </div>
+        <div class="card-detail" *ngIf="status?.vpn?.dns">
+          DNS {{ status?.vpn?.dns }}
+        </div>
+        <div class="card-detail" *ngIf="vpnUptime()">
+          Uptime {{ vpnUptime() }}
         </div>
       </div>
     </div>
@@ -21,7 +31,7 @@
         <clr-icon shape="wifi" size="36"></clr-icon>
         <div class="card-value">{{ status?.wifi?.ssid || '—' }}</div>
         <div class="card-label">WiFi — {{ status?.wifi?.state || 'unknown' }}</div>
-        <div class="card-detail" *ngIf="status?.wifi?.rssi != null">
+        <div class="card-detail" *ngIf="(status?.wifi?.rssi ?? 0) < 0">
           {{ status?.wifi?.rssi }} dBm
           <span class="signal-bars">
             <span class="bar"

--- a/iot-ui/src/app/dashboard/dashboard.component.ts
+++ b/iot-ui/src/app/dashboard/dashboard.component.ts
@@ -2,7 +2,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { DataStoreService } from '../../common/datastore.service';
 import { PubSubService } from '../../common/pubsubsvc.service';
-import { StatusSnapshot } from '../../common/app-globals';
+import { StatusSnapshot, fmtDuration } from '../../common/app-globals';
 
 @Component({
   selector: 'app-dashboard',
@@ -58,6 +58,14 @@ export class DashboardComponent implements OnDestroy {
     if (s === 'connected') return 'connected';
     if (!s || s === 'disconnected' || s === 'exited') return 'disconnected';
     return 'starting';
+  }
+  /// Tunnel uptime = now − vpn.connected.unix, humanised. Empty when the tunnel
+  /// is not connected or the connect timestamp isn't published yet (older
+  /// firmware), so the row simply hides via *ngIf.
+  vpnUptime(): string {
+    const t = this.status?.vpn?.connected_unix;
+    if (!t || (this.status?.vpn?.state || '').toLowerCase() !== 'connected') return '';
+    return fmtDuration(Math.floor(Date.now() / 1000) - t);
   }
 
   // ── LwM2M connection lifecycle (iot.conn.state) ───────────────────

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -70,6 +70,7 @@
       <app-status-badge icon="wifi" [label]="'WiFi ' + wifiState" [state]="wifiState"></app-status-badge>
       <span class="live-stat"><clr-icon shape="world"></clr-icon> {{ wanIface }}</span>
       <span class="live-stat"><clr-icon shape="cog"></clr-icon> {{ serviceCount }} services</span>
+      <span class="live-stat" *ngIf="deviceUptime"><clr-icon shape="clock"></clr-icon> up {{ deviceUptime }}</span>
       <span class="access-badge" [class.viewer]="!isAdmin">{{ isAdmin ? 'Admin' : 'Viewer' }}</span>
 
       <div class="live-spacer"></div>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -6,7 +6,7 @@ import { PubSubService } from '../../common/pubsubsvc.service';
 import { ThemeService } from '../../common/theme.service';
 import { DebugService } from '../../common/debug.service';
 import { DataStoreService } from '../../common/datastore.service';
-import { StatusSnapshot } from '../../common/app-globals';
+import { StatusSnapshot, fmtDuration } from '../../common/app-globals';
 
 @Component({
   selector: 'app-main',
@@ -157,6 +157,12 @@ export class MainComponent {
     return 'starting';   // bootstrapping / bootstrapped / dm-* in progress
   }
   get wanIface(): string { return this.status?.wan?.active_iface || '-'; }
+  /// Host uptime since boot (status.device.uptime_sec), humanised. Empty on
+  /// older firmware that doesn't publish it → the top-bar stat hides via *ngIf.
+  get deviceUptime(): string {
+    const u = this.status?.device?.uptime_sec;
+    return (u && u > 0) ? fmtDuration(u) : '';
+  }
   get serviceCount(): number {
     if (!this.status?.services) return 0;
     let n = 0;

--- a/iot-ui/src/common/app-globals.ts
+++ b/iot-ui/src/common/app-globals.ts
@@ -1,5 +1,18 @@
 // ── TypeScript interfaces mirroring the iot data-store schemas ──────
 
+/// Humanise a duration in seconds → "3d 4h", "2h 13m", "5m 12s", "42s".
+export function fmtDuration(sec: number): string {
+  sec = Math.max(0, Math.floor(sec));
+  const d = Math.floor(sec / 86400);
+  const h = Math.floor((sec % 86400) / 3600);
+  const m = Math.floor((sec % 3600) / 60);
+  const s = sec % 60;
+  if (d > 0) return `${d}d ${h}h`;
+  if (h > 0) return `${h}h ${m}m`;
+  if (m > 0) return `${m}m ${s}s`;
+  return `${s}s`;
+}
+
 export interface StatusSnapshot {
   ok: boolean;
   lwm2m:    Lwm2mStatus;
@@ -9,6 +22,8 @@ export interface StatusSnapshot {
   wan:      WanStatus;
   routing:  RoutingStatus;
   services: ServicesStatus;
+  /// Host (this device / cloud container) runtime info — e.g. uptime since boot.
+  device?:  DeviceStatus;
   /// Flat passthrough of ds keys the SPA caches verbatim (domain bump keys
   /// like log.version / services.stats.version, shared with the cloud build).
   cloud?:   Record<string, unknown>;
@@ -44,6 +59,14 @@ export interface VpnStatus {
   exit_code?: number;
   gate_reason?: string;
   bound_iface?: string;
+  /// Unix epoch (seconds) when the tunnel last reached CONNECTED. 0/absent =
+  /// not connected. The UI derives "uptime" = now − connected_unix.
+  connected_unix?: number;
+}
+
+export interface DeviceStatus {
+  /// Seconds since the host booted (from /proc/uptime).
+  uptime_sec?: number;
 }
 
 export interface WifiStatus {

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -569,7 +569,8 @@ void install_handlers(Router& router,
                 "iot.update.version", "iot.update.state", "iot.update.result",
                 // VPN
                 "vpn.state", "vpn.assigned.ip", "vpn.assigned.gateway",
-                "vpn.assigned.netmask", "vpn.assigned.dns", "vpn.pid",
+                "vpn.assigned.netmask", "vpn.assigned.dns", "vpn.connected.unix",
+                "vpn.pid",
                 "vpn.exit_code", "vpn.gate.reason", "vpn.bound.iface",
                 // WiFi
                 "wifi.assoc.state", "wifi.assoc.ssid", "wifi.signal.rssi",
@@ -685,6 +686,7 @@ void install_handlers(Router& router,
                 else if (k == "vpn.assigned.gateway")  vpn["gateway"] = sv();
                 else if (k == "vpn.assigned.netmask")  vpn["netmask"] = sv();
                 else if (k == "vpn.assigned.dns")      vpn["dns"] = sv();
+                else if (k == "vpn.connected.unix")    vpn["connected_unix"] = iv();
                 else if (k == "vpn.pid")               vpn["pid"] = iv();
                 else if (k == "vpn.exit_code")         vpn["exit_code"] = iv();
                 else if (k == "vpn.gate.reason")       vpn["gate_reason"] = sv();
@@ -787,6 +789,16 @@ void install_handlers(Router& router,
             resp["routing"]  = routing;
             resp["services"] = services;
             resp["cloud"]    = cloud;
+            // Host uptime (this device / cloud container) from /proc/uptime —
+            // first token is seconds since boot. Surfaced in the top status bar.
+            {
+                json device = json::object();
+                std::ifstream upf("/proc/uptime");
+                double up = 0.0;
+                if (upf >> up)
+                    device["uptime_sec"] = static_cast<long long>(up);
+                resp["device"] = device;
+            }
             r.body = resp.dump();
             return r;
         });

--- a/modules/openvpn/client/schemas/vpn.lua
+++ b/modules/openvpn/client/schemas/vpn.lua
@@ -26,6 +26,8 @@
 --   vpn.assigned.gateway  - pushed VPN gateway
 --   vpn.assigned.netmask  - pushed netmask
 --   vpn.assigned.dns      - comma-joined DNS list (array variant: FUP)
+--   vpn.connected.unix    - epoch secs the tunnel reached CONNECTED (0 = down);
+--                           UI derives tunnel uptime = now - this
 --   vpn.pid               - live openvpn subprocess pid
 --   vpn.exit_code         - last openvpn exit code (set when state=exited)
 --   vpn.gate.reason       - "ok" while running, "wan_down" while gated on
@@ -86,6 +88,8 @@ return {
         access  = "Viewer", type = "string" },
     ["vpn.assigned.dns"]     = {
         access  = "Viewer", type = "string" },
+    ["vpn.connected.unix"]   = {
+        access  = "Viewer", type = "integer", min = 0, default = 0 },
     ["vpn.pid"]              = {
         access  = "Viewer", type = "integer", min = 0 },
     ["vpn.exit_code"]        = {

--- a/modules/openvpn/client/src/ds_bridge.cpp
+++ b/modules/openvpn/client/src/ds_bridge.cpp
@@ -1,5 +1,6 @@
 #include "ds_bridge.hpp"
 
+#include <ctime>
 #include <mutex>
 #include <type_traits>
 #include <utility>
@@ -36,6 +37,7 @@ constexpr const char* kAssignedIp      = "vpn.assigned.ip";
 constexpr const char* kAssignedGateway = "vpn.assigned.gateway";
 constexpr const char* kAssignedNetmask = "vpn.assigned.netmask";
 constexpr const char* kAssignedDns     = "vpn.assigned.dns";
+constexpr const char* kConnectedUnix   = "vpn.connected.unix";
 constexpr const char* kPid             = "vpn.pid";
 constexpr const char* kExitCode        = "vpn.exit_code";
 constexpr const char* kGateReason      = "vpn.gate.reason";
@@ -300,6 +302,20 @@ void DsBridge::set_state(const std::string& s) {
         ACE_ERROR((LM_WARNING,
                    ACE_TEXT("%D [ovpn:%t] %M %N:%l set %C='%C' failed: %C\n"),
                    kState, s.c_str(), rs.err.c_str()));
+    }
+    // Stamp the tunnel connect time exactly on the transition INTO "connected"
+    // (so the UI can show uptime = now − vpn.connected.unix), and clear it to 0
+    // on the way out so a disconnected tunnel reports no uptime. Only fire on a
+    // real transition — set_state() is called for every mgmt STATE line, and
+    // re-stamping on each "connected" event would reset the uptime each poll.
+    if (s != m_prev_state) {
+        if (s == "connected") {
+            m_impl->client.set(kConnectedUnix,
+                static_cast<std::int32_t>(std::time(nullptr)));
+        } else if (m_prev_state == "connected") {
+            m_impl->client.set(kConnectedUnix, std::int32_t{0});
+        }
+        m_prev_state = s;
     }
 }
 void DsBridge::set_assigned_ip(const std::string& s) {

--- a/modules/openvpn/client/src/ds_bridge.hpp
+++ b/modules/openvpn/client/src/ds_bridge.hpp
@@ -143,6 +143,10 @@ private:
     std::unique_ptr<Impl> m_impl;
     std::string           m_path;
     bool                  m_ok = false;
+    // Last vpn.state we published — lets set_state() stamp vpn.connected.unix
+    // exactly on the transition INTO "connected" (and clear it on the way out)
+    // so the UI can show a stable tunnel uptime that doesn't reset every poll.
+    std::string           m_prev_state;
 };
 
 } // namespace openvpn_client

--- a/modules/wan/wifi/client/src/supervisor.cpp
+++ b/modules/wan/wifi/client/src/supervisor.cpp
@@ -461,6 +461,8 @@ int Supervisor::run() {
             if (!m_wpa.running()) {
                 m_ds.set_assoc_state("exited");
                 m_ds.set_pid_wpa(0u);
+                m_assoc_bssid.clear();
+                m_ds.set_signal_rssi(0);   // no association → no signal
                 return 0;
             }
             continue;
@@ -476,6 +478,20 @@ int Supervisor::run() {
             std::string reply;
             if (m_ctrl.request("SCAN_RESULTS", reply)) {
                 auto rows = parse_scan_results(reply);
+                // Publish the associated AP's signal as wifi.signal.rssi so the
+                // UI shows live signal strength instead of the schema default 0.
+                // (SCAN_RESULTS works on drivers whose SIGNAL_POLL doesn't, e.g.
+                // RPi brcmfmac.) Rate-limited via the RSSI coalescer; read here
+                // before `rows` is moved into the serializer below.
+                if (!m_assoc_bssid.empty()) {
+                    for (const auto& e : rows) {
+                        if (e.bssid == m_assoc_bssid) {
+                            if (m_rssi.should_publish(e.signal))
+                                m_ds.set_signal_rssi(e.signal);
+                            break;
+                        }
+                    }
+                }
                 auto cap  = m_ds.scan_max_results().value_or(20u);
                 m_ds.set_scan_results(
                     cap_and_serialize_scan_results(std::move(rows),
@@ -486,6 +502,7 @@ int Supervisor::run() {
         } else if (ev->kind == ctrl::CtrlEvent::Kind::Connected) {
             m_ds.set_assoc_ssid(ev->ssid);
             m_ds.set_assoc_bssid(ev->bssid);
+            m_assoc_bssid = ev->bssid;
             auto dhcp_path = pick_dhcp_client(
                 m_ds.dhcp_client().value_or("auto"),
                 m_ds.dhcp_path().value_or(""));

--- a/modules/wan/wifi/client/src/supervisor.hpp
+++ b/modules/wan/wifi/client/src/supervisor.hpp
@@ -171,6 +171,11 @@ private:
     ctrl::Client          m_ctrl;
     Lifecycle             m_fsm;
 
+    /// BSSID of the currently-associated AP (from the CONNECTED ctrl event).
+    /// Used to pick our AP's signal out of each SCAN_RESULTS batch and publish
+    /// wifi.signal.rssi. Empty while not associated.
+    std::string           m_assoc_bssid;
+
     /// L16/D6 — services.wifi.client.enable gate. Composes with the
     /// NM-conflict gate; disable dominates conflict (the daemon
     /// returns "disabled" even if NM would otherwise refuse start).


### PR DESCRIPTION
Surfaces connectivity data the daemons already track, plus two new uptime fields, on the device-ui **Dashboard** + top status bar. All four were requested together; they share files (`app-globals`, `handler.cpp`, dashboard template) so they land as one PR.

### VPN dashboard card
- Show **netmask, gateway, DNS** (already in `/status`; the card only printed the IP).
- Show **tunnel uptime**: openvpn-client stamps `vpn.connected.unix` on the transition *into* `connected` (cleared on the way out) in `DsBridge::set_state` (NTP-synced device clock); `/status` exposes `vpn.connected_unix`; the card renders `now − that`.

### Device uptime (top status bar)
- `iot-httpd` `/status` reads `/proc/uptime` → `device.uptime_sec`; top bar shows `up <duration>`. (Per-host: the device, or the cloud container.)

### WiFi RSSI — fix "0 dBm"
- Root cause: `set_signal_rssi` was **defined but never called**, so `wifi.signal.rssi` was never written → `/status` defaulted to `0` → dashboard showed `0 dBm`.
- Fix: wifi-client publishes the associated AP's **scan** signal (matched by BSSID, rate-limited via the existing `RssiCoalescer`) on each `SCAN_RESULTS`, and resets to 0 when association drops. Works on drivers whose `SIGNAL_POLL` times out (RPi brcmfmac — confirmed `iw` reports e.g. `-53 dBm` while `SIGNAL_POLL` times out). Dashboard only renders RSSI when `< 0`, hiding the sentinel.

### Shared
- `fmtDuration()` humaniser → `app-globals`; `StatusSnapshot` gains `device` + `vpn.connected_unix`. New UI fields degrade gracefully on older firmware (absent → hidden).

**Deploy:** device-ui rebuild + the C++ daemons (openvpn-client, wifi-client, iot-httpd) — needs an image rebuild to verify on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)