### PR TITLE
fix(yocto): add BBPATH .= LAYERDIR so wic finds meta-iot/wic/iot-ab.wks.in

### DIFF
--- a/yocto/meta-iot/conf/layer.conf
+++ b/yocto/meta-iot/conf/layer.conf
@@ -7,6 +7,12 @@
 # Layer dependencies: poky (core) + meta-openembedded (openembedded-layer).
 # Target Yocto release: Scarthgap (5.0 LTS).
 
+# Add this layer's root to BBPATH. Without it the layer still parses (BBFILES
+# below uses absolute ${LAYERDIR} paths), but anything that searches BBPATH
+# misses us — notably wic's WKS_SEARCH_PATH ("<BBPATH>/wic"), so a wks shipped
+# in meta-iot/wic/ (the IOT_AB=1 iot-ab.wks.in) is "not found" at do_image_wic.
+BBPATH .= ":${LAYERDIR}"
+
 BBFILE_COLLECTIONS += "iot"
 BBFILE_PATTERN_iot := "^${LAYERDIR}/"
 BBFILE_PRIORITY_iot = "6"


### PR DESCRIPTION
## Problem

The IOT_AB=1 (RAUC A/B) image build failed at the final imaging step:

```
do_image_wic: No kickstart files from WKS_FILES were found:
iot-ab.wks.in iot-image.wks. Please set WKS_FILE or WKS_FILES appropriately.
```

`iot-ab.wks.in` is present at `yocto/meta-iot/wic/iot-ab.wks.in` and `WKS_FILE`
is set correctly by `entrypoint.sh` — yet wic couldn't find it.

## Root cause

`meta-iot/conf/layer.conf` was missing the standard **`BBPATH .= ":${LAYERDIR}"`**
line that every OE `layer.conf` carries. The layer still parsed (BBFILES uses
absolute `${LAYERDIR}` paths, so all recipes built), but wic derives its
`WKS_SEARCH_PATH` from `"<each BBPATH entry>/wic"`. With meta-iot absent from
`BBPATH`, the `meta-iot/wic/` directory was never on the search path.

Single-rootfs RPi builds were unaffected — their wks comes from
meta-raspberrypi (which sets BBPATH). The A/B image is the **first** to ship
its own wks from meta-iot, which is what exposed the gap.

## Fix

Add `BBPATH .= ":${LAYERDIR}"` to `meta-iot/conf/layer.conf`.

meta-iot is bind-mounted read-only into the build container, so the next
`IOT_AB=1 ./build.sh` picks this up with **no builder-image rebuild**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)