### PR TITLE
feat(ui): match favicon to the IoT node-mesh logo (both UIs)

### DIFF
--- a/apps/cloud/ui/src/favicon.svg
+++ b/apps/cloud/ui/src/favicon.svg
@@ -1,18 +1,41 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Outer ring — network -->
-  <circle cx="32" cy="32" r="30" fill="none" stroke="#2e7d32" stroke-width="2.5"
-          stroke-dasharray="8 3" opacity="0.5"/>
-  <circle cx="32" cy="32" r="22" fill="none" stroke="#2e7d32" stroke-width="2"
-          stroke-dasharray="5 2" opacity="0.7"/>
-  <!-- Device node — central hexagon -->
-  <polygon points="32,12 48,22 48,42 32,52 16,42 16,22"
-           fill="#1b5e20" stroke="#2e7d32" stroke-width="1.5"/>
-  <!-- Inner dot — connected -->
-  <circle cx="32" cy="32" r="6" fill="#66bb6a"/>
-  <circle cx="32" cy="32" r="3" fill="#c8e6c9"/>
-  <!-- Signal arcs -->
-  <path d="M16 26 Q24 18 32 26" fill="none" stroke="#66bb6a" stroke-width="1.5"
-        stroke-linecap="round" opacity="0.8"/>
-  <path d="M32 38 Q40 46 48 38" fill="none" stroke="#66bb6a" stroke-width="1.5"
-        stroke-linecap="round" opacity="0.8"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <!-- Favicon: same IoT node-mesh mark as the login/sidebar logo, tuned
+       for small sizes (bolder edges & nodes). No third-party artwork. -->
+  <defs>
+    <linearGradient id="iotFavBadge" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#127d99"/>
+      <stop offset="1" stop-color="#0a5468"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Badge -->
+  <rect x="4" y="4" width="112" height="112" rx="28" fill="url(#iotFavBadge)"/>
+
+  <!-- Edges: hub -> satellite nodes -->
+  <g stroke="#bfeef6" stroke-width="3.4" stroke-linecap="round" opacity="0.9">
+    <line x1="60" y1="60" x2="60" y2="26"/>
+    <line x1="60" y1="60" x2="89" y2="43"/>
+    <line x1="60" y1="60" x2="89" y2="77"/>
+    <line x1="60" y1="60" x2="60" y2="94"/>
+    <line x1="60" y1="60" x2="31" y2="77"/>
+    <line x1="60" y1="60" x2="31" y2="43"/>
+  </g>
+
+  <!-- Satellite nodes -->
+  <g fill="#eafcff">
+    <circle cx="60" cy="26" r="8"/>
+    <circle cx="89" cy="77" r="8"/>
+    <circle cx="60" cy="94" r="8"/>
+    <circle cx="31" cy="43" r="8"/>
+  </g>
+
+  <!-- Accent nodes -->
+  <g fill="#4fd1c5">
+    <circle cx="89" cy="43" r="8"/>
+    <circle cx="31" cy="77" r="8"/>
+  </g>
+
+  <!-- Central hub (the "thing") -->
+  <circle cx="60" cy="60" r="16" fill="#eafcff"/>
+  <circle cx="60" cy="60" r="8" fill="#0a5468"/>
 </svg>

--- a/iot-ui/src/favicon.svg
+++ b/iot-ui/src/favicon.svg
@@ -1,18 +1,41 @@
-<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64">
-  <!-- Outer ring — network -->
-  <circle cx="32" cy="32" r="30" fill="none" stroke="#2e7d32" stroke-width="2.5"
-          stroke-dasharray="8 3" opacity="0.5"/>
-  <circle cx="32" cy="32" r="22" fill="none" stroke="#2e7d32" stroke-width="2"
-          stroke-dasharray="5 2" opacity="0.7"/>
-  <!-- Device node — central hexagon -->
-  <polygon points="32,12 48,22 48,42 32,52 16,42 16,22"
-           fill="#1b5e20" stroke="#2e7d32" stroke-width="1.5"/>
-  <!-- Inner dot — connected -->
-  <circle cx="32" cy="32" r="6" fill="#66bb6a"/>
-  <circle cx="32" cy="32" r="3" fill="#c8e6c9"/>
-  <!-- Signal arcs -->
-  <path d="M16 26 Q24 18 32 26" fill="none" stroke="#66bb6a" stroke-width="1.5"
-        stroke-linecap="round" opacity="0.8"/>
-  <path d="M32 38 Q40 46 48 38" fill="none" stroke="#66bb6a" stroke-width="1.5"
-        stroke-linecap="round" opacity="0.8"/>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120">
+  <!-- Favicon: same IoT node-mesh mark as the login/sidebar logo, tuned
+       for small sizes (bolder edges & nodes). No third-party artwork. -->
+  <defs>
+    <linearGradient id="iotFavBadge" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#127d99"/>
+      <stop offset="1" stop-color="#0a5468"/>
+    </linearGradient>
+  </defs>
+
+  <!-- Badge -->
+  <rect x="4" y="4" width="112" height="112" rx="28" fill="url(#iotFavBadge)"/>
+
+  <!-- Edges: hub -> satellite nodes -->
+  <g stroke="#bfeef6" stroke-width="3.4" stroke-linecap="round" opacity="0.9">
+    <line x1="60" y1="60" x2="60" y2="26"/>
+    <line x1="60" y1="60" x2="89" y2="43"/>
+    <line x1="60" y1="60" x2="89" y2="77"/>
+    <line x1="60" y1="60" x2="60" y2="94"/>
+    <line x1="60" y1="60" x2="31" y2="77"/>
+    <line x1="60" y1="60" x2="31" y2="43"/>
+  </g>
+
+  <!-- Satellite nodes -->
+  <g fill="#eafcff">
+    <circle cx="60" cy="26" r="8"/>
+    <circle cx="89" cy="77" r="8"/>
+    <circle cx="60" cy="94" r="8"/>
+    <circle cx="31" cy="43" r="8"/>
+  </g>
+
+  <!-- Accent nodes -->
+  <g fill="#4fd1c5">
+    <circle cx="89" cy="43" r="8"/>
+    <circle cx="31" cy="77" r="8"/>
+  </g>
+
+  <!-- Central hub (the "thing") -->
+  <circle cx="60" cy="60" r="16" fill="#eafcff"/>
+  <circle cx="60" cy="60" r="8" fill="#0a5468"/>
 </svg>


### PR DESCRIPTION
## Summary
The login + sidebar logo was refreshed to the original IoT **node-mesh** mark in PR #277, but the **browser-tab favicon** is a separate file (`favicon.svg`) that still carried the old green ring/hexagon design — so the tab icon didn't match the new brand.

This ports the same node-mesh badge into `favicon.svg` for **both** UIs:
- `apps/cloud/ui/src/favicon.svg`
- `iot-ui/src/favicon.svg`

Edges and nodes are slightly bolder than the full logo so the mark stays legible at 16px.

## Notes
- There is **no `.ico`** anywhere in the repo — both `index.html` files reference `favicon.svg` (`<link rel="icon" type="image/svg+xml">`), so this single SVG is the tab icon.
- Pure asset change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)