### PR TITLE
fix(ota): re-push resends Object-5 (campaign id, not endpoint@version)

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -978,16 +978,27 @@ int main(int argc, char** argv) {
                             std::string fullUrl = abs +
                                 (abs.find('?') == std::string::npos ? "?" : "&") +
                                 "sha256=" + sha + "&version=" + ver;
+                            // Campaign id: a monotonic per-push counter that
+                            // stamps every job. lwm2m-dm keys "already pushed"
+                            // on endpoint+cid, so re-pushing even the SAME
+                            // version (fresh cid) re-sends — fixing the old
+                            // grow-only endpoint@version guard that made a
+                            // re-push a no-op until lwm2m-dm restarted. A
+                            // persisted counter (not a clock) → unique across
+                            // restarts and same-second double-pushes.
+                            int cid = ds_int(ds, "cloud.update.seq", 0) + 1;
+                            ds.set("cloud.update.seq",
+                                   data_store::Value{static_cast<std::int32_t>(cid)});
                             nlohmann::json pending = nlohmann::json::array();
                             nlohmann::json status  = nlohmann::json::array();
                             for (const auto& s : serials) {
                                 if (!s.is_string()) continue;
                                 std::string serial = s.get<std::string>();
                                 if (!ep_known(serial)) continue;
-                                pending.push_back({{"endpoint", serial},
+                                pending.push_back({{"endpoint", serial}, {"cid", cid},
                                     {"url", fullUrl}, {"sha256", sha}, {"version", ver}});
                                 status.push_back({{"serial", serial}, {"state", 1},
-                                    {"result", 0}, {"version", ver}, {"ts", 0}});
+                                    {"result", 0}, {"version", ver}, {"ts", cid}});
                             }
                             ds.set("cloud.update.pending",
                                    data_store::Value{pending.dump()});

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -10,6 +10,7 @@
 #include <cstdlib>   // std::system (OTA apply launcher)
 #include <fstream>
 #include <functional>
+#include <map>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -492,10 +493,14 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
     // tunnel, which resumes the push.
     auto* dsCertPush = ds.client();
 
-    // OTA: endpoints we've already pushed an update to this run (keyed by
-    // endpoint+version) so we send the Object-5 write+execute at-most-once —
-    // re-running opkg every tick would be wrong.
-    auto otaSent = std::make_shared<std::set<std::string>>();
+    // OTA: the campaign id (cloud.update.pending "cid") we last pushed to each
+    // endpoint, so the Object-5 write+execute fires at-most-once PER CAMPAIGN —
+    // re-running opkg every tick would be wrong, but a NEW push (operator
+    // re-pushes the same or a new version → fresh cid from cloud.update.seq)
+    // MUST re-send. Bounded to one entry per endpoint (overwritten), unlike the
+    // old grow-only endpoint@version set that made a same-version re-push a
+    // no-op until this daemon restarted.
+    auto otaSent = std::make_shared<std::map<std::string, std::string>>();
 
     app->udpAdapter()->on_tick_server([registry, wapp_srv, last_poll,
                                        publish_regs, dsCertPush, otaSent,
@@ -685,8 +690,16 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                     if (job.value("endpoint", "") != reg.endpoint) continue;
                                     std::string url = job.value("url", "");
                                     std::string ver = job.value("version", "");
-                                    std::string key = reg.endpoint + "@" + ver;
-                                    if (url.empty() || otaSent->count(key)) break;
+                                    // Campaign id: a fresh push (operator re-pushes
+                                    // → new cloud.update.seq) yields a new cid, so
+                                    // even a same-version re-push re-sends. Fallback
+                                    // to version for pre-cid pending rows.
+                                    std::string cid = job.contains("cid")
+                                        ? std::to_string(job.value("cid", 0))
+                                        : ver;
+                                    if (url.empty()) break;
+                                    auto prev = otaSent->find(reg.endpoint);
+                                    if (prev != otaSent->end() && prev->second == cid) break;
                                     std::string utok{static_cast<char>(0x05)};
                                     auto w = ::lwm2m::dmsrv::build_write(
                                         next_msgid(), utok, /*oid*/5, /*iid*/0,
@@ -695,7 +708,7 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                     auto ex = ::lwm2m::dmsrv::build_execute(
                                         next_msgid(), utok, 5, 0, 2, "");
                                     ctx->send_async(ex, reg.peerHost, reg.peerPort);
-                                    otaSent->insert(key);
+                                    (*otaSent)[reg.endpoint] = cid;
                                     ACE_DEBUG((LM_INFO,
                                         ACE_TEXT("%D lwm2m:thread:%t %M %N:%l pushed OTA "
                                                  "update to %C ver=%C peer=%C:%u\n"),

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -184,11 +184,21 @@ return {
     -- Per-endpoint update status (Object-5 readback), written by lwm2m-dm,
     -- read by cloud-ui. JSON array of
     --   { "serial":"...", "state":<0..3>, "result":<0..9>,
-    --     "version":"0.2.0", "ts":<unix> }
+    --     "version":"0.2.0", "ts":<cid> }
     ["cloud.update.status"] = {
         access  = "Admin",
         type    = "string",
         default = "[]",
+    },
+    -- Monotonic OTA campaign counter. iot-cloudd bumps it on every push and
+    -- stamps each cloud.update.pending job with the new value as "cid";
+    -- lwm2m-dm pushes Object-5 at-most-once per (endpoint, cid), so a re-push
+    -- (fresh cid) re-sends even the SAME version. Persisted so the id is unique
+    -- across restarts and same-second double-pushes.
+    ["cloud.update.seq"] = {
+        access  = "Admin",
+        type    = "integer",
+        default = 0,
     },
 
     -- ── PSK provisioning (serial-derived endpoint + per-endpoint PSK) ──


### PR DESCRIPTION
## Problem

The OTA at-most-once guard in `lwm2m-dm` keyed on `endpoint@version` in a **grow-only in-memory `std::set`**, inserted on *send*. Consequences:
- Re-pushing the **same version** was a silent **no-op** until `lwm2m-dm` restarted.
- A **failed/stuck** campaign couldn't be retried from the cloud-ui.

(Flagged in #265 as deferred.)

## Fix — monotonic campaign id (`cid`)

- **iot-cloudd** bumps a persisted `cloud.update.seq` on every push and stamps each `cloud.update.pending` job with it as `"cid"`.
- **lwm2m-dm** tracks the last cid pushed per endpoint in a **bounded `map<endpoint, cid>`** (replacing the grow-only set) and sends Object-5 at-most-once per **(endpoint, cid)**.

Result: a re-push (fresh `cid`) **re-sends even an identical version**, while still firing exactly once per campaign and once per reconnect. Falls back to `version` for pre-`cid` pending rows (back-compat). `cloud.update.status.ts` now carries the `cid` for correlation (the UI never rendered it as a timestamp).

## Changes

| File | Change |
|---|---|
| `apps/cloud/server/src/main.cpp` | Bump + stamp `cid`; `ts = cid`. |
| `apps/src/main.cpp` | `otaSent` `set<endpoint@version>` → `map<endpoint, cid>`; gate on `(endpoint, cid)`; `+<map>`. |
| `modules/server/lwm2m/schemas/cloud.lua` | + `cloud.update.seq`. |

## Still out of scope

True **auto**-retry on device-reported failure needs the Object-5 result **readback → `cloud.update.status`** (a pre-existing TODO). This PR makes a **manual** re-push actually work, which was the concrete bug.

## Testing

- C++ reviewed by inspection (`otaSent` usages consistent; nlohmann `contains()` present; `Value{int32_t}` matches existing call sites). Container build not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)