### PR TITLE
feat(ota): VPN-independent firmware download with retry/resume

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,16 @@ ssh root@<pi-ip> 'opkg install /tmp/iot-*.ipk'
 ```
 
 In the field, app updates ride **LwM2M Object 5 (Firmware Update)** instead of
-the manual `scp`/`opkg` above: the cloud points the device at an `.ipk` in its
-firmware feed and the `iot-ota-stage` helper pulls + verifies (sha256) the .ipk
+the manual `scp`/`opkg` above: the cloud points the device at an `.ipk` (or a
+`.tar.gz` bundle of every `iot-*.ipk`, for a whole-userspace upgrade) in its
+firmware feed and the `iot-ota-stage` helper pulls + verifies (sha256) it
 into a tmpfs spool and trips an inotify trigger; the separate `iot-swupdate`
 service then installs it, runs config/schema migrations, and restarts or reboots
-— decoupled so it survives replacing the running binaries. See the OTA section in
+— decoupled so it survives replacing the running binaries. The download runs
+**direct over the public WAN, not the VPN tunnel** (the sha256 arrives over the
+trusted DTLS control plane, so the payload transport needn't be trusted), with
+retry+resume — so OTA works even when the tunnel is down and a bundle can safely
+replace the VPN client itself. See the OTA section in
 [`yocto/meta-iot/README.md`](yocto/meta-iot/README.md#ota-updates-lwm2m-object-5)
 and the design in [`apps/docs/tdd-yocto-swupdate.md`](apps/docs/tdd-yocto-swupdate.md).
 

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -946,8 +946,37 @@ int main(int argc, char** argv) {
                                     if (e.value("endpoint", "") == s) return true;
                                 return false;
                             };
-                            std::string fullUrl = url +
-                                (url.find('?') == std::string::npos ? "?" : "&") +
+                            // Resolve a RELATIVE ipk_url (e.g. "/firmware/x.ipk")
+                            // against the cloud's PUBLIC base so the download
+                            // never depends on the VPN tunnel. Precedence:
+                            //   1. explicit cloud.firmware.base.url, else
+                            //   2. http://<host of cloud.dm.uri> — the same
+                            //      public address the device already reaches for
+                            //      DTLS (port 80, the published HTTP feed).
+                            // An absolute ipk_url (has "://") is used verbatim
+                            // (back-compat: an operator may still point at a CDN
+                            // or, deliberately, the tunnel IP).
+                            std::string abs = url;
+                            if (url.find("://") == std::string::npos) {
+                                std::string base =
+                                    ds_str(ds, "cloud.firmware.base.url", "");
+                                if (base.empty()) {
+                                    std::string dm = ds_str(ds, "cloud.dm.uri", "");
+                                    auto sp = dm.find("://");
+                                    std::string host =
+                                        (sp == std::string::npos) ? dm : dm.substr(sp + 3);
+                                    auto c = host.find_first_of(":/");
+                                    if (c != std::string::npos) host = host.substr(0, c);
+                                    if (!host.empty()) base = "http://" + host;
+                                }
+                                while (!base.empty() && base.back() == '/')
+                                    base.pop_back();
+                                if (!base.empty())
+                                    abs = base + (url.empty() || url[0] == '/'
+                                                  ? url : "/" + url);
+                            }
+                            std::string fullUrl = abs +
+                                (abs.find('?') == std::string::npos ? "?" : "&") +
                                 "sha256=" + sha + "&version=" + ver;
                             nlohmann::json pending = nlohmann::json::array();
                             nlohmann::json status  = nlohmann::json::array();

--- a/apps/docs/tdd-yocto-swupdate.md
+++ b/apps/docs/tdd-yocto-swupdate.md
@@ -94,7 +94,14 @@ stages + triggers**, but **does not install**.
   1. Parse `?sha256=`, `?version=`, `?reboot=` query params (same parser as
      today).
   2. `iot.update.state = 1` (downloading); `wget`/`curl` the URL to
-     `/run/iot/update/<pkg>.ipk` over the VPN tunnel.
+     `/run/iot/update/<pkg>.ipk` **direct over the public WAN** (the cloud
+     resolves a relative `ipk_url` against its public address — `cloud.dm.uri`
+     host or `cloud.firmware.base.url` — NOT the VPN tunnel, so OTA still works
+     when the tunnel is down and a bundle can safely replace the VPN client
+     itself). Retried with backoff + **resume** (`curl -C -` / `wget -c`) up to
+     `iot.update.retries` (default 5) so a flaky uplink doesn't fail a campaign;
+     integrity is still pinned by the sha256 below, which arrives over the
+     trusted DTLS control plane.
   3. Verify sha256 if given → on mismatch `iot.update.result = 5`, state 0, abort
      (no trigger written).
   4. `iot.update.state = 2` (downloaded); write `update.meta`

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -153,6 +153,14 @@ return {
         type    = "string",
         default = "",
     },
+    -- Download retry budget for iot-ota-stage. The firmware download rides the
+    -- public WAN (not the VPN tunnel), so a flaky uplink is retried with
+    -- backoff + resume up to this many attempts before failing the campaign.
+    ["iot.update.retries"] = {
+        access  = "Admin",
+        type    = "integer",
+        default = 5,
+    },
     -- Apply progress, written by iot-ota-apply, read by device-ui and
     -- mirrored into Object 5 (/5/0/3, /5/0/5) on client (re)start so a
     -- post-restart server readback reflects the outcome.

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -142,10 +142,25 @@ return {
     --     { "pkg":"iot-bundle", "version":"1.1.0", "arch":"raspberrypi3-64",
     --       "ipk_url":"/firmware/iot-bundle-1.1.0-raspberrypi3-64.tar.gz",
     --       "sha256":"<hex>" } ]
+    -- PREFER a RELATIVE ipk_url ("/firmware/..."): iot-cloudd resolves it
+    -- against the cloud's PUBLIC address (cloud.firmware.base.url, else the
+    -- host of cloud.dm.uri), so the device downloads DIRECT over WAN and OTA
+    -- never depends on the VPN tunnel. An absolute "http(s)://..." ipk_url is
+    -- still honoured verbatim (CDN, or a deliberate tunnel IP).
     ["cloud.firmware.manifest"] = {
         access  = "Admin",
         type    = "string",
         default = "[]",
+    },
+    -- Public base URL the device downloads firmware from when a manifest
+    -- ipk_url is relative ("/firmware/..."). Empty → iot-cloudd derives
+    -- http://<host-of-cloud.dm.uri> (the same public address the device
+    -- already reaches for DTLS — NOT the VPN tunnel IP). Set this to force
+    -- HTTPS or a CDN, e.g. "https://ota.example.com".
+    ["cloud.firmware.base.url"] = {
+        access  = "Admin",
+        type    = "string",
+        default = "",
     },
     -- Update request from cloud-ui (carrier — iot-cloudd clears to ""):
     --   { "serials":["100000abcd",...], "pkg":"iot", "version":"0.2.0",

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
@@ -58,13 +58,43 @@ DL="$SPOOL/$NAME"
 
 set_state 1   # downloading
 log "downloading $URL -> $DL"
-if command -v wget >/dev/null 2>&1; then
-    wget --no-check-certificate -q -O "$DL" "$URL" || fail 8 "download failed"
-elif command -v curl >/dev/null 2>&1; then
-    curl -ksSL -o "$DL" "$URL" || fail 8 "download failed"
-else
-    fail 9 "no wget/curl on device"
-fi
+
+# The download rides the public WAN (the manifest points at the cloud's public
+# feed, not the VPN tunnel), so a flaky uplink is expected. Retry with backoff
+# and RESUME (curl -C -, wget -c) so a mid-transfer drop continues from the byte
+# offset already on disk instead of starting over — important for the larger
+# .tar.gz bundle. Give up only after TRIES attempts; sha256 below still guards
+# integrity. TRIES is operator-overridable via ds, with a safe default.
+TRIES="$($DSCLI get iot.update.retries 2>/dev/null | awk 'NF{print $1}')"
+case "$TRIES" in ''|*[!0-9]*) TRIES=5 ;; esac
+DELAY=5            # backoff seconds, doubles each round (5,10,20,...), capped 60
+download_once() {
+    if command -v curl >/dev/null 2>&1; then
+        # -C - resumes; --retry handles curl-internal transient errors too.
+        curl -fksSL --connect-timeout 20 --retry 2 -C - -o "$DL" "$URL"
+    elif command -v wget >/dev/null 2>&1; then
+        # -c continues a partial file; -T per-read timeout so a stalled
+        # socket fails fast instead of hanging the whole campaign.
+        wget --no-check-certificate -q -c -T 30 -O "$DL" "$URL"
+    else
+        return 99   # no downloader → caller maps to result 9
+    fi
+}
+attempt=1
+while : ; do
+    # `&& break` (not `if/fi`): on failure the list's status stays
+    # download_once's real rc — an `if ... fi` with no else resets $? to 0.
+    download_once && break
+    rc=$?
+    [ "$rc" = 99 ] && fail 9 "no wget/curl on device"
+    if [ "$attempt" -ge "$TRIES" ]; then
+        fail 8 "download failed after ${attempt} attempt(s)"
+    fi
+    log "download attempt ${attempt}/${TRIES} failed (rc=$rc); resuming in ${DELAY}s"
+    sleep "$DELAY"
+    DELAY=$(( DELAY * 2 )); [ "$DELAY" -gt 60 ] && DELAY=60
+    attempt=$(( attempt + 1 ))
+done
 [ -s "$DL" ] || fail 8 "empty download"
 
 # sha256 is verified against the downloaded artifact (the tarball for a bundle,


### PR DESCRIPTION
## Summary

Makes the OTA firmware download **independent of the VPN tunnel** and **resilient to a flaky WAN**. Builds on #264 (the iot-* bundle).

**Why decouple from the VPN:** trust is already anchored in the DTLS control plane — the `sha256` arrives over that authenticated/encrypted channel, so it pins the content regardless of how the payload is fetched. The download transport therefore needn't be trusted. Tunnelling it was actively fragile:
- a bundle updates the `openvpn-client` / `net-router` packages **themselves**;
- a device with a down tunnel was **unrecoverable** — exactly when you'd want to push a fix;
- the heavy download is the part most exposed to WAN flakiness, and the tunnel adds a second failure domain.

The LwM2M control plane already goes **direct device → cloud public IP** (`cloud.dm.uri`), and `/firmware/` is served by the public `iot-httpd` — so the public path needs no new exposure.

## Changes

| Area | Change |
|---|---|
| `apps/cloud/server/src/main.cpp` | Resolve a **relative** manifest `ipk_url` (`/firmware/...`) against the cloud's public base: `cloud.firmware.base.url` if set, else `http://<host of cloud.dm.uri>`. Absolute `http(s)://` urls used verbatim (CDN, or a deliberate tunnel IP) — back-compatible. |
| `iot-ota-stage` | Download retry with backoff + **resume** (`curl -C -` / `wget -c`, busybox-safe) up to `iot.update.retries` (default 5). sha256 still pins integrity. Fixed `$?` capture (`&& break`, not `if/fi`). |
| `cloud.lua` / `iot.lua` | + `cloud.firmware.base.url`, + `iot.update.retries`. |
| README, tdd-yocto-swupdate | Document the public-WAN (non-tunnel) download + relative-url convention. |

## Migration

Existing **absolute** manifest urls keep working. To go VPN-independent, set `ipk_url` to a relative `/firmware/...` (the `iot-bundle.bb`-generated `.manifest.json` already does), or set `cloud.firmware.base.url` to a public HTTPS/CDN origin.

## Not in scope (flagged)

`otaSent[endpoint@version]` is in-memory + set on send, so a **failed** campaign isn't auto-re-pushed and a same-version re-push is a no-op until `lwm2m-dm` restarts. Deferred — separate change.

## Testing

- `sh -n` clean; URL resolver + `rc`-capture validated in isolation.
- Cloud image / Yocto container build **not** run yet (heavy); C++ + Lua reviewed by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)