### PR TITLE
fix(rauc): bump A/B rootfs banks 768M→1024M so the .raucb fits the slot

### DIFF
--- a/yocto/meta-iot/wic/iot-ab.wks.in
+++ b/yocto/meta-iot/wic/iot-ab.wks.in
@@ -19,9 +19,14 @@
 # mountpoints are added unless --no-fstab-update), so /var/lib/iot mounts the
 # `data` label at boot — an image/bank swap never touches ds state or certs.
 
+# Bank size (1024M) must exceed the standalone rootfs ext4 RAUC carries in the
+# .raucb — that image is inflated by IMAGE_ROOTFS_EXTRA_SPACE (512M of on-target
+# headroom for opkg/logs) to ~824M, and `rauc install` writes it raw to the
+# inactive slot. 768M banks flash fine (wic builds them from the rootfs dir,
+# ~300M used) but an OTA into a 768M slot would fail "image larger than slot".
 part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4096 --size 100M
-part /     --source rootfs --fstype=ext4 --label rootA --align 4096 --size 768M
-part /     --source rootfs --fstype=ext4 --label rootB --align 4096 --size 768M
+part /     --source rootfs --fstype=ext4 --label rootA --align 4096 --size 1024M
+part /     --source rootfs --fstype=ext4 --label rootB --align 4096 --size 1024M
 part /var/lib/iot --fstype=ext4 --label data --align 4096 --size 256M
 
 bootloader --ptable msdos


### PR DESCRIPTION
## Problem

The A/B image builds and flashes, but an actual OTA via the `.raucb` bundle
would fail at `rauc install`: the slot image (standalone rootfs ext4) is
**~824M** — rootfs content + `IMAGE_ROOTFS_EXTRA_SPACE` (512M on-target
headroom) — and RAUC writes it raw to the inactive bank, which was only
**768M**.

The SD flash succeeds because wic builds each bank from the rootfs *directory*
(~300M used, fits 768M); only the raw-image OTA path exceeds the slot.

## Fix

Bump `rootA`/`rootB` to **1024M** each in `iot-ab.wks.in`. New layout:
`100M boot + 2×1024M rootfs + 256M data ≈ 2.4 GB` — fine for any SD card. Added
an inline comment documenting the rule (bank must exceed the EXTRA_SPACE-inflated
slot ext4) so it doesn't regress.

Build-side only; takes effect on the next `IOT_AB=1` build (meta-iot is
bind-mounted, no builder-image rebuild). **A reflash is required** to get the
new partition layout onto the device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)