### PR TITLE
fix(yocto): rauc system.conf file-clash fails IOT_AB do_rootfs

### DIFF
--- a/yocto/meta-iot/dynamic-layers/rauc/recipes-core/rauc/rauc_%.bbappend
+++ b/yocto/meta-iot/dynamic-layers/rauc/recipes-core/rauc/rauc_%.bbappend
@@ -26,7 +26,11 @@ do_install:append() {
     install -m 0644 ${WORKDIR}/${RAUC_KEYRING_FILE} ${D}${sysconfdir}/rauc/keyring.pem
 }
 
-FILES:${PN} += " \
-    ${sysconfdir}/rauc/system.conf \
-    ${sysconfdir}/rauc/keyring.pem \
-"
+# system.conf belongs to the meta-rauc `rauc-conf` package, which already ships
+# a template at this path. Claiming it in the main `rauc` package too made BOTH
+# ipks carry /etc/rauc/system.conf, so opkg aborts do_rootfs with a file clash
+# ("file is already provided by package rauc-conf"). Our do_install:append
+# overwrites the template with the iot slot map; ownership stays with rauc-conf.
+# keyring.pem is our own addition (not in any other package) → main `rauc` pkg.
+FILES:rauc-conf += " ${sysconfdir}/rauc/system.conf "
+FILES:${PN}     += " ${sysconfdir}/rauc/keyring.pem "


### PR DESCRIPTION
## Symptom

An `IOT_AB=1` build failed at `iot-image:do_rootfs`:
```
opkg … install … rauc … returned 255
… /etc/rauc/system.conf is already provided by package * rauc-conf
```

## Root cause

The meta-rauc version in use splits `system.conf` into a dedicated **`rauc-conf`** package (ships a template there). Our `rauc_%.bbappend` installed `system.conf` **and** claimed it in `FILES:${PN}`, so **both** the `rauc` and `rauc-conf` ipks carried `/etc/rauc/system.conf`. opkg refuses overlapping files between packages → `do_rootfs` aborts (255).

Latent bug — only surfaces now that the build reaches rootfs assembly (the earlier OOM fix, PR #246, got it this far). Not from any app-code change.

## Fix

Move `system.conf` to `FILES:rauc-conf`. Our `do_install:append` still overwrites the meta-rauc template with the iot A/B slot map; ownership now sits with **one** package (`rauc-conf`). `keyring.pem` is our own addition (not provided elsewhere) and stays in the main `rauc` package — it never clashed.

Only affects `IOT_AB=1` (RAUC A/B) builds; the default single-rootfs image is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)