### PR TITLE
fix(flash): wipe partition table on the raw node, not buffered /dev/diskN

### DIFF
--- a/yocto/flash-sd.sh
+++ b/yocto/flash-sd.sh
@@ -314,9 +314,11 @@ else
         sudo wipefs -a "$DEV" || true
     fi
     # Zero the first 16 MiB to clear MBR/GPT + any leftover superblocks.
-    # On macOS, we need to use the raw disk node for dd, which requires sudo.
-    sudo dd if=/dev/zero of="$DEV" bs="$BS" count=4 conv=fsync 2>/dev/null \
-        || sudo dd if=/dev/zero of="$DEV" bs="$BS" count=4
+    # Write the RAW node ($TARGET, /dev/rdiskN on macOS): dd to the buffered
+    # whole-disk node (/dev/diskN) is rejected by macOS with "Operation not
+    # permitted". On Linux $TARGET == $DEV, so this is correct on both.
+    sudo dd if=/dev/zero of="$TARGET" bs="$BS" count=4 conv=fsync 2>/dev/null \
+        || sudo dd if=/dev/zero of="$TARGET" bs="$BS" count=4
     sync
     log_info "Partition table cleared."
 fi


### PR DESCRIPTION
## Problem

`./flash-sd.sh /dev/disk4` failed on macOS at the format step:

```
═══ Formatting (wiping partition table) on /dev/disk4 ═══
dd: /dev/disk4: Operation not permitted
```

The wipe dd'd `/dev/zero` to **`$DEV`** — the *buffered* whole-disk node (`/dev/disk4`), which macOS rejects with "Operation not permitted" even under `sudo`. The image-write step already used **`$TARGET`** (the *raw* node, `/dev/rdisk4`) correctly, and the wipe's own comment said "we need to use the raw disk node" — the code just referenced the wrong variable.

## Fix

Point the wipe dd at `$TARGET` (raw node). On Linux `$TARGET == $DEV`, so it's correct on both platforms; no behavior change for Linux.

## Note

If a user still hits "Operation not permitted" on the **raw** node after this, that's a separate macOS cause — the terminal app needs **Full Disk Access** (System Settings → Privacy & Security → Full Disk Access; `sudo` alone isn't enough on Catalina+). Not addressed here as it's an OS-level grant, not a script issue.

## Testing

`bash -n` clean. (Real validation is a flash run on macOS hardware.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)