### PR TITLE
feat(ota): iot-* bundle for whole-userspace LwM2M upgrade in one shot

### DIFF
--- a/apps/docs/tdd-yocto-swupdate.md
+++ b/apps/docs/tdd-yocto-swupdate.md
@@ -103,6 +103,17 @@ stages + triggers**, but **does not install**.
      is now the .path unit's job.
 - Multiple packages in one campaign: the stager may drop several `<pkg>.ipk`
   before the single final `touch` (opkg installs them together, resolving deps).
+- **Bundle (`.tar.gz`) — whole-userspace upgrade in one LwM2M push.** When the
+  URL basename ends in `.tar.gz`/`.tgz` the artifact is an **iot-* bundle**
+  (built by `iot-bundle.bb`: every `iot-*.ipk` tarred flat). The stager
+  downloads + sha256-verifies the **tarball**, then `gzip -dc | tar -xf -`
+  extracts the `.ipk`s straight into the spool (busybox-safe — no reliance on
+  `tar -z`) and drops the tarball, so the existing multi-package path (above)
+  installs them all. This is what lets the cloud upgrade a device's full
+  userspace — and a whole *list* of devices, since the cloud push already fans a
+  single `cloud.update.request{serials:[…]}` out to every endpoint — in one
+  shot. Lighter than the RAUC A/B `.raucb` image bundle (no reboot unless a
+  base/kernel package lands).
 
 ### 3.3 Watcher — `iot-swupdate.path` (systemd, inotify)
 

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -132,10 +132,16 @@ return {
     },
 
     -- ── OTA software update (LwM2M Firmware Update Object 5) ──────────
-    -- Operator-curated catalogue of .ipk packages available in the
-    -- cloud firmware feed (served by iot-httpd at /firmware/...). JSON:
+    -- Operator-curated catalogue of artifacts in the cloud firmware feed
+    -- (served by iot-httpd at /firmware/...). An entry's ipk_url may point at
+    -- a single .ipk OR a .tar.gz BUNDLE of every iot-*.ipk (built by
+    -- iot-bundle.bb) — the device's iot-ota-stage extracts a bundle and
+    -- opkg-installs all packages in one shot. JSON:
     --   [ { "pkg":"iot", "version":"0.2.0", "arch":"aarch64",
-    --       "ipk_url":"/firmware/iot_0.2.0_aarch64.ipk", "sha256":"<hex>" } ]
+    --       "ipk_url":"/firmware/iot_0.2.0_aarch64.ipk", "sha256":"<hex>" },
+    --     { "pkg":"iot-bundle", "version":"1.1.0", "arch":"raspberrypi3-64",
+    --       "ipk_url":"/firmware/iot-bundle-1.1.0-raspberrypi3-64.tar.gz",
+    --       "sha256":"<hex>" } ]
     ["cloud.firmware.manifest"] = {
         access  = "Admin",
         type    = "string",

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -211,8 +211,10 @@ print_summary() {
         img=$(find "$OUT_DIR/$machine/images" -name 'iot-image*.wic.bz2' -type f 2>/dev/null | sort | tail -1 || true)
         local ipk_count
         ipk_count=$(find "$OUT_DIR/$machine/ipk" -name 'iot-*.ipk' -type f 2>/dev/null | wc -l | tr -d ' ' || true)
+        local bundle
+        bundle=$(find "$OUT_DIR/$machine/images" -name 'iot-bundle-*.tar.gz' -type f 2>/dev/null | sort | tail -1 || true)
         if [ -n "$img" ]; then
-            echo "  ✅ $machine  →  $(basename "$img")  +  ${ipk_count} iot .ipk"
+            echo "  ✅ $machine  →  $(basename "$img")  +  ${ipk_count} iot .ipk${bundle:+  +  $(basename "$bundle")}"
         elif [ "$ipk_count" -gt 0 ]; then
             echo "  ⚠️  $machine  →  ${ipk_count} iot .ipk (no image — package-only build)"
         elif [ -d "$OUT_DIR/$machine" ]; then
@@ -241,6 +243,12 @@ print_summary() {
   ── Push iot app updates over ssh (opkg feed) ────────────────────────
     scp $OUT_DIR/raspberrypi3-64/ipk/*/iot-*.ipk root@<pi-ip>:/tmp/
     ssh root@<pi-ip> 'opkg install /tmp/iot-*.ipk'
+
+  ── OTA the whole iot-* userspace over LwM2M (one shot, many devices) ─
+    # Copy the bundle into the cloud firmware feed + add its manifest row,
+    # then push from the cloud-ui Software Update page (multi-select devices).
+    scp $OUT_DIR/raspberrypi3-64/images/iot-bundle-*.tar.gz* <cloud>:/firmware/
+    # Paste images/iot-bundle-*.tar.gz.manifest.json into cloud.firmware.manifest
 EOF
     fi
     echo ""

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -214,6 +214,12 @@ if [ -n "${IOT_AB:-}" ] && case " $* " in *" iot-image "*) true;; *) false;; esa
     set -- "$@" update-bundle
 fi
 
+# Also build the single-shot iot-* OTA tarball (iot-bundle.bb) alongside any
+# image build — one tar.gz of every iot-*.ipk, pushed in a single LwM2M Object 5
+# upgrade to a list of endpoints. Skip for package-only builds (e.g.
+# packagegroup-iot): the feed is enough there.
+case " $* " in *" iot-image "*) set -- "$@" iot-bundle ;; esac
+
 echo ""
 echo "→ Starting bitbake for $MACHINE: $@ ..."
 echo ""
@@ -230,6 +236,8 @@ echo "── SD-card image(s): ──"
 find tmp/deploy/images -name '*.wic.bz2' -type f 2>/dev/null | sort || true
 echo "── RAUC A/B bundle(s): ──"
 find tmp/deploy/images -name '*.raucb' -type f 2>/dev/null | sort || true
+echo "── iot-* OTA bundle(s) (single-shot LwM2M push): ──"
+find tmp/deploy/images -name 'iot-bundle-*.tar.gz' -type f 2>/dev/null | sort || true
 echo "── iot .ipk feed: ──"
 find tmp/deploy/ipk -name 'iot-*.ipk' -type f 2>/dev/null | sort || true
 echo ""

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
@@ -42,31 +42,54 @@ for kv in $(echo "$QUERY" | tr '&' ' '); do
 done
 
 # Name the staged file from the URL basename so several distinct packages in one
-# campaign don't collide; fall back to fw.ipk.
+# campaign don't collide. A .tar.gz/.tgz is a multi-package BUNDLE (every
+# iot-*.ipk in one shot, built by iot-bundle.bb); a bare .ipk is a single
+# package; anything else falls back to fw.ipk.
 NAME="$(basename "$BASE")"
-case "$NAME" in *.ipk) ;; *) NAME="fw.ipk" ;; esac
+BUNDLE=0
+case "$NAME" in
+    *.tar.gz|*.tgz) BUNDLE=1 ;;
+    *.ipk) ;;
+    *) NAME="fw.ipk" ;;
+esac
 
 mkdir -p "$SPOOL"
-IPK="$SPOOL/$NAME"
+DL="$SPOOL/$NAME"
 
 set_state 1   # downloading
-log "downloading $URL -> $IPK"
+log "downloading $URL -> $DL"
 if command -v wget >/dev/null 2>&1; then
-    wget --no-check-certificate -q -O "$IPK" "$URL" || fail 8 "download failed"
+    wget --no-check-certificate -q -O "$DL" "$URL" || fail 8 "download failed"
 elif command -v curl >/dev/null 2>&1; then
-    curl -ksSL -o "$IPK" "$URL" || fail 8 "download failed"
+    curl -ksSL -o "$DL" "$URL" || fail 8 "download failed"
 else
     fail 9 "no wget/curl on device"
 fi
-[ -s "$IPK" ] || fail 8 "empty download"
+[ -s "$DL" ] || fail 8 "empty download"
 
+# sha256 is verified against the downloaded artifact (the tarball for a bundle,
+# the .ipk otherwise) — the cloud computes it over the same file.
 if [ -n "$SHA" ]; then
-    GOT="$(sha256sum "$IPK" 2>/dev/null | awk '{print $1}')"
+    GOT="$(sha256sum "$DL" 2>/dev/null | awk '{print $1}')"
     if [ "$GOT" != "$SHA" ]; then
-        rm -f "$IPK"
+        rm -f "$DL"
         fail 5 "sha256 mismatch (want $SHA got $GOT)"
     fi
     log "sha256 verified"
+fi
+
+# A bundle expands into the spool so iot-swupdate's `opkg install *.ipk` glob
+# applies every package atomically. Decompress via gzip|tar (busybox-safe:
+# avoids relying on tar's built-in -z) and drop the tarball.
+if [ "$BUNDLE" = 1 ]; then
+    if ( cd "$SPOOL" && gzip -dc "$DL" | tar -xf - ) 2>/dev/null; then
+        rm -f "$DL"
+    else
+        rm -f "$DL"
+        fail 9 "bundle extract failed"
+    fi
+    ls "$SPOOL"/*.ipk >/dev/null 2>&1 || fail 9 "no .ipk in bundle"
+    log "extracted bundle $NAME -> $(ls "$SPOOL"/*.ipk | wc -l) package(s)"
 fi
 set_state 2   # downloaded
 

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
@@ -1,0 +1,71 @@
+SUMMARY = "Single-shot OTA bundle of every iot-*.ipk (LwM2M Object 5)"
+DESCRIPTION = "Packs the whole iot-* .ipk feed into one iot-bundle-<ver>.tar.gz \
+so the cloud can upgrade a device's full userspace in ONE LwM2M Firmware \
+Update push instead of one package at a time. The device's iot-ota-stage \
+downloads + sha256-verifies the tarball, extracts the .ipk files into the \
+update spool, and iot-swupdate's existing `opkg install *.ipk` glob applies \
+them all. Lighter than the RAUC A/B full-image bundle (update-bundle.bb): \
+userspace only, no reboot unless a base/kernel package lands."
+LICENSE = "MIT"
+LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda2f7b4f302"
+
+# Keep the leading semver in sync with the repo-root /VERSION (same source of
+# truth as iot_git.bb's PV and the baked-in iot.version).
+PV = "1.1.0"
+
+# No source to fetch/compile — this recipe only repackages the already-built
+# feed in do_deploy. nopackages skips the empty packaging tasks; deploy gives
+# us do_deploy + DEPLOYDIR (sstate-copied into DEPLOY_DIR_IMAGE).
+inherit nopackages deploy
+
+# The bundle contents (which iot-* packages exist) are machine-specific, so the
+# artifact is too — keep it out of the shared/allarch sstate bucket.
+PACKAGE_ARCH = "${MACHINE_ARCH}"
+
+# Every iot-*.ipk comes from the single `iot` recipe (split via FILES:${PN}-*),
+# so one task dependency guarantees the whole feed is written before we bundle.
+do_deploy[depends] += "iot:do_package_write_ipk"
+
+do_deploy() {
+    feed="${DEPLOY_DIR_IPK}"
+    stage="${WORKDIR}/bundle"
+    rm -rf "${stage}"
+    mkdir -p "${stage}"
+
+    # The deploy feed accumulates every version ever built; pick the NEWEST
+    # .ipk per package basename (the part before the first '_') so the bundle
+    # never ships two versions of the same package.
+    seen=""
+    for f in $(find "${feed}" -name 'iot-*.ipk' -type f -printf '%T@ %p\n' \
+                 | sort -rn | awk '{print $2}'); do
+        base="$(basename "${f}")"
+        pkg="${base%%_*}"
+        case " ${seen} " in *" ${pkg} "*) continue ;; esac
+        seen="${seen} ${pkg}"
+        cp -f "${f}" "${stage}/"
+    done
+
+    if [ -z "$(ls -A "${stage}" 2>/dev/null)" ]; then
+        bbfatal "iot-bundle: no iot-*.ipk found under ${feed} — is the 'iot' recipe built?"
+    fi
+
+    name="iot-bundle-${PV}-${MACHINE}.tar.gz"
+    # Archive root holds the flat .ipk files (extracted straight into the spool
+    # by iot-ota-stage). Sorted + no mtime/owner noise → reproducible-ish.
+    tar --numeric-owner --owner=0 --group=0 -C "${stage}" -czf "${DEPLOYDIR}/${name}" .
+
+    sha="$(sha256sum "${DEPLOYDIR}/${name}" | awk '{print $1}')"
+    echo "${sha}  ${name}" > "${DEPLOYDIR}/${name}.sha256"
+
+    # Paste-ready row for the cloud's cloud.firmware.manifest ds key. The cloud
+    # serves the bundle from /firmware/<name>; the operator copies the tarball
+    # into the iot-firmware volume and appends this object to the manifest array.
+    cat > "${DEPLOYDIR}/${name}.manifest.json" <<EOF
+{ "pkg": "iot-bundle", "version": "${PV}", "arch": "${MACHINE}",
+  "ipk_url": "/firmware/${name}", "sha256": "${sha}" }
+EOF
+
+    bbnote "iot-bundle: packed $(ls -1 "${stage}" | wc -l) iot-*.ipk into ${name} (sha256 ${sha})"
+}
+
+addtask deploy before do_build after do_compile


### PR DESCRIPTION
## Summary

Adds a `.tar.gz` bundle of every `iot-*.ipk` so the cloud can upgrade a device's **full userspace** — and a whole **list of endpoints** — in a single LwM2M Object 5 push.

The multi-endpoint fan-out already existed (cloud-ui multi-select → `cloud.update.request{serials:[…]}` → per-endpoint `cloud.update.pending` → lwm2m-dm). The only gap was that one push delivers one URL; this bundle closes it. **No C++, cloud-ui, or installer changes** — `iot-swupdate` already does `opkg install *.ipk` over a glob.

## Changes

| File | Change |
|---|---|
| `yocto/.../lwm2m/iot-bundle.bb` *(new)* | Deploy recipe: tars the newest `iot-*.ipk` per package into `iot-bundle-<ver>-<machine>.tar.gz` + `.sha256` + a paste-ready `.manifest.json`. Gated on `iot:do_package_write_ipk` (all `iot-*` ship from the single `iot` recipe). |
| `yocto/entrypoint.sh` | Appends `iot-bundle` to bitbake targets on image builds (mirrors the `update-bundle` pattern); lists the bundle in the build report. |
| `yocto/.../files/iot-ota-stage` | Detects a `.tar.gz`/`.tgz` URL → sha256-verifies the **tarball** → `gzip -dc \| tar -xf -` extracts the `.ipk`s into the spool (busybox-safe, no reliance on `tar -z`). Single-`.ipk` path unchanged. |
| `yocto/build.sh` | Bundle shown in the per-machine summary + a "push over LwM2M" next-steps block. |
| `modules/server/lwm2m/schemas/cloud.lua` | Manifest comment documents the bundle row. |
| `apps/docs/tdd-yocto-swupdate.md` | New bundle paragraph in §3.2. |

## Operator flow

1. Build → `iot-bundle-1.1.0-raspberrypi3-64.tar.gz` lands in `images/`.
2. Copy it (+ sha) into the cloud's `/firmware/` volume; paste the generated `.manifest.json` row into `cloud.firmware.manifest`.
3. Cloud-ui → Software Update → pick **"iot-bundle 1.1.0"**, multi-select devices, **Update N device(s)**. One push, whole userspace, all selected endpoints.

Chosen **.tar.gz** over bzip2: busybox `tar -z`/`bzip2` aren't guaranteed, and the device path uses `gzip -dc | tar` so it doesn't depend on tar's built-in decompressors.

## Testing

- `sh -n` / `bash -n` clean on all edited scripts.
- Yocto container build **not** run yet (long build); recipe validated by inspection. Worth a build + HW round-trip before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)