### PR TITLE
docs: reflect this session's fixes across the affected docs

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -550,6 +550,12 @@ How it works on the image:
 > network, restrict `http.listen.ip` (bind to localhost / the VPN iface) or
 > front it with auth.
 
+> **Default device-ui logins** — auth is **on** by default
+> (`http.auth.enabled=true`). The image seeds two accounts (`iot-ds-seed`, first
+> boot): `admin` / `admin` (full access) and `engineer` / `engineer` (read-only
+> **Viewer** — can't change config, run the Terminal, or provision). Change both
+> in the **Users** page before production.
+
 Notes / limits:
 - The advert hardcodes port **8080**; if you change `http.listen.port` the
   mDNS record is stale (edit `/etc/avahi/services/iot-http.service` to match).

--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -536,6 +536,16 @@ All state keys default to `"stopped"`. Each daemon self-reports `"running"`
 immediately after connecting to ds-server, and `"exited"` at shutdown.
 The Services page polls every 5s.
 
+**ds-server state + L22 telemetry stream live in `/status`.** `iot-httpd`
+dual-emits the `services.ds.*` keys (state + cpu/mem/fd/threads) into the flat
+`cloud` passthrough the cloud-ui Services page reads. Without that they only
+landed in the nested `services` block (which the *device*-ui reads) and never in
+the `cloud` block (which only matched `services.cloud.*`), so the cloud
+ds-server row showed a stale `"stopped"` + `—` telemetry even though it was
+running — which it always is, since every other daemon reports *through* it.
+The flat key for ds-server state is `services.ds.state` (the other services use
+`services.cloud.*`).
+
 ## Related modules
 
 | Module | Role |

--- a/apps/docs/tdd-wifi-autostart.md
+++ b/apps/docs/tdd-wifi-autostart.md
@@ -38,6 +38,23 @@ first or `find_package(GTest)` fails. The `:lp` httpd image has it baked in.)
 - Per-device secure WiFi credential provisioning (placeholder default is
   world-readable in the image — fine for lab, not production).
 
+## Companion fix — NTP sync on a WiFi-only, no-RTC board
+
+Because `wlan0` is brought up **outside** systemd-networkd (by wpa_supplicant +
+udhcpc here), networkd manages only `eth0`, which is `RequiredForOnline=yes` by
+default. On a headless WiFi-only RPi the cable-less `eth0` pins networkd's global
+`Online state: offline`, which **parks `systemd-timesyncd`** — it never sends an
+NTP packet. The Pi has no RTC, so the clock stays at its stale save-file value
+and every TLS handshake fails `certificate is not yet valid` (this is what broke
+the OpenVPN tunnel until the clock was set by hand).
+
+Fix: the image ships `meta-iot/.../files/10-iot-wired.network` (sorts before the
+stock `80-wired.network`, wins the `eth*/en*` match) with
+`RequiredForOnline=no`, so a cable-less `eth0` no longer drags the system
+offline and timesyncd syncs over WiFi within seconds of boot. Durable across
+reboots with no RTC: timesyncd's save-file restores a forward-only clock at
+early boot, kept fresh now that NTP actually syncs. (PR #240.)
+
 ## 1. Goal
 
 On a fresh Raspberry Pi boot with the `iot` image, the `wifi-client` daemon

--- a/modules/openvpn/client/docs/design.md
+++ b/modules/openvpn/client/docs/design.md
@@ -87,7 +87,10 @@ Sequence on a fresh PUSH_REPLY:
 3. openvpn(8) emits management lines: `>STATE:…,ASSIGN_IP,…,10.8.0.6,…`,
    then `>PUSH_REPLY:…`, then `>STATE:…,CONNECTED,…`.
 4. Our `Lifecycle::step` parses + DsBridge writes
-   `vpn.assigned.{ip,gateway,netmask,dns}` to ds-server.
+   `vpn.assigned.{ip,gateway,netmask,dns}` to ds-server. `DsBridge::set_state`
+   also stamps `vpn.connected.unix` (epoch secs) on the transition INTO
+   `connected` and clears it (0) on the way out, so the UI can render tunnel
+   uptime = now − that.
 5. Other apps observe via `ds-cli get vpn.assigned.ip` or
    `Client::watch`.
 

--- a/modules/wan/wifi/client/docs/design.md
+++ b/modules/wan/wifi/client/docs/design.md
@@ -146,6 +146,13 @@ Write keys (daemon → operator): `wifi.assoc.state`, `wifi.assoc.ssid`,
 `wifi.scan.last.unix`, `wifi.dhcp.state`, `wifi.dhcp.ip`,
 `wifi.pid.wpa`, `wifi.pid.dhcp`, `wifi.last.error`.
 
+`wifi.signal.rssi` is the **associated AP's** signal (dBm, negative): on each
+`SCAN_RESULTS` batch the supervisor picks the row whose BSSID matches the
+connected AP and publishes its signal (rate-limited via the RSSI coalescer),
+resetting to 0 when the association drops. It is sourced from scan results
+rather than wpa `SIGNAL_POLL`, which times out on some drivers (RPi brcmfmac —
+there `iw dev wlan0 link` reports a signal but `SIGNAL_POLL` does not).
+
 ### `wifi.networks` JSON shape
 
 ```json

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -31,6 +31,11 @@
 # Requirements:
 #   - podman or docker
 #   - ~50 GB free disk space (Yocto downloads + build + image)
+#   - RAM: 8 GB works but is slow. entrypoint.sh derives BB_NUMBER_THREADS /
+#     PARALLEL_MAKE from available RAM (+ bitbake PSI pressure regulation) to
+#     avoid OOM-killed compiles (cc1plus on gcc/nodejs-native). More RAM = more
+#     parallelism: 8 GB→1 recipe at a time, 14 GB→2, 24 GB→4. Bump the podman VM
+#     with `podman machine set --memory <MB>` (machine stopped) for faster builds.
 #   - Internet access (first build fetches ~8 GB of sources)
 #
 # Persistent caches (named volumes, survive across runs → incremental):


### PR DESCRIPTION
Documentation-only follow-up to the PRs merged this session — updates each "respective doc" so it matches the code.

| Doc | Update | For PR |
|-----|--------|--------|
| `modules/wan/wifi/client/docs/design.md` | how `wifi.signal.rssi` is sourced (associated AP's scan signal, BSSID-matched + coalesced; `SIGNAL_POLL` times out on brcmfmac) | #245 |
| `modules/openvpn/client/docs/design.md` | `DsBridge` stamps `vpn.connected.unix` on connect → UI tunnel uptime | #245 |
| `apps/cloud/CLAUDE.md` | ds-server state + L22 telemetry now stream live in `/status` (dual-emitted into the flat `cloud` block) | #242 |
| `apps/docs/tdd-wifi-autostart.md` | companion no-RTC NTP fix (`10-iot-wired.network`, `RequiredForOnline=no`) | #240 |
| `DEPLOY.md` | default device-ui logins — `admin`/`admin` + read-only `engineer`/`engineer` | #244 |
| `yocto/build.sh` | RAM requirement + RAM-aware concurrency / PSI guards vs OOM-killed compiles | #246 |

(Truthful-terminal-label docs — `tdd-device-shell.md`, `http.lua` — were already updated in #243.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)