### PR TITLE
fix(build): raw-string delimiter collision in firmware-upload handler (#270)

### DIFF
--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -45,7 +45,7 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
           <input #fileInput type="file" accept=".ipk,.tar.gz,.tgz" hidden (change)="onPick($event)" />
           <clr-icon shape="upload-cloud" size="28"></clr-icon>
           <span *ngIf="!uploading && !pendingFile">Drag &amp; drop an <code>.ipk</code> or <code>.tar.gz</code> bundle, or click to browse</span>
-          <span *ngIf="!uploading && pendingFile">{{ pendingFile.name }} ({{ (pendingFile.size/1048576) | number:'1.0-1' }} MB) — confirm details and upload</span>
+          <span *ngIf="!uploading && pendingFile">{{ pendingFile?.name }} ({{ ((pendingFile?.size ?? 0)/1048576) | number:'1.0-1' }} MB) — confirm details and upload</span>
           <span *ngIf="uploading">Uploading {{ uploadName }} — {{ uploadPct }}%…</span>
         </div>
         <div class="form-grid" *ngIf="pendingFile" style="margin-top:12px; align-items:end;">

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -536,7 +536,7 @@ void install_handlers(Router& router,
                 std::ofstream f(path, mode);
                 if (!f) {
                     r.status = 500;
-                    r.body = R"({"ok":false,"err":"cannot write firmware feed (perms? feed mounted read-only?)"})";
+                    r.body = R"({"ok":false,"err":"cannot write firmware feed - perms or read-only mount"})";
                     return r;
                 }
                 if (!req.body.empty())


### PR DESCRIPTION
## Problem

PR #270 turned both **Build & Push Cloud Image** and **Build & Push Device Image** red (they share the `iot-httpd` binary from `modules/http-server`). Root cause: the 500-error body in the new `/api/v1/firmware/upload` handler used a `R"(...)"` raw string that *contains* the sequence `?)"`:

```cpp
R"({"ok":false,"err":"cannot write firmware feed (perms? feed mounted read-only?)"})"
```

A raw string literal ends at the **first** `)"`, so it terminated early inside the message; the trailing `})";` became stray tokens, derailing the entire `install_handlers()` parse (the flood of `'router' does not name a type` errors at handler.cpp:543+).

## Fix
- Reword the message to drop the parens → no `)"` inside: `"cannot write firmware feed - perms or read-only mount"`.
- Harden the cloud-ui dropzone for `strictTemplates: true`: optional-chain `pendingFile` (`File | null`) in the size/name interpolation.

## Note
The earlier OTA PRs (#264–#268) built **green** in CI — only #270's new handler had this. Verified no other `)"` collisions in the added raw strings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)