### PR TITLE
docs(ota): reflect iot-bundle, VPN-independent download, re-push

### DIFF
--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -310,6 +310,12 @@ scp yocto/build/raspberrypi3-64/ipk/*/iot-*.ipk root@<pi-ip>:/tmp/
 ssh root@<pi-ip> 'opkg install /tmp/iot-*.ipk && systemctl restart iot-httpd'
 ```
 
+> This is the bench path. In the field, updates go **over LwM2M from the cloud
+> UI** (no ssh): push a single `.ipk` or the whole-userspace `iot-bundle.tar.gz`
+> to a multi-selected list of devices; the download runs direct over the public
+> WAN with retry/resume. See
+> [`yocto/meta-iot/README.md`](yocto/meta-iot/README.md#ota-updates-lwm2m-object-5).
+
 Full Yocto / layer docs, including how to change the architecture, the
 image payload, or the Wi-Fi firmware package:
 [`yocto/meta-iot/README.md`](yocto/meta-iot/README.md).

--- a/SALES.md
+++ b/SALES.md
@@ -21,7 +21,7 @@ operator reach each NAT'd device's local web UI from one cloud dashboard.
 | **Device-UI-over-VPN** | Every device serves its own web UI behind NAT; the cloud reverse-proxies each one (per-device nftables DNAT) so operators reach it with one click — **Launch UI**. |
 | **Cloud Operator Dashboard** | Angular 14 + Clarity SPA: endpoints, VPN, routing/forwarding, LwM2M config, services, logs, multi-user login (SHA-256, Admin/Viewer roles). |
 | **On-device UI** | The same UI on the device for local commissioning, WiFi/WAN, VPN, and live LwM2M/VPN status. |
-| **OTA software update** | Cloud firmware feed + LwM2M Object 5; multi-select push from the cloud UI; the device pulls, verifies sha256, installs the `.ipk`, and restarts — detached so it survives replacing the running binary. |
+| **OTA software update** | Cloud firmware feed + LwM2M Object 5; multi-select push from the cloud UI upgrades a whole list of devices in one shot — a single `.ipk` or a `.tar.gz` bundle of the entire `iot-*` userspace. The device pulls **direct over the public WAN (not the tunnel)** with retry + resume, verifies sha256 (pinned over the trusted DTLS channel), installs, and restarts — detached so it survives replacing the running binary, and so a stuck VPN can't block its own fix. |
 | **Schema-enforced data store** | A small AF_UNIX key/value store (`ds-server`) is the single IPC backbone; typed, schema-validated, per-key ACLs, live watch + hot-reload, write-through persistence. |
 | **Service control plane** | Per-daemon enable/disable/restart, dependency gating, rate-limiting, live log level + log viewer. |
 | **Build & ship anywhere** | Dev + thin runtime OCI images, docker-compose stacks for cloud and device, and a full **Yocto** layer that builds a bootable Raspberry Pi 3B image **and** the per-daemon `.ipk` feed — entirely inside a container, no host Yocto install. |
@@ -137,11 +137,14 @@ We'd rather you know up front. Current, honest limits of the platform:
 - No built-in horizontal scaling, load balancing, or geo-distribution.
 
 **Updates**
-- **OTA is Phase 1:** userspace `.ipk` packages via LwM2M Object 5 + the cloud
-  feed (multi-select push, device self-update). **Full-image / A-B partition /
-  rollback OTA is Phase 2 and not yet implemented.** A redesigned
-  inotify-triggered installer for Yocto is *designed* but not yet shipped
-  (`apps/docs/tdd-yocto-swupdate.md`).
+- **OTA covers userspace today:** single `.ipk` *or* a `.tar.gz` bundle of the
+  whole `iot-*` userspace, via LwM2M Object 5 + the cloud feed (multi-select
+  push to a list of endpoints, VPN-independent download with retry/resume,
+  re-pushable per campaign, device self-update). The inotify-triggered installer
+  (`iot-ota-stage` + `iot-swupdate`) **is shipped**
+  (`apps/docs/tdd-yocto-swupdate.md`). **Atomic full-image / A-B partition /
+  rollback OTA (RAUC, behind `IOT_AB=1`) — build + bootloader wiring is done but
+  pending hardware acceptance** (`apps/docs/tdd-ab-image-ota.md`).
 
 **Hardware & platform**
 - **Reference target is the Raspberry Pi 3B** (Yocto), with qemuarm64/ARMv7

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -154,16 +154,28 @@ ssh root@<pi-ip> 'opkg install /tmp/iot-*.ipk'
 
 The manual `scp` + `opkg` step above is for the bench. In the field, app
 updates ride the **LwM2M Object 5 (Firmware Update)** flow — the cloud points
-the device at an `.ipk` in its firmware feed, and the device pulls and applies
-it over the VPN tunnel. This is split into a **stager** and an
-**inotify-triggered installer** (full design: `apps/docs/tdd-yocto-swupdate.md`):
+the device at an artifact in its firmware feed and the device pulls and applies
+it. The artifact is either a **single `.ipk`** or a **`.tar.gz` bundle of every
+`iot-*.ipk`** (built by `iot-bundle.bb`) for a whole-userspace upgrade in one
+push; the cloud-ui multi-selects endpoints, so one push can target a whole list
+of devices. The download runs **direct over the public WAN, not the VPN
+tunnel** — the cloud resolves a relative manifest `ipk_url` (`/firmware/...`)
+against its public address (`cloud.firmware.base.url`, else the host of
+`cloud.dm.uri`), and the `sha256` that pins integrity arrives over the trusted
+DTLS control plane, so the payload transport needn't be trusted. This keeps OTA
+working when the tunnel is down and lets a bundle safely replace the VPN client
+itself. The flow is split into a **stager** and an **inotify-triggered
+installer** (full design: `apps/docs/tdd-yocto-swupdate.md`):
 
 - `iot-ota-stage` (`/usr/bin/iot-ota-stage`, in `iot-lwm2m`) is the worker the
   LwM2M client invokes on a /5/0/0 write. It runs **detached**
-  (`systemd-run --unit=iot-ota-stage`): download the `.ipk` (honouring
-  `?sha256=` / `?version=` / `?reboot=` params) → verify sha256 → write it to the
-  tmpfs spool `/run/iot/update/` → `touch` the empty `update` trigger. It does
-  **not** install.
+  (`systemd-run --unit=iot-ota-stage`): download the artifact (honouring
+  `?sha256=` / `?version=` / `?reboot=` params) with **retry + resume**
+  (`curl -C -` / `wget -c`, up to `iot.update.retries`, default 5) so a flaky
+  uplink doesn't fail the campaign → verify sha256 → for a `.tar.gz` bundle,
+  extract the `.ipk`s into the spool (so the installer's `*.ipk` glob applies
+  them all) → write to the tmpfs spool `/run/iot/update/` → `touch` the empty
+  `update` trigger. It does **not** install.
 - `iot-swupdate.path` (systemd **inotify** watch on the trigger) fires
   `iot-swupdate.service` → `/usr/bin/iot-swupdate`, which: snapshots + re-arms,
   `opkg install --force-reinstall --force-downgrade`, runs config/schema
@@ -185,9 +197,16 @@ it over the VPN tunnel. This is split into a **stager** and an
   | `iot.update.state`  | 0 idle · 1 downloading · 2 downloaded · 3 updating  |
   | `iot.update.result` | 0 initial · 1 success · 5 integrity · 8 uri · 9 install |
 
-This is Phase 1 (single `.ipk` package update). Full-image A/B updates are
-out of scope here. See `apps/docs/` and the device/cloud OTA notes for the
-end-to-end push from the cloud UI.
+Re-pushing is idempotent per **campaign**: iot-cloudd stamps each push with a
+monotonic `cloud.update.seq` (`cid`), and lwm2m-dm pushes Object 5 at-most-once
+per `(endpoint, cid)` — so a fresh push re-sends even an identical version,
+while a stuck campaign isn't re-fired every tick.
+
+This covers per-`.ipk` and whole-userspace (`iot-bundle`) updates. Atomic
+full-image **A/B** updates (RAUC `.raucb`, behind `IOT_AB=1`) are a separate
+path — `iot-swupdate` branches on `.raucb` → `rauc install` + reboot — see
+`apps/docs/tdd-ab-image-ota.md`. See `apps/docs/` and the device/cloud OTA
+notes for the end-to-end push from the cloud UI.
 
 ## What this layer provides
 


### PR DESCRIPTION
## Summary

Brings the overview/operator docs in line with the OTA work merged in #264/#265/#266. No code — docs only.

## Changes

| File | Update |
|---|---|
| `yocto/meta-iot/README.md` | The canonical "OTA updates (LwM2M Object 5)" section: artifact is a single `.ipk` **or** a `.tar.gz` `iot-*` bundle (whole-userspace, multi-device); download is **direct over the public WAN, not the tunnel**, with retry+resume; bundle extraction in the stager; per-campaign `cid` re-push semantics; A/B (`.raucb`, `IOT_AB=1`) called out as a separate path. Removes the stale "applies it over the VPN tunnel". |
| `SALES.md` | OTA feature row + "Updates" note: whole-userspace bundle, VPN-independent download, multi-device push; the inotify installer **is shipped** (was "designed, not yet shipped"); A/B is build-wired pending HW acceptance. |
| `DEPLOY.md` | Note that field updates go over LwM2M from the cloud UI, not just the bench `scp`/`opkg` path. |

## Notes

`README.md` and `apps/docs/tdd-yocto-swupdate.md` were already updated in #264/#265. Verified no remaining "over the VPN tunnel" download claims across the doc set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)