### PR TITLE
feat(net): publish net.iface.active.ip; LwM2M /4/0/4 reads it from ds

### DIFF
--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -504,7 +504,9 @@ cloud.endpoints          → JSON array of provisioned endpoints
     "tun_ip":        "10.9.0.12",
     "proxy_port":    10000,
     "registered":    true,
-    "last_seen_unix": 1718123456
+    "last_seen_unix": 1718123456,
+    "isp_ip":        "65.49.1.75",     // device public/ISP IP (openvpn real-addr)
+    "lan_ip":        "192.168.1.3"     // device LAN IP on its active WAN iface
   }]
 cloud.lwm2m.registrations → JSON array of currently-registered endpoints.
                             SOLE writer = lwm2m-dm (from its ClientRegistry on
@@ -512,8 +514,30 @@ cloud.lwm2m.registrations → JSON array of currently-registered endpoints.
                             iot-cloudd watches it and merges online/offline +
                             last_seen into cloud.endpoints (separate key avoids
                             a two-writer clobber on tun_ip/proxy_port).
-  [{ "endpoint": "100000abcd", "registered": true, "last_seen_unix": 1718123456 }]
+  [{ "endpoint": "100000abcd", "registered": true, "last_seen_unix": 1718123456,
+     "installed_version": "1.2.0", "lan_ip": "192.168.1.3" }]
 ```
+
+**Two device IP columns (`isp_ip` / `lan_ip`).** The Endpoints table shows both
+the device's public IP and its local IP — sourced from *different* planes:
+
+- **`isp_ip`** (public/ISP) comes from the **OpenVPN management plane**:
+  `iot-cloudd`'s `poll_vpn_client_ips` parses the server `status` ROUTING TABLE
+  (`<virtual-ip>,<CN>,<real-addr>,<ref>`); the `real-addr` is the NAT public IP
+  the tunnel arrives from. No device cooperation needed; empty when the tunnel
+  is down.
+- **`lan_ip`** (local) comes from the **LwM2M plane**: `lwm2m-dm` server-reads
+  the device's `/4/0/4` (Connectivity Monitoring → IP Addresses) over the
+  tunnel; the device serves it from `net.iface.active.ip`, which **net-router**
+  publishes for whichever WAN iface (eth0/wlan0/wwan0) it currently routes
+  through (see `modules/net/router/docs/design.md`). lwm2m-dm writes it into
+  `cloud.lwm2m.registrations`; `iot-cloudd` merges it into `cloud.endpoints`
+  (`update_lan_ip`) and rehydrate restores it. Empty until the first read.
+
+Same merge discipline as `installed_version` (/3/0/3): lwm2m-dm is the sole
+writer of `cloud.lwm2m.registrations`, iot-cloudd merges into `cloud.endpoints`
+— so the device-reported facts never two-writer-clobber the registry's
+`tun_ip`/`proxy_port`.
 
 ### VPN Server (cloud.vpn.*)
 ```

--- a/apps/docs/lwm2m-object-handling.md
+++ b/apps/docs/lwm2m-object-handling.md
@@ -300,7 +300,40 @@ merge matches by exact endpoint string.
 
 ---
 
-## 5. File map
+## 5. Server-initiated Reads (firmware version + LAN IP)
+
+Beyond Register/Update the DM server also **reads** two device resources so the
+cloud Endpoints table can show what the device is running and where it lives:
+
+| Resource | Object/RID | Device source | Endpoints column |
+|----------|------------|---------------|------------------|
+| Firmware version | `/3/0/3` (Device → Firmware Version) | `iot.version` (compiled-in) | Installed Version |
+| IP Addresses | `/4/0/4` (Connectivity Monitoring → IP Addresses) | `net.iface.active.ip` (net-router) | LAN IP |
+
+**Flow** (`apps/src/main.cpp`, DM-side poll loop):
+
+1. The DM poll loop issues a CoAP **Read** for each registered endpoint —
+   `/3/0/3` (tagged `0x06`) and `/4/0/4` (oid 4, iid 0, rid 4, tagged `0x07`).
+2. `dmResponseHandler` routes the tagged responses: `0x06` → version map,
+   `0x07` → `epLanIps` map.
+3. `publish_regs` folds both into `cloud.lwm2m.registrations`
+   (`installed_version`, `lan_ip`) alongside the online/offline state.
+4. **iot-cloudd** merges them into `cloud.endpoints` (`update_version`,
+   `update_lan_ip`) — display-only, no reverse index, same single-writer
+   discipline as §4 so the device-reported facts never clobber
+   `tun_ip`/`proxy_port`.
+
+The device serves `/4/0/4` live: `install_connmon` takes an `ipReader` wired in
+`install_canonical_objects` to `deviceHooks.ipAddresses`, which reads
+`net.iface.active.ip` from ds — net-router owns interface selection, so the LAN
+IP always tracks the active WAN bearer (eth0/wlan0/wwan0) and follows DHCP
+renews. The public/ISP IP shown next to it is **not** from LwM2M — iot-cloudd
+derives it from the OpenVPN management `status` real-address (see
+`apps/cloud/CLAUDE.md` → "Two device IP columns").
+
+---
+
+## 6. File map
 
 | Concern | File |
 |---------|------|
@@ -311,6 +344,7 @@ merge matches by exact endpoint string.
 | Client object install | `apps/src/lwm2m_object_stubs.cpp` |
 | Registration server + registry (lifetime timer) | `apps/src/lwm2m_registration_server.cpp`, `apps/src/lwm2m_registration.cpp` |
 | Online/offline publish (lwm2m-dm) + merge (iot-cloudd) | `apps/src/main.cpp` (`wire_server`), `apps/cloud/server/src/main.cpp` (`reconcile_registrations`); key `cloud.lwm2m.registrations` |
+| Server-read version (`/3/0/3`) + LAN IP (`/4/0/4`) | `apps/src/main.cpp` (DM poll loop, `dmResponseHandler`, `publish_regs`); device serves `/4/0/4` via `install_connmon` `ipReader` → `net.iface.active.ip` |
 | Registration client (`/rd`, Update) | `apps/src/lwm2m_registration_client.cpp` |
 | PSK provisioning (mint DM PSK) | `apps/cloud/server/src/main.cpp`, `apps/src/psk_gen.cpp` |
 | Bootstrap/DM provisioning source | data-store: `cloud.endpoint.credentials`, `cloud.bs.uri`, `cloud.dm.uri/lifetime/binding` (no static lua) |

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -16,11 +16,6 @@
 #include <sstream>
 #include <unordered_map>
 
-#include <ifaddrs.h>      // getifaddrs — active-iface IP for LwM2M /4/0/4
-#include <net/if.h>       // IFF_LOOPBACK / IFF_UP
-#include <netinet/in.h>   // sockaddr_in
-#include <arpa/inet.h>    // inet_ntop
-
 #include <ace/Log_Msg.h>
 #include <ace/OS_NS_unistd.h>   // ACE_OS::sleep
 #include <ace/Time_Value.h>
@@ -918,46 +913,17 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     // /4/0/4 (Connectivity Monitoring IP Addresses) → the device's IP on its
     // ACTIVE WAN interface (eth0 / wlan0 / wwan0), so the cloud Endpoints table
     // shows the address the device is actually reachable at — not hard-wired to
-    // WiFi. net-router publishes the active iface name (net.iface.active); we
-    // read that iface's live IPv4 via getifaddrs. Falls back to the WiFi DHCP
-    // lease (wifi.dhcp.ip) when the active iface is unknown (no net-router).
+    // WiFi. net-router owns interface state: it picks the highest-priority
+    // OPER-UP iface and publishes that iface's routable IPv4 as
+    // net.iface.active.ip (bearer-agnostic, follows DHCP renews). We just read
+    // that ds key — no getifaddrs / interface enumeration in the lwm2m process.
     deviceHooks.ipAddresses = [dsc]() -> std::string {
-        // Active WAN iface name from net-router (may be empty if it isn't
-        // running yet); when known we pin to it, otherwise we pick the first
-        // real interface — never assuming a particular bearer.
-        std::string active;
-        {
-            std::vector<data_store::Client::GetResult> got;
-            if (dsc && dsc->get({std::string("net.iface.active")}, got).ok &&
-                !got.empty() && got[0].has_value)
-                if (auto s = data_store::to_string(got[0].value)) active = *s;
-        }
-        struct ifaddrs* ifa = nullptr;
-        if (::getifaddrs(&ifa) != 0) return {};
-        std::string ip;
-        for (auto* p = ifa; p; p = p->ifa_next) {
-            if (!p->ifa_addr || p->ifa_addr->sa_family != AF_INET) continue;
-            const std::string name = p->ifa_name ? p->ifa_name : "";
-            if (!active.empty()) {
-                if (name != active) continue;          // pin to the active iface
-            } else {
-                // Bearer-agnostic fallback: skip loopback, down ifaces, and the
-                // VPN tunnel; take the first real interface (eth*/wlan*/wwan*…).
-                if ((p->ifa_flags & IFF_LOOPBACK) || !(p->ifa_flags & IFF_UP))
-                    continue;
-                if (name.rfind("tun", 0) == 0) continue;
-            }
-            char buf[INET_ADDRSTRLEN] = {0};
-            ::inet_ntop(AF_INET,
-                &reinterpret_cast<struct sockaddr_in*>(p->ifa_addr)->sin_addr,
-                buf, sizeof(buf));
-            std::string cand(buf);
-            if (cand.rfind("169.254.", 0) == 0) continue;   // skip link-local
-            ip = std::move(cand);
-            break;
-        }
-        ::freeifaddrs(ifa);
-        return ip;
+        if (!dsc) return {};
+        std::vector<data_store::Client::GetResult> got;
+        if (dsc->get({std::string("net.iface.active.ip")}, got).ok &&
+            !got.empty() && got[0].has_value)
+            if (auto s = data_store::to_string(got[0].value)) return *s;
+        return {};
     };
     ::lwm2m::objects::install_canonical_objects(*plumb.store, configDir,
                                                 std::move(deviceHooks),

--- a/modules/net/router/docs/design.md
+++ b/modules/net/router/docs/design.md
@@ -60,7 +60,7 @@ An iptables fallback is FUP only if a target without nftables surfaces.
 ## Schema layout
 
 `schemas/net.lua` (installed to `/etc/iot/ds-schemas/net.lua` by D7's
-install rule). 9 read keys + 6 write keys; **all are optional** — the
+install rule). 9 read keys + 7 write keys; **all are optional** — the
 daemon starts on boot regardless of config. `net.lwm2m.target.ip` (once
 required) now only gates the optional DNAT/port-forward chain
 (`build_nft_ruleset` omits it when the target/ports are empty); the
@@ -69,6 +69,18 @@ while none is, so dependent services (lwm2m/openvpn) come up without it.
 Custom rules ship as a JSON-encoded string in `net.custom.rules`; shape
 is validated at the JSON-parse step in the daemon (the schema can't
 json-parse).
+
+The lifecycle publishes two facts about the WAN uplink it selects:
+`net.iface.active` (the highest-priority OPER-UP iface *name*) and
+`net.iface.active.ip` (that iface's routable IPv4 — the device's LAN IP).
+The IP is captured in `iface_monitor` during the same `ip -j addr show`
+pass that gates routability (`State::addr_ip`), and is tracked/emitted
+*independently of the name* so a DHCP renew on the same iface re-publishes
+it. The LwM2M Connectivity-Monitoring hook (`/4/0/4` IP Addresses, in
+`apps/src/main.cpp`) reads `net.iface.active.ip` straight from ds rather
+than re-enumerating interfaces itself — net-router is the single owner of
+interface state, so the cloud Endpoints "LAN IP" column reflects exactly
+the iface this daemon routes through.
 
 See [L13 plan §2.D1](../../../../log/L13/plan.md) for the full
 key list; the schema file itself is the canonical reference.

--- a/modules/net/router/schemas/net.lua
+++ b/modules/net/router/schemas/net.lua
@@ -21,6 +21,9 @@
 --   net.tun.ip                - current IP on net.tun.dev (mirrors vpn.assigned.ip)
 --   net.tun.gateway           - current gateway on the tun
 --   net.iface.active          - highest-priority interface currently OPER UP
+--   net.iface.active.ip       - that interface's routable IPv4 (LAN IP); the
+--                               LwM2M /4/0/4 hook publishes it as the device's
+--                               LAN IP without re-enumerating interfaces
 --   net.rules.applied.count   - count of nft rules installed by this daemon
 --   net.last.apply.unix       - unix timestamp of last successful `nft -f -`
 --
@@ -68,6 +71,8 @@ return {
     ["net.tun.gateway"]           = {
         access  = "Viewer", type = "string" },
     ["net.iface.active"]          = {
+        access  = "Viewer", type = "string" },
+    ["net.iface.active.ip"]       = {
         access  = "Viewer", type = "string" },
     ["net.rules.applied.count"]   = {
         access  = "Viewer", type = "integer", min = 0 },

--- a/modules/net/router/src/daemon.cpp
+++ b/modules/net/router/src/daemon.cpp
@@ -155,6 +155,7 @@ Status run_daemon(const std::string& socketPath,
     };
     sinks.set_state               = [&ds](const std::string& s) { ds.set_state(s); };
     sinks.set_iface_active        = [&ds](const std::string& s) { ds.set_iface_active(s); };
+    sinks.set_iface_active_ip     = [&ds](const std::string& s) { ds.set_iface_active_ip(s); };
     sinks.set_rules_applied_count = [&ds](std::uint32_t n)      { ds.set_rules_applied_count(n); };
     sinks.set_last_apply_unix     = [&ds](std::uint32_t t)      { ds.set_last_apply_unix(t); };
 

--- a/modules/net/router/src/ds_bridge.cpp
+++ b/modules/net/router/src/ds_bridge.cpp
@@ -31,6 +31,7 @@ constexpr const char* kState               = "net.state";
 constexpr const char* kTunIp               = "net.tun.ip";
 constexpr const char* kTunGateway          = "net.tun.gateway";
 constexpr const char* kIfaceActive         = "net.iface.active";
+constexpr const char* kIfaceActiveIp        = "net.iface.active.ip";
 constexpr const char* kRulesAppliedCount   = "net.rules.applied.count";
 constexpr const char* kLastApplyUnix       = "net.last.apply.unix";
 
@@ -223,6 +224,10 @@ void DsBridge::set_tun_gateway(const std::string& s) {
 void DsBridge::set_iface_active(const std::string& s) {
     if (!m_ok) return;
     m_impl->client.set(kIfaceActive, s);
+}
+void DsBridge::set_iface_active_ip(const std::string& s) {
+    if (!m_ok) return;
+    m_impl->client.set(kIfaceActiveIp, s);
 }
 void DsBridge::set_rules_applied_count(std::uint32_t n) {
     if (!m_ok) return;

--- a/modules/net/router/src/ds_bridge.hpp
+++ b/modules/net/router/src/ds_bridge.hpp
@@ -66,6 +66,7 @@ public:
     void set_tun_ip(const std::string& s);
     void set_tun_gateway(const std::string& s);
     void set_iface_active(const std::string& s);
+    void set_iface_active_ip(const std::string& s);
     void set_rules_applied_count(std::uint32_t n);
     void set_last_apply_unix(std::uint32_t t);
 

--- a/modules/net/router/src/iface_monitor.cpp
+++ b/modules/net/router/src/iface_monitor.cpp
@@ -57,7 +57,8 @@ void parse_addr_show(const std::string& body, State& out) {
             if (!a.contains("family") || a["family"] != "inet") continue;
             if (!a.contains("local") || !a["local"].is_string()) continue;
             if (is_routable_v4(a["local"].get<std::string>())) {
-                out.addr = true;
+                out.addr    = true;
+                out.addr_ip = a["local"].get<std::string>();
                 return;
             }
         }

--- a/modules/net/router/src/iface_monitor.hpp
+++ b/modules/net/router/src/iface_monitor.hpp
@@ -20,6 +20,7 @@ struct State {
     bool        present = false;  ///< iface exists in the kernel
     bool        up      = false;  ///< OPER state == "UP"
     bool        addr    = false;  ///< has a routable (non-link-local) IPv4 addr
+    std::string addr_ip;    ///< that routable IPv4 (e.g. "192.168.1.3"), empty if none
     std::string gateway;    ///< default route's `via`, empty if none
 };
 

--- a/modules/net/router/src/lifecycle.cpp
+++ b/modules/net/router/src/lifecycle.cpp
@@ -64,13 +64,21 @@ Lifecycle::State Lifecycle::step(const Inputs& in) {
 
     // 3) Emit net.iface.active if the pick changed (empty string when
     //    nothing is up — operator-visible signal that we're offline).
-    std::string new_active;
+    std::string new_active, new_active_ip;
     if (auto idx = iface::pick_active(in.ifaces_in_priority_order)) {
-        new_active = in.ifaces_in_priority_order[*idx].name;
+        new_active    = in.ifaces_in_priority_order[*idx].name;
+        new_active_ip = in.ifaces_in_priority_order[*idx].addr_ip;
     }
     if (new_active != m_last_iface) {
         m_last_iface = new_active;
         if (m_sinks.set_iface_active) m_sinks.set_iface_active(new_active);
+    }
+    // The active iface's IP changes independently of the name (DHCP renew on
+    // the same iface), so track + emit it separately. Consumers (LwM2M /4/0/4)
+    // read net.iface.active.ip rather than re-enumerating interfaces.
+    if (new_active_ip != m_last_iface_ip) {
+        m_last_iface_ip = new_active_ip;
+        if (m_sinks.set_iface_active_ip) m_sinks.set_iface_active_ip(new_active_ip);
     }
 
     // 4) State: apply failure dominates; otherwise track the WAN uplink —

--- a/modules/net/router/src/lifecycle.hpp
+++ b/modules/net/router/src/lifecycle.hpp
@@ -39,6 +39,7 @@ public:
         std::function<bool(const std::vector<iface::State>&)>  apply_routes;
         std::function<void(const std::string&)>                set_state;
         std::function<void(const std::string&)>                set_iface_active;
+        std::function<void(const std::string&)>                set_iface_active_ip;
         std::function<void(std::uint32_t)>                     set_rules_applied_count;
         std::function<void(std::uint32_t)>                     set_last_apply_unix;
     };
@@ -82,6 +83,7 @@ private:
     std::uint32_t m_apply_count  = 0;
     std::string   m_last_ruleset;
     std::string   m_last_iface;
+    std::string   m_last_iface_ip;
 
     void transition(State next);
 };

--- a/modules/net/router/src/main_impl.cpp
+++ b/modules/net/router/src/main_impl.cpp
@@ -34,6 +34,7 @@ const std::vector<std::string>& known_keys() {
         "net.tun.ip",
         "net.tun.gateway",
         "net.iface.active",
+        "net.iface.active.ip",
         "net.rules.applied.count",
         "net.last.apply.unix",
     };

--- a/modules/net/router/test/iface_monitor_test.cpp
+++ b/modules/net/router/test/iface_monitor_test.cpp
@@ -126,6 +126,7 @@ TEST(IfaceProbe, UpInterfaceWithGatewayPopulated) {
     EXPECT_TRUE(s.present);
     EXPECT_TRUE(s.up);
     EXPECT_TRUE(s.addr);
+    EXPECT_EQ("192.168.1.50", s.addr_ip);   // the routable IPv4 is captured
     EXPECT_EQ("192.168.1.1", s.gateway);
     EXPECT_EQ("eth0", s.name);
     ASSERT_EQ(3u, fr.calls.size());     // link + addr + route
@@ -140,6 +141,7 @@ TEST(IfaceProbe, UpInterfaceWithOnlyLinkLocalV4HasNoAddr) {
     auto s = probe("eth0", fr.make());
     EXPECT_TRUE(s.up);
     EXPECT_FALSE(s.addr);
+    EXPECT_TRUE(s.addr_ip.empty());          // link-local is not captured
 }
 
 TEST(IfaceProbe, UpInterfaceWithNoV4HasNoAddr) {

--- a/modules/net/router/test/lifecycle_test.cpp
+++ b/modules/net/router/test/lifecycle_test.cpp
@@ -23,6 +23,7 @@ struct Capture {
     std::vector<std::vector<State>>     route_calls;
     std::vector<std::string>            state_writes;
     std::vector<std::string>            iface_writes;
+    std::vector<std::string>            iface_ip_writes;
     std::vector<std::uint32_t>          rules_applied_count_writes;
     std::vector<std::uint32_t>          last_apply_unix_writes;
     bool nft_ok    = true;
@@ -42,6 +43,7 @@ struct Capture {
         };
         s.set_state              = [this](const std::string& v){ state_writes.push_back(v); };
         s.set_iface_active       = [this](const std::string& v){ iface_writes.push_back(v); };
+        s.set_iface_active_ip    = [this](const std::string& v){ iface_ip_writes.push_back(v); };
         s.set_rules_applied_count= [this](std::uint32_t v){ rules_applied_count_writes.push_back(v); };
         s.set_last_apply_unix    = [this](std::uint32_t v){ last_apply_unix_writes.push_back(v); };
         return s;
@@ -50,6 +52,7 @@ struct Capture {
 
 State up(const std::string& n, const std::string& gw = "10.0.0.1") {
     State s; s.name = n; s.present = true; s.up = true; s.addr = true;
+    s.addr_ip = "192.168.1.50";
     s.gateway = gw;
     return s;
 }
@@ -94,6 +97,8 @@ TEST(Lifecycle, EmptyTargetIpStillRunsWithBaseRulesetAndNoDnat) {
 
     ASSERT_EQ(1u, cap.iface_writes.size());
     EXPECT_EQ("eth0", cap.iface_writes[0]);
+    ASSERT_EQ(1u, cap.iface_ip_writes.size());
+    EXPECT_EQ("192.168.1.50", cap.iface_ip_writes[0]);
     ASSERT_EQ(1u, cap.state_writes.size());
     EXPECT_EQ("steady", cap.state_writes[0]);
 }


### PR DESCRIPTION
## Summary

net-router becomes the single owner of the device's active-interface IP. It already parsed each iface's routable IPv4 during the `ip -j addr show` routability gate but discarded the string — now it keeps it (`State::addr_ip`) and publishes **`net.iface.active.ip`** for whichever WAN iface the lifecycle routes through (eth0/wlan0/wwan0), tracked independently of the iface *name* so a DHCP renew on the same iface re-publishes.

The LwM2M Connectivity-Monitoring hook (`/4/0/4` IP Addresses) now reads that ds key instead of running `getifaddrs` + enumerating interfaces in the lwm2m process. The cloud Endpoints **LAN IP** column reflects exactly the iface net-router selects, bearer-agnostic.

## Changes

- **iface_monitor**: `State::addr_ip`; `parse_addr_show` keeps the routable IPv4
- **lifecycle**: emit `net.iface.active.ip` on change (`Sinks.set_iface_active_ip`), separate from the name
- **ds_bridge / daemon / main_impl / net.lua**: wire + schema the new key
- **apps/src/main.cpp**: `/4/0/4` hook reads the ds key; drops `getifaddrs` + `<ifaddrs.h>`/`<net/if.h>`/`<netinet/in.h>`/`<arpa/inet.h>` (~45 lines → 6)
- **tests**: `addr_ip` capture (iface_monitor), emit (lifecycle)
- **docs**: net-router design, `apps/cloud/CLAUDE.md` (ISP/LAN IP columns + the two-planes explanation), `lwm2m-object-handling.md` §5 server-initiated reads

## Test

Standalone TUs (`iface_monitor.cpp`, `lifecycle.cpp`) syntax-check clean locally; full gtest build is containerized (needs Lua). New assertions cover `addr_ip` capture and the publish path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)