### PR TITLE
feat(cloud-ui): upload firmware bundle via browse/drag-drop (no scp/ds-cli)

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -143,7 +143,7 @@ services:
     network_mode: "service:iot-cloudd"
     volumes:
       - iot-run:/var/run/iot
-      - iot-firmware:/var/lib/iot/firmware:ro   # OTA .ipk feed (served at /firmware/)
+      - iot-firmware:/var/lib/iot/firmware      # OTA .ipk feed (served at /firmware/; RW so the cloud-ui can upload bundles via POST /api/v1/firmware/upload)
       - iot-tls:/etc/iot/tls                    # self-signed cert — auto-provisioned by the image entrypoint
     environment:
       - TLS_HOST=${TLS_HOST:-}                  # cert CN/SAN for https (run.sh passes the host IP)

--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -35,7 +35,38 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
           <div></div>
           <div></div>
         </div>
-        <p class="hint" *ngIf="!manifest.length">No firmware in the catalogue. Seed the iot-firmware volume and set <code>cloud.firmware.manifest</code>.</p>
+        <p class="hint" *ngIf="!manifest.length">No firmware in the catalogue yet — add one below (or seed <code>cloud.firmware.manifest</code> manually).</p>
+
+        <!-- Add firmware: browse / drag & drop a bundle straight into the feed -->
+        <h4>Add Firmware</h4>
+        <div class="dropzone" [class.over]="dragOver" [class.busy]="uploading"
+             (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)"
+             (drop)="onDrop($event)" (click)="fileInput.click()">
+          <input #fileInput type="file" accept=".ipk,.tar.gz,.tgz" hidden (change)="onPick($event)" />
+          <clr-icon shape="upload-cloud" size="28"></clr-icon>
+          <span *ngIf="!uploading && !pendingFile">Drag &amp; drop an <code>.ipk</code> or <code>.tar.gz</code> bundle, or click to browse</span>
+          <span *ngIf="!uploading && pendingFile">{{ pendingFile.name }} ({{ (pendingFile.size/1048576) | number:'1.0-1' }} MB) — confirm details and upload</span>
+          <span *ngIf="uploading">Uploading {{ uploadName }} — {{ uploadPct }}%…</span>
+        </div>
+        <div class="form-grid" *ngIf="pendingFile" style="margin-top:12px; align-items:end;">
+          <clr-input-container>
+            <label>Package</label>
+            <input clrInput [(ngModel)]="upPkg" placeholder="iot-bundle" />
+          </clr-input-container>
+          <clr-input-container>
+            <label>Version</label>
+            <input clrInput [(ngModel)]="upVersion" placeholder="1.1.0" />
+          </clr-input-container>
+          <clr-input-container>
+            <label>Arch</label>
+            <input clrInput [(ngModel)]="upArch" placeholder="raspberrypi3-64" />
+          </clr-input-container>
+          <div class="btn-cell">
+            <button class="btn btn-primary" (click)="startUpload()" [disabled]="uploading || !upPkg">
+              {{ uploading ? 'Uploading…' : 'Upload to feed' }}
+            </button>
+          </div>
+        </div>
 
         <!-- Target devices (multi-select) -->
         <h4>Target Devices</h4>
@@ -107,6 +138,11 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
       transition: width 0.3s ease; border-radius: 4px; }
     .pbar > span.err { background: #c92100; }
     .pbar-pct { margin-left: 6px; font-size: 12px; color: #607d8b; vertical-align: middle; }
+    .dropzone { display: flex; align-items: center; gap: 12px; padding: 18px;
+      border: 2px dashed #b0bec5; border-radius: 8px; color: #607d8b;
+      cursor: pointer; font-size: 13px; transition: all 0.15s; background: #fafcfd; }
+    .dropzone:hover, .dropzone.over { border-color: #0072a3; color: #0072a3; background: #f0f8fc; }
+    .dropzone.busy { opacity: 0.6; pointer-events: none; }
   `]
 })
 export class SoftwareUpdateComponent implements OnInit, OnDestroy {
@@ -116,6 +152,16 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   selected: Ep[] = [];
   selectedUrl = '';
   pushing = false;
+  // Firmware upload (browse / drag-drop into the feed)
+  dragOver = false;
+  uploading = false;
+  uploadName = '';
+  uploadPct = 0;
+  pendingFile: File | null = null;
+  upPkg = '';
+  upVersion = '';
+  upArch = '';
+  private static readonly CHUNK = 4 * 1024 * 1024;
   private active = true;
   private sub = new Subscription();
 
@@ -196,6 +242,58 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
       },
       error: () => { this.pushing = false; this.toast.error('Update failed'); }
     });
+  }
+
+  // ── Firmware upload (browse / drag-drop into the cloud feed) ───────
+  onDragOver(e: DragEvent): void { e.preventDefault(); this.dragOver = true; }
+  onDragLeave(e: DragEvent): void { e.preventDefault(); this.dragOver = false; }
+  onDrop(e: DragEvent): void {
+    e.preventDefault(); this.dragOver = false;
+    const f = e.dataTransfer?.files?.[0]; if (f) this.stageFile(f);
+  }
+  onPick(e: Event): void {
+    const input = e.target as HTMLInputElement;
+    const f = input.files?.[0]; if (f) this.stageFile(f);
+    input.value = '';   // allow re-picking the same file
+  }
+
+  // Stage the file + pre-fill pkg/version/arch from its name (operator edits).
+  private stageFile(f: File): void {
+    if (!/\.(ipk|tar\.gz|tgz)$/i.test(f.name)) {
+      this.toast.error('Pick a .ipk, .tar.gz or .tgz file'); return;
+    }
+    this.pendingFile = f;
+    const base = f.name.replace(/\.(tar\.gz|tgz|ipk)$/i, '');
+    this.upPkg = base; this.upVersion = ''; this.upArch = '';
+    // .ipk = name_version_arch ; bundle = pkg-version-arch (version starts w/ a digit)
+    let m = base.match(/^(.+)_([^_]+)_([^_]+)$/);
+    if (!m) m = base.match(/^(.+)-(\d[\w.+]*)-([\w.+-]+)$/);
+    if (m) { this.upPkg = m[1]; this.upVersion = m[2]; this.upArch = m[3]; }
+  }
+
+  startUpload(): void {
+    const file = this.pendingFile;
+    if (!file || this.uploading || !this.upPkg) return;
+    this.uploading = true; this.uploadName = file.name; this.uploadPct = 0;
+    const total = file.size;
+    const sendFrom = (offset: number): void => {
+      const end = Math.min(offset + SoftwareUpdateComponent.CHUNK, total);
+      const final = end >= total;
+      this.sub.add(this.http.uploadFirmwareChunk(file.name, this.upVersion, this.upArch,
+          this.upPkg, file.slice(offset, end), offset, final).subscribe({
+        next: (r) => {
+          if (!r.ok) { this.uploading = false; this.toast.error(r.err || 'Upload failed'); return; }
+          this.uploadPct = total ? Math.round((end / total) * 100) : 100;
+          if (final) {
+            this.uploading = false; this.pendingFile = null;
+            this.toast.success('Added ' + file.name + ' to the firmware feed');
+            this.loadManifest();   // dropdown picks up the new row
+          } else { sendFrom(end); }
+        },
+        error: (e) => { this.uploading = false; this.toast.error(e?.error?.err || 'Upload failed'); }
+      }));
+    };
+    sendFrom(0);
   }
 
   ngOnDestroy(): void { this.active = false; this.sub.unsubscribe(); }

--- a/apps/cloud/ui/src/common/httpsvc.service.ts
+++ b/apps/cloud/ui/src/common/httpsvc.service.ts
@@ -134,4 +134,20 @@ export class HttpsvcService {
       `${this.api}/api/v1/users?id=${encodeURIComponent(id)}`,
       { withCredentials: true });
   }
+
+  // ── Firmware feed upload (Software Update) ────────────────────────
+  // Chunked browse/drag-drop into the cloud firmware feed: offset=0 truncates,
+  // final=1 finalises (server computes sha256 + upserts cloud.firmware.manifest).
+  // pkg/version/arch are pre-filled from the filename and operator-confirmable.
+  uploadFirmwareChunk(name: string, version: string, arch: string, pkg: string,
+                      chunk: Blob, offset: number, final: boolean):
+                      Observable<{ ok: boolean; err?: string; sha256?: string }> {
+    return this.http.post<{ ok: boolean; err?: string; sha256?: string }>(
+      `${this.api}/api/v1/firmware/upload?name=${encodeURIComponent(name)}` +
+        `&version=${encodeURIComponent(version)}&arch=${encodeURIComponent(arch)}` +
+        `&pkg=${encodeURIComponent(pkg)}&offset=${offset}&final=${final ? 1 : 0}`,
+      chunk,
+      { headers: new HttpHeaders({ 'Content-Type': 'application/octet-stream' }),
+        withCredentials: true });
+  }
 }

--- a/modules/http-server/inc/handler.hpp
+++ b/modules/http-server/inc/handler.hpp
@@ -18,7 +18,8 @@ namespace http_server {
 /// need the store for login/logout.
 void install_handlers(Router& router,
                       data_store::Client* ds,
-                      SessionStore* auth);
+                      SessionStore* auth,
+                      const std::string& firmware_dir = "");
 
 /// Install /api/v1/cloud/* handlers (L21/D7).  Pointers must outlive
 /// the router.  Call after install_handlers().

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -14,6 +14,7 @@
 #include <chrono>
 #include <condition_variable>
 #include <fstream>
+#include <iterator>
 #include <memory>
 #include <mutex>
 #include <thread>
@@ -85,7 +86,8 @@ bool save_accounts(data_store::Client* ds, const json& arr) {
 
 void install_handlers(Router& router,
                       data_store::Client* ds,
-                      SessionStore* auth) {
+                      SessionStore* auth,
+                      const std::string& firmware_dir) {
     // ─── GET / → redirect to the SPA login ───────────────────
     // The UI lives under /webui/; hitting the bare host (e.g. just the
     // IP) should land on the login page instead of a 404, so users can
@@ -475,6 +477,102 @@ void install_handlers(Router& router,
                 ACE_DEBUG((LM_INFO,
                            ACE_TEXT("%D httpd:thread:%t %M %N:%l OTA upload complete %C; "
                                     "triggered iot-swupdate\n"), safe.c_str()));
+            }
+            r.body = R"({"ok":true})";
+            return r;
+        });
+
+    // ── POST /api/v1/firmware/upload?name=<f>&version=&arch=&pkg= ──
+    // Cloud-side: browse / drag-drop a .ipk or .tar.gz bundle in the cloud-ui
+    // straight into the firmware FEED (firmware_dir, served at /firmware/) and
+    // add it to cloud.firmware.manifest — no scp / ds-cli for the operator.
+    // Chunked like /update/upload (offset=0 truncates, final=1 finalises). On
+    // the final chunk the server computes the sha256 over the assembled file
+    // (authoritative) and upserts the manifest row keyed by ipk_url. Only
+    // active where a firmware feed exists (the cloud); a device has none → 400.
+    router.add("POST", "/api/v1/firmware/upload",
+        [ds, auth, firmware_dir](const HttpParser::Request& req) -> HttpResponse {
+            HttpResponse r;
+            std::string access_level = "Admin";
+            if (auth && auth->enabled()) {
+                std::string token = extract_session_cookie(req.headers, auth->cookie_name());
+                if (!token.empty()) { const auto* s = auth->validate(token); if (s) access_level = s->access; }
+            }
+            if (access_level != "Admin") {
+                r.status = 403; r.body = R"({"ok":false,"err":"admin required"})"; return r;
+            }
+            if (firmware_dir.empty()) {
+                r.status = 400; r.body = R"({"ok":false,"err":"no firmware feed on this host"})"; return r;
+            }
+            auto qp = [&](const char* k) -> std::string {
+                auto it = req.query.find(k); return it != req.query.end() ? it->second : std::string();
+            };
+            std::string name = qp("name");
+            if (auto p = name.find_last_of('/'); p != std::string::npos) name = name.substr(p + 1);
+            std::string safe;
+            for (char c : name)
+                safe.push_back((std::isalnum(static_cast<unsigned char>(c)) ||
+                                c == '.' || c == '_' || c == '-') ? c : '_');
+            auto ends_with = [&](const char* e) {
+                std::string s(e);
+                return safe.size() >= s.size() &&
+                       safe.compare(safe.size() - s.size(), s.size(), s) == 0;
+            };
+            if (safe.empty() || !(ends_with(".ipk") || ends_with(".tar.gz") || ends_with(".tgz"))) {
+                r.status = 400; r.body = R"({"ok":false,"err":"name must end in .ipk, .tar.gz or .tgz"})"; return r;
+            }
+            bool first = true, final = true;
+            if (auto it = req.query.find("offset"); it != req.query.end())
+                first = (it->second == "0" || it->second.empty());
+            if (auto it = req.query.find("final"); it != req.query.end())
+                final = (it->second == "1" || it->second == "true");
+            if (req.body.empty() && first) {
+                r.status = 400; r.body = R"({"ok":false,"err":"empty upload"})"; return r;
+            }
+            const std::string path = firmware_dir + "/" + safe;
+            {
+                std::ios::openmode mode = std::ios::binary | std::ios::out |
+                                          (first ? std::ios::trunc : std::ios::app);
+                std::ofstream f(path, mode);
+                if (!f) {
+                    r.status = 500;
+                    r.body = R"({"ok":false,"err":"cannot write firmware feed (perms? feed mounted read-only?)"})";
+                    return r;
+                }
+                if (!req.body.empty())
+                    f.write(req.body.data(), static_cast<std::streamsize>(req.body.size()));
+                if (!f) { r.status = 500; r.body = R"({"ok":false,"err":"feed write failed"})"; return r; }
+            }
+            if (final) {
+                // Authoritative sha256 over the assembled file.
+                std::ifstream in(path, std::ios::binary);
+                std::string data((std::istreambuf_iterator<char>(in)),
+                                  std::istreambuf_iterator<char>());
+                const std::string sha = sha256_hex(data);
+                const std::string ipk_url = "/firmware/" + safe;
+                std::string pkg = qp("pkg"), ver = qp("version"), arch = qp("arch");
+                if (pkg.empty()) pkg = safe;   // fallback so the row is never blank
+                // Upsert into cloud.firmware.manifest, keyed by ipk_url.
+                json arr = json::array();
+                if (ds) {
+                    std::vector<data_store::Client::GetResult> g;
+                    if (ds->get({std::string("cloud.firmware.manifest")}, g).ok &&
+                        !g.empty() && g[0].has_value)
+                        if (auto cur = data_store::to_string(g[0].value))
+                            try { auto p = json::parse(*cur); if (p.is_array()) arr = p; }
+                            catch (const std::exception&) {}
+                }
+                json out = json::array();
+                for (auto& e : arr)
+                    if (e.value("ipk_url", "") != ipk_url) out.push_back(e);
+                out.push_back({{"pkg", pkg}, {"version", ver}, {"arch", arch},
+                               {"ipk_url", ipk_url}, {"sha256", sha}});
+                if (ds) ds->set("cloud.firmware.manifest", data_store::Value{out.dump()});
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D httpd:thread:%t %M %N:%l firmware upload complete %C "
+                                    "(sha256 %C) → manifest\n"), safe.c_str(), sha.c_str()));
+                r.body = std::string(R"({"ok":true,"sha256":")") + sha + R"("})";
+                return r;
             }
             r.body = R"({"ok":true})";
             return r;

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -307,7 +307,7 @@ int main(int argc, char** argv) {
     http_server::Router router;
     if (!wwwDir.empty()) router.set_static_dir(wwwDir);
     if (!fwDir.empty()) router.set_firmware_dir("/firmware/", fwDir);
-    http_server::install_handlers(router, &ds, &auth_store);
+    http_server::install_handlers(router, &ds, &auth_store, fwDir);
     // Per-device UI reverse proxy at /dev/<ep>/ (cloud-only effect; on a device
     // there is no cloud.endpoints so any /dev/ hit just 502s).
     http_server::install_proxy_handler(router, &ds, &auth_store);


### PR DESCRIPTION
## Summary

Lets a non-technical operator **add a firmware bundle to the cloud feed from the Software Update page** — browse or drag & drop — instead of `scp` → volume `cp` → `ds-cli set cloud.firmware.manifest`. Reuses the device-ui chunked-upload pattern.

## Server (`iot-httpd`)
- **New `POST /api/v1/firmware/upload?name=&version=&arch=&pkg=`** (Admin-only). Chunked (`offset=0` truncates, `final=1` finalises) straight into the firmware feed (`firmware-dir`). On the final chunk it **computes the sha256 over the assembled file** (authoritative) and **upserts `cloud.firmware.manifest`** keyed by `ipk_url`. Only active where a feed is configured (cloud); a device returns 400.
- `install_handlers` gains a `firmware_dir` param (default `""`); `main.cpp` passes the CLI `firmware-dir` through.

## Compose
- Mount `iot-firmware` **RW** in `iot-httpd` (was `:ro`) so uploads can write. `iot-httpd` runs as root (no `USER` in the Dockerfile), so no perms/chown change is needed. Mount-mode is a container property → a `./run.sh` restart applies it, no volume recreate.

## Cloud-ui (Software Update)
- Dropzone (browse/drag-drop). The filename **pre-fills editable pkg/version/arch fields** (operator confirms — chosen over embedding a manifest in the tarball, per discussion). Chunked upload via `uploadFirmwareChunk()`; on success it reloads the manifest so the bundle appears in the Package dropdown right away.

## Design note
The manifest stays **cloud-owned metadata** (sha server-side, `ipk_url=/firmware/<name>`). The `.tar.gz` bundle remains pure `.ipk` payload — nothing embedded. (A RAUC `.raucb` already self-describes; not relevant here.)

## Testing
- **Not built** — no `node` on this host (Angular builds via `nodejs-native` in the container) and no cloud image build here. C++ reviewed by inspection (mirrors the existing `/update/upload` handler; `sha256_hex` from auth.hpp, nlohmann for the manifest, `<iterator>` added for the file read). Cloud-ui braces balance; wiring verified. Validate via the cloud image rebuild + `ng build`.
- After deploy: drop `iot-bundle-1.1.0-raspberrypi3-64.tar.gz` on the page → confirm fields → it lands in `/var/lib/iot/firmware` + appears in the dropdown → push as usual.

🤖 Generated with [Claude Code](https://claude.com/claude-code)