### PR TITLE
fix(cloud): stop two benign startup conditions logging as ERROR

### DIFF
--- a/apps/src/udp_adapter.cpp
+++ b/apps/src/udp_adapter.cpp
@@ -4,6 +4,7 @@
 #include "udp_adapter.hpp"
 #include "data_store/log_buffer.hpp"   // LogBuffer::attach_current_thread
 
+#include <cerrno>                 // EADDRINUSE
 #include <ace/Log_Msg.h>
 #include <ace/Reactor.h>
 #include <ace/Signal.h>          // ACE_Sig_Set
@@ -47,10 +48,26 @@ ServiceContext_t::~ServiceContext_t() {
 
 int ServiceContext_t::open() {
     if (m_sock.open(m_selfAddr) == -1) {
-        ACE_ERROR_RETURN((LM_ERROR,
-                          ACE_TEXT("%D [UdpSvc:%t] %M %N:%l bind failed host:%s port:%d errno:%d\n"),
-                          m_selfHost.c_str(), m_selfPort, errno),
-                         -1);
+        const int e = errno;
+        if (e == EADDRINUSE) {
+            // Expected on a single-/shared-port server deploy: the BS and DM
+            // instances each also probe the peer port and the loser hits
+            // EADDRINUSE. The socket that DID bind serves both /bs and /rd
+            // (both handlers are attached to every service context — see
+            // apps/src/main.cpp), so this is benign, not a failure. Log it as a
+            // WARNING (visible, but not an error) and skip just this socket.
+            ACE_DEBUG((LM_WARNING,
+                       ACE_TEXT("%D [UdpSvc:%t] %M %N:%l port %d already in use "
+                                "(EADDRINUSE) — expected when BS/DM share a port; "
+                                "the bound socket still serves /bs + /rd\n"),
+                       m_selfPort));
+        } else {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D [UdpSvc:%t] %M %N:%l bind failed host:%s "
+                                "port:%d errno:%d\n"),
+                       m_selfHost.c_str(), m_selfPort, e));
+        }
+        return -1;
     }
 
     if (m_scheme == Scheme_t::CoAPs && m_dtlsAdapter) {

--- a/modules/server/dnat/src/device_dnat.cpp
+++ b/modules/server/dnat/src/device_dnat.cpp
@@ -94,11 +94,23 @@ bool apply_ruleset(const std::string& script, const std::string& nft_path) {
 }
 
 bool enable_ip_forward() {
-    FILE* f = ::fopen("/proc/sys/net/ipv4/ip_forward", "w");
-    if (!f) return false;
-    const int n = ::fputs("1\n", f);
-    ::fclose(f);
-    return n >= 0;
+    // Try to turn it on.
+    if (FILE* f = ::fopen("/proc/sys/net/ipv4/ip_forward", "w")) {
+        const int n = ::fputs("1\n", f);
+        ::fclose(f);
+        if (n >= 0) return true;
+    }
+    // Couldn't write — common in a container where /proc/sys is read-only. That
+    // is NOT a failure when forwarding is ALREADY enabled (e.g. the compose sets
+    // the namespaced sysctl `net.ipv4.ip_forward=1` at container start). Report
+    // the effective state by reading it back, so the caller only logs an error
+    // when forwarding is genuinely off.
+    bool on = false;
+    if (FILE* r = ::fopen("/proc/sys/net/ipv4/ip_forward", "r")) {
+        on = (::fgetc(r) == '1');
+        ::fclose(r);
+    }
+    return on;
 }
 
 } // namespace dnat


### PR DESCRIPTION
After a cloud image update, two `LM_ERROR` lines alarmed the operator, but both are benign — verified end-to-end (device-UI proxy routes over the tunnel; the device re-registers through 5683 fine).

1. **`could not enable net.ipv4.ip_forward (device-UI DNAT may not route)`** — `enable_ip_forward()` returned false whenever it couldn't *write* `/proc/sys/net/ipv4/ip_forward`, which is normal in a container (read-only `/proc/sys`) where forwarding is **already on** via the compose `sysctls: net.ipv4.ip_forward=1`. Now it reads the value back on write failure and returns the **effective** state, so the ERROR only fires when forwarding is genuinely off.

2. **`bind failed … 5683 errno:98` (EADDRINUSE)** — logged as `LM_ERROR` even though it's expected and tolerated by design: on a single-/shared-port BS+DM deploy both handlers attach to every socket, so the socket that *did* bind serves both `/bs` and `/rd` (`apps/src/main.cpp:336`). EADDRINUSE now logs `LM_WARNING` with an "expected" note; other bind errors stay `LM_ERROR`.

No behavior change — logging truthfulness only. Needs a cloud image rebuild to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)