### PR TITLE
feat(yocto): make `engineer` a real login account (dev image)

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -166,11 +166,29 @@ inherit cmake pkgconfig useradd
 # client may read the write-only PSK keys. The shared `iot` group lets
 # `engineer` reach ds-server's 0660 socket (ds-server chgrp's the socket
 # to `iot`). The lwm2m package owns these accounts.
+#
+# `engineer` is ALSO a real interactive login account (shell /bin/sh, home
+# /home/engineer, password "engineer") for field/console + ssh access —
+# alongside the debug-tweaks empty-root login. The shell + home come from
+# USERADD_PARAM; the password is set at FIRST BOOT via chpasswd in
+# pkg_postinst_ontarget below (plaintext → chpasswd hashes it), which sidesteps
+# the fragile `$`-escaping of a baked `useradd -p '$6$...'` hash.
+# SECURITY: a known credential baked into every image — a DEV/debug convenience
+# (same posture as debug-tweaks). REMOVE for production: drop the postinst and
+# restore --shell /usr/sbin/nologin (the daemon role doesn't need a shell).
 USERADD_PACKAGES = "${PN}-lwm2m"
 GROUPADD_PARAM:${PN}-lwm2m = "--system engineer; --system iot"
-USERADD_PARAM:${PN}-lwm2m = "--system --no-create-home \
-    --shell /usr/sbin/nologin --gid engineer --groups iot \
+USERADD_PARAM:${PN}-lwm2m = "--system --create-home \
+    --shell /bin/sh --gid engineer --groups iot \
     --comment 'IoT LwM2M client' engineer"
+
+# First-boot: give `engineer` the login password "engineer". Runs as root on the
+# target (ontarget), so chpasswd can write /etc/shadow; by first boot the user
+# already exists (created by the useradd postinst above). Non-zero return re-runs
+# it next boot, so a transient failure self-heals. See the SECURITY note above.
+pkg_postinst_ontarget:${PN}-lwm2m() {
+    echo 'engineer:engineer' | chpasswd
+}
 
 # ── CMake configuration ─────────────────────────────────────────────
 # OECMAKE_SOURCEPATH points cmake at the apps/CMakeLists.txt.


### PR DESCRIPTION
## What

Turns the Linux `engineer` account from a **locked, nologin service account** into a **real interactive login** — `/bin/sh`, `/home/engineer`, password **`engineer`** — so you can `ssh engineer@<device>` / log in at the console, alongside the existing `debug-tweaks` empty-root login.

Previously (and the source of the confusion):
```
/etc/passwd:  engineer:x:996:995:IoT LwM2M client:/home/engineer:/usr/sbin/nologin
/etc/shadow:  engineer:!          # locked — no password, no shell
```
The only "engineer/engineer" with a password was the **device-ui web login** (a read-only Viewer seeded by `iot-ds-seed`) — a different thing from the Linux user.

## How

- `USERADD_PARAM`: `--shell /bin/sh --create-home` (was `--shell /usr/sbin/nologin --no-create-home`).
- Password set at **first boot** via `echo 'engineer:engineer' | chpasswd` in `pkg_postinst_ontarget` (runs as root on-target). This deliberately avoids baking a `useradd -p '$6$…'` hash, whose `$`-escaping through bitbake + the useradd shell `eval` is fragile and **can't be CI-validated** (image CI runs only on `main`, not PRs) — a wrong guess would break `main` or silently set a garbled hash. `chpasswd` takes plaintext and hashes it itself.

The lwm2m daemon is unaffected — `systemd User=engineer` execs the binary directly, not a login shell.

> [!WARNING]
> **Security:** this bakes a known credential (`engineer`/`engineer`) into every image — a **dev/debug** convenience, same posture as the `debug-tweaks` empty-root password. The recipe's SECURITY note documents reverting for production (drop the postinst, restore `/usr/sbin/nologin`).

> [!NOTE]
> Recipe-only; not built locally (no toolchain here, and image CI builds on `main`). Validates on the next image build + reflash: `ssh engineer@<device>` with password `engineer`, and `whoami` in a console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)