### PR TITLE
refactor: http.workers default 4 in schema, drop the hardcoded seeds

### DIFF
--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -395,14 +395,17 @@ http.listen.scheme       → "http" | "https"
 http.tls.cert            → TLS cert PEM path (required for https)
 http.tls.key             → TLS key PEM path (required for https)
 http.tls.ca              → CA bundle PEM path (optional — enables mTLS)
-http.workers             → Handler thread pool (0 = inline, default). ds-ONLY:
-                           no CLI arg / env — the compose used to pass
-                           http-workers= which silently overrode this key, so
-                           the UI showed 0 while the daemon ran 4. Now ds is
-                           the single source of truth (set it in the HTTP page).
+http.workers             → Handler thread pool (0 = inline; schema default 4 —
+                           enough for the cloud-ui long-polls). ds-ONLY: no CLI
+                           arg / env — the compose used to pass http-workers=
+                           which silently overrode this key, so the UI showed 0
+                           while the daemon ran 4. Now ds is the single source of
+                           truth (set it in the HTTP page).
 http.auth.enabled        → Auth gate (true = enabled, from auth.lua)
 ```
-Hot-reloaded: all except `http.workers` (needs a restart).
+Hot-reloaded: all except `http.workers` — a change there makes iot-httpd
+**self-restart** to resize the pool (cloud restarts via compose
+`restart: unless-stopped`; device unit uses `Restart=always`).
 
 ### Bootstrap Server (cloud.bs.*)
 ```

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -671,19 +671,8 @@ int main(int argc, char** argv) {
     // iot-cloudd doesn't matter.
     ds.set("http.auth.cookie.name",
            data_store::Value{std::string("iot-cloud-session")});
-    // Seed http.workers for the cloud httpd. The cloud-ui relies on blocking
-    // long-polls (the shared /status poll), so the schema default 0 (inline)
-    // stalls it. Unlike the device (iot-ds-seed) the cloud has no first-boot
-    // seed, and run.sh intentionally doesn't pass http-workers on the CLI (ds is
-    // the single source of truth). Bump it from the inline default to 4; an
-    // operator's own higher value is left untouched. httpd applies it live — it
-    // self-restarts when http.workers changes — so start order doesn't matter.
-    if (ds_int(ds, "http.workers", 0) == 0) {
-        ds.set("http.workers", data_store::Value{static_cast<std::int32_t>(4)});
-        ACE_DEBUG((LM_INFO,
-                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l seeded http.workers=4 "
-                            "(was inline 0)\n")));
-    }
+    // (http.workers needs no cloud-side seed: the http.* schema default is 4,
+    // enough for the cloud-ui long-polls. Operators tune it on the HTTP page.)
     if (!server::dnat::enable_ip_forward()) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l could not enable "

--- a/modules/http-server/schemas/http.lua
+++ b/modules/http-server/schemas/http.lua
@@ -44,11 +44,16 @@ return {
     ["http.tls.ca"]        = {
         access  = "Admin", type = "string",  default = "" },
 
-    -- Handler thread-pool size. 0 = run handlers inline on the reactor
-    -- thread (default). >0 off-loads handlers to N worker threads so a
-    -- blocking long-poll can't stall other connections. CLI: http-workers=N.
+    -- Handler thread-pool size. 0 = run handlers inline on the reactor thread;
+    -- >0 off-loads handlers to N worker threads so a blocking long-poll (the
+    -- shared /status poll, the Terminal shell) can't stall other connections.
+    -- Default 4: both the device-ui and cloud-ui rely on those long-polls, so
+    -- inline (0) stalls them — 4 is a safe floor with headroom for the status
+    -- poll + a shell + a couple of requests. Operators tune it on the HTTP page;
+    -- iot-httpd applies a change by self-restarting (the pool is sized at
+    -- startup). CLI http-workers=N still overrides at startup if ever passed.
     ["http.workers"]       = {
-        access  = "Admin", type = "integer", default = 0, min = 0, max = 64 },
+        access  = "Admin", type = "integer", default = 4, min = 0, max = 64 },
 
     -- ── Remote shell (device-ui Terminal page) ──────────────────────
     -- Master switch for the forkpty-backed shell at /api/v1/shell/*.

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
@@ -8,14 +8,12 @@
 # re-clobbers operator changes made later via the UI / ds-cli — including across
 # an OS update (the flag lives with the persisted state, not in the rootfs).
 #
+# (http.workers is no longer seeded here — the http.* schema default is now 4,
+# which the device-ui long-polls need; there's nothing device-specific to
+# override. Operators tune it on the HTTP Config page; iot-httpd self-restarts
+# to apply a change.)
+#
 # Current seed:
-#   http.workers = 2
-#     The schema default is 0 (handlers run inline on the reactor thread). The
-#     device-ui relies on blocking long-polls (the shared /status poll, and the
-#     Terminal shell's /api/v1/shell/output) which would stall an inline server,
-#     so a fresh device needs a worker pool. 2 is enough for the status poll +
-#     one shell session; bump via the HTTP Config page (restart required —
-#     http.workers is not hot-reloaded).
 #   auth.users.accounts = [ engineer / Viewer ]
 #     Seed a read-only "engineer" device-ui login (password "engineer") next to
 #     the built-in admin (admin/admin), so a field engineer can view the device
@@ -51,20 +49,13 @@ fi
 ENGINEER_HASH="7826b958b79c70626801b880405eb5111557dadceb2fee2b1ed69a18eed0c6dc"
 ENGINEER_ACCOUNTS="[{\"id\":\"engineer\",\"hash\":\"$ENGINEER_HASH\",\"access\":\"Viewer\"}]"
 
-# Seed all device-only defaults; write the flag only if EVERY step succeeds, so
-# a partial failure retries cleanly on the next boot (|| guards keep `set -e`
-# from aborting before we can report which step failed).
-ok=1
-$DSCLI set http.workers 2 \
-    || { ok=0; echo "iot-ds-seed: failed to set http.workers" >&2; }
-$DSCLI set auth.users.accounts "$ENGINEER_ACCOUNTS" \
-    || { ok=0; echo "iot-ds-seed: failed to set auth.users.accounts" >&2; }
-
-if [ "$ok" = 1 ]; then
+# Seed the device-only default(s); write the flag only on success so a failure
+# retries cleanly on the next boot.
+if $DSCLI set auth.users.accounts "$ENGINEER_ACCOUNTS"; then
     mkdir -p "$STATE"
     : > "$FLAG"
-    echo "iot-ds-seed: seeded http.workers=2 + engineer (Viewer) account (first boot)"
+    echo "iot-ds-seed: seeded engineer (Viewer) account (first boot)"
 else
-    echo "iot-ds-seed: a seed step failed; will retry next boot" >&2
+    echo "iot-ds-seed: failed to set auth.users.accounts; will retry next boot" >&2
     exit 0   # leave the flag unwritten so the next boot retries
 fi


### PR DESCRIPTION
Follow-up to #250. Per review feedback — don't hardcode the worker count in `iot-cloudd`; put the default in the schema.

- **`http.lua`**: `http.workers` default `0` → **`4`**. 4 is a safe floor for the device-ui *and* cloud-ui blocking long-polls (`/status`, Terminal shell). Operators tune it on the HTTP page; `iot-httpd` self-restarts to apply (from #250).
- **`iot-cloudd`**: removed the `http.workers=4` seed — the schema default covers the cloud now.
- **`iot-ds-seed`**: removed the `http.workers=2` seed (its only purpose was escaping the old inline-`0` default). The device now uses the schema default `4` like the cloud. The seed keeps provisioning the read-only `engineer` device-ui account.
- Doc (`apps/cloud/CLAUDE.md`) updated. No test pins the old default.

Net: one source of truth for the default (the schema), no per-daemon/per-seed hardcodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)