### PR TITLE
fix(rauc): add LIC_FILES_CHKSUM to update-bundle (license-checksum QA)

### DIFF
--- a/yocto/meta-iot/dynamic-layers/rauc/recipes-core/bundles/update-bundle.bb
+++ b/yocto/meta-iot/dynamic-layers/rauc/recipes-core/bundles/update-bundle.bb
@@ -5,6 +5,11 @@ cloud pushes its URL; iot-swupdate runs `rauc install`, the bootloader switches 
 banks on reboot, and iot-ota-confirm health-checks + marks the bank good (else \
 the bootloader rolls back). See apps/docs/tdd-ab-image-ota.md."
 LICENSE = "MIT"
+# This recipe ships no upstream source of its own — it bundles the iot-image
+# rootfs and pulls in the dev signing key/cert via SRC_URI. But once SRC_URI is
+# non-empty with a non-CLOSED license, OE's `license-checksum` QA demands a
+# LIC_FILES_CHKSUM. Point it at poky's canonical MIT text (the stack is MIT).
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
 
 # `bundle` ships in meta-rauc. This recipe lives under dynamic-layers/rauc/ and
 # is registered via BBFILES_DYNAMIC (layer.conf), so it's parsed ONLY when


### PR DESCRIPTION
## Problem

The A/B build now passes `do_image_wic` (after #259) and reaches the `.raucb`
bundle, which fails in `do_populate_lic`:

```
do_populate_lic: QA Issue: update-bundle: Recipe file fetches files and
does not have license file information (LIC_FILES_CHKSUM) [license-checksum]
```

## Root cause

`update-bundle.bb` sets `LICENSE = "MIT"` and has a `SRC_URI` (the dev signing
key/cert via `file://dev-ca.{cert,key}.pem`). OE's `license-checksum` QA
requires a `LIC_FILES_CHKSUM` for any recipe that fetches files under a
non-`CLOSED` license — and the recipe had none.

## Fix

The recipe carries no upstream source of its own (it bundles the iot-image
rootfs), so point `LIC_FILES_CHKSUM` at poky's canonical MIT text:

```
LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
```

Unblocks `do_populate_lic` → bundle signing. Parsed only on `IOT_AB=1` builds
(dynamic-layer, meta-rauc-gated), so default single-rootfs builds are
unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)