### PR TITLE
feat(ota): show package name + download progress in both UIs

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -926,6 +926,7 @@ int main(int argc, char** argv) {
                         std::string url = req.value("url", "");
                         std::string sha = req.value("sha256", "");
                         std::string ver = req.value("version", "");
+                        std::string pkg = req.value("pkg", "");
                         // Validate url against the manifest (and fill sha/ver).
                         bool known = false;
                         auto man = nlohmann::json::parse(
@@ -935,6 +936,7 @@ int main(int argc, char** argv) {
                                 known = true;
                                 if (sha.empty()) sha = m.value("sha256",  "");
                                 if (ver.empty()) ver = m.value("version", "");
+                                if (pkg.empty()) pkg = m.value("pkg",     "");
                                 break;
                             }
                         }
@@ -998,7 +1000,8 @@ int main(int argc, char** argv) {
                                 pending.push_back({{"endpoint", serial}, {"cid", cid},
                                     {"url", fullUrl}, {"sha256", sha}, {"version", ver}});
                                 status.push_back({{"serial", serial}, {"state", 1},
-                                    {"result", 0}, {"version", ver}, {"ts", cid}});
+                                    {"result", 0}, {"version", ver}, {"pkg", pkg},
+                                    {"ts", cid}});
                             }
                             ds.set("cloud.update.pending",
                                    data_store::Value{pending.dump()});

--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -7,7 +7,7 @@ import { ToastService } from '../../common/toast.service';
 
 interface FwPkg { pkg: string; version: string; arch: string; ipk_url: string; sha256: string; }
 interface Ep { endpoint: string; tun_ip: string; proxy_port: number; registered: boolean; installed_version?: string; }
-interface UpdStatus { serial: string; state: number; result: number; version: string; ts: number; }
+interface UpdStatus { serial: string; state: number; result: number; version: string; pkg?: string; ts: number; }
 
 @Component({
   selector: 'app-software-update',
@@ -62,15 +62,23 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
         <h4 style="margin-top:28px;">Update Status</h4>
         <clr-datagrid>
           <clr-dg-column>Serial</clr-dg-column>
+          <clr-dg-column>Package</clr-dg-column>
           <clr-dg-column>State</clr-dg-column>
+          <clr-dg-column>Progress</clr-dg-column>
           <clr-dg-column>Result</clr-dg-column>
           <clr-dg-column>Version</clr-dg-column>
 
           <clr-dg-row *clrDgItems="let s of status">
             <clr-dg-cell><code>{{ s.serial }}</code></clr-dg-cell>
+            <clr-dg-cell>{{ s.pkg || '—' }}</clr-dg-cell>
             <clr-dg-cell>
               <app-status-badge [label]="stateLabel(s.state)"
                 [state]="s.state===0 ? 'connected' : 'idle'"></app-status-badge>
+            </clr-dg-cell>
+            <clr-dg-cell>
+              <div class="pbar"><span [style.width.%]="progressPct(s)"
+                [class.err]="s.result>=5"></span></div>
+              <span class="pbar-pct">{{ progressPct(s) }}%</span>
             </clr-dg-cell>
             <clr-dg-cell>
               <app-status-badge [label]="resultLabel(s.result)"
@@ -93,6 +101,12 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
     .hint { color: #888; font-size: 12px; margin-top: 8px; }
     .btn-cell { display: flex; align-items: flex-end; }
     .btn-cell .btn-primary { white-space: nowrap; }
+    .pbar { display: inline-block; width: 90px; height: 8px; background: #e0e6e9;
+      border-radius: 4px; overflow: hidden; vertical-align: middle; }
+    .pbar > span { display: block; height: 100%; background: #0072a3;
+      transition: width 0.3s ease; border-radius: 4px; }
+    .pbar > span.err { background: #c92100; }
+    .pbar-pct { margin-left: 6px; font-size: 12px; color: #607d8b; vertical-align: middle; }
   `]
 })
 export class SoftwareUpdateComponent implements OnInit, OnDestroy {
@@ -152,6 +166,17 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     if (r === 8) return 'uri error';
     if (r === 9) return 'install error';
     return 'error ' + r;
+  }
+  // Cloud-side progress is PHASE-based (the device's byte-accurate % shows on the
+  // device-ui): the cloud sees the coarse Object-5 state, not the live download.
+  // 100% once the device reports success or its installed version matches the
+  // target; a failed job freezes the bar (rendered red) at the phase it died.
+  progressPct(s: UpdStatus): number {
+    if (s.result === 1) return 100;
+    const ep = this.endpoints.find(e => e.endpoint === s.serial);
+    if (ep?.installed_version && ep.installed_version === s.version) return 100;
+    if (s.result >= 5) return s.state >= 2 ? 80 : 30;
+    return [0, 30, 65, 90][s.state] ?? 0;
   }
 
   pushUpdate(): void {

--- a/iot-ui/src/app/software-update/software-update.component.ts
+++ b/iot-ui/src/app/software-update/software-update.component.ts
@@ -21,11 +21,30 @@ import { ToastService } from '../../common/toast.service';
               <app-ds-hint *dsDebug key="iot.version"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell>{{ version || '—' }}</clr-dg-cell>
           </clr-dg-row>
+          <clr-dg-row *ngIf="pkg">
+            <clr-dg-cell>Package
+              <app-ds-hint *dsDebug key="iot.update.package"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell><code>{{ pkg }}</code></clr-dg-cell>
+          </clr-dg-row>
           <clr-dg-row>
             <clr-dg-cell>State
               <app-ds-hint *dsDebug key="iot.update.state"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell><app-status-badge [label]="stateLabel"
               [state]="state===0 ? 'connected' : 'idle'"></app-status-badge></clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="state===1">
+            <clr-dg-cell>Download
+              <app-ds-hint *dsDebug key="iot.update.progress"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell>
+              <ng-container *ngIf="progress > 0; else indeterminate">
+                <div class="pbar"><span [style.width.%]="progress"></span></div>
+                <span class="pbar-pct">{{ progress }}%</span>
+              </ng-container>
+              <ng-template #indeterminate>
+                <div class="pbar indet"><span></span></div>
+                <span class="pbar-pct">downloading…</span>
+              </ng-template>
+            </clr-dg-cell>
           </clr-dg-row>
           <clr-dg-row>
             <clr-dg-cell>Result
@@ -141,12 +160,21 @@ import { ToastService } from '../../common/toast.service';
       cursor: pointer; font-size: 13px; transition: all 0.15s; background: #fafcfd; }
     .dropzone:hover, .dropzone.over { border-color: #0072a3; color: #0072a3; background: #f0f8fc; }
     .dropzone.busy { opacity: 0.6; pointer-events: none; }
+    .pbar { display: inline-block; width: 140px; height: 8px; background: #e0e6e9;
+      border-radius: 4px; overflow: hidden; vertical-align: middle; }
+    .pbar > span { display: block; height: 100%; background: #0072a3;
+      transition: width 0.3s ease; border-radius: 4px; }
+    .pbar.indet > span { width: 35%; animation: pbar-slide 1.1s ease-in-out infinite; }
+    .pbar-pct { margin-left: 8px; font-size: 12px; color: #607d8b; vertical-align: middle; }
+    @keyframes pbar-slide { 0% { margin-left: -35%; } 100% { margin-left: 100%; } }
   `]
 })
 export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   version = '';       // iot.version — the running/installed release (footer value)
   state = 0;
   result = 0;
+  pkg = '';           // iot.update.package — artifact being applied (name + version)
+  progress = 0;       // iot.update.progress — download % (0 when size unknown)
   bank = '';          // iot.boot.bank — running A/B rootfs bank (empty = single-rootfs)
   confirmed = false;  // iot.boot.confirmed — this boot marked good
   // iot.boot.banks — both A/B banks (empty on a single-rootfs image).
@@ -198,6 +226,12 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     }));
     this.sub.add(this.ds.observe('iot.update.result').subscribe(v => {
       this.result = Number(v) || 0;
+    }));
+    this.sub.add(this.ds.observe('iot.update.package').subscribe(v => {
+      this.pkg = String(v ?? '');
+    }));
+    this.sub.add(this.ds.observe('iot.update.progress').subscribe(v => {
+      this.progress = Math.max(0, Math.min(100, Number(v) || 0));
     }));
     // A/B boot status changes only once per boot — read it once. iot.boot.banks
     // is also written at boot (before the UI connects), so read it here too; the

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -174,6 +174,22 @@ return {
         type    = "integer",
         default = 0,
     },
+    -- Download progress 0..100, written by iot-ota-stage during the download
+    -- (bytes-on-disk / Content-Length). Stays 0 when the size is unknown (the
+    -- device-ui then shows an indeterminate bar). 100 = fully downloaded.
+    ["iot.update.progress"] = {
+        access  = "Admin",
+        type    = "integer",
+        default = 0,
+    },
+    -- Human label for the artifact being applied (e.g.
+    -- "iot-bundle-1.1.0-raspberrypi3-64.tar.gz (1.1.0)"), written by
+    -- iot-ota-stage. Shown in the device-ui Software Update status.
+    ["iot.update.package"] = {
+        access  = "Admin",
+        type    = "string",
+        default = "",
+    },
 
     -- A/B image OTA (Phase 2). Which rootfs bank is running, and whether this
     -- boot has been health-checked + confirmed good (else the bootloader rolls

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
@@ -22,8 +22,10 @@ SOCK="/run/iot/data_store.sock"
 DSCLI="ds-cli --socket=${SOCK}"
 SPOOL="/run/iot/update"
 
-set_state()  { $DSCLI set iot.update.state  "$1" >/dev/null 2>&1 || true; }
-set_result() { $DSCLI set iot.update.result "$1" >/dev/null 2>&1 || true; }
+set_state()    { $DSCLI set iot.update.state    "$1" >/dev/null 2>&1 || true; }
+set_result()   { $DSCLI set iot.update.result   "$1" >/dev/null 2>&1 || true; }
+set_progress() { $DSCLI set iot.update.progress "$1" >/dev/null 2>&1 || true; }
+set_package()  { $DSCLI set iot.update.package  "$1" >/dev/null 2>&1 || true; }
 log() { logger -t iot-ota-stage "$*" 2>/dev/null; echo "iot-ota-stage: $*"; }
 fail() { log "FAILED ($1): $2"; set_result "$1"; set_state 0; exit 1; }
 
@@ -56,6 +58,12 @@ esac
 mkdir -p "$SPOOL"
 DL="$SPOOL/$NAME"
 
+# Surface what's being applied + reset the progress gauge for the UIs. The
+# package label is the artifact name plus version when known (e.g.
+# "iot-bundle-1.1.0-raspberrypi3-64.tar.gz (1.1.0)").
+set_package "${NAME}${VER:+ ($VER)}"
+set_progress 0
+
 set_state 1   # downloading
 log "downloading $URL -> $DL"
 
@@ -80,6 +88,32 @@ download_once() {
         return 99   # no downloader → caller maps to result 9
     fi
 }
+
+# Best-effort total size (Content-Length, following redirects) so the device-ui
+# can show a true byte-accurate download %. Empty/unknown → the gauge stays at 0
+# and the UI shows an indeterminate "downloading" bar instead of a false number.
+TOTAL=""
+if command -v curl >/dev/null 2>&1; then
+    TOTAL="$(curl -fksSLI "$URL" 2>/dev/null | tr 'A-Z' 'a-z' \
+            | awk -F': *' '/^content-length:/{gsub(/\r/,"",$2); v=$2} END{print v}')"
+fi
+case "$TOTAL" in ''|*[!0-9]*) TOTAL=0 ;; esac
+
+# Background poller: while the download runs, publish bytes-on-disk / TOTAL as a
+# 0..99 percentage (100 is set only once the file is complete + verified).
+poll_progress() {
+    [ "$TOTAL" -gt 0 ] || return 0
+    while :; do
+        sz="$(wc -c < "$DL" 2>/dev/null || echo 0)"
+        pct=$(( sz * 100 / TOTAL )); [ "$pct" -gt 99 ] && pct=99
+        set_progress "$pct"
+        sleep 1
+    done
+}
+poll_progress & POLLER=$!
+# Kill the poller no matter how we leave (success, fail, or signal).
+trap 'kill "$POLLER" 2>/dev/null' EXIT INT TERM
+
 attempt=1
 while : ; do
     # `&& break` (not `if/fi`): on failure the list's status stays
@@ -95,7 +129,9 @@ while : ; do
     DELAY=$(( DELAY * 2 )); [ "$DELAY" -gt 60 ] && DELAY=60
     attempt=$(( attempt + 1 ))
 done
+kill "$POLLER" 2>/dev/null; trap - EXIT INT TERM
 [ -s "$DL" ] || fail 8 "empty download"
+set_progress 100   # bytes fully on disk; sha256 verify is the next gate
 
 # sha256 is verified against the downloaded artifact (the tarball for a bundle,
 # the .ipk otherwise) — the cloud computes it over the same file.


### PR DESCRIPTION
## Summary

Both Software Update pages now show **what** is being applied (package name) and **how far** the download has got — instead of only the coarse `idle/downloading/updating` label.

## Device-ui — true byte-accurate %
- `iot-ota-stage` publishes `iot.update.package` (artifact name + version) and `iot.update.progress` (0–100) via a background poller that divides bytes-on-disk by the `Content-Length` (from a HEAD). Unknown size → progress stays `0` and the UI shows an **indeterminate** bar. The poller is `trap`-cleaned on any exit (success/fail/signal).
- New `iot.lua` keys: `iot.update.progress`, `iot.update.package`.
- New rows: **Package** + a **Download** progress bar (live % or indeterminate while `state=downloading`).

## Cloud-ui — package name + phase-based progress
- `iot-cloudd` carries the manifest `pkg` into each `cloud.update.status` row (preserved when lwm2m-dm updates `state` in place).
- New **Package** column + a **Progress** bar derived from the Object-5 state buckets (downloading → downloaded → updating), **100%** once the device reports success or its installed version matches the target, and **red + frozen** at the phase a job failed.

## Honest scope note

Cloud-side progress is **phase-based**, not byte-accurate: the cloud only sees the coarse Object-5 state, not the device's live download. The **device-ui has the true byte %**. Byte-accurate cloud-side % would require polling a new Object-5 progress resource back over CoAP per device (extends the existing `/3/0/3`,`/4/0/4` readback) — deliberately left as a separate follow-up so the riskier async-CoAP change doesn't ride with these certain wins.

## Testing

- `iot-ota-stage`: `sh -n` clean; progress math + poller logic validated in isolation.
- UIs: **not** built — `node` isn't available on this host; the Angular apps build via `nodejs-native` in the container (same as prior UI PRs). Reviewed by inspection (property/subscription/template refs consistent; `Ep.installed_version` optional-chained).
- C++ (`pkg` into status row) reviewed by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)