### PR TITLE
feat(ota): A/B both-banks view + manual bank switch with auto-rollback

### DIFF
--- a/apps/docs/tdd-ab-image-ota.md
+++ b/apps/docs/tdd-ab-image-ota.md
@@ -112,6 +112,30 @@ Reuse the OTA ds keys, extended:
   drag-zone accepts `.ipk` (Phase 1, opkg) **or** `.raucb` (Phase 2, A/B) — it
   routes by extension.
 
+### 6.1 Both-banks view + manual bank switch (shipped)
+
+The Software page shows **both** banks — bootname, installed version, and
+good/running status — and an operator can switch the active bank from there.
+
+- **`iot.boot.banks`** — JSON array `[{bootname,slot,version,state,booted}, …]`,
+  published by `iot-ota-confirm` at boot (and re-emitted after `mark-good`). It
+  sources `rauc status --output-format=shell`; the booted bank's version is the
+  authoritative `iot.version`, the other bank's comes from its persisted slot
+  status — which is why `system.conf` now sets a central
+  `statusfile=/var/lib/iot/rauc.status` on the shared data partition (so the
+  booted bank can read the inactive bank's `bundle.version`).
+- **`iot.boot.switch.request`** — the device-ui writes the **target bootname**
+  ("A"/"B", or "other"). The lwm2m client watches it and launches
+  `iot-bank-switch` as root (via `systemd-run`, the same unprivileged→root
+  bridge as `iot-ota-stage`); it `rauc status mark-active`s the target slot,
+  clears the key, and reboots.
+- **Rollback is automatic and needs no UI:** the bootloader's `boot-attempts=3`
+  reverts to the previous bank if the switched-to bank never reaches a healthy
+  `mark-good` (`iot-ota-confirm`). The UI surfaces this in the confirm dialog.
+- Files: `iot-bank-switch` (script), `iot-ota-confirm` (publishes banks),
+  `apps/src/main.cpp` (watch), `iot.lua` (keys), `system.conf` (statusfile),
+  `iot-ui/.../software-update.component.ts` (banks table + switch modal).
+
 ## 7. Yocto work (sketch)
 
 - Add `meta-rauc` (+ RPi community layer); switch RPi to u-boot (or use the

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -837,6 +837,27 @@ static int ota_launch_apply(const std::string& uri) {
     return 0;
 }
 
+/// A/B bank switch: run iot-bank-switch (root, detached) with the requested
+/// target bank ("A"/"B"/"other"). It `rauc status mark-active`s that bank and
+/// reboots; the bootloader rolls back if the new bank fails to come up. Same
+/// systemd-run pattern as ota_launch_apply (this daemon runs unprivileged).
+static int bank_switch_launch(const std::string& target) {
+    if (target.empty()) return -1;
+    std::string cmd =
+        "systemd-run --unit=iot-bank-switch --collect /usr/bin/iot-bank-switch "
+        + ota_shquote(target);
+    int rc = std::system(cmd.c_str());
+    if (rc != 0) {
+        ACE_ERROR((LM_ERROR,
+            ACE_TEXT("%D [ab] %M %N:%l bank-switch launch failed rc=%d cmd=%C\n"),
+            rc, cmd.c_str()));
+        return -1;
+    }
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ab] %M %N:%l launched iot-bank-switch %C\n"),
+        target.c_str()));
+    return 0;
+}
+
 ClientPlumbing wire_client(std::shared_ptr<App>& app,
                            const std::string& endpoint,
                            const std::string& configDir,
@@ -939,6 +960,17 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
                     if (!s->empty()) ota_launch_apply(*s);
                 }
             }, &wh);
+
+        // device-ui A/B bank switch: a write to iot.boot.switch.request (the
+        // target bank) reboots the device into that bank. iot-bank-switch
+        // clears the key, so we ignore the empty-string reset it writes back.
+        data_store::Client::WatchHandle wbs = data_store::Client::kInvalidHandle;
+        dsc->watch("iot.boot.switch.request",
+            [](const data_store::Client::Event& e) {
+                if (auto s = data_store::to_string(e.value)) {
+                    if (!s->empty()) bank_switch_launch(*s);
+                }
+            }, &wbs);
     }
 
     plumb.dm = std::make_shared<::lwm2m::DmClient>(plumb.store);

--- a/iot-ui/src/app/software-update/software-update.component.ts
+++ b/iot-ui/src/app/software-update/software-update.component.ts
@@ -33,13 +33,65 @@ import { ToastService } from '../../common/toast.service';
             <clr-dg-cell><app-status-badge [label]="resultLabel"
               [state]="result===1 ? 'connected' : (result>=5 ? 'exited' : 'idle')"></app-status-badge></clr-dg-cell>
           </clr-dg-row>
-          <clr-dg-row *ngIf="bank">
+          <clr-dg-row *ngIf="bank && !banks.length">
             <clr-dg-cell>Running Bank <span class="hint">(A/B image)</span>
               <app-ds-hint *dsDebug key="iot.boot.bank"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell><app-status-badge [label]="bank + (confirmed ? ' · confirmed' : ' · unconfirmed')"
               [state]="confirmed ? 'connected' : 'starting'"></app-status-badge></clr-dg-cell>
           </clr-dg-row>
         </clr-datagrid>
+
+        <!-- A/B banks: both rootfs banks, their installed version, and a
+             switch-and-reboot action on the inactive one. -->
+        <ng-container *ngIf="banks.length">
+          <h4>A/B Banks <span class="hint">(dual-bank image)</span>
+            <app-ds-hint *dsDebug key="iot.boot.banks"></app-ds-hint></h4>
+          <clr-datagrid style="margin-bottom:8px;">
+            <clr-dg-column>Bank</clr-dg-column>
+            <clr-dg-column>Installed Version</clr-dg-column>
+            <clr-dg-column>Status</clr-dg-column>
+            <clr-dg-column>Action</clr-dg-column>
+            <clr-dg-row *ngFor="let b of banks">
+              <clr-dg-cell>{{ b.bootname || '?' }} <span class="hint">({{ b.slot }})</span></clr-dg-cell>
+              <clr-dg-cell>{{ b.version || '—' }}</clr-dg-cell>
+              <clr-dg-cell>
+                <app-status-badge
+                  [label]="b.booted ? ('running' + (confirmed ? ' · confirmed' : ' · unconfirmed')) : (b.state || 'standby')"
+                  [state]="b.booted ? (confirmed ? 'connected' : 'starting') : (b.state === 'bad' ? 'exited' : 'idle')">
+                </app-status-badge>
+              </clr-dg-cell>
+              <clr-dg-cell>
+                <button *ngIf="!b.booted" class="btn btn-sm btn-outline" (click)="askSwitch(b)"
+                        [disabled]="switching">Switch &amp; reboot</button>
+                <span *ngIf="b.booted" class="hint">current</span>
+              </clr-dg-cell>
+            </clr-dg-row>
+          </clr-datagrid>
+          <p class="hint">Switching marks the selected bank for the next boot and reboots the device.
+            If the new bank fails to come up cleanly after {{ bootAttempts }} attempts, the bootloader
+            automatically rolls back to the current bank.</p>
+        </ng-container>
+
+        <!-- Reboot confirmation (switching banks reboots the device). -->
+        <clr-modal [(clrModalOpen)]="showSwitchModal">
+          <h3 class="modal-title">Switch bank &amp; reboot?</h3>
+          <div class="modal-body">
+            <p>Reboot into bank <strong>{{ switchTarget?.bootname }}</strong>
+               (version {{ switchTarget?.version || 'unknown' }})?</p>
+            <p class="hint">The device reboots immediately. If the selected bank does not come up
+               cleanly it rolls back to the current bank automatically — but the device will be
+               briefly offline either way.</p>
+          </div>
+          <div class="modal-footer">
+            <button type="button" class="btn btn-outline" (click)="showSwitchModal=false"
+                    [disabled]="switching">Cancel</button>
+            <button type="button" class="btn btn-danger" (click)="confirmSwitch()"
+                    [disabled]="switching">
+              <span *ngIf="!switching">Switch &amp; reboot</span>
+              <span *ngIf="switching">Rebooting…</span>
+            </button>
+          </div>
+        </clr-modal>
 
         <!-- Self-update trigger -->
         <h4>Apply a package (.ipk URL)</h4>
@@ -97,6 +149,12 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   result = 0;
   bank = '';          // iot.boot.bank — running A/B rootfs bank (empty = single-rootfs)
   confirmed = false;  // iot.boot.confirmed — this boot marked good
+  // iot.boot.banks — both A/B banks (empty on a single-rootfs image).
+  banks: Array<{ bootname: string; slot: string; version: string; state: string; booted: boolean }> = [];
+  readonly bootAttempts = 3;          // system.conf boot-attempts (rollback threshold)
+  showSwitchModal = false;
+  switchTarget: { bootname: string; slot: string; version: string; state: string; booted: boolean } | null = null;
+  switching = false;
   url = '';
   busy = false;
   dragOver = false;
@@ -141,14 +199,55 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     this.sub.add(this.ds.observe('iot.update.result').subscribe(v => {
       this.result = Number(v) || 0;
     }));
-    // A/B boot status changes only once per boot — read it once.
-    this.sub.add(this.http.dbGet(['iot.boot.bank', 'iot.boot.confirmed']).subscribe(r => {
+    // A/B boot status changes only once per boot — read it once. iot.boot.banks
+    // is also written at boot (before the UI connects), so read it here too; the
+    // observe below only delivers later changes (mark-good / post-switch).
+    this.sub.add(this.http.dbGet(['iot.boot.bank', 'iot.boot.confirmed', 'iot.boot.banks']).subscribe(r => {
       if (r.ok && r.data) {
         const d = r.data as Record<string, unknown>;
         this.bank = d['iot.boot.bank'] != null ? String(d['iot.boot.bank']) : '';
         this.confirmed = d['iot.boot.confirmed'] === true;
+        this.parseBanks(d['iot.boot.banks']);
       }
     }));
+    // Live refresh when iot-ota-confirm marks the booted bank good, or a switch
+    // re-publishes.
+    this.sub.add(this.ds.observe('iot.boot.banks').subscribe(v => this.parseBanks(v)));
+  }
+
+  private parseBanks(v: unknown): void {
+    if (v == null || v === '') { this.banks = []; return; }
+    try {
+      const arr = typeof v === 'string' ? JSON.parse(v) : v;
+      this.banks = Array.isArray(arr) ? arr.map(b => ({
+        bootname: String((b as Record<string, unknown>)['bootname'] ?? ''),
+        slot:     String((b as Record<string, unknown>)['slot'] ?? ''),
+        version:  String((b as Record<string, unknown>)['version'] ?? ''),
+        state:    String((b as Record<string, unknown>)['state'] ?? ''),
+        booted:   (b as Record<string, unknown>)['booted'] === true,
+      })) : [];
+    } catch { this.banks = []; }
+  }
+
+  askSwitch(b: { bootname: string; slot: string; version: string; state: string; booted: boolean }): void {
+    this.switchTarget = b;
+    this.showSwitchModal = true;
+  }
+
+  confirmSwitch(): void {
+    if (!this.switchTarget) return;
+    this.switching = true;
+    // Send the target bank's bootname; iot-bank-switch (device) marks it active
+    // and reboots. The key is cleared device-side after handling.
+    this.http.dbSet([{ key: 'iot.boot.switch.request', value: this.switchTarget.bootname }]).subscribe({
+      next: (r) => {
+        this.switching = false;
+        this.showSwitchModal = false;
+        if (r.ok) this.toast.success('Bank switch requested — the device is rebooting…');
+        else this.toast.error(r.err || 'Bank switch failed');
+      },
+      error: () => { this.switching = false; this.toast.error('Bank switch failed'); }
+    });
   }
 
   apply(): void {

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -181,6 +181,26 @@ return {
         type    = "boolean",
         default = false,
     },
+    -- Both A/B banks for the device-ui Software page: a JSON array
+    --   [{ "bootname":"A", "slot":"rootfs.0", "version":"1.2.0",
+    --      "state":"good", "booted":true }, { ...B... }]
+    -- Written by iot-ota-confirm at boot (and by iot-bank-switch after a
+    -- mark-active). Empty on a single-rootfs / non-RAUC image.
+    ["iot.boot.banks"] = {
+        access  = "Admin",
+        type    = "string",
+        default = "",
+    },
+    -- Bank-switch trigger: device-ui writes the TARGET bootname ("A"|"B", or
+    -- "other" for the inactive bank). The lwm2m client watches it and runs
+    -- iot-bank-switch (root, via systemd-run), which `rauc status mark-active`s
+    -- that bank and reboots. The bootloader's boot-attempts counter rolls back
+    -- to the previous bank if the new one fails to come up. Cleared after use.
+    ["iot.boot.switch.request"] = {
+        access  = "Admin",
+        type    = "string",
+        default = "",
+    },
 
     -- data-store self-benchmark summary (JSON), written by ds-bench at the end
     -- of a run: { config, mem:{rss_kb,hwm_kb}, per-op {ops,p50,p95,p99} }.

--- a/yocto/meta-iot/dynamic-layers/rauc/recipes-core/rauc/files/system.conf
+++ b/yocto/meta-iot/dynamic-layers/rauc/recipes-core/rauc/files/system.conf
@@ -12,6 +12,12 @@ bootloader=uboot
 # bank is marked good by iot-ota-confirm once healthy (see that service).
 boot-attempts=3
 mountprefix=/run/rauc
+# Central slot-status file on the shared, persistent data partition (p4, mounted
+# at /var/lib/iot — survives a bank swap). Without it RAUC keeps status per-slot
+# inside each rootfs, so the booted bank can't read the OTHER bank's installed
+# version; a central file lets `rauc status` report both banks' versions for the
+# device-ui Software page (iot.boot.banks). Persists each slot's bundle.version.
+statusfile=/var/lib/iot/rauc.status
 
 [keyring]
 # Trust anchor for bundle signatures. The matching signing key lives in CI

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-bank-switch
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-bank-switch
@@ -1,0 +1,71 @@
+#!/bin/sh
+# iot-bank-switch <A|B|other|rootfs.N> — switch the active RAUC bank + reboot.
+#
+# Launched DETACHED as root (systemd-run --unit=iot-bank-switch by the lwm2m
+# client, which watches iot.boot.switch.request — same pattern as iot-ota-stage).
+# Marks the requested bank as the bootloader's next-boot choice
+# (`rauc status mark-active`) and reboots into it. The bootloader's boot-attempts
+# counter (system.conf) automatically rolls back to the previous bank if the new
+# one fails to come up healthy — iot-ota-confirm only marks-good a bank that
+# boots cleanly, so an unbootable/unhealthy switch self-reverts after the
+# configured attempts. No-op on a non-RAUC (single-rootfs) image.
+#
+# See apps/docs/tdd-ab-image-ota.md.
+
+set -u
+
+TARGET="${1:-}"
+SOCK="/run/iot/data_store.sock"
+DSCLI="ds-cli --socket=${SOCK}"
+log()    { logger -t iot-bank-switch "$*" 2>/dev/null; echo "iot-bank-switch: $*"; }
+set_ds() { $DSCLI set "$1" "$2" >/dev/null 2>&1 || true; }
+# Always clear the trigger after handling so re-requesting the same bank re-fires.
+clear_req() { set_ds iot.boot.switch.request '""'; }
+
+[ -n "$TARGET" ] || { log "no target bank given"; clear_req; exit 1; }
+
+if ! command -v rauc >/dev/null 2>&1; then
+    log "rauc absent — non-A/B image, cannot switch banks"
+    clear_req; exit 0
+fi
+
+# Source the slot table (valid sh; single-quoted values → safe to eval).
+eval "$(rauc status --output-format=shell 2>/dev/null)" || true
+booted="${RAUC_SYSTEM_BOOTED_SLOT:-}"
+
+# Resolve the requested target to a slot identifier rauc accepts. rauc itself
+# understands "other"/"booted"/<slot-name> (e.g. rootfs.1) but NOT a bootname
+# (A/B), so map A/B → slot name; pass "other" straight through.
+target_slot=""
+case "$TARGET" in
+    other|OTHER|toggle) target_slot="other" ;;
+    booted)             log "refusing to switch to the booted bank"; clear_req; exit 0 ;;
+    *)
+        for i in ${RAUC_SLOTS:-}; do
+            eval "name=\${RAUC_SLOT_NAME_$i:-}"
+            eval "bn=\${RAUC_SLOT_BOOTNAME_$i:-}"
+            if [ "$TARGET" = "$bn" ] || [ "$TARGET" = "$name" ]; then target_slot="$name"; fi
+        done
+        ;;
+esac
+
+[ -n "$target_slot" ] || { log "cannot resolve target bank '$TARGET'"; clear_req; exit 1; }
+
+# Don't reboot to switch to the bank we're already running.
+if [ "$target_slot" = "$booted" ]; then
+    log "target bank ($TARGET → $target_slot) is already booted; not switching"
+    clear_req; exit 0
+fi
+
+log "marking bank '$target_slot' active (booted=$booted); rebooting to activate"
+if ! rauc status mark-active "$target_slot" >/dev/null 2>&1; then
+    log "rauc status mark-active '$target_slot' failed"
+    set_ds iot.update.result 9     # install/activation error
+    clear_req; exit 1
+fi
+
+set_ds iot.update.state 5          # awaiting-confirm (iot-ota-confirm runs next boot)
+clear_req
+sync
+log "bank switch armed; rebooting now"
+systemctl reboot

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm
@@ -22,10 +22,48 @@ if ! command -v rauc >/dev/null 2>&1; then
     exit 0
 fi
 
+# Publish BOTH banks as a JSON array for the device-ui Software page:
+#   [{ "bootname":"A","slot":"rootfs.0","version":"1.2.0","state":"good","booted":true }, …]
+# Sources `rauc status --output-format=shell` (valid sh — eval'd to define the
+# RAUC_* vars) so it's tolerant of slot ordering. The booted bank's version is
+# iot.version (the authoritative running release); the other bank's comes from
+# its persisted slot status (RAUC_SLOT_BUNDLE_VERSION_*, needs `statusfile` in
+# system.conf), empty until that bank has been RAUC-installed. HW-validate the
+# RAUC_* field names against the deployed rauc version.
+publish_banks() {
+    booted="$1"
+    iotver="$($DSCLI get iot.version 2>/dev/null | sed 's/^iot\.version=//' | tr -d "\"'")"
+    # eval the shell-format status into RAUC_* vars (single-quoted values → safe).
+    eval "$(rauc status --output-format=shell 2>/dev/null)" || true
+    if [ -z "${RAUC_SLOTS:-}" ]; then
+        set_ds iot.boot.banks '""'
+        return
+    fi
+    json="["; first=1
+    for i in $RAUC_SLOTS; do
+        eval "name=\${RAUC_SLOT_NAME_$i:-}"
+        eval "bn=\${RAUC_SLOT_BOOTNAME_$i:-}"
+        eval "bs=\${RAUC_SLOT_BOOT_STATUS_$i:-unknown}"
+        eval "ver=\${RAUC_SLOT_BUNDLE_VERSION_$i:-}"
+        [ -n "$name" ] || continue
+        if [ "$name" = "$booted" ]; then isb=true; [ -n "$iotver" ] && ver="$iotver"; else isb=false; fi
+        [ -n "$bs" ] || bs="unknown"
+        [ "$first" = 1 ] || json="$json,"; first=0
+        json="$json{\"bootname\":\"$bn\",\"slot\":\"$name\",\"version\":\"$ver\",\"state\":\"$bs\",\"booted\":$isb}"
+    done
+    json="$json]"
+    # iot.boot.banks is a STRING key and ds-cli JSON-parses its argument, so the
+    # array text must be passed as a JSON string: escape backslashes then quotes
+    # and wrap in literal quotes.
+    esc="$(printf '%s' "$json" | sed 's/\\/\\\\/g; s/"/\\"/g')"
+    $DSCLI set iot.boot.banks "\"$esc\"" >/dev/null 2>&1 || true
+}
+
 # Which rootfs bank booted (e.g. "rootfs.0"/"A"). Publish for the UI.
 BANK="$(rauc status --output-format=shell 2>/dev/null \
         | sed -n 's/^RAUC_SYSTEM_BOOTED_SLOT=\(.*\)/\1/p' | tr -d "\"'")"
 [ -n "$BANK" ] && set_ds iot.boot.bank "\"$BANK\""
+publish_banks "$BANK"
 
 # Healthy = ds answers AND the core daemons are active. (Deliberately NOT gating
 # on LwM2M registration — a transient cloud outage must not trigger a rollback
@@ -45,6 +83,7 @@ while [ "$i" -lt 90 ]; do          # up to ~90 s for the stack to come up
         set_ds iot.boot.confirmed true
         set_ds iot.update.result 1     # success
         set_ds iot.update.state  0     # idle
+        publish_banks "$BANK"          # re-emit so this bank now reads state=good
         log "boot ${BANK:-?} confirmed good (marked good)"
         exit 0
     fi

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -51,6 +51,7 @@ SRC_URI = "\
     file://iot-swupdate.service \
     file://iot-ota-confirm \
     file://iot-ota-confirm.service \
+    file://iot-bank-switch \
     file://migrations/README.md \
     file://migrations/0000-template.sh.example \
     file://gen_wifi_default.py \
@@ -219,6 +220,7 @@ do_install() {
     install -m 0755 ${WORKDIR}/iot-ota-stage    ${D}${bindir}/iot-ota-stage
     install -m 0755 ${WORKDIR}/iot-swupdate     ${D}${bindir}/iot-swupdate
     install -m 0755 ${WORKDIR}/iot-ota-confirm  ${D}${bindir}/iot-ota-confirm
+    install -m 0755 ${WORKDIR}/iot-bank-switch  ${D}${bindir}/iot-bank-switch
 
     # iot-dump: operator/debug tool — dumps all data-store keys + values for
     # a module (e.g. `iot-dump iot-wifi-client`). Ships with ds-cli.
@@ -363,6 +365,7 @@ FILES:${PN}-lwm2m = "\
     ${bindir}/iot-ota-stage \
     ${bindir}/iot-swupdate \
     ${bindir}/iot-ota-confirm \
+    ${bindir}/iot-bank-switch \
     ${datadir}/iot/migrations \
     ${systemd_system_unitdir}/iot-lwm2m-client.service \
     ${systemd_system_unitdir}/iot-lwm2m-server.service \


### PR DESCRIPTION
## What

The device-ui **Software** page now shows **both** rootfs banks — bootname,
installed version, and good/running status — and an Admin can **switch the
active bank**, which reboots the device into it. If the switched-to bank fails
to come up healthy, the bootloader rolls back to the previous bank
automatically (no UI involvement).

## How it fits together

```
device-ui  ──writes──▶ iot.boot.switch.request = "B"
                              │  (lwm2m client watches, runs as engineer)
                              ▼
                   systemd-run iot-bank-switch B   (root, detached)
                              │  rauc status mark-active rootfs.1; reboot
                              ▼
              u-boot boots B with boot-attempts=3 try-counter
                              │
                   iot-ota-confirm: healthy? ──yes──▶ rauc mark-good (B sticks)
                              │                         publishes iot.boot.banks
                              └──no, after 3 tries──▶ bootloader reverts to A
```

This reuses the exact unprivileged→root bridge the OTA path already uses
(`systemd-run`, like `iot-ota-stage`) — the lwm2m client never runs as root.

## Changes

- **`iot.boot.banks`** (new ds key, JSON): both banks published by
  `iot-ota-confirm` at boot + after `mark-good`. Booted bank's version =
  authoritative `iot.version`; inactive bank's version from its persisted slot
  status.
- **`system.conf`**: central `statusfile=/var/lib/iot/rauc.status` on the shared
  data partition, so the booted bank can read the *other* bank's
  `bundle.version`.
- **`iot.boot.switch.request`** (new ds key): device-ui writes the target
  bootname; `iot-bank-switch` (new script) marks it active and reboots.
- **`apps/src/main.cpp`**: watch on `iot.boot.switch.request` →
  `bank_switch_launch` (mirrors `ota_launch_apply`).
- **UI** (`software-update.component.ts`): both-banks datagrid + per-bank
  "Switch & reboot" button + reboot confirm modal.
- Recipe install (`iot_git.bb`), docs (`tdd-ab-image-ota.md §6.1`).

## Test

- `iot.lua` parses; `iot-bank-switch` + `iot-ota-confirm` pass `sh -n`;
  `iot-ui` `ng build` clean.
- Device-side RAUC specifics (mark-active semantics, per-slot version reporting,
  u-boot boot-select) are HW-validate scaffold — consistent with the rest of the
  A/B stack, to be confirmed on the Pi.

🤖 Generated with [Claude Code](https://claude.com/claude-code)