### PR TITLE
feat(cloud): show device ISP (public) IP in the Endpoints table

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -110,6 +110,7 @@ void sync_endpoints_to_ds(data_store::Client& ds,
         item["state"]         = ep.registered ? "online" : "offline";
         item["tun_ip"]        = ep.tun_ip;       // registry allocation
         item["dev_tun_ip"]    = ep.dev_tun_ip;   // openvpn-assigned (actual)
+        item["isp_ip"]        = ep.wan_ip;        // device public/ISP IP (real-addr)
         item["proxy_port"]    = ep.proxy_port;
         item["registered"]    = ep.registered;
         item["last_seen_unix"] = ep.last_seen_unix;
@@ -248,8 +249,9 @@ bool reconcile_registrations(data_store::Client& ds,
 // pre-allocated IP is not honored by openvpn). The serial here is already in
 // the cert-CN sanitized form (':' → '_'), matching sanitize_cn(endpoint).
 // Best-effort — empty map on any connect/IO failure (openvpn not up yet).
-std::map<std::string, std::string> poll_vpn_client_ips(std::uint16_t mgmt_port) {
-    std::map<std::string, std::string> out;   // sanitized-serial → virtual IP
+struct VpnClientNet { std::string vip; std::string wan_ip; };
+std::map<std::string, VpnClientNet> poll_vpn_client_ips(std::uint16_t mgmt_port) {
+    std::map<std::string, VpnClientNet> out;  // sanitized-serial → {vip, wan_ip}
     ACE_INET_Addr addr(mgmt_port, "127.0.0.1");
     ACE_SOCK_Connector conn;
     ACE_SOCK_Stream stream;
@@ -286,11 +288,25 @@ std::map<std::string, std::string> poll_vpn_client_ips(std::uint16_t mgmt_port) 
         std::size_t comma = resp.find(',', vstart);
         std::string vip = (comma != std::string::npos && comma < pos)
                               ? resp.substr(vstart, comma - vstart) : std::string();
+        // Real (public/ISP) address = the field AFTER the CN: `…,CN,real-addr,…`.
+        // It is ip:port; keep just the ip.
+        std::string wan;
+        {
+            std::size_t c1 = resp.find(',', at + suffix.size());  // comma after CN
+            if (c1 != std::string::npos && c1 < end) {
+                std::size_t c2 = resp.find(',', c1 + 1);
+                std::string ra = (c2 != std::string::npos && c2 < end)
+                                     ? resp.substr(c1 + 1, c2 - (c1 + 1))
+                                     : std::string();
+                wan = ra.substr(0, ra.find(':'));   // strip :port
+                if (wan.find_first_of(",\n\r ") != std::string::npos) wan.clear();
+            }
+        }
         pos = at + suffix.size();
         if (!serial.empty() && !vip.empty() &&
             serial.find_first_of(",\n\r ") == std::string::npos &&
             vip.find_first_of(",\n\r ") == std::string::npos) {
-            out[serial] = vip;
+            out[serial] = VpnClientNet{vip, wan};
         }
     }
     return out;
@@ -326,6 +342,7 @@ std::size_t rehydrate_registry(data_store::Client& ds,
                     static_cast<std::uint16_t>(e.value("proxy_port", 0)),
                     e.value("registered", false));
                 info.dev_tun_ip     = e.value("dev_tun_ip", std::string());
+                info.wan_ip         = e.value("isp_ip", std::string());
                 info.last_seen_unix = e.value("last_seen_unix", std::int64_t{0});
                 info.installed_version =
                     e.value("installed_version", std::string());
@@ -987,13 +1004,15 @@ int main(int argc, char** argv) {
                     auto it = ips.find(
                         server::openvpn::CertAuthority::sanitize_cn(e.ep));
                     if (it != ips.end()) {
-                        ip_changed |= ep_reg.update_dev_tun_ip(e.ep, it->second);
+                        ip_changed |= ep_reg.update_dev_tun_ip(e.ep, it->second.vip);
+                        ep_reg.update_wan_ip(e.ep, it->second.wan_ip);
                     } else {
                         // Tunnel down for this endpoint — clear the stale
                         // assigned IP so the cloud UI gates Launch UI off and
                         // the DNAT stops targeting a dead vip (dev_tun_ip is
                         // the per-device "VPN up" signal the UI keys on).
                         ip_changed |= ep_reg.update_dev_tun_ip(e.ep, "");
+                        ep_reg.update_wan_ip(e.ep, "");
                     }
                 }
                 if (ip_changed) {

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -5,7 +5,8 @@ import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 import { DebugService } from '../../common/debug.service';
 
-interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; proxy_port:number; registered:boolean;
+interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; isp_ip?:string;
+                   proxy_port:number; registered:boolean;
                    last_seen_unix?:number; lifetime?:number; location?:string; }
 
 /** Per-endpoint credential record, as minted by iot-cloudd into the
@@ -65,6 +66,7 @@ interface EpCred {
         <clr-dg-column>State</clr-dg-column>
         <clr-dg-column>Tunnel IP</clr-dg-column>
         <clr-dg-column>Device Tunnel IP</clr-dg-column>
+        <clr-dg-column>ISP IP</clr-dg-column>
         <clr-dg-column>Proxy Port</clr-dg-column>
         <clr-dg-column>Next Heart Beat in</clr-dg-column>
         <clr-dg-column>Location</clr-dg-column>
@@ -79,6 +81,7 @@ interface EpCred {
           </clr-dg-cell>
           <clr-dg-cell><code>{{ serverTunIp || '—' }}</code></clr-dg-cell>
           <clr-dg-cell><code>{{ e.dev_tun_ip || '—' }}</code></clr-dg-cell>
+          <clr-dg-cell><code>{{ e.isp_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
           <clr-dg-cell>
             <code>{{ nextHeartbeat(e) }}</code>

--- a/modules/server/lwm2m/inc/endpoint_registry.hpp
+++ b/modules/server/lwm2m/inc/endpoint_registry.hpp
@@ -22,6 +22,9 @@ struct EndpointInfo {
     std::string dev_tun_ip;  // device's ACTUAL openvpn-assigned IP (from the
                              // server mgmt status), e.g. "10.9.0.2"; the DNAT
                              // targets this. Empty until the device connects.
+    std::string wan_ip;      // device's public/ISP IP (the real-address openvpn
+                             // sees the tunnel coming from), e.g. "65.49.1.75".
+                             // From the same mgmt status. Empty when tunnel down.
     std::uint16_t proxy_port = 0;  // 5001+
     bool registered = false;       // LwM2M registration active
     std::int64_t last_seen_unix = 0;  // last Register/Update, 0 = never
@@ -73,6 +76,10 @@ public:
     /// targets this `dev_tun_ip`. Returns true only if the value changed
     /// (false if unknown ep or unchanged).
     bool update_dev_tun_ip(const std::string& ep, const std::string& ip);
+
+    /// Record the device's public/ISP IP (the openvpn real-address). Display
+    /// only — no reverse index. Returns true only if the value changed.
+    bool update_wan_ip(const std::string& ep, const std::string& ip);
 
     /// Record the device's running firmware version (LwM2M /3/0/3), learned
     /// from lwm2m-dm via cloud.lwm2m.registrations. Stored for display only (no

--- a/modules/server/lwm2m/src/endpoint_registry.cpp
+++ b/modules/server/lwm2m/src/endpoint_registry.cpp
@@ -61,6 +61,16 @@ bool EndpointRegistry::update_dev_tun_ip(const std::string& ep,
     return true;
 }
 
+bool EndpointRegistry::update_wan_ip(const std::string& ep,
+                                     const std::string& ip) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    auto it = m_by_ep.find(ep);
+    if (it == m_by_ep.end()) return false;       // unknown endpoint
+    if (it->second.wan_ip == ip) return false;   // unchanged
+    it->second.wan_ip = ip;                       // display only, no index
+    return true;
+}
+
 bool EndpointRegistry::update_version(const std::string& ep,
                                       const std::string& version) {
     std::lock_guard<std::mutex> lk(m_mutex);


### PR DESCRIPTION
First of the two requested IP columns — the **ISP / public IP** (the device's internet-facing address).

It's essentially free: cloudd already parses OpenVPN's `status` ROUTING TABLE (`<virtual-ip>,<CN>,<real-addr>,<ref>`) for `dev_tun_ip`, and the `<real-addr>` (= the device's public IP) sits in the same line, discarded. Now captured + surfaced.

- `poll_vpn_client_ips` → `{vip, wan_ip}` per client (parses real-addr, strips `:port`).
- `EndpointInfo.wan_ip` + `EndpointRegistry::update_wan_ip` (set with `dev_tun_ip` each poll; cleared on tunnel drop).
- `cloud.endpoints` carries `isp_ip`; rehydrate restores it.
- cloud-ui Endpoints table: new **ISP IP** column.

**No device change** — works with the current device once the cloud image is rebuilt.

The **LAN IP** column is the bigger second piece: the device currently returns a *placeholder* for LwM2M `/4/0/4` (the read handler returns the resource name, not the value), so it needs device-side wiring (`/4/0/4` → `wifi.dhcp.ip`) + a dm server-initiated Read (machinery exists, mirrors `/3/0/3`) + merge + UI — and a device reflash to take effect. Tracked as the follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)