### PR TITLE
ci: build on yocto/** changes + fix(ota): extract dropped .tar.gz bundles

### DIFF
--- a/.github/workflows/cloud-image.yml
+++ b/.github/workflows/cloud-image.yml
@@ -10,6 +10,7 @@ on:
     paths:
       - 'apps/**'
       - 'modules/**'
+      - 'yocto/**'
       - '.github/workflows/cloud-image.yml'
       - '!**/*.md'
   workflow_dispatch:  # manual trigger

--- a/.github/workflows/device-image.yml
+++ b/.github/workflows/device-image.yml
@@ -9,6 +9,7 @@ on:
     paths:
       - 'apps/**'
       - 'modules/**'
+      - 'yocto/**'
       - '.github/workflows/device-image.yml'
       - '!**/*.md'
   workflow_dispatch:  # manual trigger

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
@@ -84,6 +84,23 @@ fi
 # ── 2. snapshot + re-arm ───────────────────────────────────────────
 WORK="$SPOOL/.work-$$"
 mkdir -p "$WORK"
+
+# A drag-and-drop bundle (.tar.gz/.tgz) lands here UN-extracted: the device-ui
+# /api/v1/update/upload path drops the tarball and trips us directly, bypassing
+# iot-ota-stage (which is what normally expands a bundle for the cloud/URL push).
+# Expand any bundle in the spool into its .ipks so the *.ipk snapshot below
+# installs them all. busybox-safe: gzip -dc | tar (not tar -z). On the cloud/URL
+# path iot-ota-stage already extracted + removed the tarball, so this is a no-op.
+for b in "$SPOOL"/*.tar.gz "$SPOOL"/*.tgz; do
+    [ -e "$b" ] || continue
+    if ( cd "$SPOOL" && gzip -dc "$b" | tar -xf - ) 2>/dev/null; then
+        log "expanded bundle $(basename "$b")"
+    else
+        log "bundle extract FAILED: $(basename "$b")"
+    fi
+    rm -f "$b"
+done
+
 moved=0
 for f in "$SPOOL"/*.ipk; do
     [ -e "$f" ] || continue


### PR DESCRIPTION
Two related gaps found while verifying the OTA/update flow on hardware.

## 1. CI: image builds didn't trigger on `yocto/**`
`device-image.yml` / `cloud-image.yml` only triggered on `apps/**` and `modules/**`, so a pure recipe/layer/unit/image change under `yocto/**` landed on `main` **unvalidated** (e.g. the engineer-login recipe in #281 triggered no build). Adds `yocto/**` to both push `paths:`. The trailing `!**/*.md` still skips docs-only pushes.

## 2. OTA: device-ui `.tar.gz` bundle drop never installed
The device-ui **"drop a package"** upload (`POST /api/v1/update/upload`) writes the file into `/run/iot/update` and trips `iot-swupdate` directly, **bypassing `iot-ota-stage`** (which is what normally expands a bundle). `iot-swupdate` only installed `*.ipk`, so a dropped `.tar.gz` bundle was never extracted — it logged *"no .ipk staged; nothing to do"* and the device stayed on the old version, despite the UI advertising `.tar.gz` support.

Fix: `iot-swupdate` now expands any `*.tar.gz`/`*.tgz` in the spool into its `.ipk`s before the snapshot (busybox-safe `gzip -dc | tar`). The cloud/URL push is unaffected — `iot-ota-stage` already extracts + removes the tarball there, so the new loop is a no-op on that path.

> [!NOTE]
> Shell validated with `sh -n`/`bash -n`; YAML is a one-line list addition. Image build validates on merge (this PR touches the workflow files, so it now triggers — and going forward `yocto/**` changes will too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)