### PR TITLE
fix(cloud-ui): DM Config lifetime fallback 86400 → 90 (match schema)

### DIFF
--- a/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/apps/cloud/ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -30,7 +30,7 @@ export class Lwm2mConfigComponent implements OnInit, OnDestroy {
     // per-endpoint into cloud.endpoint.credentials — see the Endpoints page.
     this.dmForm = fb.group({
       dm_uri:        ['coaps://0.0.0.0:5683'],
-      lifetime:      [86400],
+      lifetime:      [90],
       binding:       ['U'],
     });
   }
@@ -52,7 +52,7 @@ export class Lwm2mConfigComponent implements OnInit, OnDestroy {
   private applyData(d: Record<string, unknown>): void {
     this.dmForm.patchValue({
       dm_uri:   d['cloud.dm.uri']      || 'coaps://0.0.0.0:5683',
-      lifetime: d['cloud.dm.lifetime'] || 86400,
+      lifetime: d['cloud.dm.lifetime'] || 90,
       binding:  d['cloud.dm.binding']  || 'U',
     });
   }


### PR DESCRIPTION
DM Config (LwM2M → Device Management) already edits `cloud.dm.lifetime` — so the BS-Config field (#274) was redundant and is closed. This aligns DM Config's hardcoded **fallback/initial** value from the old `86400` to **90** (the NAT-keepalive default from #273), so the first paint and the no-value fallback match the schema. The live ds value still wins via prefetch; this is just the stale local default.

cloud-ui only; `ng build`-validated post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)