### PR TITLE
feat(cloud-ui): configure registration lifetime in LwM2M → BS Config

### DIFF
--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.html
@@ -21,7 +21,13 @@
         <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.uri"></app-ds-hint></clr-control-helper>
       </clr-input-container>
 
-      <div></div>
+      <clr-input-container>
+        <label>Lifetime (s) — RID 1 <span class="hint">(NAT keepalive; default 90)</span></label>
+        <input clrInput type="number" min="0" [disabled]="!isAdmin" formControlName="dm_lifetime"
+               placeholder="90" />
+        <clr-control-helper *dsDebug><app-ds-hint key="cloud.dm.lifetime"></app-ds-hint></clr-control-helper>
+      </clr-input-container>
+
       <div></div>
     </div>
 

--- a/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
+++ b/apps/cloud/ui/src/app/lwm2m/bs-config/bs-config.component.ts
@@ -21,7 +21,7 @@ export class BsConfigComponent implements OnInit, OnDestroy {
   loading = true;
   savingBs = false;
   private sub = new Subscription();
-  private readonly KEYS = ['cloud.bs.uri', 'cloud.dm.uri'];
+  private readonly KEYS = ['cloud.bs.uri', 'cloud.dm.uri', 'cloud.dm.lifetime'];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
 
@@ -38,6 +38,10 @@ export class BsConfigComponent implements OnInit, OnDestroy {
     this.bsForm = fb.group({
       bs_uri:        ['coaps://0.0.0.0:5684'],
       dm_uri:        ['coaps://0.0.0.0:5683'],
+      // Registration lifetime (s) pushed to the device at bootstrap (Server
+      // Object RID 1). Doubles as the NAT keepalive — default 90 (≈ half the
+      // 120 s assured-UDP conntrack timeout); see cloud.dm.lifetime in cloud.lua.
+      dm_lifetime:   [90],
     });
   }
 
@@ -59,6 +63,7 @@ export class BsConfigComponent implements OnInit, OnDestroy {
     this.bsForm.patchValue({
       bs_uri: d['cloud.bs.uri'] || 'coaps://0.0.0.0:5684',
       dm_uri: d['cloud.dm.uri'] || 'coaps://0.0.0.0:5683',
+      dm_lifetime: Number(d['cloud.dm.lifetime']) || 90,
     });
   }
 
@@ -68,6 +73,7 @@ export class BsConfigComponent implements OnInit, OnDestroy {
     this.ds.write([
       { key: 'cloud.bs.uri',           value: v.bs_uri },
       { key: 'cloud.dm.uri',           value: v.dm_uri },
+      { key: 'cloud.dm.lifetime',      value: v.dm_lifetime },
     ]).subscribe({
       next: (r) => {
         this.savingBs = false;


### PR DESCRIPTION
## Summary

Adds a **Lifetime (s)** field to the cloud-ui **LwM2M → Bootstrap Config** page, so operators can set the registration lifetime from the UI instead of `ds-cli`.

- Bound to **`cloud.dm.lifetime`** (Server Object RID 1 — pushed to the device at bootstrap, next to the DM URI).
- **Prefilled from the data-store**: `cloud.dm.lifetime` is already in the prefetch `ALL_KEYS`, so the field shows the live stored value, defaulting to **90** (the NAT-keepalive value from #273) when unset.
- Number input, Admin-gated, saved with the other BS server config (`saveBs`); 4-column `.form-grid` padded per the UI conventions.

## Risk
cloud-ui only (TS + HTML) — mirrors the existing `bs_uri`/`dm_uri` fields exactly (same `formControlName`/`[disabled]`/`clr-input-container` pattern + `type="number"` like vpn-config's port fields). Validated by `ng build` in the cloud-image CI post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)