### PR TITLE
feat(lwm2m): size registration lifetime to NAT timeout (keepalive) + document

### DIFF
--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -419,12 +419,43 @@ cloud.bs.psk.key         → BS PSK secret (RID 5, opaque)
 ### Device Management (cloud.dm.*)
 ```
 cloud.dm.uri             → DM server URI (pushed to devices, RID 0)
-cloud.dm.lifetime        → Default registration lifetime (RID 1, default 86400)
+cloud.dm.lifetime        → Default registration lifetime (RID 1, default 90 — NAT keepalive, see below)
 cloud.dm.binding         → Default binding mode (RID 7, default "U")
 cloud.dm.psk.id          → DM PSK identity (post-bootstrap)
 cloud.dm.psk.key         → DM PSK key (post-bootstrap, opaque)
 cloud.dm.lwm2m.version   → LwM2M version (default "1.1")
 ```
+
+#### Registration lifetime & NAT keepalive
+
+The LwM2M control plane is **direct device→cloud DTLS over UDP (:5683)** — the
+device is behind the home-router / ISP **NAT**, whose UDP conntrack mapping
+expires after a short idle. If it expires, the cloud can no longer reach the
+device (OTA push, server Reads) until the device speaks again. So the
+registration **Update doubles as the NAT keepalive**: the device sends one at
+`lifetime − 30s` (the fixed `updateMarginSeconds`), and that traffic keeps the
+mapping alive.
+
+`cloud.dm.lifetime` is therefore sized to the NAT timeout, **not** left at a
+day. netfilter conntrack defaults (what most gateways are built on):
+
+| Flow | conntrack timeout | sysctl |
+|------|-------------------|--------|
+| UDP, unreplied | **30 s** | `nf_conntrack_udp_timeout` |
+| UDP, assured/stream | **120 s** | `nf_conntrack_udp_timeout_stream` |
+| TCP, established | **432000 s (5 d)** | `nf_conntrack_tcp_timeout_established` |
+
+- **Default `lifetime = 90`** → Update every **60 s** ≈ half the 120 s
+  assured-UDP timeout (classic keepalive = timeout/2). Also covers most CGNATs.
+- **Aggressive CGNAT (30–60 s UDP):** lower to `60` (→30 s Update).
+- The **VPN tunnel** is openvpn over **TCP** + `ping 10` (10 s), so its mapping
+  never idles out — it needs no tuning. The 24 h default only makes sense if
+  LwM2M itself is **routed over the tunnel** (then the tunnel's keepalive covers
+  it and `lifetime` can go back to 86400). Until that's done, keep it NAT-sized.
+
+A lost registration (e.g. cloud `lwm2m-dm` restart) is *also* recovered fast by
+the **VPN-reconnect-triggered re-Register** in the client (`apps/src/main.cpp`,
+`vpn.state` watch) — complementary to this keepalive.
 
 ### Provision (per-device)
 ```

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -17,10 +17,15 @@
 return {
   namespace = "iot",
   keys = {
+    -- Device-side default/fallback registration lifetime (s). The effective
+    -- value is normally the one the cloud pushes at bootstrap (cloud.dm.lifetime,
+    -- default 90 — sized so the registration Update doubles as a NAT keepalive;
+    -- see cloud.lua). Kept aligned at 90 so a pre-bootstrap/direct-Register run
+    -- behaves the same.
     ["iot.lifetime"]   = {
         access  = "Admin",
       type    = "integer",
-      default = 86400,
+      default = 90,
       min     = 0,
       max     = 2592000,     -- 30 days; LwM2M Registration lifetime cap
     },

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -80,15 +80,29 @@ return {
       type    = "string",
       default = "coaps://0.0.0.0:5683",
     },
-    -- Default registration lifetime pushed to devices at bootstrap
-    -- (Server Object OID 1, RID 1).  Devices may request a different
-    -- value; the DM server can accept or negotiate.
+    -- Default registration lifetime (seconds) pushed to devices at bootstrap
+    -- (Server Object OID 1, RID 1). Devices may request a different value.
+    --
+    -- This DOUBLES AS THE NAT KEEPALIVE. The device sends a registration Update
+    -- at (lifetime - 30s margin), and that Update is what keeps the gateway's
+    -- UDP conntrack mapping for the DIRECT LwM2M/DTLS flow (:5683) alive so the
+    -- cloud can reach the device (OTA push, server reads). Aligned to netfilter
+    -- conntrack defaults:
+    --   UDP unreplied ......... 30 s   (nf_conntrack_udp_timeout)
+    --   UDP assured/stream ... 120 s   (nf_conntrack_udp_timeout_stream)
+    --   TCP established .... 432000 s   (the VPN's own plane — openvpn's 10s
+    --                                    ping keeps that alive, not this key)
+    -- default 90 → Update every 60 s ≈ half the 120 s assured timeout (classic
+    -- keepalive = timeout/2). Lower to 60 (→30 s Update) for aggressive CGNAT
+    -- (30-60 s UDP). Raise toward 86400 ONLY if LwM2M is routed over the VPN
+    -- tunnel (openvpn's ping then handles NAT — see apps/cloud/CLAUDE.md
+    -- "Registration lifetime & NAT keepalive").
     ["cloud.dm.lifetime"] = {
         access  = "Admin",
-      type    = "integer",
-      default = 86400,
-      min     = 0,
-      max     = 2592000,
+        type    = "integer",
+        default = 90,
+        min     = 0,
+        max     = 2592000,
     },
     -- Default binding mode pushed to devices at bootstrap
     -- (Server Object OID 1, RID 7).  "U" = UDP (standard).


### PR DESCRIPTION
## Why

LwM2M-DM is **direct device→cloud DTLS over UDP (:5683)** through the home/ISP **NAT**. The UDP conntrack mapping idles out fast; with the old `86400` (24h) lifetime the device's registration Update fired ~once/day, so the mapping died between updates and the cloud couldn't reach the device (OTA push, Reads) — and a lost registration took ~24h to recover.

## Change

Size the lifetime so the **registration Update doubles as the NAT keepalive**:

- **`cloud.dm.lifetime` + `iot.lifetime`: `86400` → `90`** → Update every **60 s** (`updateMarginSeconds=30`) ≈ half the **120 s** assured-UDP conntrack timeout (classic keepalive = timeout/2); also under most 60 s CGNATs.

| Flow | conntrack default | sysctl |
|---|---|---|
| UDP unreplied | 30 s | `nf_conntrack_udp_timeout` |
| UDP assured/stream | 120 s | `nf_conntrack_udp_timeout_stream` |
| TCP established | 432000 s | `nf_conntrack_tcp_timeout_established` |

- Documented the table + tuning in `cloud.lua` and **`apps/cloud/CLAUDE.md` → "Registration lifetime & NAT keepalive"**: lower to `60` for aggressive CGNAT; raise back to `86400` **only** if LwM2M is routed over the VPN tunnel (the tunnel is TCP + openvpn `ping 10`, so its mapping never idles).

Complementary to the VPN-reconnect re-Register (#272): keepalive keeps the path warm; re-Register recovers a registration lost to a cloud restart.

## Risk
Schema (Lua) + docs only — no C++. Side benefit: cloud now detects a genuinely-dropped device within ~90 s instead of 24 h.

🤖 Generated with [Claude Code](https://claude.com/claude-code)