### PR TITLE
feat(ui): original IoT node-mesh logo — login + sidebar, both UIs

### DIFF
--- a/apps/cloud/ui/src/assets/iot-logo.svg
+++ b/apps/cloud/ui/src/assets/iot-logo.svg
@@ -1,30 +1,44 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
-  <!-- Outer rings -->
-  <circle cx="80" cy="80" r="74" fill="none" stroke="#2e7d32" stroke-width="3"
-          stroke-dasharray="10 4" opacity="0.3"/>
-  <circle cx="80" cy="80" r="56" fill="none" stroke="#2e7d32" stroke-width="2.5"
-          stroke-dasharray="6 3" opacity="0.5"/>
-  <circle cx="80" cy="80" r="38" fill="none" stroke="#43a047" stroke-width="2"
-          opacity="0.6"/>
-  <!-- Device hexagon -->
-  <polygon points="80,28 106,48 106,112 80,132 54,112 54,48"
-           fill="#1b5e20" stroke="#2e7d32" stroke-width="2"/>
-  <!-- Inner core -->
-  <circle cx="80" cy="80" r="14" fill="#43a047"/>
-  <circle cx="80" cy="80" r="7" fill="#a5d6a7"/>
-  <!-- Signal nodes -->
-  <circle cx="80" cy="28" r="4" fill="#66bb6a"/>
-  <circle cx="106" cy="48" r="4" fill="#66bb6a"/>
-  <circle cx="54" cy="48" r="4" fill="#66bb6a"/>
-  <circle cx="106" cy="112" r="4" fill="#66bb6a"/>
-  <circle cx="54" cy="112" r="4" fill="#66bb6a"/>
-  <!-- Link lines -->
-  <line x1="80" y1="28" x2="80" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="106" y1="48" x2="94" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="54" y1="48" x2="66" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="106" y1="112" x2="94" y2="94" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="54" y1="112" x2="66" y2="94" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <!-- IoT label -->
-  <text x="80" y="156" text-anchor="middle" font-family="monospace"
-        font-size="16" font-weight="bold" fill="#c8e6c9" letter-spacing="6">IoT</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="100" height="100" role="img" aria-label="IoT">
+  <!-- Original IoT mark: a connected node-mesh (central hub + satellite nodes),
+       the universal IoT visual language. No third-party brand artwork. -->
+  <defs>
+    <linearGradient id="iotBadge" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#127d99"/>
+      <stop offset="1" stop-color="#0a5468"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Badge -->
+  <rect x="4" y="4" width="112" height="112" rx="28" fill="url(#iotBadge)"/>
+
+  <!-- Soft signal ring -->
+  <circle cx="60" cy="60" r="40" fill="none" stroke="#9fe3ef" stroke-width="1.5" opacity="0.22"/>
+
+  <!-- Edges: hub -> satellite nodes -->
+  <g stroke="#bfeef6" stroke-width="2.4" stroke-linecap="round" opacity="0.85">
+    <line x1="60" y1="60" x2="60" y2="26"/>
+    <line x1="60" y1="60" x2="89" y2="43"/>
+    <line x1="60" y1="60" x2="89" y2="77"/>
+    <line x1="60" y1="60" x2="60" y2="94"/>
+    <line x1="60" y1="60" x2="31" y2="77"/>
+    <line x1="60" y1="60" x2="31" y2="43"/>
+  </g>
+
+  <!-- Satellite nodes -->
+  <g fill="#eafcff">
+    <circle cx="60" cy="26" r="6.5"/>
+    <circle cx="89" cy="77" r="6.5"/>
+    <circle cx="60" cy="94" r="6.5"/>
+    <circle cx="31" cy="43" r="6.5"/>
+  </g>
+
+  <!-- Accent nodes -->
+  <g fill="#4fd1c5">
+    <circle cx="89" cy="43" r="6.5"/>
+    <circle cx="31" cy="77" r="6.5"/>
+  </g>
+
+  <!-- Central hub (the "thing") -->
+  <circle cx="60" cy="60" r="14" fill="#eafcff"/>
+  <circle cx="60" cy="60" r="7" fill="#0a5468"/>
 </svg>

--- a/iot-ui/src/assets/iot-logo.svg
+++ b/iot-ui/src/assets/iot-logo.svg
@@ -1,30 +1,44 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 160 160">
-  <!-- Outer rings -->
-  <circle cx="80" cy="80" r="74" fill="none" stroke="#2e7d32" stroke-width="3"
-          stroke-dasharray="10 4" opacity="0.3"/>
-  <circle cx="80" cy="80" r="56" fill="none" stroke="#2e7d32" stroke-width="2.5"
-          stroke-dasharray="6 3" opacity="0.5"/>
-  <circle cx="80" cy="80" r="38" fill="none" stroke="#43a047" stroke-width="2"
-          opacity="0.6"/>
-  <!-- Device hexagon -->
-  <polygon points="80,28 106,48 106,112 80,132 54,112 54,48"
-           fill="#1b5e20" stroke="#2e7d32" stroke-width="2"/>
-  <!-- Inner core -->
-  <circle cx="80" cy="80" r="14" fill="#43a047"/>
-  <circle cx="80" cy="80" r="7" fill="#a5d6a7"/>
-  <!-- Signal nodes -->
-  <circle cx="80" cy="28" r="4" fill="#66bb6a"/>
-  <circle cx="106" cy="48" r="4" fill="#66bb6a"/>
-  <circle cx="54" cy="48" r="4" fill="#66bb6a"/>
-  <circle cx="106" cy="112" r="4" fill="#66bb6a"/>
-  <circle cx="54" cy="112" r="4" fill="#66bb6a"/>
-  <!-- Link lines -->
-  <line x1="80" y1="28" x2="80" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="106" y1="48" x2="94" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="54" y1="48" x2="66" y2="66" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="106" y1="112" x2="94" y2="94" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <line x1="54" y1="112" x2="66" y2="94" stroke="#66bb6a" stroke-width="1.5" opacity="0.6"/>
-  <!-- IoT label -->
-  <text x="80" y="156" text-anchor="middle" font-family="monospace"
-        font-size="16" font-weight="bold" fill="#c8e6c9" letter-spacing="6">IoT</text>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" width="100" height="100" role="img" aria-label="IoT">
+  <!-- Original IoT mark: a connected node-mesh (central hub + satellite nodes),
+       the universal IoT visual language. No third-party brand artwork. -->
+  <defs>
+    <linearGradient id="iotBadge" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#127d99"/>
+      <stop offset="1" stop-color="#0a5468"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Badge -->
+  <rect x="4" y="4" width="112" height="112" rx="28" fill="url(#iotBadge)"/>
+
+  <!-- Soft signal ring -->
+  <circle cx="60" cy="60" r="40" fill="none" stroke="#9fe3ef" stroke-width="1.5" opacity="0.22"/>
+
+  <!-- Edges: hub -> satellite nodes -->
+  <g stroke="#bfeef6" stroke-width="2.4" stroke-linecap="round" opacity="0.85">
+    <line x1="60" y1="60" x2="60" y2="26"/>
+    <line x1="60" y1="60" x2="89" y2="43"/>
+    <line x1="60" y1="60" x2="89" y2="77"/>
+    <line x1="60" y1="60" x2="60" y2="94"/>
+    <line x1="60" y1="60" x2="31" y2="77"/>
+    <line x1="60" y1="60" x2="31" y2="43"/>
+  </g>
+
+  <!-- Satellite nodes -->
+  <g fill="#eafcff">
+    <circle cx="60" cy="26" r="6.5"/>
+    <circle cx="89" cy="77" r="6.5"/>
+    <circle cx="60" cy="94" r="6.5"/>
+    <circle cx="31" cy="43" r="6.5"/>
+  </g>
+
+  <!-- Accent nodes -->
+  <g fill="#4fd1c5">
+    <circle cx="89" cy="43" r="6.5"/>
+    <circle cx="31" cy="77" r="6.5"/>
+  </g>
+
+  <!-- Central hub (the "thing") -->
+  <circle cx="60" cy="60" r="14" fill="#eafcff"/>
+  <circle cx="60" cy="60" r="7" fill="#0a5468"/>
 </svg>


### PR DESCRIPTION
Replaces the logo across **both UIs** with a fresh, **fully-original** IoT mark: a teal rounded-badge **node-mesh** (central hub + six satellite nodes, two accented) — universal IoT visual language, pure geometric SVG, **no third-party/brand artwork** (the clean alternative to the OMA logo, zero IP obligation).

Asset-only — every spot already references `assets/iot-logo.svg`, so no markup changes:
- **cloud-ui**: login (`login.component.html`) + sidebar brand (`main.component.html`) → `apps/cloud/ui/src/assets/iot-logo.svg`
- **device-ui**: login + sidebar brand → `iot-ui/src/assets/iot-logo.svg`

`ng build` copies assets; validated in the cloud + device image builds post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)