### PR TITLE
feat(cloud): show device LAN IP in the Endpoints table (LwM2M /4/0/4)

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -111,6 +111,7 @@ void sync_endpoints_to_ds(data_store::Client& ds,
         item["tun_ip"]        = ep.tun_ip;       // registry allocation
         item["dev_tun_ip"]    = ep.dev_tun_ip;   // openvpn-assigned (actual)
         item["isp_ip"]        = ep.wan_ip;        // device public/ISP IP (real-addr)
+        item["lan_ip"]        = ep.lan_ip;        // device LAN IP (LwM2M /4/0/4)
         item["proxy_port"]    = ep.proxy_port;
         item["registered"]    = ep.registered;
         item["last_seen_unix"] = ep.last_seen_unix;
@@ -183,6 +184,7 @@ bool reconcile_registrations(data_store::Client& ds,
     const std::string js = ds_str(ds, "cloud.lwm2m.registrations", "[]");
     std::unordered_map<std::string, std::int64_t> online;  // ep → last_seen_unix
     std::unordered_map<std::string, std::string>  versions;  // ep → /3/0/3
+    std::unordered_map<std::string, std::string>  lanIps;    // ep → /4/0/4
     std::unordered_map<std::string, std::uint32_t> lifetimes; // ep → lifetime(s)
     std::unordered_map<std::string, std::string>  locations;  // ep → /rd/<id>
     try {
@@ -195,6 +197,8 @@ bool reconcile_registrations(data_store::Client& ds,
                 if (ep.empty()) continue;
                 auto ver = e.value("version", std::string());
                 if (!ver.empty()) versions[ep] = std::move(ver);
+                auto lan = e.value("lan_ip", std::string());
+                if (!lan.empty()) lanIps[ep] = std::move(lan);
                 if (auto lt = e.value("lifetime", std::uint32_t{0}); lt != 0)
                     lifetimes[ep] = lt;
                 if (auto loc = e.value("location", std::string()); !loc.empty())
@@ -216,6 +220,9 @@ bool reconcile_registrations(data_store::Client& ds,
         // (a device read once but now offline keeps its last-known version).
         auto vit = versions.find(ep.ep);
         if (vit != versions.end() && reg.update_version(ep.ep, vit->second))
+            changed = true;
+        auto nit = lanIps.find(ep.ep);
+        if (nit != lanIps.end() && reg.update_lan_ip(ep.ep, nit->second))
             changed = true;
         // Heartbeat interval + /rd location (Endpoints table columns).
         {
@@ -343,6 +350,7 @@ std::size_t rehydrate_registry(data_store::Client& ds,
                     e.value("registered", false));
                 info.dev_tun_ip     = e.value("dev_tun_ip", std::string());
                 info.wan_ip         = e.value("isp_ip", std::string());
+                info.lan_ip         = e.value("lan_ip", std::string());
                 info.last_seen_unix = e.value("last_seen_unix", std::int64_t{0});
                 info.installed_version =
                     e.value("installed_version", std::string());

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -5,7 +5,7 @@ import { SessionService } from '../../common/session.service';
 import { ToastService } from '../../common/toast.service';
 import { DebugService } from '../../common/debug.service';
 
-interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; isp_ip?:string;
+interface EpInfo { endpoint:string; tun_ip:string; dev_tun_ip?:string; isp_ip?:string; lan_ip?:string;
                    proxy_port:number; registered:boolean;
                    last_seen_unix?:number; lifetime?:number; location?:string; }
 
@@ -67,6 +67,7 @@ interface EpCred {
         <clr-dg-column>Tunnel IP</clr-dg-column>
         <clr-dg-column>Device Tunnel IP</clr-dg-column>
         <clr-dg-column>ISP IP</clr-dg-column>
+        <clr-dg-column>LAN IP</clr-dg-column>
         <clr-dg-column>Proxy Port</clr-dg-column>
         <clr-dg-column>Next Heart Beat in</clr-dg-column>
         <clr-dg-column>Location</clr-dg-column>
@@ -82,6 +83,7 @@ interface EpCred {
           <clr-dg-cell><code>{{ serverTunIp || '—' }}</code></clr-dg-cell>
           <clr-dg-cell><code>{{ e.dev_tun_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell><code>{{ e.isp_ip || '—' }}</code></clr-dg-cell>
+          <clr-dg-cell><code>{{ e.lan_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
           <clr-dg-cell>
             <code>{{ nextHeartbeat(e) }}</code>

--- a/apps/inc/lwm2m_object_3_device.hpp
+++ b/apps/inc/lwm2m_object_3_device.hpp
@@ -51,6 +51,13 @@ struct DeviceHooks {
     /// deviceObject/0.lua value or the compiled-in fallback. Leave nullptr
     /// to keep the static metadata behaviour.
     std::function<std::string()> firmwareVersion;
+    /// Optional reader for Connectivity Monitoring RID 4 (IP Addresses, /4/0/4).
+    /// When set, the device serves its live IP (e.g. wifi.dhcp.ip from ds)
+    /// instead of the static "0.0.0.0", so a server Read /4/0/4 surfaces the
+    /// device's LAN IP — the cloud (lwm2m-dm) reads it for the Endpoints table.
+    /// Leave nullptr to keep the static stub. (Lives in DeviceHooks for wiring
+    /// convenience though it backs Object 4, not Object 3.)
+    std::function<std::string()> ipAddresses;
 };
 
 /// Install OID 3 into `store`. `configDir` is the path under which the

--- a/apps/inc/lwm2m_object_stubs.hpp
+++ b/apps/inc/lwm2m_object_stubs.hpp
@@ -28,7 +28,8 @@ namespace lwm2m { namespace objects {
 /// Connectivity Monitoring (OID 4) — RID set per OMA registry.
 /// Resources are read-only with placeholder values until a real
 /// network-bearer reader lands.
-int install_connmon(ObjectStore& store);
+int install_connmon(ObjectStore& store,
+                    std::function<std::string()> ipReader = {});
 
 /// Location (OID 6) — Latitude / Longitude / Timestamp.
 int install_location(ObjectStore& store);

--- a/apps/src/lwm2m_object_stubs.cpp
+++ b/apps/src/lwm2m_object_stubs.cpp
@@ -77,7 +77,7 @@ std::string join_path(const std::string& configDir, const std::string& tail) {
 
 } // namespace
 
-int install_connmon(ObjectStore& store) {
+int install_connmon(ObjectStore& store, std::function<std::string()> ipReader) {
     ObjectDescriptor d;
     d.oid = 4; d.name = "Connectivity Monitoring";
     d.urn = "urn:oma:lwm2m:oma:4:1.1";
@@ -88,7 +88,16 @@ int install_connmon(ObjectStore& store) {
     inst.resources[1] = read_only(1,  "Available Network Bearer",ResourceType::Integer, "41");
     inst.resources[2] = read_only(2,  "Radio Signal Strength",   ResourceType::Integer, "-70");
     inst.resources[3] = read_only(3,  "Link Quality",            ResourceType::Integer, "100");
-    inst.resources[4] = read_only(4,  "IP Addresses",            ResourceType::String,  "0.0.0.0");
+    if (ipReader) {
+        // Live IP (wifi.dhcp.ip from ds) so a server Read /4/0/4 surfaces the
+        // device's LAN IP; the cloud shows it in the Endpoints table.
+        Resource ip; ip.rid = 4; ip.name = "IP Addresses";
+        ip.type = ResourceType::String; ip.ops = Operations::R;
+        ip.read = std::move(ipReader);
+        inst.resources[4] = std::move(ip);
+    } else {
+        inst.resources[4] = read_only(4, "IP Addresses", ResourceType::String, "0.0.0.0");
+    }
     inst.resources[6] = read_only(6,  "Link Utilization",        ResourceType::Integer, "0");
     inst.resources[7] = read_only(7,  "APN",                     ResourceType::String,  "");
     d.instances[0] = std::move(inst);
@@ -160,8 +169,11 @@ int install_canonical_objects(ObjectStore& store,
                               CertHooks certHooks) {
     int rc = 0;
     rc |= install_access_control(store, configDir);
+    // Lift the Object-4 IP reader out before deviceHooks is moved into the
+    // Device-object installer (it backs /4/0/4, wired here for convenience).
+    auto ipReader = std::move(deviceHooks.ipAddresses);
     rc |= install_device(store, configDir, std::move(deviceHooks));
-    rc |= install_connmon(store);
+    rc |= install_connmon(store, std::move(ipReader));
     rc |= install_firmware_apply(store, configDir, std::move(fwHooks));
     rc |= install_location(store);
     rc |= install_connstats(store);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -364,6 +364,7 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
     // threads. Allocated for every instance but only wired for dm (publish_regs
     // null elsewhere), so non-DM instances issue no version reads.
     auto epVersions = std::make_shared<std::unordered_map<std::string, std::string>>();
+    auto epLanIps   = std::make_shared<std::unordered_map<std::string, std::string>>();
     auto seqToEp    = std::make_shared<std::unordered_map<std::uint32_t, std::string>>();
     auto verMtx     = std::make_shared<std::mutex>();
     auto verSeq     = std::make_shared<std::uint32_t>(0);
@@ -379,7 +380,7 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                     .count());
         };
         publish_regs = std::make_shared<std::function<void()>>(
-            [registry, dsClient, lastSeen, now_unix, epVersions, verMtx]() {
+            [registry, dsClient, lastSeen, now_unix, epVersions, epLanIps, verMtx]() {
                 if (!dsClient) return;
                 const std::int64_t nowUnix = now_unix();
                 nlohmann::json arr = nlohmann::json::array();
@@ -400,12 +401,15 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                           // cloud-UI Endpoints table.
                                           {"lifetime", kv.second.lifetime},
                                           {"location", kv.second.location}};
-                    // Carry the last-read installed version, if any.
+                    // Carry the last-read installed version + LAN IP, if any.
                     {
                         std::lock_guard<std::mutex> lk(*verMtx);
                         auto vit = epVersions->find(ep);
                         if (vit != epVersions->end() && !vit->second.empty())
                             row["version"] = vit->second;
+                        auto lit = epLanIps->find(ep);
+                        if (lit != epLanIps->end() && !lit->second.empty())
+                            row["lan_ip"] = lit->second;
                     }
                     arr.push_back(std::move(row));
                 }
@@ -438,10 +442,14 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
         for (auto& [type, ctx] : services) {
             (void)type;
             ctx->coapAdapter()->dmResponseHandler(
-                [epVersions, seqToEp, verMtx, publish_regs]
+                [epVersions, epLanIps, seqToEp, verMtx, publish_regs]
                 (const CoAPAdapter::CoAPMessage& m) {
                     const auto& tok = m.tokens;
-                    if (tok.size() < 4 || tok[0] != 0x06) return;
+                    // 0x06 tag = Read /3/0/3 (firmware version); 0x07 = Read
+                    // /4/0/4 (LAN IP). Both stamp a 24-bit seq we map back to the
+                    // endpoint; the tag selects which field the reply fills.
+                    if (tok.size() < 4 || (tok[0] != 0x06 && tok[0] != 0x07)) return;
+                    const std::uint8_t  kind = tok[0];
                     const std::uint32_t seq =
                         (static_cast<std::uint32_t>(tok[1]) << 16) |
                         (static_cast<std::uint32_t>(tok[2]) << 8)  |
@@ -453,9 +461,9 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                         if (it == seqToEp->end()) return;
                         const std::string ep = it->second;
                         seqToEp->erase(it);
-                        if (!m.payload.empty() &&
-                            (*epVersions)[ep] != m.payload) {
-                            (*epVersions)[ep] = m.payload;
+                        auto& target = (kind == 0x06) ? *epVersions : *epLanIps;
+                        if (!m.payload.empty() && target[ep] != m.payload) {
+                            target[ep] = m.payload;
                             changed = true;
                         }
                     }
@@ -639,6 +647,26 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                         /*oid*/ 3, /*iid*/ 0, /*rid*/ 3,
                         /*accept*/ -1);
                     ctx->send_async(vreq, reg.peerHost, reg.peerPort);
+
+                    // Read /4/0/4 (Connectivity Monitoring IP Addresses) → the
+                    // device's LAN IP for the Endpoints table. Same correlation
+                    // scheme, distinguished by a 0x07 token tag.
+                    std::uint32_t lseq;
+                    {
+                        std::lock_guard<std::mutex> lk(*verMtx);
+                        lseq = (++(*verSeq)) & 0x00FFFFFFu;
+                        (*seqToEp)[lseq] = reg.endpoint;
+                    }
+                    std::string ltok;
+                    ltok.push_back(static_cast<char>(0x07));
+                    ltok.push_back(static_cast<char>((lseq >> 16) & 0xFF));
+                    ltok.push_back(static_cast<char>((lseq >> 8)  & 0xFF));
+                    ltok.push_back(static_cast<char>( lseq        & 0xFF));
+                    auto lreq = ::lwm2m::dmsrv::build_read(
+                        next_msgid(), ltok,
+                        /*oid*/ 4, /*iid*/ 0, /*rid*/ 4,
+                        /*accept*/ -1);
+                    ctx->send_async(lreq, reg.peerHost, reg.peerPort);
                 }
 
                 // OTA: push a pending firmware update over Object 5 (Package
@@ -878,6 +906,16 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     deviceHooks.firmwareVersion = [dsc]() -> std::string {
         std::vector<data_store::Client::GetResult> got;
         if (dsc && dsc->get({"iot.version"}, got).ok && !got.empty() && got[0].has_value)
+            if (auto s = data_store::to_string(got[0].value))
+                if (!s->empty()) return *s;
+        return {};
+    };
+    // /4/0/4 (Connectivity Monitoring IP Addresses) → the device's LAN IP
+    // (wifi.dhcp.ip). A server Read surfaces it so the cloud Endpoints table can
+    // show the device's local-network address (useful when its DHCP IP hops).
+    deviceHooks.ipAddresses = [dsc]() -> std::string {
+        std::vector<data_store::Client::GetResult> got;
+        if (dsc && dsc->get({"wifi.dhcp.ip"}, got).ok && !got.empty() && got[0].has_value)
             if (auto s = data_store::to_string(got[0].value))
                 if (!s->empty()) return *s;
         return {};

--- a/modules/server/lwm2m/inc/endpoint_registry.hpp
+++ b/modules/server/lwm2m/inc/endpoint_registry.hpp
@@ -25,6 +25,9 @@ struct EndpointInfo {
     std::string wan_ip;      // device's public/ISP IP (the real-address openvpn
                              // sees the tunnel coming from), e.g. "65.49.1.75".
                              // From the same mgmt status. Empty when tunnel down.
+    std::string lan_ip;      // device's local-network IP (LwM2M /4/0/4 =
+                             // wifi.dhcp.ip), e.g. "192.168.1.3". Learned from
+                             // lwm2m-dm; empty until first read.
     std::uint16_t proxy_port = 0;  // 5001+
     bool registered = false;       // LwM2M registration active
     std::int64_t last_seen_unix = 0;  // last Register/Update, 0 = never
@@ -86,6 +89,10 @@ public:
     /// reverse index). Returns true only if the value changed (false if unknown
     /// ep or unchanged).
     bool update_version(const std::string& ep, const std::string& version);
+
+    /// Record the device's LAN IP (LwM2M /4/0/4), learned from lwm2m-dm via
+    /// cloud.lwm2m.registrations. Display only. Returns true if it changed.
+    bool update_lan_ip(const std::string& ep, const std::string& ip);
 
     /// Lookup by endpoint name.  Returns nullptr when not found.
     const EndpointInfo* lookup_by_ep(const std::string& ep) const;

--- a/modules/server/lwm2m/src/endpoint_registry.cpp
+++ b/modules/server/lwm2m/src/endpoint_registry.cpp
@@ -82,6 +82,16 @@ bool EndpointRegistry::update_version(const std::string& ep,
     return true;
 }
 
+bool EndpointRegistry::update_lan_ip(const std::string& ep,
+                                     const std::string& ip) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+    auto it = m_by_ep.find(ep);
+    if (it == m_by_ep.end()) return false;       // unknown endpoint
+    if (it->second.lan_ip == ip) return false;   // unchanged
+    it->second.lan_ip = ip;                       // display only, no index
+    return true;
+}
+
 bool EndpointRegistry::update_reg_meta(const std::string& ep,
                                        std::uint32_t lifetime,
                                        const std::string& location) {


### PR DESCRIPTION
Second of the two requested IP columns — the device's **LAN IP** (e.g. `192.168.1.3`).

It lives only in the *device's* ds (`wifi.dhcp.ip`), so the cloud reads it over LwM2M, **mirroring the proven `/3/0/3` installed-version path exactly**.

**Device** (`apps/src`, `apps/inc`): `DeviceHooks.ipAddresses` reader → wired to `wifi.dhcp.ip`; `install_connmon` serves Object 4 / RID 4 (IP Addresses) live instead of the `"0.0.0.0"` stub.

**lwm2m-dm** (`apps/src/main.cpp`): poll loop issues a server-initiated Read `/4/0/4`, tagged `0x07` (vs `0x06` for `/3/0/3`); the response handler maps the reply to the endpoint → `epLanIps`; `publish_regs` carries it as `lan_ip` in `cloud.lwm2m.registrations`.

**cloud**: `EndpointInfo.lan_ip` + `update_lan_ip`; merge reads `lan_ip`; `cloud.endpoints` carries it; rehydrate restores it.

**cloud-ui**: new **LAN IP** column.

### Caveats
- **Untestable from here** — needs a device **reflash** with this firmware (the device currently returns a placeholder for `/4/0/4`). Validate on hardware after the next flash.
- Assumes `/4/0/4` is served via the ObjectStore (same path `/3/0/3` already works through).

Pairs with #254 (ISP IP). Together the Endpoints table shows both the public and local IPs per device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)