### PR TITLE
feat(httpd): apply http.workers changes live + seed it on the cloud

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -671,6 +671,19 @@ int main(int argc, char** argv) {
     // iot-cloudd doesn't matter.
     ds.set("http.auth.cookie.name",
            data_store::Value{std::string("iot-cloud-session")});
+    // Seed http.workers for the cloud httpd. The cloud-ui relies on blocking
+    // long-polls (the shared /status poll), so the schema default 0 (inline)
+    // stalls it. Unlike the device (iot-ds-seed) the cloud has no first-boot
+    // seed, and run.sh intentionally doesn't pass http-workers on the CLI (ds is
+    // the single source of truth). Bump it from the inline default to 4; an
+    // operator's own higher value is left untouched. httpd applies it live — it
+    // self-restarts when http.workers changes — so start order doesn't matter.
+    if (ds_int(ds, "http.workers", 0) == 0) {
+        ds.set("http.workers", data_store::Value{static_cast<std::int32_t>(4)});
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l seeded http.workers=4 "
+                            "(was inline 0)\n")));
+    }
     if (!server::dnat::enable_ip_forward()) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l could not enable "

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -549,6 +549,28 @@ int main(int argc, char** argv) {
             lastDs = cur;
             if (tlsDirty) reload_tls();
             if (listenDirty) rebind();
+
+            // http.workers can't be hot-resized (the pool is fixed-size), so
+            // apply an operator change by cleanly self-restarting — the new
+            // process rebuilds the pool at the new size. The cloud httpd restarts
+            // via compose `restart: unless-stopped`; the device unit uses
+            // Restart=always. The UI's long-poll reconnects after the ~2s cycle.
+            {
+                std::vector<data_store::Client::GetResult> wgot;
+                auto wrs = ds.get({"http.workers"}, wgot);
+                if (wrs.ok && !wgot.empty() && wgot[0].has_value) {
+                    if (auto n = data_store::to_int32(wgot[0].value);
+                        n && *n >= 0 &&
+                        static_cast<std::size_t>(*n) != pool.size()) {
+                        ACE_DEBUG((LM_INFO,
+                                   ACE_TEXT("%D httpd:thread:%t %M %N:%l "
+                                            "http.workers %u->%d changed; "
+                                            "restarting to apply\n"),
+                                   static_cast<unsigned>(pool.size()), *n));
+                        g_stop.store(true);
+                    }
+                }
+            }
         }
     }
 

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-httpd.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-httpd.service
@@ -25,7 +25,11 @@ SupplementaryGroups=iot
 AmbientCapabilities=CAP_NET_BIND_SERVICE
 CapabilityBoundingSet=CAP_NET_BIND_SERVICE
 
-Restart=on-failure
+# Restart=always (not on-failure) so the daemon comes back after a CLEAN exit
+# too: iot-httpd self-restarts to apply an http.workers change (the pool is
+# sized at startup and can't be hot-resized). `systemctl stop` is an intentional
+# stop and is NOT restarted; the StartLimit above still guards against flapping.
+Restart=always
 RestartSec=2s
 
 StandardOutput=journal


### PR DESCRIPTION
## Why

- `http.workers` sizes the handler thread-pool **at startup** and was the one `http.*` key not hot-reloaded, so changing it in the UI did nothing until a manual restart — confusing.
- After the cloud image update (which stopped passing `http-workers` on the CLI — ds-only by design), the cloud booted at the schema default **0** (inline), which stalls the cloud-ui's blocking long-polls. There was no cloud equivalent of the device's `iot-ds-seed`.

## Changes

1. **httpd self-restarts on change** (`modules/http-server/src/main.cpp`): the existing ~2 s config-watch loop now compares `http.workers` to the live `pool.size()` and, when it differs, logs and sets the graceful-stop flag. The pool is fixed-size (can't hot-resize), so a clean restart rebuilds it at the new size. Long-poll reconnects after the ~2 s cycle.
2. **`iot-httpd.service`**: `Restart=on-failure` → `Restart=always`, so the clean self-restart actually comes back on the device (cloud already restarts via compose `restart: unless-stopped`). `systemctl stop` still won't loop; `StartLimit` guards flapping.
3. **cloud seed** (`apps/cloud/server/src/main.cpp`): `iot-cloudd` (which already seeds ds keys at startup, cloud-only) sets `http.workers=4` when it's the inline default `0`; an operator's higher value is preserved. With #1, a fresh/updated cloud converges to 4 on its own and never sits inline. Device keeps its `iot-ds-seed` `http.workers=2`.

## Caveats

- Untestable from here (core daemon) — kept the logic minimal (compare value, clean exit via the existing graceful-stop path).
- Changing Worker Threads now drops the UI long-poll for ~2 s while httpd cycles, then reconnects — automatic, no manual Services-page restart.

Needs a device + cloud image rebuild to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)