### PR TITLE
fix(wifi): disable brcmfmac power-save so the link stops flapping

### DIFF
--- a/apps/docs/tdd-wifi-autostart.md
+++ b/apps/docs/tdd-wifi-autostart.md
@@ -55,6 +55,19 @@ offline and timesyncd syncs over WiFi within seconds of boot. Durable across
 reboots with no RTC: timesyncd's save-file restores a forward-only clock at
 early boot, kept fresh now that NTP actually syncs. (PR #240.)
 
+## Companion fix — WiFi power-save flapping (RPi brcmfmac)
+
+The RPi3 brcmfmac (BCM43430) enables WiFi **power-save after each association**
+(`dmesg`: `brcmf_cfg80211_set_power_mgmt: power save enabled`). On an idle link
+the chip sleeps, misses beacons, gets disassociated, then reconnects — usually
+to a **new DHCP lease**, so the LAN IP hops around and the OpenVPN tunnel +
+LwM2M registration flap in lockstep (the cloud's device-UI DNAT toggles
+`1↔0 rule(s)`). It is not reboots/crashes: the daemons show `NRestarts=0`.
+
+Fix: the `udhcpc-ds.script` lease hook runs `iw dev <iface> set power_save off`
+on every `bound`/`renew` (post-association, where the driver re-enables it), and
+`iw` is pulled into the wifi-client package. Best-effort — it never breaks DHCP.
+
 ## 1. Goal
 
 On a fresh Raspberry Pi boot with the `iot` image, the `wifi-client` daemon

--- a/modules/wan/wifi/client/scripts/udhcpc-ds.script
+++ b/modules/wan/wifi/client/scripts/udhcpc-ds.script
@@ -44,6 +44,13 @@ fi
 # 2) Mirror the lease to the data-store.
 case "$1" in
     bound|renew)
+        # RPi brcmfmac re-enables WiFi power-save after each association, which
+        # makes the link idle-disassociate — flapping the IP / VPN / LwM2M. Turn
+        # it off on every lease (post-association); best-effort, must never break
+        # DHCP. See apps/docs/tdd-wifi-autostart.md.
+        if [ -n "${interface:-}" ]; then
+            iw dev "$interface" set power_save off >/dev/null 2>&1 || true
+        fi
         dsset wifi.dhcp.ip            "$(jq_str "${ip:-}")"
         dsset wifi.dhcp.mask          "$(jq_str "${subnet:-}")"
         dsset wifi.dhcp.gateway       "$(jq_str "${router:-}")"

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -425,9 +425,12 @@ FILES:${PN}-wifi-client = "\
     ${systemd_system_unitdir}/iot-wifi-client.service \
 "
 # iot-ds-cli: the udhcpc lease hook writes the lease via ds-cli.
+# iw: the lease hook runs `iw dev <iface> set power_save off` to stop the RPi
+#     brcmfmac WiFi from idle-disassociating (link/IP/VPN/LwM2M flapping).
 RDEPENDS:${PN}-wifi-client = "\
     ace-tao \
     wpa-supplicant \
+    iw \
     ${PN}-ds-cli \
 "
 RRECOMMENDS:${PN}-wifi-client = "\


### PR DESCRIPTION
## Symptom

The OpenVPN tunnel + LwM2M registration kept **flapping** (cloud device-UI DNAT toggling `1↔0 rule(s)` every minute or two), and the device's LAN IP hopped around (`.8 → .3`).

## Root cause

RPi3 brcmfmac (BCM43430) enables **WiFi power-save after each association** (`dmesg: brcmf_cfg80211_set_power_mgmt: power save enabled`). The idle chip sleeps, misses beacons, disassociates, reconnects — usually to a **new DHCP lease**, so the IP hops and the VPN/LwM2M (which ride the same WiFi) drop in lockstep. Confirmed it's not reboots/crashes: uptime ~10 h, `iot-wifi-client`/`iot-openvpn-client` `NRestarts=0`, and `iw dev wlan0 get power_save` = **on**. Disabling it live (`iw … power_save off`) stopped the flapping.

## Fix

`udhcpc-ds.script` lease hook runs `iw dev <iface> set power_save off` on every `bound`/`renew` — post-association, exactly where the driver re-enables it — so it survives reboots and every WiFi reconnect. Best-effort (`|| true`) so it can never break DHCP. `iw` added to `RDEPENDS:${PN}-wifi-client`.

Doc: `apps/docs/tdd-wifi-autostart.md` (companion-fix section). Pairs with the WiFi-RSSI fix already on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)