### PR TITLE
feat(lwm2m): re-Register on VPN reconnect (fast recovery after cloud restart)

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1146,6 +1146,36 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     // 1 Hz ticker: drives Update emission + Observe pmax + (TODO) initial
     // Register once bootstrap completes.
     std::weak_ptr<::lwm2m::RegistrationClient> wreg = plumb.reg;
+    // VPN-reconnect-triggered re-Register. A cloud/DM restart is otherwise only
+    // noticed at the next registration Update (lifetime - margin ≈ up to 24h),
+    // so the device sits offline for a long time. The openvpn client detects the
+    // link drop via ping-restart (~120s) and republishes vpn.state; on a genuine
+    // reconnect edge (up → dropped → up) force a re-Register so the device comes
+    // back online within ~2 min. The phase guard avoids firing on the FIRST
+    // connect (the normal bootstrap/Register path handles that). Runs on the ds
+    // listener thread (serialised per key), same as the iot.server.uri watch;
+    // request_reregister() just sets a flag the 1 Hz tick consumes, so it's safe.
+    if (dsc) {
+        auto vpnPhase = std::make_shared<int>(0);  // 0 pre-connect, 1 up, 2 dropped
+        data_store::Client::WatchHandle wvpn = data_store::Client::kInvalidHandle;
+        dsc->watch("vpn.state",
+            [wreg, vpnPhase](const data_store::Client::Event& e) {
+                const std::string st = data_store::to_string(e.value).value_or("");
+                if (st == "connected") {
+                    if (*vpnPhase == 2) {
+                        if (auto reg = wreg.lock()) {
+                            reg->request_reregister();
+                            ACE_DEBUG((LM_INFO,
+                                ACE_TEXT("%D lwm2m:thread:%t %M %N:%l VPN reconnected "
+                                         "after a drop — forcing LwM2M re-Register\n")));
+                        }
+                    }
+                    *vpnPhase = 1;
+                } else if (*vpnPhase == 1) {
+                    *vpnPhase = 2;   // tunnel dropped after being up
+                }
+            }, &wvpn);
+    }
     std::weak_ptr<::lwm2m::DmClient>           wdm  = plumb.dm;
     std::weak_ptr<App>                         wapp = app;
     std::weak_ptr<::lwm2m::bootstrap::Client>  wbs  = plumb.bs;


### PR DESCRIPTION
## Problem

When the cloud's `lwm2m-dm` restarts (e.g. a redeploy), the device's DTLS session and the DM's in-memory registration are gone — but the device only re-registers at its next **registration Update**, which fires at `lifetime − margin`. With the default `cloud.dm.lifetime = 86400` (24h), the device stays **offline for up to ~24h**, recovering only via a manual `systemctl restart iot-lwm2m-client`. (Confirmed on hardware this session: after a Vultr redeploy the endpoint sat `offline`.)

## Fix

Watch `vpn.state` in the LwM2M client. The openvpn client already detects the link drop via `ping-restart` (~120s) and republishes `vpn.state`, so on a genuine **reconnect edge** (`up → dropped → up`) we call `request_reregister()` → the device re-registers within ~2 min, no manual kick.

- **Phase guard** (`0` pre-connect / `1` up / `2` dropped) so it does **not** fire on the first connect (normal bootstrap/Register already covers that) — only on a real reconnect after a drop.
- Runs on the ds listener thread (serialised per key), same model as the existing `iot.server.uri` watch; `request_reregister()` only sets a flag the 1 Hz tick consumes.

## Related design note (not in this PR)

The deeper issue is NAT/conntrack timeout on the direct LwM2M-DTLS (UDP) plane: with a 24h lifetime the UDP mapping (default ~30s) is dead between updates, so the cloud can't reach the device for OTA push anyway. The robust fix is to **route LwM2M over the VPN tunnel** (openvpn's 10s ping keeps the path alive; NAT timeout becomes irrelevant) rather than shortening `lifetime`. This PR is complementary — it gets a lost registration back fast regardless. Tunnel-routing is a separate change.

## Testing

Build-validated by CI (no local compiler). Logic: edge-detection reviewed; reuses the proven `dsc->watch` + `request_reregister()` paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)