### PR TITLE
Integrate rpi3B driver: vendor as plain tree + build + self-test unit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 # Prerequisites
 *.d
 
+# Throwaway local consume-check for the rpi3B submodule integration
+/build-rpi3bcheck/
+
 # Compiled Object files
 *.slo
 *.lo

--- a/.gitmodules
+++ b/.gitmodules
@@ -4,3 +4,7 @@
 [submodule "apps/3rdparty/tinydtls"]
 	path = apps/3rdparty/tinydtls
 	url = https://github.com/legatoproject/tinydtls.git
+[submodule "modules/rpi3B"]
+	path = modules/rpi3B
+	url = https://github.com/naushada/rpi3B.git
+	branch = feat/i2c-spi-drivers-and-fixes

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,4 +7,4 @@
 [submodule "modules/rpi3B"]
 	path = modules/rpi3B
 	url = https://github.com/naushada/rpi3B.git
-	branch = feat/i2c-spi-drivers-and-fixes
+	branch = main

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -179,6 +179,16 @@ The script builds the container image (`iot-yocto-builder`, defined by
 `yocto/Containerfile`), runs `bitbake iot-image`, and copies the output
 to `yocto/build/<machine>/` (`images/<machine>/*.wic.bz2` + `ipk/`).
 
+> **Source branch (`IOT_BRANCH`).** The recipe fetches the iot source from
+> `IOT_BRANCH` (default `main`). While the rpi3B driver integration lives on a
+> feature branch, `yocto/entrypoint.sh` and `yocto/kas-iot.yml` pin it to
+> `feat/add-rpi3b-submodule` so the image carries the vendored `modules/rpi3B`
+> driver + the `iot-rpi3b-selftest` boot oneshot. Override per build with
+> `IOT_BRANCH=main ./build.sh`, and add `IOT_FRESH=1` to force a fresh re-clone
+> of the branch tip (bypasses a stale cached checkout). Revert both files to
+> `main` once the branch merges. After boot, check the driver self-test with
+> `systemctl status iot-rpi3b-selftest` / `journalctl -u iot-rpi3b-selftest`.
+
 The **first** build compiles the whole distribution (toolchain, glibc,
 ACE, kernel…) — hours. Reruns are incremental via the persistent
 `iot-yocto-sstate` / `iot-yocto-downloads` volumes (only `meta-iot`

--- a/README.md
+++ b/README.md
@@ -227,11 +227,12 @@ deploy walkthrough: [`DEPLOY.md`](DEPLOY.md) Path C.
 
 ### PACKAGECONFIG
 
-| Option   | Default | Effect |
-|----------|---------|--------|
-| `mongo`  | ON      | Links mongocxx/bsoncxx. RegistryMirror. Turn OFF for embedded IoT. |
-| `gtest`  | OFF     | Builds unit-test binaries. |
-| `systemd`| ON      | Installs systemd units + env files. OFF for sysvinit images. |
+| Option           | Default | Effect |
+|------------------|---------|--------|
+| `mongo`          | ON      | Links mongocxx/bsoncxx. RegistryMirror. Turn OFF for embedded IoT. |
+| `gtest`          | OFF     | Builds unit-test binaries. |
+| `rpi3b-selftest` | ON      | Builds the vendored rpi3B driver gtest suite and ships it as the `iot-rpi3b-selftest` boot oneshot (pulls in `gtest`). Turn OFF to build only the `rpi3b_driver` library. |
+| `systemd`        | ON      | Installs systemd units + env files. OFF for sysvinit images. |
 
 Override in `local.conf` or via kas:
 
@@ -249,10 +250,33 @@ PACKAGECONFIG:remove:pn-iot = "mongo"
 | `iot-openvpn-client`    | `/usr/bin/openvpn-client` | ACE, openvpn |
 | `iot-net-router`        | `/usr/bin/net-router`  | ACE, nftables, iproute2 |
 | `iot-wifi-client`       | `/usr/bin/wifi-client` | ACE, wpa-supplicant, udhcpc |
+| `iot-rpi3b-selftest`    | `/usr/bin/rpi3B_test`  | — (gtest, auto via shlibs) |
 | `iot-config`            | `/etc/iot/`            | — |
 
 Tiered `packagegroup-iot-{core,full,debug}` meta-packages pull in
 what you need — from a minimal LwM2M device to a full gateway.
+`iot-rpi3b-selftest` is part of `packagegroup-iot-full`.
+
+### rpi3B driver library + self-test
+
+The [`naushada/rpi3B`](https://github.com/naushada/rpi3B) BCM2837 driver layer
+(GPIO/CLOCK/IRQ/I2C/SPI) is vendored under `modules/rpi3B` (committed as a plain
+tree, matching the `apps/3rdparty` convention so the plain `git://` fetch picks
+it up) and built as the `rpi3b_driver` static library, linked into `lwm2m`. When
+the `rpi3b-selftest` PACKAGECONFIG is on, its GoogleTest suite is built and
+shipped as the **`iot-rpi3b-selftest`** systemd oneshot, which runs the
+register-layout self-test once at boot and logs pass/fail to the journal:
+
+```sh
+systemctl status iot-rpi3b-selftest
+journalctl -u iot-rpi3b-selftest
+```
+
+> **Build branch knob.** `IOT_BRANCH` selects the iot source branch the recipe
+> fetches (default `main`). While the rpi3B integration lives on a feature
+> branch, `yocto/entrypoint.sh` and `yocto/kas-iot.yml` set
+> `IOT_BRANCH = "feat/add-rpi3b-submodule"`; revert both to `main` once that
+> branch merges.
 
 ## Leshan interop pass (NFR-INTEROP-001)
 

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -115,6 +115,19 @@ add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/wan/wifi/client
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/http-server
                  ${CMAKE_BINARY_DIR}/http-server)
 
+# rpi3B bare-metal driver library (BCM2837 GPIO/CLOCK/IRQ/I2C/SPI), pulled in as
+# a git submodule under ../modules/rpi3B. Adds the librpi3b_driver.a target
+# (alias rpi3b::driver) + its public headers so iot apps can link the drivers.
+# The on-target gtest self-test binary is only built when
+# IOT_BUILD_RPI3B_SELFTEST=ON (the Yocto recipe sets this and adds googletest);
+# a plain `cmake apps` build just gets the library.
+option(IOT_BUILD_RPI3B_SELFTEST "Build the rpi3B gtest self-test binary" OFF)
+if(IOT_BUILD_RPI3B_SELFTEST)
+    set(RPI3B_BUILD_TESTS ON CACHE BOOL "" FORCE)
+endif()
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/rpi3B
+                 ${CMAKE_BINARY_DIR}/rpi3B)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store/inc)
 
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)
@@ -190,6 +203,7 @@ target_link_options(lwm2m PRIVATE -L${ACE_ROOT}/lib)
 target_link_libraries(lwm2m
                         ${TINYDTLS_LINK_LIB}
                         datastore_client
+                        rpi3b_driver
                         ${ACE_LINK_LIB}
                         z
                         readline

--- a/modules/rpi3B/.gitignore
+++ b/modules/rpi3B/.gitignore
@@ -1,0 +1,16 @@
+# CMake / build output
+build/
+build-*/
+cmake-build-*/
+CMakeCache.txt
+CMakeFiles/
+*.o
+*.a
+*.so
+*.gcda
+*.gcno
+gmon.out
+
+# Editor / OS
+.DS_Store
+compile_commands.json

--- a/modules/rpi3B/CMakeLists.txt
+++ b/modules/rpi3B/CMakeLists.txt
@@ -1,0 +1,50 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(rpi3B CXX)
+
+# Detect whether this project is being built on its own or pulled in via
+# add_subdirectory() (e.g. as a submodule of the iot repo). PROJECT_IS_TOP_LEVEL
+# only exists from CMake 3.21, so compute it manually for the 3.16 floor.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(RPI3B_TOP_LEVEL ON)
+else()
+    set(RPI3B_TOP_LEVEL OFF)
+endif()
+
+option(RPI3B_BUILD_APP   "Build the standalone rpi3Bdriver executable" ${RPI3B_TOP_LEVEL})
+option(RPI3B_BUILD_TESTS "Build the rpi3B gtest self-test suite"       ${RPI3B_TOP_LEVEL})
+
+# C++20 is required: the driver headers use abbreviated-template constructors
+# (e.g. `GPIO(auto region)`) for test/region placement. The old -std=c++17 root
+# could never compile the drivers for this reason (see DRIVER_REVIEW.md §2.1).
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+set(CMAKE_VERBOSE_MAKEFILE ON)
+
+# ── Driver library ──────────────────────────────────────────────────────────
+# The actual peripheral drivers live in src/<peri>/<peri>.cpp. The previous
+# glob ("src/*.cpp") missed every one of them and only compiled main.cpp
+# (see docs/DRIVER_REVIEW.md §2.1); src/*/*.cpp picks them all up.
+file(GLOB RPI3B_DRIVER_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*/*.cpp")
+
+add_library(rpi3b_driver STATIC ${RPI3B_DRIVER_SOURCES})
+target_include_directories(rpi3b_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+target_compile_options(rpi3b_driver PRIVATE -Wall -Wextra)
+
+# Consumers (e.g. the iot apps build) link this alias.
+add_library(rpi3b::driver ALIAS rpi3b_driver)
+
+install(TARGETS rpi3b_driver ARCHIVE DESTINATION lib)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION include/rpi3b
+        FILES_MATCHING PATTERN "*.hpp")
+
+# ── Standalone executable (top-level builds only) ───────────────────────────
+if(RPI3B_BUILD_APP)
+    add_executable(rpi3Bdriver src/main.cpp)
+    target_link_libraries(rpi3Bdriver PRIVATE rpi3b_driver)
+endif()
+
+# ── Test / self-test suite ──────────────────────────────────────────────────
+if(RPI3B_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/modules/rpi3B/README.md
+++ b/modules/rpi3B/README.md
@@ -1,0 +1,130 @@
+# rpi3B — bare-metal peripheral drivers for the Raspberry Pi 3B (BCM2837)
+
+A small, header-light C++ driver layer for the Broadcom **BCM2837** SoC on the
+Raspberry Pi 3B. Each peripheral is modelled as a memory-mapped register block
+that the driver classes read/modify/write through typed, field-level accessors.
+
+Peripherals: **GPIO**, **Clock manager (CM_GPn)**, **Interrupt controller**,
+**I2C (BSC1)**, **SPI0**.
+
+> See [`docs/DRIVER_REVIEW.md`](docs/DRIVER_REVIEW.md) for the design review,
+> the per-peripheral issue log, and what is fixed vs. still open.
+
+---
+
+## Framework
+
+Every peripheral follows the same three layers:
+
+| Layer | File | Responsibility |
+|-------|------|----------------|
+| Register block | `inc/memory_map.hpp` | `enum Register` (word offsets), field enums, and a placement `operator new` returning the peripheral's **physical base** on hardware (or a caller-supplied buffer in tests). |
+| Driver class | `inc/<peri>.hpp` | Holds a reference to the register block; exposes field `set/clr/get` + helpers. |
+| Implementation | `src/<peri>/<peri>.cpp` | Bit manipulation against `m_register[...]`. |
+
+The placement-`new` trick lets the **same code** run two ways:
+
+```cpp
+GPIO gpio;                         // hardware: registers overlay MMIO at 0x3F200000
+                                   // (real Pi only — see "Status" below)
+
+std::vector<std::uint32_t> buf(RPi3B::GPIORegistersAddress::BCM2837_MAX);
+GPIO gpio(buf.data());             // test/host: registers overlay a heap buffer
+```
+
+Physical bases: GPIO `0x3F200000`, Clock `0x3F101070`*, IRQ `0x3F00B200`,
+I2C/BSC1 `0x3F804000`, SPI0 `0x3F204000`.
+<sub>*Clock base is tracked as an open issue — see DRIVER_REVIEW §2.3.</sub>
+
+---
+
+## Build
+
+Requires CMake ≥ 3.16 and a C++20 compiler. GoogleTest is only needed for the
+test suite.
+
+```bash
+cmake -S . -B build
+cmake --build build
+```
+
+Targets / options:
+
+| Target / option | Default | Purpose |
+|-----------------|---------|---------|
+| `rpi3b_driver` (alias `rpi3b::driver`) | always | STATIC driver library (`src/*/*.cpp`). |
+| `rpi3Bdriver` | top-level only | Standalone demo executable (`src/main.cpp`). |
+| `rpi3B_test` | top-level only | GoogleTest suite. |
+| `-DRPI3B_BUILD_APP=ON/OFF` | top-level | Build the demo executable. |
+| `-DRPI3B_BUILD_TESTS=ON/OFF` | top-level | Build + register the gtest suite. |
+
+When pulled in via `add_subdirectory(...)`, only `rpi3b_driver` is built by
+default (app/tests off), so a parent project just links the library:
+
+```cmake
+add_subdirectory(rpi3B)
+target_link_libraries(my_app PRIVATE rpi3b_driver)   # headers come transitively
+```
+
+The public headers are C++17-consumable (the `auto`-param ctors are written as
+explicit templates), so a C++17 parent can link the C++20-built library.
+
+### Tests
+
+```bash
+cmake -S . -B build -DRPI3B_BUILD_TESTS=ON
+cmake --build build
+ctest --test-dir build            # or: ./build/test/rpi3B_test
+```
+
+Tests construct each driver over a `std::vector<uint32_t>` and assert the
+register **bit-layout** — no hardware required.
+
+---
+
+## Usage sketches
+
+```cpp
+// GPIO — drive GPIO17 as an output, set it high
+GPIO gpio;
+gpio.output(17);
+gpio.GPSETn(17);
+
+// I2C (BSC1) — address a device and start a write
+I2C i2c;
+i2c.enable();
+i2c.slave_address(0x48);
+i2c.data_length(2);
+i2c.write_byte(0xAB);
+i2c.start_write();
+
+// SPI0 — mode 0, CE0, one byte
+SPI spi;
+spi.mode(/*cpol=*/0, /*cpha=*/0);
+spi.chip_select(0);
+spi.clear_fifo();
+spi.begin_transfer();
+spi.write_byte(0x55);
+```
+
+> Register addressing is by **BCM GPIO number** (not 40-pin header pin). I2C/SPI
+> additionally require the relevant pins muxed to ALT0 (GPIO2/3 for I2C1,
+> GPIO7–11 for SPI0) and the peripheral clock divided appropriately.
+
+---
+
+## Status
+
+These drivers are **host-side register bit-layout models**. The classes poke
+fixed physical addresses via placement `new` but do **not** `mmap` `/dev/mem`,
+and there is no freestanding/cross toolchain, linker script, or `_start`. So the
+code is exercised and verified on the host; making it drive real silicon needs
+the `/dev/mem` (or `/dev/gpiomem`) mapping plus pin-mux/clock setup.
+
+## Use in the iot Yocto image
+
+This repo is vendored into [`naushada/iot`](https://github.com/naushada/iot)
+under `modules/rpi3B` and built as the `rpi3b_driver` library. Its
+gtest suite ships as the **`iot-rpi3b-selftest`** systemd oneshot, which runs the
+bit-layout suite once at boot and records pass/fail in the journal (gated by the
+recipe's `rpi3b-selftest` PACKAGECONFIG).

--- a/modules/rpi3B/docs/DRIVER_REVIEW.md
+++ b/modules/rpi3B/docs/DRIVER_REVIEW.md
@@ -1,0 +1,201 @@
+# RPi3B (BCM2837) Bare-Metal Driver — Review & Issue Log
+
+This document captures (1) how the current driver framework is structured, and
+(2) the defects found while reviewing the half-finished GPIO / Clock / Interrupt
+drivers. It is the reference for the I2C/SPI work, which deliberately follows the
+same framework while avoiding the bugs listed here.
+
+---
+
+## 1. Framework architecture
+
+The project is a bare-metal C++17 driver targeting the BCM2837 SoC on the
+Raspberry Pi 3B. Every peripheral is modelled with the **same three-layer
+pattern**:
+
+```
+memory_map.hpp                inc/<peri>.hpp              src/<peri>/<peri>.cpp
++------------------------+    +--------------------+      +--------------------+
+| <Peri>RegistersAddress |    | class <PERI>       |      | field get/set/clr  |
+|  - enum Register {...}  | <- |  RegBlock& m_memory| <--  | bit manipulation   |
+|  - enum field configs   |    |  accessor methods  |      |                    |
+|  - operator new(region) |    +--------------------+      +--------------------+
+|  - device_register[]    |
++------------------------+
+```
+
+### 1.1 Register block struct (`memory_map.hpp`)
+Each peripheral has a POD-like struct, e.g. `GPIORegistersAddress`, containing:
+
+- `enum Register : uint32_t { ... MAX }` — the **word offsets** of each hardware
+  register (index 0,1,2… ⇒ byte offset 0x0,0x4,0x8…).
+- Config enums (e.g. `Config`, `PullUpDownConfig`) for field values.
+- `using device_register = volatile std::atomic<std::uint32_t>;`
+- `device_register m_register[Register::MAX];` — the actual register window.
+- An overloaded **placement `operator new(size_t, void* region)`**:
+  - `region == nullptr` → returns the real peripheral **physical base address**
+    (e.g. GPIO `0x3F200000`), so on hardware the struct overlays MMIO.
+  - `region != nullptr` → returns `region`, so unit tests can place the struct
+    over an ordinary heap buffer (`std::vector<uint32_t>`).
+
+### 1.2 Driver class (`inc/<peri>.hpp`)
+Holds a **reference** to the register block, bound in the constructor:
+
+```cpp
+GPIO()              : m_memory(*new RPi3B::GPIORegistersAddress) {}     // hardware
+GPIO(auto region)   : m_memory(*new(region) RPi3B::GPIORegistersAddress) {}  // test
+```
+
+Methods read/modify/write fields of `m_memory.m_register[...]`.
+
+### 1.3 Tests (`test/<peri>_test.{hpp,cpp}`)
+A GoogleTest fixture allocates `std::vector<uint32_t>(Register::MAX)` and
+constructs the driver over it (`m_driver(DRIVER(m_memory_region.data()))`), so
+register reads/writes hit the vector instead of real MMIO. Tests therefore only
+verify the **bit-layout arithmetic**, not real hardware behaviour.
+
+### 1.4 Build
+- Root `CMakeLists.txt` builds the `rpi3Bdriver` executable as a **hosted** binary.
+- `test/CMakeLists.txt` builds `rpi3B_test` and explicitly lists the peripheral
+  `.cpp` files plus GoogleTest.
+
+---
+
+## 2. Issues found
+
+Severity legend: **[H]** breaks correct behaviour on hardware · **[M]** logic
+bug / inconsistency · **[L]** cosmetic / warning.
+
+### 2.1 Build / framework wide
+- **[H] Root executable never compiles the drivers.** Root
+  `CMakeLists.txt` uses `file(GLOB SOURCES "src/*.cpp")`, but the driver sources
+  live in `src/gpio/`, `src/clock/`, `src/interrupt/`. Only `src/main.cpp` is
+  compiled into `rpi3Bdriver`; the drivers are never linked. (Tests work because
+  `test/CMakeLists.txt` lists them explicitly.) Fix: glob `src/*/*.cpp`.
+- **[H] No freestanding/cross toolchain.** The project compiles as a normal host
+  program (`-pg`, default sysroot). There is no `aarch64-none-elf` toolchain
+  file, no linker script, no startup/`_start`, so the artifact is **not loadable
+  on the Pi**. The `operator new` returning `0x3F200000` would segfault if ever
+  dereferenced on the host. Today the framework is effectively a host-side
+  bit-layout simulator.
+- **[M] `volatile std::atomic<uint32_t>` for MMIO.** For 32-bit aligned MMIO a
+  plain `volatile uint32_t` is the idiomatic choice. `std::atomic` adds no value
+  over the peripheral bus and is not guaranteed lock-free in a way that maps to
+  the required single bus access; its RMW operators also emit separate
+  load/modify/store anyway. Recommend `volatile uint32_t`.
+- **[L] Include guards on `.cpp` files** (`#ifndef __gpio_cpp__`) — harmless but
+  unusual.
+- **[L] Debug `printf` loop in `InterruptRegisterAddress` ctor** runs on every
+  construction and emits `-Wformat`/`-Wsign-compare` warnings (prints register
+  pointers).
+
+### 2.2 GPIO (`src/gpio/gpio.cpp`) — ✅ FIXED
+> Resolved by rewriting `gpio.cpp` to index every register directly by BCM GPIO
+> number (the `gpioNo2PinNo` indirection was removed), adding the missing `else`
+> branches, making `output()` clear-then-set, and adding a `gpio <= 53` range
+> guard. Regression tests added in `test/gpio_test.cpp`.
+
+- **[H] FSEL/SET/CLR indexing uses the *physical header pin* number, not the
+  *BCM GPIO* number.** `gpioNo2PinNo` maps BCM GPIO → 40-pin-header pin, then the
+  code indexes `GPFSELn` with `pin_no/10` and shifts by `(pin_no%10)*3`. Hardware
+  `GPFSEL`/`GPSET`/`GPLEV` registers are organised **by GPIO number** (GPIO0–9 in
+  GPFSEL0, …), so this programs the wrong pin on real hardware. The round-trip
+  tests pass only because the same wrong index is used for both write and read.
+  The physical pin number is irrelevant to register addressing and the
+  indirection should be removed.
+- **[H] Missing `else` on every "pin ≥ 32" branch.** In `GPSETn`, `GPCLRn`,
+  `GPLEVn(setter)`, `GPGETn`, `GPEDSn`, `GPRENn`, `GPFENn`, `GPLENn`, `GPARENn`,
+  `GPAFENn`, `GPPUDCLKn` the pattern is:
+  ```cpp
+  if (pin_no < 32) { reg0 |= (1U << pin_no); }
+  reg1 |= (1U << (pin_no - 32));   // <-- runs even when pin_no < 32
+  ```
+  When `pin_no < 32`, `pin_no - 32` underflows (unsigned) and the shift is `>= 32`
+  (undefined behaviour), and it wrongly touches the `…1` register. Only `GPHENn`
+  has the correct `else`. All the others need the `else`.
+- **[M] `output()` does not clear the FSEL field before setting.** It does
+  `m_register[..] |= (1U << ((pin%10)*3))`, setting only bit 0 of the 3-bit field
+  without clearing it first. Switching a pin that was an alt-function to output
+  yields a corrupted mode (e.g. `0b100 → 0b101`). It should clear the 3 bits then
+  write `0b001` (as `write()` does).
+- **[M] `output()` vs `input()` index inconsistency.** `output()` indexes FSEL by
+  `pin_no`; `input()` indexes by `gpio_n`. They disagree with each other and with
+  `read()`/`write()` (which use `pin_no`). `input()` is currently untested so the
+  bug is latent.
+- **[M] GPSET/GPCLR modelled as plain latches.** Hardware `GPSET`/`GPCLR` are
+  write-1-to-act, read-undefined registers; `GPGETn` reads back `GPSET` which has
+  no hardware meaning. Acceptable for the simulator, but not hardware-faithful.
+- **[L] Unused `pin_no` in `input()`; unused `gpio_n` params in `GPPUD`.**
+
+### 2.3 Clock (`src/clock/clock.cpp`)
+- **[H] Clock manager base address is wrong.** `operator new` returns
+  `0x3F000000 + 0x00100000 = 0x3F100000`. The GP clock control registers
+  (`CM_GP0CTL`…) are at physical **`0x3F101070`** (bus `0x7E101070`). The `0x1070`
+  offset is missing, so on hardware this points into the wrong block.
+- **[H] Missing clock password (0x5A) on writes.** Every write to a
+  `CM_*CTL`/`CM_*DIV` register must carry `PASSWD = 0x5A` in bits [31:24], else the
+  hardware **ignores the write**. No clock write sets it.
+- **[H] Two conflicting bit layouts for CTL ENAB/KILL/MASH.** The generic
+  `set_CM_GPnCTL` uses ENAB`<<4`, KILL`<<5`, MASH`<<8`; the per-register
+  `CM_GP0CTL`/`CM_GP1CTL`/`CM_GP2CTL` use ENAB`<<5`, KILL`<<6`, MASH`<<10`. Per
+  the datasheet the correct layout is **ENAB bit4, KILL bit5, MASH bits[10:9]**.
+  So `set_CM_GPnCTL` is right for ENAB/KILL but wrong for MASH (should be `<<9`),
+  and the per-register variants are wrong for all three.
+- **[M] `get_CM_GPnDIV` read masks are wrong.** DIVF reads
+  `reg & ~(1U<<12)` (clears only bit 12) and BOTH reads `reg & ~(1U<<24)`. They
+  should mask the low 12/24 bits: `& ~((~0U)<<12)` / `& ~((~0U)<<24)` — exactly
+  what the per-register `CM_GPnDIV` reads already do. Inconsistent.
+- **[M] `read(reg, CM_GPnCTL_Type)` returns uninitialised `value` on default.**
+  `CLOCK::control_type value;` is declared without init and only set inside known
+  `case`s (`-Wsometimes-uninitialized`).
+- **[L] `(~(~0U<<4)) & value | (...)` precedence warning** (`-Wbitwise-op-
+  parentheses`) in the three `CM_GPnCTL` `ALL` cases; behaviour is intended but
+  the `auto all_value = 0;` makes it `int`.
+
+### 2.4 Interrupt (`src/interrupt/interrupt.cpp`) — ✅ FIXED (handler/enable logic)
+> Resolved: `enable`/`disable` now select bank 1 for IRQ 0–31 and bank 2 (shift
+> `n-32`) for 32–63; `isEnabled` reads back the Enable register without
+> side-effects and with correct `&`/`==` precedence; `install_IRQHandler`/
+> `install_FIQHandler` assign the IVT slot directly instead of dereferencing a
+> wild pointer. Regression tests added in `test/interrupt_test.cpp`. The IVT
+> placement note below (`[M]`) is a design observation left as-is.
+
+- **[H] enable/disable register selection inverted and out of range.**
+  ```cpp
+  if (irqNumber > 31) Enable_IRQs_1 |= 1U << irqNumber;        // wrong reg + shift>=32 UB
+  else                Enable_IRQs_2 |= 1U << (irqNumber - 32); // wrong reg + underflow
+  ```
+  IRQs 0–31 belong to `Enable_IRQs_1` (shift `number`), IRQs 32–63 to
+  `Enable_IRQs_2` (shift `number-32`). The condition is inverted and both shifts
+  are wrong. Same defect in `disable()` and `isEnabled()`.
+- **[H] `isEnabled()` mutates a read-only pending register.** It does
+  `tmpReg &= (1U << number)` on the `IRQ_Pending` register **reference**, i.e. it
+  writes back into the (volatile) register during a query. It also reads
+  *pending* to answer an *enabled?* question, which is semantically wrong. Plus
+  `(tmpReg >> number) & 1U == 1U` has a precedence bug (`==` binds before `&`).
+- **[H] `install_IRQHandler` dereferences a wild pointer.**
+  `IVT& theIVT = *reinterpret_cast<IVT*>(m_ivt[IVT::Number::Reset]);` casts a
+  *function pointer slot value* (initially garbage/null) to an `IVT*` and
+  dereferences it. It also ignores the `IRQNumber` argument. It should simply do
+  `m_ivt[IVT::Number::IRQ] = cb;`. Same in `install_FIQHandler`.
+- **[M] IVT placement is inconsistent / unrealistic.** The default ctor places
+  the IVT at `0x00000000`; the region ctor places it right after the IRQ
+  registers. On ARM the exception vectors live at the VBAR-relative base, not
+  adjacent to peripheral MMIO.
+
+---
+
+## 3. How I2C/SPI follow the framework (and avoid the bugs)
+
+The new I2C (BSC) and SPI0 drivers reuse the exact framework pattern
+(register-block struct + placement `new` + driver class + gtest-over-vector), but:
+
+- Index registers **directly by datasheet word offset** — no pin-number
+  indirection (avoids 2.2).
+- Use correct physical bases: **BSC1 `0x3F804000`**, **SPI0 `0x3F204000`**.
+- Provide field-level `set/clr/get` with one consistent bit layout (avoids 2.3).
+- Keep read accessors side-effect free and initialise return values (avoids 2.4).
+
+> Note: like the existing drivers these are **host-side bit-layout models**; real
+> transfers additionally need correct GPIO ALT0 muxing, clock divider setup, and
+> the build/toolchain fixes in 2.1 before they run on a Pi.

--- a/modules/rpi3B/docs/DRIVER_REVIEW.md
+++ b/modules/rpi3B/docs/DRIVER_REVIEW.md
@@ -1,9 +1,16 @@
 # RPi3B (BCM2837) Bare-Metal Driver — Review & Issue Log
 
-This document captures (1) how the current driver framework is structured, and
-(2) the defects found while reviewing the half-finished GPIO / Clock / Interrupt
-drivers. It is the reference for the I2C/SPI work, which deliberately follows the
+This document captures (1) how the driver framework is structured, and
+(2) the defects found while reviewing the originally half-finished GPIO / Clock /
+Interrupt drivers. It is the reference for the I2C/SPI work, which follows the
 same framework while avoiding the bugs listed here.
+
+**Status (current):** The **GPIO** and **Interrupt** defects (§2.2, §2.4) are
+**fixed and merged** (PR #1), with regression tests. **I2C (BSC1)** and **SPI0**
+are **implemented and shipped** (§3). The build is now library-consumable
+(`rpi3b_driver` static lib) and the repo is vendored into the `iot` Yocto image
+as the `iot-rpi3b-selftest` boot oneshot. The **Clock** defects (§2.3) and the
+remaining design notes in §2.1 are **still open**.
 
 ---
 
@@ -67,11 +74,14 @@ Severity legend: **[H]** breaks correct behaviour on hardware · **[M]** logic
 bug / inconsistency · **[L]** cosmetic / warning.
 
 ### 2.1 Build / framework wide
-- **[H] Root executable never compiles the drivers.** Root
-  `CMakeLists.txt` uses `file(GLOB SOURCES "src/*.cpp")`, but the driver sources
-  live in `src/gpio/`, `src/clock/`, `src/interrupt/`. Only `src/main.cpp` is
-  compiled into `rpi3Bdriver`; the drivers are never linked. (Tests work because
-  `test/CMakeLists.txt` lists them explicitly.) Fix: glob `src/*/*.cpp`.
+- **[H] Root executable never compiles the drivers.** ✅ **FIXED.** Root
+  `CMakeLists.txt` used `file(GLOB SOURCES "src/*.cpp")`, but the driver sources
+  live in `src/gpio/`, `src/clock/`, `src/interrupt/` — so only `src/main.cpp`
+  was compiled and the project never actually built the drivers (it also failed
+  under `-std=c++17` on the headers' abbreviated-template ctors). Resolved by the
+  CMake refactor: a `rpi3b_driver` STATIC library globs `src/*/*.cpp`, builds as
+  C++20, and the public headers are kept C++17-consumable (explicit-template
+  ctors) so the C++17 `iot` build can link it.
 - **[H] No freestanding/cross toolchain.** The project compiles as a normal host
   program (`-pg`, default sysroot). There is no `aarch64-none-elf` toolchain
   file, no linker script, no startup/`_start`, so the artifact is **not loadable
@@ -185,9 +195,10 @@ bug / inconsistency · **[L]** cosmetic / warning.
 
 ---
 
-## 3. How I2C/SPI follow the framework (and avoid the bugs)
+## 3. I2C/SPI — shipped, and how they avoid the bugs
 
-The new I2C (BSC) and SPI0 drivers reuse the exact framework pattern
+The I2C (BSC1) and SPI0 drivers (`inc/i2c.hpp`, `inc/spi.hpp`, `src/i2c`,
+`src/spi`, with gtests in `test/`) reuse the exact framework pattern
 (register-block struct + placement `new` + driver class + gtest-over-vector), but:
 
 - Index registers **directly by datasheet word offset** — no pin-number

--- a/modules/rpi3B/inc/clock.hpp
+++ b/modules/rpi3B/inc/clock.hpp
@@ -1,0 +1,68 @@
+#ifndef __clock_hpp__
+#define __clock_hpp__
+
+#include <cstdint>
+#include <cstdio>
+#include <atomic>
+#include "memory_map.hpp"
+
+
+class CLOCK {
+    public:
+        using gpio_number = std::uint32_t;
+        using divisor_type = std::uint32_t;
+        using control_type = std::uint32_t;
+
+        CLOCK() : m_memory(*new RPi3B::ClockRegistersAddress) {}
+
+        template<typename Region>
+        CLOCK(Region region) : m_memory(*new(region) RPi3B::ClockRegistersAddress) {}
+
+        ~CLOCK() = default;
+
+        void set_CM_GPnDIV(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor field, divisor_type value);
+        void clr_CM_GPnDIV(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor field);
+        divisor_type get_CM_GPnDIV(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor field);
+
+        void set_CM_GPnCTL(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type field, divisor_type value);
+        void clr_CM_GPnCTL(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type field);
+        control_type get_CM_GPnCTL(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type field);
+
+
+        void CM_GP0DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor, divisor_type value);
+        divisor_type CM_GP0DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor) const;
+        void CM_GP1DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor, divisor_type value);
+        divisor_type CM_GP1DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor) const;
+        void CM_GP2DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor, divisor_type value);
+        divisor_type CM_GP2DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor) const;
+        void write(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor divif ,divisor_type value);
+        divisor_type read(RPi3B::ClockRegistersAddress::Register, RPi3B::ClockRegistersAddress::ClockDivisor divif) const;
+
+        /**
+         * @brief
+         *      CLOCK Control Interface
+        */
+        void CM_GP0CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctl, divisor_type value);
+        divisor_type CM_GP0CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type) const;
+        void CM_GP1CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctl, divisor_type value);
+        divisor_type CM_GP1CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type) const;
+        void CM_GP2CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctl, divisor_type value);
+        divisor_type CM_GP2CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type) const;
+        void write(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type type ,divisor_type value);
+        divisor_type read(RPi3B::ClockRegistersAddress::Register, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type type) const;
+
+        auto& memory() const {
+            return(m_memory);
+        }
+
+    private:
+        RPi3B::ClockRegistersAddress& m_memory;
+};
+
+
+
+
+
+
+
+#endif /*__clock_hpp__*/

--- a/modules/rpi3B/inc/gpio.hpp
+++ b/modules/rpi3B/inc/gpio.hpp
@@ -1,0 +1,247 @@
+#ifndef __gpio_hpp__
+#define __gpio_hpp__
+
+#include <cstdint>
+#include <cstdio>
+#include <atomic>
+
+#include "memory_map.hpp"
+
+class GPIO {
+    public:
+        using gpio_number = std::uint32_t;
+        using pin_number = std::uint32_t;
+
+        GPIO() : m_memory(*new RPi3B::GPIORegistersAddress) {}
+
+        template<typename Region>
+        GPIO(Region region) : m_memory(*new(region) RPi3B::GPIORegistersAddress) {}
+
+        ~GPIO() = default;
+
+        /**
+         * @brief
+            * 000 = GPIO Pin n is an input
+            * 001 = GPIO Pin n is an output
+            * 100 = GPIO Pin n takes alternate function 0
+            * 101 = GPIO Pin n takes alternate function 1
+            * 110 = GPIO Pin n takes alternate function 2
+            * 111 = GPIO Pin n takes alternate function 3
+            * 011 = GPIO Pin n takes alternate function 4
+            * 010 = GPIO Pin n takes alternate function 5
+            * 
+         * @param gpio number
+         * @return none
+         **/
+        void input(gpio_number gpio);
+        void output(gpio_number gpio);
+        /**
+         * @brief
+         *      The pin level registers return the actual value of the pin. The LEV{n} field gives the
+         *      value of the respective GPIO pin.
+         * @param gpio_no is the GPIO number
+         * @return current LEVn valueof that GPIO number
+        */
+        std::uint32_t GPLEVn(gpio_number gpio) const;
+        void GPLEVn(gpio_number gpio_n);
+
+        /**
+         * @brief
+            * The output clear registers are used to clear a GPIO pin. 
+            * The CLR{n} field defines the respective GPIO pin to clear, 
+            * writing a “0” to the field has no effect. 
+            * If the GPIO pin is being used as in input (by default) 
+            * then the value in the CLR{n} field is ignored. However, 
+            * if the pin is subsequently defined as an output then the bit will be set according to 
+            * the last set/clear operation. 
+            * Separating the set and clear functions removes the need for read-modify-write operations.
+            *
+         * @param gpio_n This is GPIO number to be cleared
+         * @return none
+         * */
+        void GPCLRn(gpio_number gpio_n);
+        /**
+         * @brief
+         *   The output set registers are used to set a GPIO pin. The SET{n} field defines the
+         *   respective GPIO pin to set, writing a “0” to the field has no effect. If the GPIO pin is
+         *   being used as in input (by default) then the value in the SET{n} field is ignored.
+         *   However, if the pin is subsequently defined as an output then the bit will be set
+         *   according to the last set/clear operation. Separating the set and clear functions
+         *   removes the need for read-modify-write operations
+         * @param gpio_n This is GPIO number which is to be set
+         * @return none
+        */
+        void GPSETn(gpio_number gpio_n);
+        std::uint32_t GPGETn(gpio_number gpio_n);
+        /**
+         * @brief
+         *      The event detect status registers are used to record level and edge events on the
+                GPIO pins. The relevant bit in the event detect status registers is set whenever: 1)
+                an edge is detected that matches the type of edge programmed in the rising/falling
+                edge detect enable registers, or 2) a level is detected that matches the type of level
+                programmed in the high/low level detect enable registers. The bit is cleared by
+                writing a “1” to the relevant bit.
+         * @param
+         * @return 
+        */
+        void GPEDSn(gpio_number gpio_n);
+        std::uint32_t GPEDSn(gpio_number gpio_n) const;
+        /**
+         * @brief
+         *      The rising edge detect enable registers define the pins for which a rising edge
+                transition sets a bit in the event detect status registers (GPEDSn). When the
+                relevant bits are set in both the GPRENn and GPFENn registers, any transition (1
+                to 0 and 0 to 1) will set a bit in the GPEDSn registers. The GPRENn registers use
+                synchronous edge detection. This means the input signal is sampled using the
+                system clock and then it is looking for a “011” pattern on the sampled signal. This
+                has the effect of suppressing glitches.
+         * @param
+         * @return
+        */
+        void GPRENn(gpio_number gpio_n);
+        std::uint32_t GPRENn(gpio_number gpio_n) const;
+
+        /**
+         * @brief
+         *      The falling edge detect enable registers define the pins for which a falling edge
+                transition sets a bit in the event detect status registers (GPEDSn). When the relevant
+                bits are set in both the GPRENn and GPFENn registers, any transition (1 to 0 and 0
+                to 1) will set a bit in the GPEDSn registers. The GPFENn registers use synchronous
+                edge detection. This means the input signal is sampled using the system clock and
+                then it is looking for a “100” pattern on the sampled signal. This has the effect of
+                suppressing glitches.
+         * @param
+         * @return
+        */
+        void GPFENn(gpio_number gpio_n);
+        std::uint32_t GPFENn(gpio_number gpio_n) const;
+
+        /**
+         * @brief
+         *      The high level detect enable registers define the pins for which a high level sets a bit in
+                the event detect status register (GPEDSn). If the pin is still high when an attempt is
+                made to clear the status bit in GPEDSn then the status bit will remain set.
+         * @param
+         * @return
+        */
+        void GPHENn(gpio_number gpio_n);
+        std::uint32_t GPHENn(gpio_number gpio_n) const;
+
+        /**
+         * @brief
+         *      The low level detect enable registers define the pins for which a low level sets a bit in
+                the event detect status register (GPEDSn). If the pin is still low when an attempt is
+                made to clear the status bit in GPEDSn then the status bit will remain set.
+         * @param
+         * @return
+        */
+        void GPLENn(gpio_number gpio_n);
+        std::uint32_t GPLENn(gpio_number gpio_n) const;
+
+        /**
+         * @brief
+         *      The asynchronous rising edge detect enable registers define the pins for which a
+                asynchronous rising edge transition sets a bit in the event detect status registers
+                (GPEDSn).
+                Asynchronous means the incoming signal is not sampled by the system clock. As such
+                rising edges of very short duration can be detected.
+         *  @param
+         *  @return
+        */
+        void GPARENn(gpio_number gpio_n);
+        std::uint32_t GPARENn(gpio_number gpio_n) const;
+
+        /**
+         * @brief
+         *      The asynchronous falling edge detect enable registers define the pins for which a
+                asynchronous falling edge transition sets a bit in the event detect status registers
+                (GPEDSn). Asynchronous means the incoming signal is not sampled by the system
+                clock. As such falling edges of very short duration can be detected.
+         * @param
+         * @return
+        */
+        void GPAFENn(gpio_number gpio_n);
+        std::uint32_t GPAFENn(gpio_number gpio_n) const;
+
+        /**
+         * @brief
+         *      The GPIO Pull-up/down Register controls the actuation of the internal pull-up/down
+                control line to ALL the GPIO pins. This register must be used in conjunction with the 2
+                GPPUDCLKn registers.
+                Note that it is not possible to read back the current Pull-up/down settings and so it is the
+                users’ responsibility to ‘remember’ which pull-up/downs are active. The reason for this is
+                that GPIO pull-ups are maintained even in power-down mode when the core is off, when
+                all register contents is lost.
+                The Alternate function table also has the pull state which is applied after a power down.
+         * @param
+         * @return
+         *      
+        */
+        void GPPUD(gpio_number gpio_n, RPi3B::GPIORegistersAddress::PullUpDownConfig cfg);
+        std::uint32_t GPPUD(gpio_number gpio_n) const;
+
+        /**
+         * @brief
+         *      The GPIO Pull-up/down Clock Registers control the actuation of internal pull-downs on
+                the respective GPIO pins. These registers must be used in conjunction with the GPPUD
+                register to effect GPIO Pull-up/down changes. The following sequence of events is
+                required:
+                    1. Write to GPPUD to set the required control signal (i.e. Pull-up or Pull-Down or neither
+                        to remove the current Pull-up/down)
+                    2. Wait 150 cycles – this provides the required set-up time for the control signal
+                    3. Write to GPPUDCLK0/1 to clock the control signal into the GPIO pads you wish to
+                        modify – NOTE only the pads which receive a clock will be modified, all others will
+                        retain their previous state.
+                    4. Wait 150 cycles – this provides the required hold time for the control signal
+                    5. Write to GPPUD to remove the control signal
+                    6. Write to GPPUDCLK0/1 to remove the clock
+         * @param
+         * @return
+         *      
+        */
+        void GPPUDCLKn(gpio_number gpio_n);
+        std::uint32_t GPPUDCLKn(gpio_number gpio_n) const;
+
+        std::uint32_t read(gpio_number gpio_n);
+        std::uint32_t read32(gpio_number gpio_n);
+        void write32(gpio_number gpio_n, std::uint32_t value);
+        void write(gpio_number gpio_n, RPi3B::GPIORegistersAddress::Config cfg);
+
+        RPi3B::GPIORegistersAddress& memory() const {
+            return(m_memory);
+        }
+
+    private:
+        RPi3B::GPIORegistersAddress& m_memory;
+
+};
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#endif /* __gpio_hpp__*/

--- a/modules/rpi3B/inc/i2c.hpp
+++ b/modules/rpi3B/inc/i2c.hpp
@@ -1,0 +1,68 @@
+#ifndef __i2c_hpp__
+#define __i2c_hpp__
+
+#include <cstdint>
+#include <cstdio>
+#include <atomic>
+
+#include "memory_map.hpp"
+
+/**
+ * @brief
+ *      I2C master driver built on the BCM2837 Broadcom Serial Controller (BSC).
+ *      Follows the same framework as GPIO/CLOCK: a reference to a placement-new
+ *      register block (real MMIO on hardware, a test buffer in unit tests) and
+ *      field-level set/clr/get accessors plus a few transaction helpers.
+ *
+ *      Register fields are addressed directly by datasheet bit position; there
+ *      is no pin-number indirection (see docs/DRIVER_REVIEW.md).
+*/
+class I2C {
+    public:
+        using value_type = std::uint32_t;
+
+        I2C() : m_memory(*new RPi3B::BSCRegistersAddress) {}
+        template<typename Region>
+        I2C(Region region) : m_memory(*new(region) RPi3B::BSCRegistersAddress) {}
+        ~I2C() = default;
+
+        /* ---- Control register (C) field access ---- */
+        void set_control(RPi3B::BSCRegistersAddress::Control field, value_type value);
+        void clr_control(RPi3B::BSCRegistersAddress::Control field);
+        value_type get_control(RPi3B::BSCRegistersAddress::Control field) const;
+
+        /* ---- Status register (S) field access (DONE/ERR/CLKT are W1C) ---- */
+        void clr_status(RPi3B::BSCRegistersAddress::Status field);
+        value_type get_status(RPi3B::BSCRegistersAddress::Status field) const;
+
+        /* ---- High level helpers ---- */
+        /// @brief Enable/disable the BSC controller (C.I2CEN).
+        void enable();
+        void disable();
+        /// @brief Program the 7-bit slave address (A register).
+        void slave_address(value_type addr);
+        value_type slave_address() const;
+        /// @brief Program the number of bytes for the next transfer (DLEN).
+        void data_length(value_type len);
+        value_type data_length() const;
+        /// @brief Clock divider (DIV): SCL = core_clock / DIV.
+        void clock_divider(value_type divider);
+        value_type clock_divider() const;
+        /// @brief Clear the FIFO (C.CLEAR).
+        void clear_fifo();
+        /// @brief Kick off a read or write transfer (sets READ/ST + I2CEN).
+        void start_read();
+        void start_write();
+        /// @brief Push one byte into / pop one byte out of the FIFO.
+        void write_byte(value_type byte);
+        value_type read_byte() const;
+
+        RPi3B::BSCRegistersAddress& memory() const {
+            return(m_memory);
+        }
+
+    private:
+        RPi3B::BSCRegistersAddress& m_memory;
+};
+
+#endif /*__i2c_hpp__*/

--- a/modules/rpi3B/inc/interrupt.hpp
+++ b/modules/rpi3B/inc/interrupt.hpp
@@ -1,0 +1,93 @@
+#ifndef __interrupt_hpp__
+#define __interrupt_hpp__
+
+#include <cstdint>
+#include <cstdio>
+#include <atomic>
+
+#include "memory_map.hpp"
+
+class IVT {
+    public:
+        using pointerToFn = void (*)();
+        /// @brief Address of below will be 0x00, 0x04, 0x08, 0x0C, 0x10, 0x14, 0x18, 0x1C
+        enum Number {
+            Reset,
+            UndefinedInstruction,
+            SWI,
+            InstructionAbort,
+            DataAbort,
+            Hypervisor,
+            IRQ,
+            FIQ,
+            End
+        };
+
+        IVT() {}
+        ~IVT() {}
+
+        /** 
+         * @brief Compiler give preference to this new operator over global new operator and invoke this new operator. 
+         * @param nBytes Number of bytes to be allocated
+         * @param region is the memory region to be return if present.
+         * @return pointer to void
+         */
+        void *operator new(std::size_t nBytes, void *region=nullptr) {
+            (void)nBytes;
+            if(nullptr == region) {
+                return reinterpret_cast<void *>((0x00000000U));
+            }
+            return(region);
+        }
+
+        pointerToFn &operator[](Number irq) {
+            return(m_IRQTable[irq]);
+        }
+
+    private:
+        pointerToFn m_IRQTable[End];
+};
+
+class IVT_Table {
+    public:
+        IVT_Table() : m_ivt(*new IVT) {}
+        template<typename Region>
+        IVT_Table(Region region) : m_ivt(*new(region) IVT) {}
+
+    
+    private:
+        IVT& m_ivt;
+};
+
+class IRQ {
+    public:
+        using irq_number = std::uint8_t;
+
+        //using IVT::IVT;
+
+        IRQ() : m_memory(*new RPi3B::InterruptRegisterAddress), m_ivt(*new IVT) {}
+
+        template<typename Region>
+        IRQ(Region region) : m_memory(*new(region) RPi3B::InterruptRegisterAddress), m_ivt(*new (region + RPi3B::InterruptRegisterAddress::Register::IRQs_ALL_MAX) IVT) {}
+
+        ~IRQ() = default;
+        void enable(irq_number number);
+        void disable(irq_number number);
+        bool isEnabled(irq_number number);
+        void install_IRQHandler(std::uint8_t IRQNumber, IVT::pointerToFn cb);
+        void install_FIQHandler(std::uint8_t IRQNumber, IVT::pointerToFn cb);
+        
+
+    private:
+        RPi3B::InterruptRegisterAddress& m_memory;
+        IVT& m_ivt;
+};
+
+
+
+
+
+
+
+
+#endif /*__interrupt_hpp__*/

--- a/modules/rpi3B/inc/memory_map.hpp
+++ b/modules/rpi3B/inc/memory_map.hpp
@@ -1,0 +1,417 @@
+#ifndef __memory_map_hpp__
+#define __memory_map_hpp__
+
+#include <cstdint>
+#include <cstdio>
+#include <atomic>
+#include <vector>
+
+namespace RPi3B {
+    struct GPIORegistersAddress {
+
+        enum Config: std::uint32_t {
+            InputMode = 0b000,
+            OutputMode = 0b001,
+            AlternateFunction0 = 0b100,
+            AlternateFunction1 = 0b101,
+            AlternateFunction2 = 0b110,
+            AlternateFunction3 = 0b111,
+            AlternateFunction4 = 0b011,
+            AlternateFunction5 = 0b010
+        };
+
+        enum PullUpDownConfig: std::uint32_t {
+            Off = 0b00,
+            EnablePullDown = 0b01,
+            EnablePullUp = 0b10,
+            Reserved = 0b11
+        };
+
+        enum Register: std::uint32_t {
+            /* GPIO Function Selection offset */
+            BCM2837_GPFSEL0,
+            BCM2837_GPFSEL1,
+            BCM2837_GPFSEL2,
+            BCM2837_GPFSEL3,
+            BCM2837_GPFSEL4,
+            BCM2837_GPFSEL5,
+            BCM2837_GPFSEL_RESERVED,
+            /* GPIO SET Address offset */
+            BCM2837_GPSET0,
+            BCM2837_GPSET1,
+            BCM2837_GPSET_RESERVED,
+            /* Offset for clearing the GPIO */
+            BCM2837_GPCLR0,
+            BCM2837_GPCLR1,
+            BCM2837_GPCLR_RESERVED,
+            /* Offset for GPIO LEV0/1 */
+            BCM2837_GPLEV0,
+            BCM2837_GPLEV1,
+            BCM2837_GPLEV_RESERVED,
+            BCM2837_GPEDS0,
+            BCM2837_GPEDS1,
+            BCM2837_GPEDS_RESERVED,
+            BCM2837_GPREN0,
+            BCM2837_GPREN1,
+            BCM2837_GPREN_RESERVED,
+            BCM2837_GPFEN0,
+            BCM2837_GPFEN1,
+            BCM2837_GPFEN_RESERVED,
+            BCM2837_GPHEN0,
+            BCM2837_GPHEN1,
+            BCM2837_GPHEN_RESERVED,
+            BCM2837_GPLEN0,
+            BCM2837_GPLEN1,
+            BCM2837_GPLEN_RESERVED,
+            BCM2837_GPAREN0,
+            BCM2837_GPAREN1,
+            BCM2837_GPAREN_RESERVED,
+            BCM2837_GPAFEN0,
+            BCM2837_GPAFEN1,
+            BCM2837_GPAFEN_RESERVED,
+            BCM2837_GPPUD,
+            BCM2837_GPPUDCLK0,
+            BCM2837_GPPUDCLK1,
+            BCM2837_RESERVED,
+            BCM2837_TEST1,
+            BCM2837_TEST2,
+            BCM2837_TEST3,
+            BCM2837_TEST4,
+            BCM2837_MAX
+        };
+    
+        using device_register = volatile std::atomic<std::uint32_t>; //@brief This ensures that this is a thread safe
+        GPIORegistersAddress() {}
+        ~GPIORegistersAddress() {}
+
+        /** 
+         * @brief Compiler give preference to this new operator over global new operator and invoke this new operator. 
+         * @param nBytes Number of bytes to be allocated
+         * @param region is the memory region to be return if present.
+         * @return pointer to void
+         */
+        void *operator new(std::size_t nBytes, void *region=nullptr) {
+            (void)nBytes;
+            if(nullptr == region) {
+                /**
+                 * @brief
+                 *      Physical addresses range from 0x3F000000 to 0x3FFFFFFF for peripherals. The
+                        bus addresses for peripherals are set up to map onto the peripheral bus address range
+                        starting at 0x7E000000. Thus a peripheral advertised here at bus address 0x7Ennnnnn is
+                        available at physical address 0x3Fnnnnnn.
+                */
+                return reinterpret_cast<void *>((0x3F000000) + (0x00200000));
+            }
+            return(region);
+        }
+
+        /** 
+         * @brief
+         * address for m_register will be 
+         * [0x3F200000, 0x3F200004, 0x3F200008, 0x3F20000C, 0x3F200010, 0x3F200014, 0x3F200018, 0x3F20001C  ... 0x3F2000B0] 
+         **/
+        device_register m_register[Register::BCM2837_MAX];
+    };
+
+    struct ClockRegistersAddress {
+
+        enum Register : std::uint32_t {
+            CM_GP0CTL,
+            CM_GP0DIV,
+            CM_GP1CTL,
+            CM_GP1DIV,
+            CM_GP2CTL,
+            CM_GP2DIV,
+            CM_GPn_MAX
+        };
+        
+        enum CM_GPnCTL_Type: std::uint32_t {
+            SRC,
+            ENAB,
+            KILL,
+            Unused,
+            BUSY,
+            FLIP,
+            MASH,
+            ALL
+        };
+
+        enum ClockSource: std::uint32_t {
+            Ground = 0,
+            Oscillator = 1,
+            Testdebug0 = 2,
+            Testdebug1 = 3,
+            PLLA = 4,
+            PLLC = 5,
+            PLLD = 6,
+            HDMI_Auxiliary = 7
+            /**
+             * @brief
+                    8-15 = GND
+                    To avoid lock-ups and glitches do not change this
+                    control while BUSY=1 and do not change this control
+                    at the same time as asserting ENAB
+            */
+        };
+
+        enum ClockMASH : std::uint32_t {
+            Integer_division = 0,
+            Stage1_MASH = 1,
+            Stage2_MASH = 2,
+            Stage3_MASH = 3
+            /**
+             * @brief
+             *      To avoid lock-ups and glitches do not change this
+                    control while BUSY=1 and do not change this control
+                    at the same time as asserting ENAB.
+            */
+        };
+
+        enum ClockDivisor: std::uint32_t {
+            /**
+             * @brief
+             *      Fractional part of divisor
+                    To avoid lock-ups and glitches do not change this
+                    control while BUSY=1.
+            */
+            DIVF,
+            /**
+             * @brief
+             *      Integer part of divisor
+                    This value has a minimum limit determined by the
+                    MASH setting. See text for details. To avoid lock-ups
+                    and glitches do not change this control while BUSY=1.
+            */
+            DIVI,
+            /**
+             * @brief
+             *      Use BOTH_VALUE to write both Integer & Fractional part
+            */
+            BOTH_VALUE
+        };
+
+        using device_register = volatile std::atomic<std::uint32_t>; //@brief This ensures that this is a thread safe
+        ClockRegistersAddress() {
+            /*
+            for(auto idx = 0; idx < Register::CM_GPn_MAX; ++idx)
+                std::printf("Clock Register is 0x%X\n", &m_register[idx]);
+            std::printf("\n");
+            */
+        }
+        ~ClockRegistersAddress() {}
+
+        /** 
+         * @brief Compiler give preference to this new operator over global new operator and invoke this new operator. 
+         * @param nBytes Number of bytes to be allocated
+         * @param region is the memory region to be return if present.
+         * @return pointer to void
+         */
+        void *operator new(std::size_t nBytes, void *region=nullptr) {
+            (void)nBytes;
+            if(nullptr == region) {
+                return reinterpret_cast<void *>((0x3F000000) + (0x00100000));
+            }
+            return(region);
+        }
+
+        /** 
+         * @brief
+         * address for m_register will be 
+         * [0x3F100000, 0x3F100004, 0x3F100008, 0x3F10000C, 0x3F100010, 0x3F100014, 0x3F100018, 0x3F10001C  ... 0x3F1000B0] 
+         **/
+        device_register m_register[Register::CM_GPn_MAX];
+    };
+
+    struct InterruptRegisterAddress {
+        enum Register : std::uint32_t {
+            IRQ_Basic_Pending,
+            IRQ_Pending1,
+            IRQ_Pending2,
+            FIQ_Control,
+            Enable_IRQs_1,
+            Enable_IRQs_2,
+            Enable_Basic_IRQs,
+            Disable_IRQs_1,
+            Disable_IRQs_2,
+            Disable_Basic_IRQs,
+            IRQs_ALL_MAX
+        };
+
+        
+        using device_register = volatile std::atomic<std::uint32_t>; //@brief This ensures that this is a thread safe
+        InterruptRegisterAddress() {
+            for(auto idx = 0; idx < Register::IRQs_ALL_MAX; ++idx)
+                std::printf("Interrupt Register is 0x%X\n", &m_register[idx]);
+            std::printf("\n");
+        }
+        ~InterruptRegisterAddress() {}
+
+        /** 
+         * @brief Compiler give preference to this new operator over global new operator and invoke this new operator. 
+         * @param nBytes Number of bytes to be allocated
+         * @param region is the memory region to be return if present.
+         * @return pointer to void
+         */
+        void *operator new(std::size_t nBytes, void *region=nullptr) {
+            (void)nBytes;
+            if(nullptr == region) {
+                return reinterpret_cast<void *>(0x3F00B200);
+            }
+            return(region);
+        }
+
+        device_register* operator[](Register offset) {
+            return(&m_register[offset]);
+        }
+
+        /** 
+         * @brief
+         * address for m_register will be 
+         * [0x3F00B200, 0x3F00B204, 0x3F00B208, 0x3F00B20C, 0x3F00B210, 0x3F00B214, 0x3F00B218, 0x3F00B21C  ... 0x3F00B220, 0x3F00B224] 
+         **/
+        device_register m_register[Register::IRQs_ALL_MAX];
+
+    };
+
+    /**
+     * @brief
+     *      Broadcom Serial Controller (BSC) register block — the BCM2837 I2C
+     *      master. Refer Section 3 "BSC" of BCM2837-ARM-Peripherals.pdf.
+     *      The Pi exposes BSC1 on the 40-pin header (GPIO2=SDA1, GPIO3=SCL1,
+     *      ALT0). BSC0 is at 0x3F205000, BSC1 at 0x3F804000 (bus 0x7E804000),
+     *      BSC2 (0x3F805000) is reserved for HDMI. Registers are spaced 4 bytes
+     *      apart, indexed directly by datasheet word offset (no pin mapping).
+    */
+    struct BSCRegistersAddress {
+
+        enum Register : std::uint32_t {
+            C,      /* 0x00 Control                */
+            S,      /* 0x04 Status                 */
+            DLEN,   /* 0x08 Data Length            */
+            A,      /* 0x0C Slave Address          */
+            FIFO,   /* 0x10 Data FIFO              */
+            DIV,    /* 0x14 Clock Divider          */
+            DEL,    /* 0x18 Data Delay             */
+            CLKT,   /* 0x1C Clock Stretch Timeout  */
+            BSC_MAX
+        };
+
+        /// @brief Fields of the Control register (C).
+        enum Control : std::uint32_t {
+            READ,   /* bit0     : 1=Read transfer, 0=Write transfer */
+            CLEAR,  /* bits[5:4]: write 0b01/0b10 to clear the FIFO  */
+            ST,     /* bit7     : Start a new transfer               */
+            INTD,   /* bit8     : Interrupt on DONE                  */
+            INTT,   /* bit9     : Interrupt on TX                    */
+            INTR,   /* bit10    : Interrupt on RX                    */
+            I2CEN,  /* bit15    : BSC controller enable              */
+            C_ALL
+        };
+
+        /// @brief Fields of the Status register (S). DONE/ERR/CLKT are W1C.
+        enum Status : std::uint32_t {
+            TA,     /* bit0  : Transfer Active            */
+            DONE,   /* bit1  : Transfer Done (W1C)        */
+            TXW,    /* bit2  : FIFO needs Writing         */
+            RXR,    /* bit3  : FIFO needs Reading         */
+            TXD,    /* bit4  : FIFO can accept data       */
+            RXD,    /* bit5  : FIFO contains data         */
+            TXE,    /* bit6  : FIFO empty                 */
+            RXF,    /* bit7  : FIFO full                  */
+            ERR,    /* bit8  : ACK error (W1C)            */
+            CLKT_TO,/* bit9  : Clock stretch timeout (W1C)*/
+            S_ALL
+        };
+
+        using device_register = volatile std::atomic<std::uint32_t>;
+        BSCRegistersAddress() {}
+        ~BSCRegistersAddress() {}
+
+        void *operator new(std::size_t nBytes, void *region=nullptr) {
+            (void)nBytes;
+            if(nullptr == region) {
+                /* BSC1 physical base (bus 0x7E804000 -> phys 0x3F804000). */
+                return reinterpret_cast<void *>(0x3F804000U);
+            }
+            return(region);
+        }
+
+        device_register m_register[Register::BSC_MAX];
+    };
+
+    /**
+     * @brief
+     *      SPI0 master register block. Refer Section 10 "SPI" of
+     *      BCM2837-ARM-Peripherals.pdf. SPI0 is at bus 0x7E204000 ->
+     *      phys 0x3F204000 and is exposed on GPIO7..11 (ALT0):
+     *      GPIO8=CE0, GPIO7=CE1, GPIO9=MISO, GPIO10=MOSI, GPIO11=SCLK.
+    */
+    struct SPIRegistersAddress {
+
+        enum Register : std::uint32_t {
+            CS,     /* 0x00 Control and Status     */
+            FIFO,   /* 0x04 TX/RX FIFO             */
+            CLK,    /* 0x08 Clock divider          */
+            DLEN,   /* 0x0C Data length (DMA)      */
+            LTOH,   /* 0x10 LoSSI output hold delay*/
+            DC,     /* 0x14 DMA DREQ controls      */
+            SPI_MAX
+        };
+
+        /// @brief Fields of the CS (control/status) register.
+        enum ControlStatus : std::uint32_t {
+            CS_LINE,  /* bits[1:0] : Chip Select (which CE line)            */
+            CPHA,     /* bit2      : Clock Phase                            */
+            CPOL,     /* bit3      : Clock Polarity                         */
+            CLEAR,    /* bits[5:4] : Clear TX (0b01) / RX (0b10) FIFO       */
+            CSPOL,    /* bit6      : Chip Select Polarity                   */
+            TA,       /* bit7      : Transfer Active                        */
+            DMAEN,    /* bit8      : DMA enable                             */
+            INTD,     /* bit9      : Interrupt on DONE                      */
+            INTR,     /* bit10     : Interrupt on RXR                       */
+            ADCS,     /* bit11     : Auto Deassert Chip Select (DMA)        */
+            REN,      /* bit12     : Read Enable (bidirectional mode)       */
+            LEN,      /* bit13     : LoSSI enable                           */
+            LMONO,    /* bit14     : unused (LoSSI)                         */
+            TE_EN,    /* bit15     : unused                                 */
+            DONE,     /* bit16     : Transfer Done (RO)                     */
+            RXD,      /* bit17     : RX FIFO contains data (RO)             */
+            TXD,      /* bit18     : TX FIFO can accept data (RO)           */
+            RXR,      /* bit19     : RX FIFO needs Reading (RO)             */
+            RXF,      /* bit20     : RX FIFO full (RO)                      */
+            CSPOL0,   /* bit21     : Chip Select 0 Polarity                 */
+            CSPOL1,   /* bit22     : Chip Select 1 Polarity                 */
+            CSPOL2,   /* bit23     : Chip Select 2 Polarity                 */
+            DMA_LEN,  /* bit24     : Enable DMA in LoSSI mode               */
+            LEN_LONG, /* bit25     : Enable Long data word in LoSSI DMA     */
+            CS_ALL
+        };
+
+        using device_register = volatile std::atomic<std::uint32_t>;
+        SPIRegistersAddress() {}
+        ~SPIRegistersAddress() {}
+
+        void *operator new(std::size_t nBytes, void *region=nullptr) {
+            (void)nBytes;
+            if(nullptr == region) {
+                /* SPI0 physical base (bus 0x7E204000 -> phys 0x3F204000). */
+                return reinterpret_cast<void *>(0x3F204000U);
+            }
+            return(region);
+        }
+
+        device_register m_register[Register::SPI_MAX];
+    };
+}
+
+
+
+
+
+
+
+
+
+
+
+#endif /*__memory_map_hpp__*/

--- a/modules/rpi3B/inc/spi.hpp
+++ b/modules/rpi3B/inc/spi.hpp
@@ -1,0 +1,64 @@
+#ifndef __spi_hpp__
+#define __spi_hpp__
+
+#include <cstdint>
+#include <cstdio>
+#include <atomic>
+
+#include "memory_map.hpp"
+
+/**
+ * @brief
+ *      SPI0 master driver for the BCM2837. Follows the same framework as
+ *      GPIO/CLOCK/I2C: a reference to a placement-new register block (real MMIO
+ *      on hardware, a test buffer in unit tests) with field-level set/clr/get
+ *      accessors over the CS register plus a few transaction helpers.
+ *
+ *      CS fields are addressed directly by datasheet bit position (see
+ *      docs/DRIVER_REVIEW.md).
+*/
+class SPI {
+    public:
+        using value_type = std::uint32_t;
+
+        SPI() : m_memory(*new RPi3B::SPIRegistersAddress) {}
+        template<typename Region>
+        SPI(Region region) : m_memory(*new(region) RPi3B::SPIRegistersAddress) {}
+        ~SPI() = default;
+
+        /* ---- CS (control/status) field access ---- */
+        void set_cs(RPi3B::SPIRegistersAddress::ControlStatus field, value_type value);
+        void clr_cs(RPi3B::SPIRegistersAddress::ControlStatus field);
+        value_type get_cs(RPi3B::SPIRegistersAddress::ControlStatus field) const;
+
+        /* ---- High level helpers ---- */
+        /// @brief Select clock polarity/phase (SPI mode 0..3).
+        void mode(value_type cpol, value_type cpha);
+        /// @brief Select the active chip-select line (0..2).
+        void chip_select(value_type ce);
+        value_type chip_select() const;
+        /// @brief CLK divider: SCLK = core_clock / divider (divider is even).
+        void clock_divider(value_type divider);
+        value_type clock_divider() const;
+        /// @brief Clear the TX and RX FIFOs (CS.CLEAR = 0b11).
+        void clear_fifo();
+        /// @brief Begin/end a transfer (CS.TA).
+        void begin_transfer();
+        void end_transfer();
+        /// @brief Push one byte to / pop one byte from the FIFO.
+        void write_byte(value_type byte);
+        value_type read_byte() const;
+        /// @brief Status helpers (read-only CS bits).
+        bool is_done() const;
+        bool can_write() const;
+        bool can_read() const;
+
+        RPi3B::SPIRegistersAddress& memory() const {
+            return(m_memory);
+        }
+
+    private:
+        RPi3B::SPIRegistersAddress& m_memory;
+};
+
+#endif /*__spi_hpp__*/

--- a/modules/rpi3B/src/clock/clock.cpp
+++ b/modules/rpi3B/src/clock/clock.cpp
@@ -1,0 +1,897 @@
+#ifndef __clock_cpp__
+#define __clock_cpp__
+
+#include "clock.hpp"
+
+void CLOCK::set_CM_GPnDIV(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor field, divisor_type value) {
+
+    switch (field)
+    {
+    case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            memory().m_register[reg] |= (((~((~0U) << 12)) & value) << 12);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            memory().m_register[reg] |= ((~((~0U) << 12)) & value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            memory().m_register[reg] |= ((~((~0U) << 24)) & value);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+}
+
+void CLOCK::clr_CM_GPnDIV(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor field) {
+    switch (field)
+    {
+    case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            memory().m_register[reg] &= ((~((~0U) << 24))  & (~((~0U) << 12)));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            memory().m_register[reg] &= ((~0U) << 12);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            memory().m_register[reg] &= ((~0U) << 24);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+}
+
+CLOCK::divisor_type CLOCK::get_CM_GPnDIV(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor field) {
+
+    CLOCK::divisor_type value = 0;
+    switch (field)
+    {
+    case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            value = (memory().m_register[reg] >> 12) & (~((~0U) << 12));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            value = memory().m_register[reg] & (~(1U << 12));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            value = memory().m_register[reg] & (~(1U << 24));
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+
+    return(value);
+}
+
+void CLOCK::set_CM_GPnCTL(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type field, divisor_type value) {
+    switch (field)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            memory().m_register[reg] |= (~(~0U << 4)) & value;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            memory().m_register[reg] |= ((value & 01) << 4);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            memory().m_register[reg] |= ((value & 01) << 5);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            memory().m_register[reg] |= ((value & 0b11) << 8);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            memory().m_register[reg] = value;
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+}
+
+void CLOCK::clr_CM_GPnCTL(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type field) {
+    switch (field)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            memory().m_register[reg] &= (~0b1111 << 0);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            memory().m_register[reg] &= (~(1U << 4));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            memory().m_register[reg] &= (~(1U << 5));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            memory().m_register[reg] &= (~(0b11 << 8));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            memory().m_register[reg] &= (~(0b1111 | (0b1 << 4) | (0b1 << 5) | (01 << 6) | (0b1 << 7) | (0b11 << 8)));
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+}
+
+CLOCK::control_type CLOCK::get_CM_GPnCTL(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type field) {
+    CLOCK::control_type value = 0;
+    switch (field)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            value = memory().m_register[reg] & 0b1111;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            value = (memory().m_register[reg] >> 4) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            value = (memory().m_register[reg] >> 5) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            value = (memory().m_register[reg] >> 8) & 0b11;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            value = memory().m_register[reg];
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+    return(value);
+}
+
+
+void CLOCK::CM_GP0DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor, CLOCK::divisor_type value) {
+
+    switch (divisor)
+    {
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP0DIV] |= (((~((~0U) << 12)) & value) << 12);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP0DIV] |= ((~((~0U) << 12)) & value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP0DIV] |= ((~((~0U) << 24)) & value);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+}
+
+CLOCK::divisor_type CLOCK::CM_GP0DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor) const {
+    divisor_type value = 0;
+
+    switch (divisor)
+    {
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP0DIV] >> 12) & (~((~0U) << 12));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            value = memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP0DIV] & (~((~0U) << 12U));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            value = memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP0DIV] & (~((~0U) << 24U));
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+    return(value);
+}
+
+void CLOCK::CM_GP1DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor, CLOCK::divisor_type value) {
+    switch (divisor)
+    {
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP1DIV] |= (((~((~0U) << 12)) & value) << 12);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP1DIV] |= (~((~0U) << 12) & value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP1DIV] |= (~((~0U) << 24) & value);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+}
+
+CLOCK::divisor_type CLOCK::CM_GP1DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor) const {
+    divisor_type value = 0;
+
+    switch (divisor)
+    {
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP1DIV] >> 12) & (~((~0U) << 12));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            value = memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP1DIV] & (~((~0U) << 12));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            value = memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP1DIV] & (~((~0U) << 24));
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+    return(value);
+}
+
+void CLOCK::CM_GP2DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor, CLOCK::divisor_type value) {
+    switch (divisor)
+    {
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP2DIV] |= ((~((~0U) << 12) & value) << 12);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP2DIV] |= (~((~0U) << 12) & value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP2DIV] |= (~((~0U) << 24) & value);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+}
+
+CLOCK::divisor_type CLOCK::CM_GP2DIV(RPi3B::ClockRegistersAddress::ClockDivisor divisor) const {
+    divisor_type value = 0;
+
+    switch (divisor)
+    {
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVI:
+        {
+            /// SET bits 12...23 ---- Integer Divisor
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP2DIV] >> 12) & (~((~0U) << 12));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::DIVF:
+        {
+            /// SET bits 0...11 --- Float divisor
+            value = memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP2DIV] & (~((~0U) << 12));
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE:
+        {
+            /// SET bits 0...23 --- both Integer & Float divisor
+            value = memory().m_register[RPi3B::ClockRegistersAddress::Register::CM_GP2DIV] & (~((~0U) << 24));
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+    return(value);
+}
+
+void CLOCK::write(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor divif, CLOCK::divisor_type value) {
+
+    switch (reg)
+    {
+        case RPi3B::ClockRegistersAddress::Register::CM_GP0DIV:
+        {
+            CM_GP0DIV(divif, value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP1DIV:
+        {
+            CM_GP1DIV(divif, value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP2DIV:
+        {
+            CM_GP2DIV(divif, value);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+}
+
+CLOCK::divisor_type CLOCK::read(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::ClockDivisor divif) const {
+
+    CLOCK::divisor_type value = 0;
+    switch (reg)
+    {
+        case RPi3B::ClockRegistersAddress::Register::CM_GP0DIV:
+        {
+            value = CM_GP0DIV(divif);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP1DIV:
+        {
+            value = CM_GP1DIV(divif);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP2DIV:
+        {
+            value = CM_GP2DIV(divif);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+    return(value);
+}
+
+void CLOCK::CM_GP0CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctl, divisor_type value) {
+    switch (ctl)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] |= (~(~0U << 4)) & value;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] |= ((value & 01) << 5);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] |= ((value & 01) << 6);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] |= ((value & (~(~0U << 2))) << 10);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            auto all_value = 0;
+            all_value = (~(~0U << 4)) & value | //SRC
+                        ((value & 01) << 5) | // ENAB
+                        ((value & 01) << 6) | //KILL
+                        ((value & (~(~0U << 2))) << 10); //MASH
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] = all_value;
+
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+}
+
+CLOCK::control_type CLOCK::CM_GP0CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctlType) const {
+    
+    CLOCK::control_type value = 0;
+    switch (ctlType)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            value = memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] & (~(~0U << 4));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] >> 5) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] >> 6) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL] >> 10) & (~(~0U << 2));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            value = memory().m_register[RPi3B::ClockRegistersAddress::CM_GP0CTL];
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+    return(value);
+}
+
+void CLOCK::CM_GP1CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctl, divisor_type value) {
+    switch (ctl)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] |= (~(~0U << 4)) & value;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] |= ((value & 01) << 5);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] |= ((value & 01) << 6);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] |= ((value & (~(~0U << 2))) << 10);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            auto all_value = 0;
+            all_value = (~(~0U << 4)) & value | //SRC
+                        ((value & 01) << 5) | // ENAB
+                        ((value & 01) << 6) | //KILL
+                        ((value & (~(~0U << 2))) << 10); //MASH
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] = all_value;
+
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+}
+
+CLOCK::control_type CLOCK::CM_GP1CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctlType) const {
+
+    CLOCK::control_type value = 0;
+    switch (ctlType)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            value = memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] & (~(~0U << 4));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] >> 5) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] >> 6) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL] >> 10) & (~(~0U << 2));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            value = memory().m_register[RPi3B::ClockRegistersAddress::CM_GP1CTL];
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+    return(value);
+}
+
+void CLOCK::CM_GP2CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctl, divisor_type value) {
+    switch (ctl)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] |= (~(~0U << 4)) & value;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] |= ((value & 01) << 5);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] |= ((value & 01) << 6);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] |= ((value & (~(~0U << 2))) << 10);
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            auto all_value = 0;
+            all_value = (~(~0U << 4)) & value | //SRC
+                        ((value & 01) << 5) | // ENAB
+                        ((value & 01) << 6) | //KILL
+                        ((value & (~(~0U << 2))) << 10); //MASH
+            memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] = all_value;
+
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+}
+
+CLOCK::control_type CLOCK::CM_GP2CTL(RPi3B::ClockRegistersAddress::CM_GPnCTL_Type ctlType) const {
+
+    CLOCK::control_type value = 0;
+    switch (ctlType)
+    {
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::SRC:
+        {
+            value = memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] & (~(~0U << 4));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ENAB:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] >> 5) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::KILL:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] >> 6) & 01;
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::BUSY:
+        {
+            /* Read only register */
+        }
+        break;
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::FLIP:
+        {
+            /* Read only register */
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::MASH:
+        {
+            value = (memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL] >> 10) & (~(~0U << 2));
+        }
+        break;
+
+    case RPi3B::ClockRegistersAddress::CM_GPnCTL_Type::ALL:
+        {
+            value = memory().m_register[RPi3B::ClockRegistersAddress::CM_GP2CTL];
+        }
+        break;
+
+    
+    default:
+        break;
+    }
+
+    return(value);
+}
+
+
+void CLOCK::write(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type type ,divisor_type value) {
+
+    switch (reg)
+    {
+        case RPi3B::ClockRegistersAddress::Register::CM_GP0CTL:
+        {
+            CM_GP0CTL(type, value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP1CTL:
+        {
+            CM_GP1CTL(type, value);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP2CTL:
+        {
+            CM_GP2CTL(type, value);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }    
+
+}
+
+CLOCK::control_type CLOCK::read(RPi3B::ClockRegistersAddress::Register reg, RPi3B::ClockRegistersAddress::CM_GPnCTL_Type type) const {
+    CLOCK::control_type value;
+    switch (reg)
+    {
+        case RPi3B::ClockRegistersAddress::Register::CM_GP0CTL:
+        {
+            value = CM_GP0CTL(type);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP1CTL:
+        {
+            value = CM_GP1CTL(type);
+        }
+        break;
+
+        case RPi3B::ClockRegistersAddress::Register::CM_GP2CTL:
+        {
+            value = CM_GP2CTL(type);
+        }
+        break;
+    
+        default:
+            /// Error Handling
+            break;
+    }
+    return(value);
+}
+
+
+#endif /*__clock_cpp__*/

--- a/modules/rpi3B/src/gpio/gpio.cpp
+++ b/modules/rpi3B/src/gpio/gpio.cpp
@@ -1,0 +1,293 @@
+#ifndef __gpio_cpp__
+#define __gpio_cpp__
+
+#include "gpio.hpp"
+
+/**
+ * @brief
+ *      All GPIO registers (GPFSELn, GPSETn, GPCLRn, GPLEVn, GPEDSn, ...) are
+ *      organised by *BCM GPIO number*, NOT by 40-pin-header physical pin number.
+ *      GPIO 0..9 live in bank/GPFSEL0, 10..19 in GPFSEL1, and so on. The earlier
+ *      gpioNo2PinNo indirection mapped the GPIO number to a header pin and then
+ *      indexed the registers by that pin, which addressed the wrong pin on real
+ *      hardware (see docs/DRIVER_REVIEW.md §2.2). The driver now indexes the
+ *      registers directly by GPIO number.
+*/
+namespace {
+    /// @brief BCM2837 exposes GPIO 0..53.
+    constexpr GPIO::gpio_number GPIO_MAX = 53;
+    inline bool valid(GPIO::gpio_number g) { return g <= GPIO_MAX; }
+}
+
+void GPIO::write32(gpio_number gpio_n, std::uint32_t value) {
+    if(valid(gpio_n)) {
+        memory().m_register[gpio_n / 10] = value;
+    }
+}
+
+void GPIO::write(gpio_number gpio_n, RPi3B::GPIORegistersAddress::Config cfg) {
+    /**
+     * @brief First clear the 3-bit FSEL field, then OR in the requested config.
+    */
+    if(valid(gpio_n)) {
+        memory().m_register[(gpio_n / 10)] &= (~(07U << ((gpio_n % 10) * 3U)));
+        memory().m_register[(gpio_n / 10)] |= (cfg << ((gpio_n % 10) * 3U));
+    }
+}
+
+std::uint32_t GPIO::read32(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        return(memory().m_register[gpio_n / 10]);
+    }
+    return(0);
+}
+
+std::uint32_t GPIO::read(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        return((memory().m_register[gpio_n / 10] >> ((gpio_n % 10U) * 3U)) & 0b111);
+    }
+    return(0);
+}
+
+std::uint32_t GPIO::GPLEVn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEV0] >> gpio_n) & 1U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEV1] >> (gpio_n - 32)) & 1U);
+    }
+    return(0);
+}
+
+void GPIO::GPLEVn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEV0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEV1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+void GPIO::output(gpio_number gpio_n) {
+    /* @brief
+     *  Each 32-bit GPFSELn holds ten 3-bit fields. Clear the field first so a
+     *  pin previously set to an alternate function becomes a clean output
+     *  (0b001), instead of OR-ing bit0 into a stale value.
+     */
+    if(valid(gpio_n)) {
+        memory().m_register[(gpio_n / 10)] &= (~(7U << ((gpio_n % 10) * 3U)));
+        memory().m_register[(gpio_n / 10)] |= (1U << ((gpio_n % 10) * 3U));
+    }
+}
+
+void GPIO::input(gpio_number gpio_n) {
+    /* @brief Input mode is 0b000: simply clear the 3-bit FSEL field. */
+    if(valid(gpio_n)) {
+        memory().m_register[(gpio_n / 10)] &= (~(7U << ((gpio_n % 10U) * 3U)));
+    }
+}
+
+void GPIO::GPCLRn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPCLR0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPCLR1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+void GPIO::GPSETn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPSET0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPSET1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPGETn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPSET0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPSET1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPEDSn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPEDS0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPEDS1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPEDSn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPEDS0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPEDS1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPRENn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPREN0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPREN1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPRENn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPREN0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPREN1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPFENn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPFEN0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPFEN1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPFENn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPFEN0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPFEN1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPHENn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPHEN0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPHEN1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPHENn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPHEN0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPHEN1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPLENn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEN0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEN1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPLENn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEN0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPLEN1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPARENn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAREN0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAREN1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPARENn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAREN0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAREN1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPAFENn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAFEN0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAFEN1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPAFENn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAFEN0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPAFEN1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+void GPIO::GPPUD(gpio_number gpio_n, RPi3B::GPIORegistersAddress::PullUpDownConfig cfg) {
+    /* GPPUD is a single global control (2-bit field); gpio_n is not an index. */
+    (void)gpio_n;
+    memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPPUD] &= (~3U);
+    memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPPUD] |= (3U & cfg);
+}
+
+std::uint32_t GPIO::GPPUD(gpio_number gpio_n) const {
+    (void)gpio_n;
+    return(memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPPUD] & 3U);
+}
+
+void GPIO::GPPUDCLKn(gpio_number gpio_n) {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPPUDCLK0] |= (1U << gpio_n);
+        } else {
+            memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPPUDCLK1] |= (1U << (gpio_n - 32));
+        }
+    }
+}
+
+std::uint32_t GPIO::GPPUDCLKn(gpio_number gpio_n) const {
+    if(valid(gpio_n)) {
+        if(gpio_n < 32) {
+            return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPPUDCLK0] >> gpio_n) & 01U);
+        }
+        return((memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPPUDCLK1] >> (gpio_n - 32)) & 01U);
+    }
+    return(0);
+}
+
+#endif /*__gpio_cpp__*/

--- a/modules/rpi3B/src/i2c/i2c.cpp
+++ b/modules/rpi3B/src/i2c/i2c.cpp
@@ -1,0 +1,129 @@
+#ifndef __i2c_cpp__
+#define __i2c_cpp__
+
+#include "i2c.hpp"
+
+namespace {
+    struct field { std::uint32_t shift; std::uint32_t width; };
+
+    /// @brief Bit position/width of each Control (C) register field.
+    field control_field(RPi3B::BSCRegistersAddress::Control f) {
+        switch (f) {
+            case RPi3B::BSCRegistersAddress::Control::READ:  return {0,  1};
+            case RPi3B::BSCRegistersAddress::Control::CLEAR: return {4,  2};
+            case RPi3B::BSCRegistersAddress::Control::ST:    return {7,  1};
+            case RPi3B::BSCRegistersAddress::Control::INTD:  return {8,  1};
+            case RPi3B::BSCRegistersAddress::Control::INTT:  return {9,  1};
+            case RPi3B::BSCRegistersAddress::Control::INTR:  return {10, 1};
+            case RPi3B::BSCRegistersAddress::Control::I2CEN: return {15, 1};
+            default:                                         return {0, 32};
+        }
+    }
+
+    /// @brief Bit position of each Status (S) register field (all width 1).
+    std::uint32_t status_shift(RPi3B::BSCRegistersAddress::Status f) {
+        switch (f) {
+            case RPi3B::BSCRegistersAddress::Status::TA:     return 0;
+            case RPi3B::BSCRegistersAddress::Status::DONE:   return 1;
+            case RPi3B::BSCRegistersAddress::Status::TXW:    return 2;
+            case RPi3B::BSCRegistersAddress::Status::RXR:    return 3;
+            case RPi3B::BSCRegistersAddress::Status::TXD:    return 4;
+            case RPi3B::BSCRegistersAddress::Status::RXD:    return 5;
+            case RPi3B::BSCRegistersAddress::Status::TXE:    return 6;
+            case RPi3B::BSCRegistersAddress::Status::RXF:    return 7;
+            case RPi3B::BSCRegistersAddress::Status::ERR:    return 8;
+            case RPi3B::BSCRegistersAddress::Status::CLKT_TO:return 9;
+            default:                                         return 0;
+        }
+    }
+
+    /// @brief Low `w` bits set, e.g. mask(2) == 0b11.
+    std::uint32_t mask(std::uint32_t w) { return (w >= 32) ? ~0U : ~((~0U) << w); }
+}
+
+void I2C::set_control(RPi3B::BSCRegistersAddress::Control f, value_type value) {
+    auto fld = control_field(f);
+    /* clear the field first, then OR in the (masked) value -- read/modify/write */
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::C] &= ~(mask(fld.width) << fld.shift);
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::C] |= ((value & mask(fld.width)) << fld.shift);
+}
+
+void I2C::clr_control(RPi3B::BSCRegistersAddress::Control f) {
+    auto fld = control_field(f);
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::C] &= ~(mask(fld.width) << fld.shift);
+}
+
+I2C::value_type I2C::get_control(RPi3B::BSCRegistersAddress::Control f) const {
+    auto fld = control_field(f);
+    return (memory().m_register[RPi3B::BSCRegistersAddress::Register::C] >> fld.shift) & mask(fld.width);
+}
+
+void I2C::clr_status(RPi3B::BSCRegistersAddress::Status f) {
+    /* DONE/ERR/CLKT are write-1-to-clear; harmless for the read-only status bits. */
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::S] = (1U << status_shift(f));
+}
+
+I2C::value_type I2C::get_status(RPi3B::BSCRegistersAddress::Status f) const {
+    return (memory().m_register[RPi3B::BSCRegistersAddress::Register::S] >> status_shift(f)) & 1U;
+}
+
+void I2C::enable() {
+    set_control(RPi3B::BSCRegistersAddress::Control::I2CEN, 1);
+}
+
+void I2C::disable() {
+    clr_control(RPi3B::BSCRegistersAddress::Control::I2CEN);
+}
+
+void I2C::slave_address(value_type addr) {
+    /* A register holds a 7-bit slave address. */
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::A] = (addr & 0x7FU);
+}
+
+I2C::value_type I2C::slave_address() const {
+    return memory().m_register[RPi3B::BSCRegistersAddress::Register::A] & 0x7FU;
+}
+
+void I2C::data_length(value_type len) {
+    /* DLEN is a 16-bit byte count. */
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::DLEN] = (len & 0xFFFFU);
+}
+
+I2C::value_type I2C::data_length() const {
+    return memory().m_register[RPi3B::BSCRegistersAddress::Register::DLEN] & 0xFFFFU;
+}
+
+void I2C::clock_divider(value_type divider) {
+    /* DIV is a 16-bit divider of the nominal 150MHz core clock. */
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::DIV] = (divider & 0xFFFFU);
+}
+
+I2C::value_type I2C::clock_divider() const {
+    return memory().m_register[RPi3B::BSCRegistersAddress::Register::DIV] & 0xFFFFU;
+}
+
+void I2C::clear_fifo() {
+    set_control(RPi3B::BSCRegistersAddress::Control::CLEAR, 0b01);
+}
+
+void I2C::start_read() {
+    enable();
+    set_control(RPi3B::BSCRegistersAddress::Control::READ, 1);
+    set_control(RPi3B::BSCRegistersAddress::Control::ST, 1);
+}
+
+void I2C::start_write() {
+    enable();
+    set_control(RPi3B::BSCRegistersAddress::Control::READ, 0);
+    set_control(RPi3B::BSCRegistersAddress::Control::ST, 1);
+}
+
+void I2C::write_byte(value_type byte) {
+    memory().m_register[RPi3B::BSCRegistersAddress::Register::FIFO] = (byte & 0xFFU);
+}
+
+I2C::value_type I2C::read_byte() const {
+    return memory().m_register[RPi3B::BSCRegistersAddress::Register::FIFO] & 0xFFU;
+}
+
+#endif /*__i2c_cpp__*/

--- a/modules/rpi3B/src/interrupt/interrupt.cpp
+++ b/modules/rpi3B/src/interrupt/interrupt.cpp
@@ -1,0 +1,68 @@
+#ifndef __interrupt_cpp__
+#define __interrupt_cpp__
+
+#include "interrupt.hpp"
+
+
+
+/**
+ * @brief
+ *      IRQs 0..31 are controlled by the *_IRQs_1 register (bit = irq number);
+ *      IRQs 32..63 by the *_IRQs_2 register (bit = irq number - 32). The earlier
+ *      code had the register selection inverted and used out-of-range shifts
+ *      (see docs/DRIVER_REVIEW.md §2.4).
+*/
+void IRQ::enable(irq_number irqNumber) {
+    if(irqNumber < 32) {
+        m_memory.m_register[RPi3B::InterruptRegisterAddress::Register::Enable_IRQs_1] |= (1U << irqNumber);
+    } else {
+        m_memory.m_register[RPi3B::InterruptRegisterAddress::Register::Enable_IRQs_2] |= (1U << (irqNumber - 32));
+    }
+}
+
+void IRQ::disable(irq_number irqNumber) {
+    if(irqNumber < 32) {
+        m_memory.m_register[RPi3B::InterruptRegisterAddress::Register::Disable_IRQs_1] |= (1U << irqNumber);
+    } else {
+        m_memory.m_register[RPi3B::InterruptRegisterAddress::Register::Disable_IRQs_2] |= (1U << (irqNumber - 32));
+    }
+}
+
+/**
+ * @brief Report whether the interrupt was enabled, by reading back the bit we
+ *        set in the Enable_IRQs register. This is side-effect free (the previous
+ *        version mutated the read-only pending register during the query) and
+ *        has the &/== precedence fixed.
+*/
+bool IRQ::isEnabled(irq_number number) {
+    if(number < 32) {
+        return(((m_memory.m_register[RPi3B::InterruptRegisterAddress::Register::Enable_IRQs_1] >> number) & 1U) == 1U);
+    }
+    return(((m_memory.m_register[RPi3B::InterruptRegisterAddress::Register::Enable_IRQs_2] >> (number - 32)) & 1U) == 1U);
+}
+
+/**
+ * @brief Install the top-level IRQ/FIQ vector. The architectural IVT has a
+ *        single IRQ (and FIQ) slot; per-peripheral dispatch happens downstream
+ *        of that vector, so IRQNumber does not select a slot here. The previous
+ *        version reinterpret_cast an (uninitialised) function-pointer slot to an
+ *        IVT* and dereferenced it — a wild pointer.
+*/
+void IRQ::install_IRQHandler(std::uint8_t IRQNumber, IVT::pointerToFn cb) {
+    (void)IRQNumber;
+    m_ivt[IVT::Number::IRQ] = cb;
+}
+
+void IRQ::install_FIQHandler(std::uint8_t IRQNumber, IVT::pointerToFn cb) {
+    (void)IRQNumber;
+    m_ivt[IVT::Number::FIQ] = cb;
+}
+
+
+
+
+
+
+
+
+#endif /*__interrupt_cpp__*/

--- a/modules/rpi3B/src/main.cpp
+++ b/modules/rpi3B/src/main.cpp
@@ -1,0 +1,31 @@
+#ifndef __main_cpp__
+#define __main_cpp__
+
+#include "gpio.hpp"
+
+std::int32_t main() {
+    GPIO &gpio = *new GPIO;
+
+    return(0);
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+#endif /*__main_cpp__*/

--- a/modules/rpi3B/src/spi/spi.cpp
+++ b/modules/rpi3B/src/spi/spi.cpp
@@ -1,0 +1,115 @@
+#ifndef __spi_cpp__
+#define __spi_cpp__
+
+#include "spi.hpp"
+
+namespace {
+    struct field { std::uint32_t shift; std::uint32_t width; };
+
+    /// @brief Bit position/width of each CS register field.
+    field cs_field(RPi3B::SPIRegistersAddress::ControlStatus f) {
+        using CS = RPi3B::SPIRegistersAddress::ControlStatus;
+        switch (f) {
+            case CS::CS_LINE:  return {0,  2};
+            case CS::CPHA:     return {2,  1};
+            case CS::CPOL:     return {3,  1};
+            case CS::CLEAR:    return {4,  2};
+            case CS::CSPOL:    return {6,  1};
+            case CS::TA:       return {7,  1};
+            case CS::DMAEN:    return {8,  1};
+            case CS::INTD:     return {9,  1};
+            case CS::INTR:     return {10, 1};
+            case CS::ADCS:     return {11, 1};
+            case CS::REN:      return {12, 1};
+            case CS::LEN:      return {13, 1};
+            case CS::LMONO:    return {14, 1};
+            case CS::TE_EN:    return {15, 1};
+            case CS::DONE:     return {16, 1};
+            case CS::RXD:      return {17, 1};
+            case CS::TXD:      return {18, 1};
+            case CS::RXR:      return {19, 1};
+            case CS::RXF:      return {20, 1};
+            case CS::CSPOL0:   return {21, 1};
+            case CS::CSPOL1:   return {22, 1};
+            case CS::CSPOL2:   return {23, 1};
+            case CS::DMA_LEN:  return {24, 1};
+            case CS::LEN_LONG: return {25, 1};
+            default:           return {0, 32};
+        }
+    }
+
+    std::uint32_t mask(std::uint32_t w) { return (w >= 32) ? ~0U : ~((~0U) << w); }
+}
+
+void SPI::set_cs(RPi3B::SPIRegistersAddress::ControlStatus f, value_type value) {
+    auto fld = cs_field(f);
+    /* clear the field first, then OR in the (masked) value -- read/modify/write */
+    memory().m_register[RPi3B::SPIRegistersAddress::Register::CS] &= ~(mask(fld.width) << fld.shift);
+    memory().m_register[RPi3B::SPIRegistersAddress::Register::CS] |= ((value & mask(fld.width)) << fld.shift);
+}
+
+void SPI::clr_cs(RPi3B::SPIRegistersAddress::ControlStatus f) {
+    auto fld = cs_field(f);
+    memory().m_register[RPi3B::SPIRegistersAddress::Register::CS] &= ~(mask(fld.width) << fld.shift);
+}
+
+SPI::value_type SPI::get_cs(RPi3B::SPIRegistersAddress::ControlStatus f) const {
+    auto fld = cs_field(f);
+    return (memory().m_register[RPi3B::SPIRegistersAddress::Register::CS] >> fld.shift) & mask(fld.width);
+}
+
+void SPI::mode(value_type cpol, value_type cpha) {
+    set_cs(RPi3B::SPIRegistersAddress::ControlStatus::CPOL, cpol);
+    set_cs(RPi3B::SPIRegistersAddress::ControlStatus::CPHA, cpha);
+}
+
+void SPI::chip_select(value_type ce) {
+    set_cs(RPi3B::SPIRegistersAddress::ControlStatus::CS_LINE, ce);
+}
+
+SPI::value_type SPI::chip_select() const {
+    return get_cs(RPi3B::SPIRegistersAddress::ControlStatus::CS_LINE);
+}
+
+void SPI::clock_divider(value_type divider) {
+    /* CLK is a 16-bit divider; SCLK = core_clock / divider. */
+    memory().m_register[RPi3B::SPIRegistersAddress::Register::CLK] = (divider & 0xFFFFU);
+}
+
+SPI::value_type SPI::clock_divider() const {
+    return memory().m_register[RPi3B::SPIRegistersAddress::Register::CLK] & 0xFFFFU;
+}
+
+void SPI::clear_fifo() {
+    set_cs(RPi3B::SPIRegistersAddress::ControlStatus::CLEAR, 0b11);
+}
+
+void SPI::begin_transfer() {
+    set_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA, 1);
+}
+
+void SPI::end_transfer() {
+    clr_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA);
+}
+
+void SPI::write_byte(value_type byte) {
+    memory().m_register[RPi3B::SPIRegistersAddress::Register::FIFO] = (byte & 0xFFU);
+}
+
+SPI::value_type SPI::read_byte() const {
+    return memory().m_register[RPi3B::SPIRegistersAddress::Register::FIFO] & 0xFFU;
+}
+
+bool SPI::is_done() const {
+    return get_cs(RPi3B::SPIRegistersAddress::ControlStatus::DONE) == 1U;
+}
+
+bool SPI::can_write() const {
+    return get_cs(RPi3B::SPIRegistersAddress::ControlStatus::TXD) == 1U;
+}
+
+bool SPI::can_read() const {
+    return get_cs(RPi3B::SPIRegistersAddress::ControlStatus::RXD) == 1U;
+}
+
+#endif /*__spi_cpp__*/

--- a/modules/rpi3B/test/CMakeLists.txt
+++ b/modules/rpi3B/test/CMakeLists.txt
@@ -1,0 +1,33 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(rpi3B_test CXX)
+
+find_package(GTest REQUIRED)
+
+# Test TUs use the C++20 abbreviated-template ctors (DRIVER(region)).
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_options(-Wall -Wextra)
+
+# Only the test translation units here; the driver code comes from the
+# rpi3b_driver library defined by the parent CMakeLists (no recompiling the
+# src/*/*.cpp files, no double definitions).
+file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+add_executable(rpi3B_test ${TEST_SOURCES})
+target_link_libraries(rpi3B_test
+                        rpi3b_driver
+                        GTest::gtest
+                        GTest::gtest_main
+                        pthread)
+
+include(GoogleTest)
+if(RPI3B_TOP_LEVEL)
+    # Native build: enumerate cases by running the binary on the host.
+    gtest_discover_tests(rpi3B_test)
+else()
+    # Cross build (e.g. Yocto): never execute the target binary at build time.
+    add_test(NAME rpi3B_test COMMAND rpi3B_test)
+endif()
+
+# Installed so an on-target systemd oneshot can run the suite as a self-test.
+install(TARGETS rpi3B_test RUNTIME DESTINATION bin)

--- a/modules/rpi3B/test/clock_test.cpp
+++ b/modules/rpi3B/test/clock_test.cpp
@@ -1,0 +1,156 @@
+#ifndef __clock_test_cpp__
+#define __clock_test_cpp__
+
+#include "clock_test.hpp"
+
+void CLOCKTest::SetUp() {
+    
+}
+
+void CLOCKTest::TearDown() {
+
+}
+
+void CLOCKTest::TestBody() {
+
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP0DIV_Read_DIVI) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI, 35);
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 35);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP1DIV_Read_DIVI) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI, 35);
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 35);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP2DIV_Read_DIVI) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI, 35);
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 35);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP0DIV_Read_DIVF) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF, 492);
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 492);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP1DIV_Read_DIVF) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF, 492);
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 492);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP2DIV_Read_DIVF) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF, 492);
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 492);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP0DIV_Read_BOTH) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((35 << 12) | 492));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 492);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 35);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP1DIV_Read_BOTH) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((35 << 12) | 492));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 492);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 35);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP2DIV_Read_BOTH) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((35 << 12) | 492));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 492);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 35);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP0DIV_Write_BOTH) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((0xFFF << 12) | 0xFFF));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 0xFFF);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 0xFFF);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP1DIV_Write_BOTH) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((0xFF2 << 12) | 0xFFD));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 0xFFD);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP1DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 0xFF2);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP2DIV_Write_BOTH) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((0x1 << 12) | 0x1));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 0x1);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 0x1);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP2DIV_Write_BOTH_Var1) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((21 << 12) | 854));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 854);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 21);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP2DIV_Write_BOTH_Var2) {
+    clock().write(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::BOTH_VALUE, ((10 << 12) | 939));
+    auto res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVF);
+    EXPECT_EQ(res, 939);
+    res = clock().read(RPi3B::ClockRegistersAddress::Register::CM_GP2DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(res, 10);
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP2DIV_clr_CM_GPnDIV_n0) {
+    clock().set_CM_GPnDIV(RPi3B::ClockRegistersAddress::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI, 429);
+    auto value = clock().get_CM_GPnDIV(RPi3B::ClockRegistersAddress::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(value, 429);
+    clock().clr_CM_GPnDIV(RPi3B::ClockRegistersAddress::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    value = clock().get_CM_GPnDIV(RPi3B::ClockRegistersAddress::CM_GP0DIV, RPi3B::ClockRegistersAddress::ClockDivisor::DIVI);
+    EXPECT_EQ(value, 0);
+    
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP0CTL_clr_CM_GP0CTL_SRC) {
+    clock().set_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::SRC, 5);
+    auto value = clock().get_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::SRC);
+    EXPECT_EQ(value, 5);
+    clock().clr_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::SRC);
+    value = clock().get_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::SRC);
+    EXPECT_EQ(value, 0);
+    
+}
+
+TEST_F(CLOCKTest, ClockRegister_CM_GP0CTL_clr_CM_GP0CTL_MASH) {
+    clock().set_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::SRC, 6);
+    auto value = clock().get_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::SRC);
+    EXPECT_EQ(value, 6);
+    clock().set_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::MASH, 1);
+    value = clock().get_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::ALL);
+    ::printf("SRC+MASH 0x%X\n", value);
+    value = clock().get_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::MASH);
+    EXPECT_EQ(value, 1);
+    clock().clr_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::MASH);
+    value = clock().get_CM_GPnCTL(RPi3B::ClockRegistersAddress::CM_GP0CTL, RPi3B::ClockRegistersAddress::MASH);
+    ::printf("0x%X\n", value);
+    EXPECT_EQ(value, 0);
+    
+}
+
+#endif /*__clock_test_cpp__*/

--- a/modules/rpi3B/test/clock_test.hpp
+++ b/modules/rpi3B/test/clock_test.hpp
@@ -1,0 +1,42 @@
+#ifndef __clock_test_hpp__
+#define __clock_test_hpp__
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+
+#include "clock.hpp"
+
+class CLOCKTest : public ::testing::Test
+{
+    public:
+        /**
+         * @brief Memory region for CLOCK instance will be taken from m_memory_region,
+         *        the CLOCK instance layout will be done from m_memory_region.
+        */
+        CLOCKTest() : m_memory_region(RPi3B::ClockRegistersAddress::Register::CM_GPn_MAX), 
+                      m_clock(CLOCK(m_memory_region.data())) {
+            /*
+            ::printf("start memory_region: 0x%X ", m_memory_region.data());
+            ::printf("end memory_region: 0x%X ", m_memory_region.data() + GPIORegistersAddress::Register::BCM2837_MAX+1);
+            ::printf("GPIO: 0x%X ", &m_gpio.memory().m_register[0]);
+            */
+        }
+        virtual ~CLOCKTest() override = default;
+        
+        virtual void SetUp() override;
+        virtual void TearDown() override;
+        virtual void TestBody() override;
+
+        CLOCK clock() const {
+            return(m_clock);
+        }
+
+    private:
+        std::vector<std::uint32_t> m_memory_region;
+        CLOCK m_clock;
+};
+
+#endif /*__clock_test_hpp__*/

--- a/modules/rpi3B/test/gpio_test.cpp
+++ b/modules/rpi3B/test/gpio_test.cpp
@@ -1,0 +1,437 @@
+#ifndef __gpio_test_cpp__
+#define __gpio_test_cpp__
+
+#include "gpio_test.hpp"
+#include <vector>
+
+void GPIOTest::SetUp() {
+
+    m_gpio2PinMap = {
+        {"GPIO_Number_1", "GPIO_PIN_"},
+        {"GPIO_Number_2", "GPIO_PIN_3"},
+        {"GPIO_Number_3", "GPIO_PIN_5"},
+        {"GPIO_Number_4", "GPIO_PIN_7"},
+        {"GPIO_Number_5", "GPIO_PIN_29"},
+        {"GPIO_Number_6", "GPIO_PIN_31"},
+        {"GPIO_Number_7", "GPIO_PIN_26"},
+        {"GPIO_Number_8", "GPIO_PIN_24"},
+        {"GPIO_Number_9", "GPIO_PIN_21"},
+        {"GPIO_Number_10", "GPIO_PIN_19"},
+        {"GPIO_Number_11", "GPIO_PIN_23"},
+        {"GPIO_Number_12", "GPIO_PIN_32"},
+        {"GPIO_Number_13", "GPIO_PIN_33"},
+        {"GPIO_Number_14", "GPIO_PIN_8"},
+        {"GPIO_Number_15", "GPIO_PIN_10"},
+        {"GPIO_Number_16", "GPIO_PIN_36"},
+        {"GPIO_Number_17", "GPIO_PIN_11"},
+        {"GPIO_Number_18", "GPIO_PIN_12"},
+        {"GPIO_Number_19", "GPIO_PIN_35"},
+        {"GPIO_Number_20", "GPIO_PIN_38"},
+        {"GPIO_Number_21", "GPIO_PIN_40"},
+        {"GPIO_Number_22", "GPIO_PIN_15"},
+        {"GPIO_Number_23", "GPIO_PIN_16"},
+        {"GPIO_Number_24", "GPIO_PIN_18"},
+        {"GPIO_Number_25", "GPIO_PIN_22"},
+        {"GPIO_Number_26", "GPIO_PIN_37"},
+        {"GPIO_Number_27", "GPIO_PIN_13"},
+        {"GPIO_Number_28", "GPIO_PIN_"},
+        {"GPIO_Number_29", "GPIO_PIN_"},
+        {"GPIO_Number_30", "GPIO_PIN_"},
+        {"GPIO_Number_31", "GPIO_PIN_"},
+        {"GPIO_Number_32", "GPIO_PIN_"},
+        {"GPIO_Number_33", "GPIO_PIN_"},
+        {"GPIO_Number_34", "GPIO_PIN_"},
+        {"GPIO_Number_35", "GPIO_PIN_"},
+        {"GPIO_Number_36", "GPIO_PIN_"},
+        {"GPIO_Number_37", "GPIO_PIN_"},
+        {"GPIO_Number_38", "GPIO_PIN_"},
+        {"GPIO_Number_39", "GPIO_PIN_"},
+        {"GPIO_Number_40", "GPIO_PIN_"},
+        {"GPIO_Number_41", "GPIO_PIN_"},
+        {"GPIO_Number_42", "GPIO_PIN_"},
+        {"GPIO_Number_43", "GPIO_PIN_"},
+        {"GPIO_Number_44", "GPIO_PIN_"},
+        {"GPIO_Number_45", "GPIO_PIN_"},
+        {"GPIO_Number_46", "GPIO_PIN_"},
+        {"GPIO_Number_47", "GPIO_PIN_"},
+        {"GPIO_Number_48", "GPIO_PIN_"},
+        {"GPIO_Number_49", "GPIO_PIN_"},
+        {"GPIO_Number_50", "GPIO_PIN_"},
+    };
+}
+
+void GPIOTest::TearDown() {
+
+}
+
+void GPIOTest::TestBody() {
+
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_InputMode) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::InputMode);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "gpio in Result:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::InputMode);
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_OutputMode) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "gpio out Result:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::OutputMode);
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_AlternateFunction0) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction0);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "AlternateFunction0:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction0);
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_AlternateFunction1) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction1);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "AlternateFunction1:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction1);
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_AlternateFunction2) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction2);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "AlternateFunction2:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction2);
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_AlternateFunction3) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction3);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "AlternateFunction3:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction3);
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_AlternateFunction4) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction4);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "AlternateFunction4:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction4);
+}
+
+TEST_F(GPIOTest, GPIO_Number_12_AlternateFunction5) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 32
+    */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction5);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "AlternateFunction5:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction5);
+}
+
+TEST_F(GPIOTest, GPIO_Number_2to9_OutputMode) {
+
+    GPIO::gpio_number gpio_n = 2;
+    for(; gpio_n < 10; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    }
+
+    gpio_n = 2;
+    for(; gpio_n < 10; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::OutputMode);    
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_10to19_OutputMode) {
+
+    GPIO::gpio_number gpio_n = 10;
+    for(; gpio_n < 20; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    }
+
+    gpio_n = 10;
+    for(; gpio_n < 20; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_20to27_OutputMode) {
+
+    GPIO::gpio_number gpio_n = 20;
+    for(; gpio_n < 28; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    }
+
+    gpio_n = 20;
+    for(; gpio_n < 28; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    }
+}
+
+#if 0
+TEST_F(GPIOTest, GPIO_Number_30to39_OutputMode) {
+
+    GPIO::gpio_number gpio_n = 30;
+    for(; gpio_n < 40; ++gpio_n) {
+        gpio().write(gpio_n, GPIORegistersAddress::Config::OutputMode);
+    }
+
+    gpio_n = 30;
+    auto res = gpio().read32(gpio_n);
+    //std::cout << "GPIO 30 to 39: 0x" << std::hex << res << std::dec << std::endl;
+
+    EXPECT_EQ(res, 0x9249249);
+}
+
+TEST_F(GPIOTest, GPIO_Number_40to49_OutputMode) {
+
+    GPIO::gpio_number gpio_n = 40;
+    for(; gpio_n < 50; ++gpio_n) {
+        gpio().write(gpio_n, GPIORegistersAddress::Config::OutputMode);
+    }
+
+    gpio_n = 40;
+    auto res = gpio().read32(gpio_n);
+    //std::cout << "GPIO 40 to 49: 0x" << std::hex << res << std::dec << std::endl;
+
+    EXPECT_EQ(res, 0x9249249);
+}
+
+TEST_F(GPIOTest, GPIO_Number_50to53_OutputMode) {
+
+    GPIO::gpio_number gpio_n = 50;
+    for(; gpio_n < 54; ++gpio_n) {
+        gpio().write(gpio_n, GPIORegistersAddress::Config::OutputMode);
+    }
+
+    gpio_n = 50;
+    auto res = gpio().read32(gpio_n);
+    //std::cout << "GPIO 50 to 53: 0x" << std::hex << res << std::dec << std::endl;
+
+    EXPECT_EQ(res, 0x249);
+}
+#endif
+
+TEST_F(GPIOTest, GPIO_Number_2to9_AlternateFunction0) {
+
+    GPIO::gpio_number gpio_n = 2;
+    for(; gpio_n < 10; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction0);
+    }
+
+    gpio_n = 2;
+    for(; gpio_n < 10; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction0);
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_10to19_AlternateFunction2) {
+
+    GPIO::gpio_number gpio_n = 10;
+    for(; gpio_n < 20; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction2);
+    }
+
+    gpio_n = 10;
+    for(; gpio_n < 20; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction2);
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_20to27_AlternateFunction5) {
+
+    GPIO::gpio_number gpio_n = 20;
+    for(; gpio_n < 28; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction5);
+    }
+
+    gpio_n = 20;
+    for(; gpio_n < 28; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction5);
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_2to19_InputMode) {
+
+    GPIO::gpio_number gpio_n = 2;
+    for(; gpio_n < 20; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::InputMode);
+    }
+
+    gpio_n = 2;
+    for(; gpio_n < 20; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::InputMode);
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_2to19_OutputMode_AlternateFunction3) {
+
+    GPIO::gpio_number gpio_n = 2;
+    for(; gpio_n < 10; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    }
+
+    for(; gpio_n < 20; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction3);
+    }
+
+    gpio_n = 2;
+    for(; gpio_n < 10; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    }
+
+    for(; gpio_n < 20; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction3);
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_20to27_InputMode_AlternateFunction4) {
+
+    GPIO::gpio_number gpio_n = 20;
+    for(; gpio_n < 25; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::InputMode);
+    }
+
+    for(; gpio_n < 28; ++gpio_n) {
+        gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction4);
+    }
+
+    gpio_n = 20;
+    for(; gpio_n < 25; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::InputMode);    
+    }
+
+    for(; gpio_n < 28; ++gpio_n) {
+        auto res = gpio().read(gpio_n);
+        EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::AlternateFunction4);    
+    }
+}
+
+TEST_F(GPIOTest, GPIO_Number_0to31_GPSETn) {
+
+    GPIO::gpio_number gpio_n = 0;
+    for(; gpio_n < 32; ++gpio_n) {
+        gpio().GPSETn(gpio_n);
+    }
+
+    gpio_n = 20;
+    auto res = gpio().GPGETn(gpio_n);
+    //std::cout << "GPIO 0 to 31: 0x" << std::hex << res << std::dec << std::endl;
+
+    EXPECT_EQ(res, 01);
+}
+
+TEST_F(GPIOTest, GPIO_Number_32to53_GPSETn) {
+
+    GPIO::gpio_number gpio_n = 32;
+    for(; gpio_n < 54; ++gpio_n) {
+        gpio().GPSETn(gpio_n);
+    }
+
+    gpio_n = 40;
+    auto res = gpio().GPGETn(gpio_n);
+    //std::cout << "GPIO 32 to 53: 0x" << std::hex << res << std::dec << std::endl;
+
+    EXPECT_EQ(res, 01);
+}
+
+TEST_F(GPIOTest, GPIO_Number_14_InputMode) {
+
+    /**
+     * GPIONumber 12 is mapped to GPIO PIN 8
+    */
+    GPIO::gpio_number gpio_n = 14;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::InputMode);
+    auto res = gpio().read(gpio_n);
+    //std::cout << "gpio in Result:" << std::to_string(res) << std::endl;
+    EXPECT_EQ(res, RPi3B::GPIORegistersAddress::Config::InputMode);
+}
+
+/* --- Regression tests for the fixes in docs/DRIVER_REVIEW.md §2.2 --- */
+
+TEST_F(GPIOTest, Output_Clears_Stale_AlternateFunction) {
+    /* output() must clear the 3-bit FSEL field, not OR bit0 into a stale value. */
+    GPIO::gpio_number gpio_n = 12;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction0); // 0b100
+    gpio().output(gpio_n);
+    EXPECT_EQ(gpio().read(gpio_n), RPi3B::GPIORegistersAddress::Config::OutputMode); // 0b001
+}
+
+TEST_F(GPIOTest, Input_Clears_Field_And_Is_Readable) {
+    GPIO::gpio_number gpio_n = 7;
+    gpio().write(gpio_n, RPi3B::GPIORegistersAddress::Config::AlternateFunction3);
+    gpio().input(gpio_n);
+    EXPECT_EQ(gpio().read(gpio_n), RPi3B::GPIORegistersAddress::Config::InputMode); // 0b000
+}
+
+TEST_F(GPIOTest, FSEL_Indexed_By_BCM_GPIO_Number) {
+    /* GPIO 10 is the first field of GPFSEL1, regardless of header pin. */
+    gpio().write(10, RPi3B::GPIORegistersAddress::Config::OutputMode);
+    auto reg = gpio().memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPFSEL1].load();
+    EXPECT_EQ(reg & 0b111, RPi3B::GPIORegistersAddress::Config::OutputMode);
+}
+
+TEST_F(GPIOTest, GPSETn_Below32_Does_Not_Touch_Bank1) {
+    gpio().GPSETn(20);
+    EXPECT_EQ(gpio().GPGETn(20), 1U);
+    EXPECT_EQ(gpio().memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPSET1].load(), 0U);
+}
+
+TEST_F(GPIOTest, GPSETn_AtOrAbove32_Targets_Bank1) {
+    gpio().GPSETn(40);
+    EXPECT_EQ(gpio().GPGETn(40), 1U);
+    auto reg = gpio().memory().m_register[RPi3B::GPIORegistersAddress::Register::BCM2837_GPSET1].load();
+    EXPECT_EQ((reg >> 8) & 1U, 1U); /* gpio 40 -> bank1 bit 8 */
+}
+
+TEST_F(GPIOTest, Out_Of_Range_GPIO_Is_NoOp) {
+    EXPECT_EQ(gpio().read(99), 0U);
+    EXPECT_EQ(gpio().GPGETn(99), 0U);
+}
+
+#endif /*__gpio_test_cpp__*/

--- a/modules/rpi3B/test/gpio_test.hpp
+++ b/modules/rpi3B/test/gpio_test.hpp
@@ -1,0 +1,44 @@
+#ifndef __gpio_test_hpp__
+#define __gpio_test_hpp__
+
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+
+#include "gpio.hpp"
+
+class GPIOTest : public ::testing::Test
+{
+    public:
+        /**
+         * @brief Memory region for GPIO instance will be taken from m_memory_region,
+         *        the GPIO instance layout will be done from m_memory_region.
+        */
+        GPIOTest() : m_memory_region(RPi3B::GPIORegistersAddress::Register::BCM2837_MAX), m_gpio(GPIO(m_memory_region.data())) {
+            /*
+            ::printf("start memory_region: 0x%X ", m_memory_region.data());
+            ::printf("end memory_region: 0x%X ", m_memory_region.data() + GPIORegistersAddress::Register::BCM2837_MAX+1);
+            ::printf("GPIO: 0x%X ", &m_gpio.memory().m_register[0]);
+            */
+        }
+        virtual ~GPIOTest() override = default;
+        
+        virtual void SetUp() override;
+        virtual void TearDown() override;
+        virtual void TestBody() override;
+
+        GPIO gpio() const {
+            return(m_gpio);
+        }
+
+    private:
+        std::vector<std::uint32_t> m_memory_region;
+        GPIO m_gpio;
+        std::unordered_map<std::string, std::string> m_gpio2PinMap;
+};
+
+
+#endif /*__gpio_test_hpp__*/

--- a/modules/rpi3B/test/i2c_test.cpp
+++ b/modules/rpi3B/test/i2c_test.cpp
@@ -1,0 +1,77 @@
+#ifndef __i2c_test_cpp__
+#define __i2c_test_cpp__
+
+#include "i2c_test.hpp"
+
+void I2CTest::SetUp() {}
+void I2CTest::TearDown() {}
+void I2CTest::TestBody() {}
+
+TEST_F(I2CTest, Enable_Disable) {
+    i2c().enable();
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::I2CEN), 1U);
+    i2c().disable();
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::I2CEN), 0U);
+}
+
+TEST_F(I2CTest, Control_Field_SetClrGet) {
+    i2c().set_control(RPi3B::BSCRegistersAddress::Control::INTR, 1);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::INTR), 1U);
+    i2c().clr_control(RPi3B::BSCRegistersAddress::Control::INTR);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::INTR), 0U);
+}
+
+TEST_F(I2CTest, Control_Multibit_CLEAR_Field) {
+    /* CLEAR is a 2-bit field at bits[5:4]. */
+    i2c().set_control(RPi3B::BSCRegistersAddress::Control::CLEAR, 0b10);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::CLEAR), 0b10U);
+}
+
+TEST_F(I2CTest, Control_Fields_Are_Independent) {
+    /* Setting one field must not disturb another (read/modify/write). */
+    i2c().set_control(RPi3B::BSCRegistersAddress::Control::I2CEN, 1);
+    i2c().set_control(RPi3B::BSCRegistersAddress::Control::READ, 1);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::I2CEN), 1U);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::READ), 1U);
+    i2c().clr_control(RPi3B::BSCRegistersAddress::Control::READ);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::I2CEN), 1U);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::READ), 0U);
+}
+
+TEST_F(I2CTest, Start_Read_Sets_READ_ST_EN) {
+    i2c().start_read();
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::I2CEN), 1U);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::READ), 1U);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::ST), 1U);
+}
+
+TEST_F(I2CTest, Start_Write_Clears_READ) {
+    i2c().start_write();
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::READ), 0U);
+    EXPECT_EQ(i2c().get_control(RPi3B::BSCRegistersAddress::Control::ST), 1U);
+}
+
+TEST_F(I2CTest, Slave_Address_Masked_To_7bits) {
+    i2c().slave_address(0x1FF);
+    EXPECT_EQ(i2c().slave_address(), 0x7FU);
+}
+
+TEST_F(I2CTest, DataLength_And_ClockDivider) {
+    i2c().data_length(34);
+    EXPECT_EQ(i2c().data_length(), 34U);
+    i2c().clock_divider(2500);
+    EXPECT_EQ(i2c().clock_divider(), 2500U);
+}
+
+TEST_F(I2CTest, FIFO_RoundTrip) {
+    i2c().write_byte(0xA5);
+    EXPECT_EQ(i2c().read_byte(), 0xA5U);
+}
+
+TEST_F(I2CTest, Status_Read) {
+    /* With a zeroed buffer all status bits read 0. */
+    EXPECT_EQ(i2c().get_status(RPi3B::BSCRegistersAddress::Status::DONE), 0U);
+    EXPECT_EQ(i2c().get_status(RPi3B::BSCRegistersAddress::Status::TA), 0U);
+}
+
+#endif /*__i2c_test_cpp__*/

--- a/modules/rpi3B/test/i2c_test.hpp
+++ b/modules/rpi3B/test/i2c_test.hpp
@@ -1,0 +1,33 @@
+#ifndef __i2c_test_hpp__
+#define __i2c_test_hpp__
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "i2c.hpp"
+
+class I2CTest : public ::testing::Test
+{
+    public:
+        /**
+         * @brief Memory region for the I2C instance is taken from
+         *        m_memory_region so register access hits the buffer, not MMIO.
+        */
+        I2CTest() : m_memory_region(RPi3B::BSCRegistersAddress::Register::BSC_MAX),
+                    m_i2c(I2C(m_memory_region.data())) {}
+        virtual ~I2CTest() override = default;
+
+        virtual void SetUp() override;
+        virtual void TearDown() override;
+        virtual void TestBody() override;
+
+        I2C i2c() const {
+            return(m_i2c);
+        }
+
+    private:
+        std::vector<std::uint32_t> m_memory_region;
+        I2C m_i2c;
+};
+
+#endif /*__i2c_test_hpp__*/

--- a/modules/rpi3B/test/interrupt_test.cpp
+++ b/modules/rpi3B/test/interrupt_test.cpp
@@ -1,0 +1,72 @@
+#ifndef __interrupt_test_cpp__
+#define __interrupt_test_cpp__
+
+#include "interrupt_test.hpp"
+
+void IRQTest::SetUp() {
+    
+}
+
+void IRQTest::TearDown() {
+
+}
+
+void IRQTest::TestBody() {
+
+}
+
+TEST_F(IRQTest, Irq) {
+    /*
+     * Refer 7.5 Section of BCM2837-ARM-Peripherals.pdf
+     * IRQ Number  Name
+     *   48         smi
+         49         gpio_int[0]
+         50         gpio_int[1]
+         51         gpio_int[2]
+         52         gpio_int[3]
+         53         i2c_int
+         54         spi_int
+         55         pcm_int
+         56
+         57         uart_int
+     */
+    ::printf("0x%X\n", irq());
+    //::printf("0x%X\n", &irq()[IVT::Reset]);
+    //::printf("0x%X\n", &irq()[IVT::UndefinedInstruction]);
+    //::printf("0x%X\n", &irq()[IVT::SWI]);
+}
+
+/* --- Regression tests for the fixes in docs/DRIVER_REVIEW.md §2.4 --- */
+
+TEST_F(IRQTest, Enable_Below32_Uses_Bank1_And_IsEnabled) {
+    irq().enable(20);
+    EXPECT_TRUE(irq().isEnabled(20));
+    EXPECT_FALSE(irq().isEnabled(21));
+}
+
+TEST_F(IRQTest, Enable_AtOrAbove32_Uses_Bank2) {
+    /* IRQ 53 == i2c_int (see table above): bank2, bit 21. */
+    irq().enable(53);
+    EXPECT_TRUE(irq().isEnabled(53));
+    EXPECT_FALSE(irq().isEnabled(20)); /* a different bank stays clear */
+}
+
+TEST_F(IRQTest, Disable_Sets_Disable_Register) {
+    irq().disable(54); /* spi_int */
+    EXPECT_TRUE(irq().isEnabled(54) == false); /* not enabled; nothing in enable reg */
+}
+
+TEST_F(IRQTest, Install_Handlers_Does_Not_Crash) {
+    /* Previously dereferenced a wild pointer; must now be a safe assignment. */
+    irq().install_IRQHandler(53, []{});
+    irq().install_FIQHandler(54, []{});
+    SUCCEED();
+}
+
+
+
+
+
+
+
+#endif /*__interrupt_test_cpp__*/

--- a/modules/rpi3B/test/interrupt_test.hpp
+++ b/modules/rpi3B/test/interrupt_test.hpp
@@ -1,0 +1,48 @@
+#ifndef __interrupt_test_hpp__
+#define __interrupt_test_hpp__
+
+
+#include <gtest/gtest.h>
+#include <sstream>
+#include <vector>
+#include <algorithm>
+#include <unordered_map>
+
+#include "interrupt.hpp"
+
+class IRQTest : public ::testing::Test
+{
+    public:
+        /**
+         * @brief Memory region for IRQ instance will be taken from m_memory_region,
+         *        the IRQ instance layout will be done from m_memory_region.
+        */
+        IRQTest() : m_memory_region(RPi3B::InterruptRegisterAddress::Register::IRQs_ALL_MAX), 
+                    m_irq(IRQ(m_memory_region.data())) {
+            
+        }
+
+        virtual ~IRQTest() override = default;
+        
+        virtual void SetUp() override;
+        virtual void TearDown() override;
+        virtual void TestBody() override;
+
+        IRQ irq() const {
+            return(m_irq);
+        }
+
+    private:
+        std::vector<std::uint32_t> m_memory_region;
+        IRQ m_irq;
+};
+
+
+
+
+
+
+
+
+
+#endif /*__interrupt_test_hpp__*/

--- a/modules/rpi3B/test/main_test.cpp
+++ b/modules/rpi3B/test/main_test.cpp
@@ -1,0 +1,14 @@
+#ifndef __main_test_cpp__
+#define __main_test_cpp__
+
+#include "gpio_test.hpp"
+
+
+int main(int argc, char **argv) {
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}
+
+
+
+#endif /*__main_test_cpp__*/

--- a/modules/rpi3B/test/spi_test.cpp
+++ b/modules/rpi3B/test/spi_test.cpp
@@ -1,0 +1,67 @@
+#ifndef __spi_test_cpp__
+#define __spi_test_cpp__
+
+#include "spi_test.hpp"
+
+void SPITest::SetUp() {}
+void SPITest::TearDown() {}
+void SPITest::TestBody() {}
+
+TEST_F(SPITest, CS_Field_SetClrGet) {
+    spi().set_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA, 1);
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA), 1U);
+    spi().clr_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA);
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA), 0U);
+}
+
+TEST_F(SPITest, ChipSelect_TwoBitField) {
+    spi().chip_select(2);
+    EXPECT_EQ(spi().chip_select(), 2U);
+    /* value must be confined to bits[1:0] */
+    spi().chip_select(0b11);
+    EXPECT_EQ(spi().chip_select(), 0b11U);
+}
+
+TEST_F(SPITest, Mode_Sets_CPOL_CPHA) {
+    spi().mode(1, 1);
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::CPOL), 1U);
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::CPHA), 1U);
+}
+
+TEST_F(SPITest, Begin_End_Transfer) {
+    spi().begin_transfer();
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA), 1U);
+    spi().end_transfer();
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::TA), 0U);
+}
+
+TEST_F(SPITest, Clear_FIFO_SetsBothBits) {
+    spi().clear_fifo();
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::CLEAR), 0b11U);
+}
+
+TEST_F(SPITest, High_Bit_Field_CSPOL2) {
+    /* CSPOL2 lives at bit23 -- exercises high-bit field math. */
+    spi().set_cs(RPi3B::SPIRegistersAddress::ControlStatus::CSPOL2, 1);
+    EXPECT_EQ(spi().get_cs(RPi3B::SPIRegistersAddress::ControlStatus::CSPOL2), 1U);
+    /* Setting a high bit must not bleed into CS_LINE at bits[1:0]. */
+    EXPECT_EQ(spi().chip_select(), 0U);
+}
+
+TEST_F(SPITest, ClockDivider) {
+    spi().clock_divider(256);
+    EXPECT_EQ(spi().clock_divider(), 256U);
+}
+
+TEST_F(SPITest, FIFO_RoundTrip) {
+    spi().write_byte(0x3C);
+    EXPECT_EQ(spi().read_byte(), 0x3CU);
+}
+
+TEST_F(SPITest, Status_Helpers_DefaultZero) {
+    EXPECT_FALSE(spi().is_done());
+    EXPECT_FALSE(spi().can_write());
+    EXPECT_FALSE(spi().can_read());
+}
+
+#endif /*__spi_test_cpp__*/

--- a/modules/rpi3B/test/spi_test.hpp
+++ b/modules/rpi3B/test/spi_test.hpp
@@ -1,0 +1,33 @@
+#ifndef __spi_test_hpp__
+#define __spi_test_hpp__
+
+#include <gtest/gtest.h>
+#include <vector>
+
+#include "spi.hpp"
+
+class SPITest : public ::testing::Test
+{
+    public:
+        /**
+         * @brief Memory region for the SPI instance is taken from
+         *        m_memory_region so register access hits the buffer, not MMIO.
+        */
+        SPITest() : m_memory_region(RPi3B::SPIRegistersAddress::Register::SPI_MAX),
+                    m_spi(SPI(m_memory_region.data())) {}
+        virtual ~SPITest() override = default;
+
+        virtual void SetUp() override;
+        virtual void TearDown() override;
+        virtual void TestBody() override;
+
+        SPI spi() const {
+            return(m_spi);
+        }
+
+    private:
+        std::vector<std::uint32_t> m_memory_region;
+        SPI m_spi;
+};
+
+#endif /*__spi_test_hpp__*/

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/rpi3b-selftest.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/rpi3b-selftest.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=rpi3B driver self-test (GoogleTest register bit-layout suite)
+Documentation=https://github.com/naushada/rpi3B
+After=local-fs.target
+# Validation oneshot: runs the rpi3B GPIO/CLOCK/IRQ/I2C/SPI register-layout
+# tests once at boot and records pass/fail in the journal. It exercises the
+# bit math over heap-backed placement-new regions, so it needs no hardware
+# access and does not poke real MMIO.
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/usr/bin/rpi3B_test --gtest_brief=1
+StandardOutput=journal
+StandardError=journal
+
+# No privileges / no device access required — the suite is pure userspace.
+DynamicUser=yes
+NoNewPrivileges=yes
+ProtectSystem=strict
+ProtectHome=yes
+PrivateDevices=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -61,6 +61,7 @@ SRC_URI = "\
     file://iot-dump \
     file://iot-ds-seed \
     file://iot-ds-seed.service \
+    file://rpi3b-selftest.service \
 "
 
 # Optional, gitignored WiFi credential seed. When an integrator drops
@@ -105,13 +106,15 @@ DEPENDS = "\
 "
 
 # ── PACKAGECONFIG ──────────────────────────────────────────────────
-# mongo:   Enables mongocxx/bsoncxx link (~15 MB in final image).
-#          Required for the RegistryMirror feature (db_adapter.cpp).
-#          Disable for resource-constrained embedded targets.
-# gtest:   Builds unit-test binaries. Dev-only; OFF by default.
-# systemd: Installs systemd unit files + env files + tmpfiles.d.
-#          Auto-detected from DISTRO_FEATURES.
-PACKAGECONFIG ??= "mongo \
+# mongo:          Enables mongocxx/bsoncxx link (~15 MB in final image).
+#                 Required for the RegistryMirror feature (db_adapter.cpp).
+#                 Disable for resource-constrained embedded targets.
+# gtest:          Builds the iot apps unit-test binaries. Dev-only; OFF by default.
+# rpi3b-selftest: Builds the rpi3B driver gtest suite (modules/rpi3B submodule)
+#                 and ships it as the rpi3b-selftest.service boot oneshot.
+# systemd:        Installs systemd unit files + env files + tmpfiles.d.
+#                 Auto-detected from DISTRO_FEATURES.
+PACKAGECONFIG ??= "mongo rpi3b-selftest \
                    ${@bb.utils.contains('DISTRO_FEATURES', 'systemd', 'systemd', '', d)} \
 "
 
@@ -134,6 +137,15 @@ PACKAGECONFIG[gtest] = "\
       -DBUILD_NET_ROUTER_TESTS=OFF \
       -DBUILD_WIFI_CLIENT_TESTS=OFF \
       -DBUILD_HTTP_SERVER_TESTS=OFF, \
+    gtest, \
+"
+
+# rpi3B driver self-test. When enabled, apps/CMakeLists.txt flips the rpi3B
+# submodule's RPI3B_BUILD_TESTS on (building /usr/bin/rpi3B_test) and pulls in
+# gtest. Disabled → only the rpi3b_driver static lib is built (no gtest dep).
+PACKAGECONFIG[rpi3b-selftest] = "\
+    -DIOT_BUILD_RPI3B_SELFTEST=ON, \
+    -DIOT_BUILD_RPI3B_SELFTEST=OFF, \
     gtest, \
 "
 
@@ -270,6 +282,13 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-httpd.service          ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-ds-seed.service        ${D}${systemd_system_unitdir}/
 
+        # rpi3B driver self-test oneshot (only when the PACKAGECONFIG is enabled;
+        # the /usr/bin/rpi3B_test binary is produced by the rpi3B submodule's
+        # cmake install when -DIOT_BUILD_RPI3B_SELFTEST=ON).
+        if ${@bb.utils.contains('PACKAGECONFIG', 'rpi3b-selftest', 'true', 'false', d)}; then
+            install -m 0644 ${WORKDIR}/rpi3b-selftest.service ${D}${systemd_system_unitdir}/
+        fi
+
         # tmpfiles.d: sole owner of /run/iot (units no longer use RuntimeDirectory=iot)
         install -d ${D}${nonarch_libdir}/tmpfiles.d
         install -m 0644 ${WORKDIR}/iot.conf ${D}${nonarch_libdir}/tmpfiles.d/
@@ -329,6 +348,7 @@ PACKAGE_BEFORE_PN = "\
     ${PN}-wifi-client \
     ${PN}-httpd \
     ${PN}-config \
+    ${PN}-rpi3b-selftest \
 "
 
 # Main package: shared library + dev artefacts
@@ -475,6 +495,17 @@ FILES:${PN}-config = "\
     ${nonarch_libdir}/systemd/system-preset/90-iot.preset \
 "
 
+# rpi3b-selftest — the rpi3B driver GoogleTest binary + boot oneshot. Populated
+# only when the rpi3b-selftest PACKAGECONFIG is enabled; ALLOW_EMPTY keeps the
+# package valid (and the SYSTEMD_SERVICE below empty) when it is disabled.
+FILES:${PN}-rpi3b-selftest = "\
+    ${bindir}/rpi3B_test \
+    ${systemd_system_unitdir}/rpi3b-selftest.service \
+"
+ALLOW_EMPTY:${PN}-rpi3b-selftest = "1"
+RDEPENDS:${PN}-rpi3b-selftest = "${@bb.utils.contains('PACKAGECONFIG', 'rpi3b-selftest', 'gtest', '', d)}"
+INSANE_SKIP:${PN}-rpi3b-selftest = "already-stripped"
+
 # ── systemd ─────────────────────────────────────────────────────────
 SYSTEMD_SERVICE:${PN}-ds-server = "iot-ds.service"
 # iot-swupdate.path is enabled (watches the OTA spool trigger); iot-swupdate.service
@@ -512,6 +543,11 @@ SYSTEMD_AUTO_ENABLE:${PN}-wifi-client = "enable"
 # lock down via http.listen.ip / auth for untrusted networks. Also enables the
 # iot-hostname oneshot (sets iot-<serial> so Avahi advertises a stable name).
 SYSTEMD_AUTO_ENABLE:${PN}-httpd = "enable"
+
+# rpi3B self-test oneshot. Conditional so disabling the PACKAGECONFIG leaves an
+# empty package with no dangling SYSTEMD_SERVICE reference.
+SYSTEMD_SERVICE:${PN}-rpi3b-selftest = "${@bb.utils.contains('PACKAGECONFIG', 'rpi3b-selftest', 'rpi3b-selftest.service', '', d)}"
+SYSTEMD_AUTO_ENABLE:${PN}-rpi3b-selftest = "enable"
 
 # ── Sanity checks ──────────────────────────────────────────────────
 # Inhibit the "binary already stripped" QA warning — we build with -g

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -503,7 +503,11 @@ FILES:${PN}-rpi3b-selftest = "\
     ${systemd_system_unitdir}/rpi3b-selftest.service \
 "
 ALLOW_EMPTY:${PN}-rpi3b-selftest = "1"
-RDEPENDS:${PN}-rpi3b-selftest = "${@bb.utils.contains('PACKAGECONFIG', 'rpi3b-selftest', 'gtest', '', d)}"
+# No manual RDEPENDS on gtest. `gtest` is a build-time DEPENDS (added via the
+# PACKAGECONFIG above, resolved through PROVIDES) — it is NOT a runtime package
+# name, so an explicit RDEPENDS:...= "gtest" fails with "Nothing RPROVIDES
+# 'gtest'". If rpi3B_test links libgtest.so, Yocto's shared-lib dependency scan
+# adds the correct runtime package automatically.
 INSANE_SKIP:${PN}-rpi3b-selftest = "already-stripped"
 
 # ── systemd ─────────────────────────────────────────────────────────

--- a/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
+++ b/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
@@ -38,6 +38,7 @@ RDEPENDS:${PN}-full = "\
     iot-openvpn-client \
     iot-net-router \
     iot-wifi-client \
+    iot-rpi3b-selftest \
     openvpn \
     nftables \
     iproute2 \


### PR DESCRIPTION
> 🚧 **Blocked by / depends on naushada/rpi3B#1** — that PR introduces the `rpi3b_driver` library target and the C++17-consumable headers this build wiring requires. **Merge rpi3B#1 first**, then mark this PR ready.

## Summary
Vendors the [rpi3B](https://github.com/naushada/rpi3B) BCM2837 driver (GPIO/CLOCK/IRQ/I2C/SPI) into the iot build and ships its GoogleTest suite as a boot-time self-test systemd oneshot.

## How it's vendored
`modules/rpi3B` is committed as a **plain tree** (not a submodule gitlink), matching the existing `apps/3rdparty/{json,tinydtls}` convention — the recipe fetches iot via plain `git://`, so a gitlink wouldn't bring the files. The `.gitmodules` entry is kept as provenance (origin URL + branch).

## Build wiring
- `apps/CMakeLists.txt`: `add_subdirectory(../modules/rpi3B)`, link `rpi3b_driver` into `lwm2m`, add `IOT_BUILD_RPI3B_SELFTEST` option (flips the submodule's `RPI3B_BUILD_TESTS`).

## Yocto / systemd
- `iot_git.bb`: `PACKAGECONFIG[rpi3b-selftest]` (passes the cmake flag + adds `gtest`, enabled by default); installs the unit; new `iot-rpi3b-selftest` package with `SYSTEMD_SERVICE`/`SYSTEMD_AUTO_ENABLE`.
- `rpi3b-selftest.service`: boot oneshot running `/usr/bin/rpi3B_test` (pure userspace, no device access).
- `packagegroup-iot-full` RDEPENDS `iot-rpi3b-selftest`.

## Testing
A C++17 consumer build against `modules/rpi3B` via `add_subdirectory` builds and runs locally. A full Yocto/bitbake build was not run here.

## Notes
- Disabling the `rpi3b-selftest` PACKAGECONFIG cleanly empties the package (`ALLOW_EMPTY` + conditional `SYSTEMD_SERVICE`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)