### PR TITLE
fix(ota): launch the stager via a root path-unit instead of systemd-run

### DIFF
--- a/apps/docs/tdd-yocto-swupdate.md
+++ b/apps/docs/tdd-yocto-swupdate.md
@@ -79,17 +79,26 @@ full, *then* `touch`es `update` as the final step. The trigger's existence ⇒ a
 complete payload is present. The trigger is **empty** by design — all metadata
 lives in `update.meta` so the trigger semantics stay "payload ready".
 
-### 3.2 Stager — `/usr/bin/iot-ota-stage <url>` (root, transient)
+### 3.2 Stager — `/usr/bin/iot-ota-stage` (root, path-triggered)
 
 A slimmed refactor of today's `iot-ota-apply`: it **downloads + verifies +
 stages + triggers**, but **does not install**.
 
-- Launched exactly as today — `ota_launch_apply()` in `apps/src/main.cpp`
-  changes its one command from `iot-ota-apply` to `iot-ota-stage`
-  (`systemd-run --unit=iot-ota-stage --collect /usr/bin/iot-ota-stage <url>`).
-  Runs as **root** (network + write the root-owned spool). Because it no longer
-  installs, it is never killed by opkg replacing a running binary, so the
-  `systemd-run` detach is now only about privilege, not self-replacement.
+- Launched via a **spool trigger**, NOT `systemd-run`. `ota_launch_apply()` in
+  `apps/src/main.cpp` runs in the lwm2m client, which is **unprivileged**
+  (`User=engineer`) and therefore **cannot** create a system transient unit —
+  `systemd-run` returns "Access denied" (polkit; no agent on the busybox image),
+  so the original `systemd-run --unit=iot-ota-stage …` silently failed and the
+  stager never ran. Instead, `ota_launch_apply()` atomically writes the package
+  URL to `/run/iot/update/stage.req` (temp + rename); the **`iot-ota-stage.path`**
+  unit (`PathExists`) fires **`iot-ota-stage.service`** (oneshot, **root**), which
+  runs `iot-ota-stage` with no argument — it reads the URL from `stage.req` and
+  removes the file to re-arm the path unit. `/run/iot/update` is `0775 root:iot`
+  (tmpfiles `iot.conf`) and the client has `SupplementaryGroups=iot`, so the
+  write needs no privilege. Same engineer→root handoff as the cert-apply →
+  `iot-vpn-cert.path` flow. Runs as **root** (network + write the root-owned
+  spool); since it no longer installs, it is never killed by opkg replacing a
+  running binary.
 - Steps:
   1. Parse `?sha256=`, `?version=`, `?reboot=` query params (same parser as
      today).

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -6,8 +6,10 @@
 #include <iostream>
 #include <vector>
 #include <algorithm>
+#include <cerrno>    // errno (OTA stage-request write)
 #include <cstdint>
-#include <cstdlib>   // std::system (OTA apply launcher)
+#include <cstdio>    // std::rename/std::remove (OTA stage-request handoff)
+#include <cstdlib>   // std::system (A/B bank-switch launcher)
 #include <fstream>
 #include <functional>
 #include <map>
@@ -836,24 +838,49 @@ static std::string ota_shquote(const std::string& s) {
 /// See apps/docs/tdd-yocto-swupdate.md.
 static int ota_launch_apply(const std::string& uri) {
     if (uri.empty()) return -1;
-    std::string cmd =
-        "systemd-run --unit=iot-ota-stage --collect /usr/bin/iot-ota-stage "
-        + ota_shquote(uri);
-    int rc = std::system(cmd.c_str());
-    if (rc != 0) {
+    // The lwm2m client runs UNPRIVILEGED (User=engineer) and CANNOT `systemd-run`
+    // a system unit — polkit denies it ("Access denied", rc=256) and the busybox
+    // image ships no polkit agent, so the stager never launches. Instead, drop
+    // the package URL into the spool request file that the root iot-ota-stage.path
+    // unit watches; it fires iot-ota-stage.service (root), which downloads +
+    // verifies and triggers iot-swupdate. /run/iot/update is 0775 root:iot
+    // (tmpfiles iot.conf) and the client has SupplementaryGroups=iot, so this
+    // write needs no privilege. Written temp + rename so the .path never fires on
+    // a half-written request. Same engineer->root handoff as the cert-apply ->
+    // iot-vpn-cert.path path. Returns 0 once queued (the download is async).
+    const std::string req = "/run/iot/update/stage.req";
+    const std::string tmp = req + ".tmp";
+    {
+        std::ofstream os(tmp, std::ios::binary | std::ios::trunc);
+        os << uri << '\n';
+        if (!os) {
+            ACE_ERROR((LM_ERROR,
+                ACE_TEXT("%D [ota] %M %N:%l write(%C) failed errno=%d\n"),
+                tmp.c_str(), errno));
+            return -1;
+        }
+    }
+    if (std::rename(tmp.c_str(), req.c_str()) != 0) {
         ACE_ERROR((LM_ERROR,
-            ACE_TEXT("%D [ota] %M %N:%l launch failed rc=%d cmd=%C\n"),
-            rc, cmd.c_str()));
+            ACE_TEXT("%D [ota] %M %N:%l rename(%C) failed errno=%d\n"),
+            req.c_str(), errno));
+        std::remove(tmp.c_str());
         return -1;
     }
-    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ota] %M %N:%l launched iot-ota-stage\n")));
+    ACE_DEBUG((LM_INFO,
+        ACE_TEXT("%D [ota] %M %N:%l queued OTA stage request "
+                 "(iot-ota-stage.path runs the stager)\n")));
     return 0;
 }
 
 /// A/B bank switch: run iot-bank-switch (root, detached) with the requested
 /// target bank ("A"/"B"/"other"). It `rauc status mark-active`s that bank and
-/// reboots; the bootloader rolls back if the new bank fails to come up. Same
-/// systemd-run pattern as ota_launch_apply (this daemon runs unprivileged).
+/// reboots; the bootloader rolls back if the new bank fails to come up.
+/// FIXME: this still uses `systemd-run`, which FAILS for the same reason the OTA
+/// path did — the client runs as engineer and polkit denies a system transient
+/// unit. A/B is unvalidated Phase 2 (gated by IOT_AB), so it's left as-is; when
+/// A/B is brought up, give it the same spool-trigger handoff as
+/// ota_launch_apply (an iot-bank-switch.path watching /run/iot/update/bank.req).
 static int bank_switch_launch(const std::string& target) {
     if (target.empty()) return -1;
     std::string cmd =

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -168,8 +168,11 @@ itself. The flow is split into a **stager** and an **inotify-triggered
 installer** (full design: `apps/docs/tdd-yocto-swupdate.md`):
 
 - `iot-ota-stage` (`/usr/bin/iot-ota-stage`, in `iot-lwm2m`) is the worker the
-  LwM2M client invokes on a /5/0/0 write. It runs **detached**
-  (`systemd-run --unit=iot-ota-stage`): download the artifact (honouring
+  LwM2M client requests on a /5/0/2 execute. The client is **unprivileged**
+  (`User=engineer`) and cannot `systemd-run` a system unit, so it drops the URL
+  into `/run/iot/update/stage.req`; the **`iot-ota-stage.path`** unit fires
+  **`iot-ota-stage.service`** (root), which runs the worker: download the
+  artifact (honouring
   `?sha256=` / `?version=` / `?reboot=` params) with **retry + resume**
   (`curl -C -` / `wget -c`, up to `iot.update.retries`, default 5) so a flaky
   uplink doesn't fail the campaign → verify sha256 → for a `.tar.gz` bundle,

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
@@ -7,8 +7,11 @@
 # install — that is iot-swupdate's job, in its own systemd unit, so it survives
 # opkg replacing the running binaries.
 #
-# Runs DETACHED as root (systemd-run --unit=iot-ota-stage by the lwm2m client)
-# so it can write the root-owned spool and reach the network.
+# Runs as root via iot-ota-stage.service (oneshot), triggered by
+# iot-ota-stage.path when the lwm2m client drops a request — the client runs as
+# `engineer` and cannot systemd-run a system unit (polkit denies it), so it hands
+# off through the spool instead. Running as root lets this write the root-owned
+# spool and reach the network. A URL argument still works for manual/dev runs.
 #
 # URL may carry ?sha256=<hex>&version=<v>&reboot=<auto|always|never>.
 #
@@ -21,6 +24,16 @@ URL="${1:-}"
 SOCK="/run/iot/data_store.sock"
 DSCLI="ds-cli --socket=${SOCK}"
 SPOOL="/run/iot/update"
+REQ="$SPOOL/stage.req"
+
+# Triggered by iot-ota-stage.path with no argument: the package URL is in the
+# request file the lwm2m client dropped. Consume it immediately — remove it so
+# the .path unit re-arms for the next campaign (mirrors how iot-swupdate removes
+# its own trigger). busybox `head -n 1` is fine; a bare `head -N` is not.
+if [ -z "$URL" ] && [ -f "$REQ" ]; then
+    URL="$(head -n 1 "$REQ" 2>/dev/null)"
+    rm -f "$REQ"
+fi
 
 set_state()    { $DSCLI set iot.update.state    "$1" >/dev/null 2>&1 || true; }
 set_result()   { $DSCLI set iot.update.result   "$1" >/dev/null 2>&1 || true; }

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage.path
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage.path
@@ -1,0 +1,15 @@
+[Unit]
+Description=Watch the OTA stage request queued by the lwm2m client (inotify)
+Documentation=https://github.com/naushada/iot
+# The lwm2m client runs UNPRIVILEGED (User=engineer) and cannot systemd-run a
+# system unit (polkit denies it). Instead it drops the package URL into
+# /run/iot/update/stage.req; this path unit fires the root stager. The triggered
+# service removes the request file to re-arm (a .path unit won't re-fire until
+# the path is gone again). Same engineer->root handoff as iot-vpn-cert.path.
+
+[Path]
+PathExists=/run/iot/update/stage.req
+Unit=iot-ota-stage.service
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Stage an OTA bundle/.ipk (download + verify), then trigger the installer
+Documentation=https://github.com/naushada/iot
+# No [Install]: activated by iot-ota-stage.path, never enabled directly.
+After=iot-ds.service
+Wants=iot-ds.service
+
+[Service]
+Type=oneshot
+# Runs as root (no DynamicUser) so it can write the root-owned /run/iot/update
+# spool and reach the network. With no argument iot-ota-stage reads the package
+# URL from /run/iot/update/stage.req (dropped by the lwm2m client) and removes it
+# to re-arm the .path unit. The opkg install itself runs separately in
+# iot-swupdate.service, which this stager triggers.
+ExecStart=/usr/bin/iot-ota-stage
+# The download (a ~21 MB bundle over a flaky WAN, with retries) plus sha256
+# verify can take a while; give it room.
+TimeoutStartSec=900

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -46,6 +46,8 @@ SRC_URI = "\
     file://wifi-client.env \
     file://httpd.env \
     file://iot-ota-stage \
+    file://iot-ota-stage.path \
+    file://iot-ota-stage.service \
     file://iot-swupdate \
     file://iot-swupdate.path \
     file://iot-swupdate.service \
@@ -225,9 +227,11 @@ do_build_ui[depends] += "nodejs-native:do_populate_sysroot"
 do_install() {
     cmake_do_install
 
-    # OTA helpers: iot-ota-stage (download+verify+stage+trigger, run detached via
-    # systemd-run by the lwm2m client) and iot-swupdate (the inotify-triggered
-    # installer, run by iot-swupdate.service). See apps/docs/tdd-yocto-swupdate.md.
+    # OTA helpers: iot-ota-stage (download+verify+stage+trigger, run as root by
+    # iot-ota-stage.service which iot-ota-stage.path fires when the unprivileged
+    # lwm2m client drops /run/iot/update/stage.req) and iot-swupdate (the
+    # inotify-triggered installer, run by iot-swupdate.service). See
+    # apps/docs/tdd-yocto-swupdate.md.
     install -d ${D}${bindir}
     install -m 0755 ${WORKDIR}/iot-ota-stage    ${D}${bindir}/iot-ota-stage
     install -m 0755 ${WORKDIR}/iot-swupdate     ${D}${bindir}/iot-swupdate
@@ -266,6 +270,8 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-openvpn-client.service ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-vpn-cert.path          ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-vpn-cert.service       ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-ota-stage.path         ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-ota-stage.service      ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-swupdate.path          ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-swupdate.service       ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-ota-confirm.service    ${D}${systemd_system_unitdir}/
@@ -389,6 +395,8 @@ FILES:${PN}-lwm2m = "\
     ${datadir}/iot/migrations \
     ${systemd_system_unitdir}/iot-lwm2m-client.service \
     ${systemd_system_unitdir}/iot-lwm2m-server.service \
+    ${systemd_system_unitdir}/iot-ota-stage.path \
+    ${systemd_system_unitdir}/iot-ota-stage.service \
     ${systemd_system_unitdir}/iot-swupdate.path \
     ${systemd_system_unitdir}/iot-swupdate.service \
     ${systemd_system_unitdir}/iot-ota-confirm.service \
@@ -512,9 +520,10 @@ INSANE_SKIP:${PN}-rpi3b-selftest = "already-stripped"
 
 # ── systemd ─────────────────────────────────────────────────────────
 SYSTEMD_SERVICE:${PN}-ds-server = "iot-ds.service"
-# iot-swupdate.path is enabled (watches the OTA spool trigger); iot-swupdate.service
-# is activated by the path unit, not enabled directly (it has no [Install]).
-SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service iot-swupdate.path iot-ota-confirm.service"
+# iot-ota-stage.path + iot-swupdate.path are enabled (they watch the OTA spool
+# triggers); their .service units are activated by the path units, not enabled
+# directly (they have no [Install]).
+SYSTEMD_SERVICE:${PN}-lwm2m = "iot-lwm2m-client.service iot-lwm2m-server.service iot-ota-stage.path iot-swupdate.path iot-ota-confirm.service"
 # iot-vpn-cert.path is enabled (watches the cert); iot-vpn-cert.service is
 # activated by the path unit, not enabled directly (it has no [Install]).
 SYSTEMD_SERVICE:${PN}-openvpn-client = "iot-openvpn-client.service iot-vpn-cert.path"


### PR DESCRIPTION
## Problem

Running the OTA software-update flow end-to-end on a **real RPi3B** (against the Vultr cloud) surfaced that the device **receives** the LwM2M Object-5 push but **never launches the updater**:

```
[fw-obj] staged package URI (154 bytes)
[ota]   launch failed rc=256  cmd=systemd-run --unit=iot-ota-stage --collect /usr/bin/iot-ota-stage 'https://…'
```

`ota_launch_apply()` runs `systemd-run` to spawn the stager, but the lwm2m client runs as **`User=engineer`** and cannot create a **system** transient unit — polkit denies it and the busybox image ships no polkit agent. Reproduced on hardware: as `root` it works (`rc=0`); as `engineer` it fails with `Failed to start transient service unit: Access denied` (`rc=1` → the logged `rc=256`). Result: `iot.update.state` stays `0` and every push silently no-ops.

## Fix

Replace `systemd-run` with the same **engineer→root spool handoff** the cert-apply path already uses (`iot-vpn-cert.path`):

- `ota_launch_apply()` atomically writes the package URL to `/run/iot/update/stage.req` (temp + rename).
- New **`iot-ota-stage.path`** (`PathExists`) fires **`iot-ota-stage.service`** (oneshot, **root**); `iot-ota-stage` with no arg reads `stage.req` and removes it to re-arm the path unit.
- `/run/iot/update` is already `0775 root:iot` (tmpfiles `iot.conf`) and the client has `SupplementaryGroups=iot`, so the write needs **no** new privilege, polkit, or tmpfiles change.

`bank_switch_launch()` (A/B, Phase 2) has the identical latent bug and is marked `FIXME` — left as-is since A/B is gated behind `IOT_AB` and unvalidated.

## Validation

The **entire downstream pipeline** was verified working on a real RPi3B by running the stager as root (faithful to what the client does with privilege): HTTPS download → `sha256 verified` → extract 12 `.ipk` → `opkg install` → migrate → `update applied` → daemon restart → re-register. This PR is the one piece that lets the **unprivileged client** trigger that pipeline.

> [!NOTE]
> **Not built locally** (no cross-toolchain / node on the dev box; image CI builds on `main`). Needs an image build + reflash to validate the launch on hardware. Reviewers: please eyeball the C++ and the new units.

## Files

| File | Change |
|------|--------|
| `apps/src/main.cpp` | `ota_launch_apply()` → spool write; `bank_switch_launch()` FIXME |
| `…/files/iot-ota-stage.path` · `.service` | new path+service units (root) |
| `…/files/iot-ota-stage` | read URL from `stage.req` when no arg; re-arm |
| `…/lwm2m/iot_git.bb` | SRC_URI / install / FILES / SYSTEMD_SERVICE wiring |
| `apps/docs/tdd-yocto-swupdate.md` · `yocto/meta-iot/README.md` | docs |

🤖 Generated with [Claude Code](https://claude.com/claude-code)