### PR TITLE
feat(sensors): mangOH Yellow I2C chip drivers — BMI160 / BME680 / OPT3001 (PR-2)

### DIFF
--- a/apps/docs/tdd-mangoh-yellow-sensors.md
+++ b/apps/docs/tdd-mangoh-yellow-sensors.md
@@ -1,11 +1,21 @@
-# TDD Plan — mangOH Yellow Sensor Integration over RPi I²C
+# TDD Plan — mangOH Yellow Integration over RPi (I²C sensors + cellular WAN)
 
-Status: **IN PROGRESS** — PR-1 (BCM2837 I²C transaction layer) implemented and
-host-unit-tested; PRs 2–4 designed below, not yet started.
+Status: **IN PROGRESS** — PR-1 (BCM2837 I²C transaction layer) and PR-2
+(per-chip sensor drivers) implemented and host-unit-tested; PRs 3–4 (LwM2M
+wiring + HW bring-up) designed below. The cellular-WAN / GPS plane (§6) is
+scoped but not yet broken into PRs.
 
 Wire the [mangOH Yellow](https://www.bipom.com/documents/mangOH_Yellow_User_Guide.pdf)
-sensor block to a Raspberry Pi 3B (BCM2837) over **I²C** and surface its
-readings through the existing LwM2M / data-store / device-ui stack.
+to a Raspberry Pi 3B (BCM2837). Two planes:
+
+1. **Sensor plane (this doc's PRs 1–4):** read the onboard BMI160 / BME680 /
+   light sensors over **I²C** and surface them through the existing
+   LwM2M / data-store / device-ui stack.
+2. **WAN plane (§6):** use the mangOH Yellow's CF3 **cellular module** as the
+   Pi's primary WAN uplink, and pull **GPS/GNSS** off the same module. All data
+   — sensors, GPS, device telemetry — flows to **cloud-iot over LwM2M**, reusing
+   the infrastructure already in place (ClientRegistry → cloud.endpoints, IPSO
+   objects, DTLS/PSK, observe/notify).
 
 ## 0. Hardware decision: I²C, not SPI
 
@@ -55,8 +65,8 @@ I²C path.
 
 | Task | PR | State | Notes |
 | --- | --- | --- | --- |
-| **A — I²C transaction layer** | 1 | ✅ **DONE** | `modules/bcm2837` `inc/i2c_bus.hpp` + `src/i2c/i2c_bus.cpp`: `I2cTransport` seam, `Bcm2837I2cTransport` (`bus_init` = GPIO2/3→ALT0 + divider + enable; `write`/`read`/`write_read`/`read_reg`/`write_reg`; `I2cResult` Ok/BadArg/Timeout/Nack/ClockTimeout). Bounded-spin FIFO pump on S.DONE with S.ERR/S.CLKT checks. Host gtests in `test/i2c_bus_test.{hpp,cpp}`. |
-| B — sensor drivers | 2 | ⬜ TODO | `modules/sensors/`: `Bmi160` (chip-id 0xD1, addr 0x68/0x69), `Bme680` (addr 0x76/0x77, Bosch calib compensation), `LightSensor` (confirm part; typ 0x44). Each ctor takes `I2cTransport&`; host tests inject a `FakeI2cTransport` with canned register maps. Add `I2cMux`/expander shim **iff** `i2cdetect` shows the sensors gated behind the mangOH expander. |
+| **A — I²C transaction layer** | 1 | ✅ **DONE** (#283) | `modules/bcm2837` `inc/i2c_bus.hpp` + `src/i2c/i2c_bus.cpp`: `I2cTransport` seam, `Bcm2837I2cTransport` (`bus_init` = GPIO2/3→ALT0 + divider + enable; `write`/`read`/`write_read`/`read_reg`/`write_reg`; `I2cResult` Ok/BadArg/Timeout/Nack/ClockTimeout). Bounded-spin FIFO pump on S.DONE with S.ERR/S.CLKT checks. Host gtests in `test/i2c_bus_test.{hpp,cpp}`. |
+| **B — sensor drivers** | 2 | ✅ **DONE** | `modules/sensors/` (`sensors_driver` lib): `Bmi160` (chip-id 0xD1, raw int16 axes), `Bme680` (chip-id 0x61, calibration-packing decode + Bosch fixed-point T/P/H compensation; gas TODO), `Opt3001` (device-id 0x3001, lux = 0.01·2^E·mantissa). `I2cSensor` base over the `I2cTransport` seam; gtests over a `FakeI2cTransport` (256-byte auto-increment register file). Add an `I2cMux`/expander shim **iff** `i2cdetect` shows the sensors gated behind the mangOH expander (PR-4 finding). |
 | C — IPSO objects | 3 | ⬜ TODO | `install_sensors(store, hooks)` in the object layer, called from `install_canonical_objects` (`apps/src/lwm2m_object_stubs.cpp`). OIDs: 3303 Temp, 3304 Humidity, 3315 Barometer, 3325 Gas/VOC, 3313 Accel, 3334 Gyro, 3301 Illuminance. Resource `read` closures return the Layer-4 cache. Observe/Notify rides the existing observe machinery (NON default, every Nth CON). |
 | D — ds keys + device-ui | 3 | ⬜ TODO | Publish `iot.sensor.*` so the local device-ui shows live values without a cloud round-trip. Reuse/extend an existing sensor namespace — do not mint a key per resource. Add a device-ui tile. |
 | E — sampler | 3 | ⬜ TODO | Periodic reader on the **ACE reactor timer** (StatsPublisher pattern), ACE_DEBUG/ACE_ERROR logging. Updates the IPSO read-closure cache + ds keys at interval N. Behind a build/PACKAGECONFIG flag + runtime config so a board without the mangOH attached no-ops. |
@@ -82,10 +92,64 @@ cmake --build modules/bcm2837/build
 ctest --test-dir modules/bcm2837/build      # or ./modules/bcm2837/build/test/bcm2837_test
 ```
 
-The new `I2cBus*` tests run over `std::vector`-backed I²C/GPIO blocks (same seam
-as the existing suite) — no Pi required. Real DONE/FIFO/RX behaviour is only
-exercised on hardware in PR-4.
+PR-2 (host, no hardware):
 
-> CI note: image workflows build on `main` only and there is no local C++
-> toolchain on the dev Mac — review each PR's C++ carefully before merge, since
-> breaks surface post-merge.
+```bash
+cmake -S modules/sensors -B modules/sensors/build -DSENSORS_BUILD_TESTS=ON
+cmake --build modules/sensors/build
+ctest --test-dir modules/sensors/build      # gtests over FakeI2cTransport
+```
+
+Both suites run over `std::vector`/in-memory register blocks — no Pi required.
+Real DONE/FIFO/RX behaviour and sensor numeric accuracy are exercised on
+hardware in PR-4.
+
+> CI note: image workflows build on `main` only — review each PR's C++ before
+> merge, since breaks surface post-merge.
+
+## 6. WAN plane — mangOH cellular uplink + GPS over LwM2M
+
+The mangOH Yellow's CF3 cellular module (Sierra Wireless WP-series) is the Pi's
+**primary WAN** and the **GPS/GNSS** source. This is a separate workstream from
+the I²C sensor drivers (PRs 1–4) — it touches `modules/wan` and the LwM2M object
+set, not `modules/sensors` — but shares the same destination: **cloud-iot over
+LwM2M**, on the infrastructure that already exists (DTLS/PSK bootstrap+register,
+ClientRegistry → `cloud.lwm2m.registrations` → EndpointRegistry → `cloud.endpoints`,
+observe/notify, IPSO objects). See `[[reference_cloud_endpoints_dataflow]]`.
+
+### 6.1 Cellular WAN
+- The WP module presents to the Pi over USB as a network interface (QMI/MBIM or
+  RNDIS/ECM) plus an AT control channel. Bring-up = enumerate modem → set APN →
+  connect (ModemManager/`mmcli` or a `qmicli`/`pppd` path) → default route.
+- Add a **`modules/wan/cellular/`** daemon as a sibling of `modules/wan/wifi/`
+  (mirrors the wifi-client structure): manage the connection, publish
+  `wan.cellular.*` state into the data-store (operator, RSSI/RSRP, APN, IP,
+  up/down), and integrate with the existing online-gate / route preference so
+  cellular is the uplink when wired/WiFi is absent. Reuse the `vpn.state` /
+  `iot.conn.state` lifecycle pattern, not a new bespoke key
+  (`[[feedback_ds_key_reuse]]`).
+- The VPN/LwM2M client already binds to "whatever the default route is", so once
+  cellular provides the route, bootstrap→register→observe flows unchanged.
+
+### 6.2 GPS / GNSS → LwM2M Object 6 (Location)
+- GPS comes off the **same WP module** (AT `+GPS`/`+QGPS` or QMI LOC / a gnss
+  NMEA device), **not** I²C — so it lives in the cellular daemon, which parses
+  fix → publishes `gps.*` (lat/lon/alt/speed/ts) into ds.
+- Surface to the cloud as **LwM2M Object 6 (Location)**: RIDs 0 Latitude,
+  1 Longitude, 2 Altitude, 5 Timestamp, 6 Speed. Install it next to the IPSO
+  sensor objects (PR-3 `install_sensors` sibling, e.g. `install_location`), with
+  read-closures bound to the `gps.*` ds keys and observe/notify on position
+  change. The cloud Endpoints table can then show device location.
+
+### 6.3 Telemetry transport recap
+Everything converges on LwM2M: sensors → IPSO 33xx, GPS → Object 6, device
+health → Object 3 + existing `iot.*` keys. No new cloud ingestion path is
+needed — the device just registers more objects, and the cloud observes them.
+
+### 6.4 Open questions (WAN)
+1. Modem stack on the Yocto image: ModemManager vs. raw `qmicli`/`pppd` — pick
+   per image size / WP firmware (QMI vs MBIM).
+2. USB enumeration: which interface the WP exposes to the Pi (composition may
+   need a `usb_modeswitch` / mode set).
+3. SIM/APN provisioning path (operator profile via device-ui vs. preconfigured).
+4. Power: the WP + Pi current draw on the mangOH supply during TX peaks.

--- a/modules/sensors/CMakeLists.txt
+++ b/modules/sensors/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(sensors CXX)
+
+# Top-level (own build) vs. pulled in via add_subdirectory() from the iot tree.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(SENSORS_TOP_LEVEL ON)
+else()
+    set(SENSORS_TOP_LEVEL OFF)
+endif()
+
+option(SENSORS_BUILD_TESTS "Build the sensors gtest suite" ${SENSORS_TOP_LEVEL})
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# The drivers depend on the I2cTransport seam from modules/bcm2837. When this
+# module is built on its own, pull bcm2837 in; in the iot build the apps
+# CMakeLists has already added it (guard avoids a double add).
+if(NOT TARGET bcm2837_driver)
+    add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../bcm2837
+                     ${CMAKE_BINARY_DIR}/bcm2837)
+endif()
+
+# Per-chip drivers live in src/<chip>/<chip>.cpp.
+file(GLOB SENSORS_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/src/*/*.cpp")
+
+add_library(sensors_driver STATIC ${SENSORS_SOURCES})
+target_include_directories(sensors_driver PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+target_link_libraries(sensors_driver PUBLIC bcm2837_driver)
+target_compile_options(sensors_driver PRIVATE -Wall -Wextra)
+
+add_library(sensors::driver ALIAS sensors_driver)
+
+install(TARGETS sensors_driver ARCHIVE DESTINATION lib)
+install(DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/inc/ DESTINATION include/sensors
+        FILES_MATCHING PATTERN "*.hpp")
+
+if(SENSORS_BUILD_TESTS)
+    enable_testing()
+    add_subdirectory(test)
+endif()

--- a/modules/sensors/README.md
+++ b/modules/sensors/README.md
@@ -1,0 +1,44 @@
+# sensors — mangOH Yellow I²C sensor drivers
+
+Per-chip drivers for the mangOH Yellow sensor block, read from a Raspberry Pi 3B
+over I²C. Each driver depends only on the **`I2cTransport`** seam from
+[`modules/bcm2837`](../bcm2837) (`i2c_bus.hpp`), so it runs over real BSC1 MMIO
+on the Pi and over an in-memory fake on the host — the suite needs no hardware.
+
+| Chip | Class | Bus addr | Provides | IPSO (PR-3) |
+|------|-------|----------|----------|-------------|
+| Bosch **BMI160** | `Bmi160` | 0x68 / 0x69 | accel + gyro (raw int16 ×3) | 3313 / 3334 |
+| Bosch **BME680** | `Bme680` | 0x76 / 0x77 | temperature, pressure, humidity¹ | 3303 / 3315 / 3304 |
+| TI **OPT3001**²  | `Opt3001` | 0x44 | illuminance (lux) | 3301 |
+
+¹ Gas/VOC resistance (IPSO 3325) needs heater-profile setup and is a follow-up.
+² The exact mangOH light-sensor part is confirmed on hardware (TDD open Q#1);
+  OPT3001 is the default fit.
+
+## Pattern
+
+```
+inc/i2c_sensor.hpp     I2cSensor base: holds I2cTransport& + 7-bit addr,
+                       read_regs / read_u8 / write_u8 helpers
+inc/<chip>.hpp         driver class: probe() / init() / read(...)
+src/<chip>/<chip>.cpp  register map + decode (anon-namespace constants)
+test/                  gtests over FakeI2cTransport (a 256-byte auto-increment
+                       register file); compensation primitives are pure + tested
+```
+
+## Build & test
+
+```bash
+cmake -S modules/sensors -B modules/sensors/build -DSENSORS_BUILD_TESTS=ON
+cmake --build modules/sensors/build
+ctest --test-dir modules/sensors/build
+```
+
+The library target is `sensors_driver` (alias `sensors::driver`); it links
+`bcm2837_driver` transitively and is consumed from the iot apps build in PR-3.
+
+> The BME680 fixed-point compensation follows the Bosch BME68x datasheet/
+> reference driver. Host tests cover register protocol, calibration-packing
+> decode, axis/lux decode, and compensation behaviour (monotonicity, clamping,
+> determinism, div-by-zero guard); exact physical accuracy is cross-checked on
+> hardware in PR-4.

--- a/modules/sensors/inc/bme680.hpp
+++ b/modules/sensors/inc/bme680.hpp
@@ -1,0 +1,75 @@
+#ifndef __bme680_hpp__
+#define __bme680_hpp__
+
+#include <cstdint>
+
+#include "i2c_sensor.hpp"
+
+/**
+ * @file bme680.hpp
+ * @brief Bosch BME680 environmental sensor (mangOH Yellow): pressure,
+ *        temperature, humidity (gas/VOC is a follow-up — see note).
+ *
+ * I²C address 0x76 (SDO low) or 0x77. Flow: probe chip-id (0x61), read the
+ * factory calibration coefficients once, then per sample trigger a forced-mode
+ * measurement, read the raw T/P/H ADC words and apply Bosch's fixed-point
+ * compensation (datasheet §3.3 / the BME68x reference driver). Temperature is
+ * computed first because pressure and humidity depend on its `t_fine`.
+ *
+ * Gas resistance needs heater-profile setup and its own compensation; it is
+ * intentionally out of scope for this driver and tracked for IPSO 3325 later.
+ */
+class Bme680 : public I2cSensor {
+    public:
+        static constexpr std::uint8_t kAddrPrimary   = 0x76;
+        static constexpr std::uint8_t kAddrSecondary = 0x77;
+        static constexpr std::uint8_t kChipId        = 0x61;
+
+        /// @brief Factory calibration coefficients (subset for T/P/H).
+        struct Calib {
+            std::uint16_t t1; std::int16_t t2; std::int8_t  t3;
+            std::uint16_t p1; std::int16_t p2; std::int8_t  p3;
+            std::int16_t  p4; std::int16_t p5; std::int8_t  p6; std::int8_t p7;
+            std::int16_t  p8; std::int16_t p9; std::uint8_t  p10;
+            std::uint16_t h1; std::uint16_t h2;
+            std::int8_t   h3; std::int8_t  h4; std::int8_t  h5;
+            std::uint8_t  h6; std::int8_t  h7;
+            std::int32_t  t_fine;   ///< updated by each temperature compensation
+        };
+
+        /// @brief One environmental sample in physical units.
+        struct Sample {
+            double temperature_c;   ///< °C
+            double pressure_pa;     ///< Pa
+            double humidity_pct;    ///< %RH
+        };
+
+        explicit Bme680(I2cTransport& bus, std::uint8_t addr = kAddrPrimary)
+            : I2cSensor(bus, addr) {}
+
+        /// @brief True if CHIP_ID reads back 0x61.
+        bool probe();
+        /// @brief Read calibration + configure oversampling (humidity x1).
+        bool init();
+        /// @brief Trigger a forced measurement and read compensated T/P/H.
+        bool read(Sample& out);
+
+        /// @brief Access the cached calibration (populated by init()).
+        const Calib& calib() const { return m_calib; }
+
+        /* ---- Pure compensation primitives (exposed for unit testing) ---- */
+
+        /// @brief Compensated temperature in 0.01 °C; updates `c.t_fine`.
+        static std::int32_t compensate_temperature(std::int32_t temp_adc, Calib& c);
+        /// @brief Compensated pressure in Pa (call after temperature).
+        static std::int32_t compensate_pressure(std::int32_t press_adc, const Calib& c);
+        /// @brief Compensated humidity in milli-%RH (call after temperature).
+        static std::int32_t compensate_humidity(std::int32_t hum_adc, const Calib& c);
+
+    private:
+        bool read_calibration();
+
+        Calib m_calib{};
+};
+
+#endif /*__bme680_hpp__*/

--- a/modules/sensors/inc/bmi160.hpp
+++ b/modules/sensors/inc/bmi160.hpp
@@ -1,0 +1,41 @@
+#ifndef __bmi160_hpp__
+#define __bmi160_hpp__
+
+#include <cstdint>
+
+#include "i2c_sensor.hpp"
+
+/**
+ * @file bmi160.hpp
+ * @brief Bosch BMI160 6-axis accelerometer + gyroscope (mangOH Yellow IMU).
+ *
+ * I²C address 0x68 (SDO low) or 0x69 (SDO high). The driver probes the chip-id,
+ * brings the accelerometer and gyroscope into normal power mode, and reads the
+ * six 16-bit signed axis registers in one burst. Values are raw LSB counts;
+ * conversion to m/s² / deg/s depends on the configured ranges and is applied by
+ * the caller (PR-3 maps them to IPSO 3313/3334).
+ */
+class Bmi160 : public I2cSensor {
+    public:
+        static constexpr std::uint8_t kAddrPrimary   = 0x68;
+        static constexpr std::uint8_t kAddrSecondary = 0x69;
+        static constexpr std::uint8_t kChipId        = 0xD1;
+
+        /// @brief One IMU sample: raw signed counts, gyro then accel.
+        struct Sample {
+            std::int16_t gx, gy, gz;   ///< gyroscope X/Y/Z
+            std::int16_t ax, ay, az;   ///< accelerometer X/Y/Z
+        };
+
+        explicit Bmi160(I2cTransport& bus, std::uint8_t addr = kAddrPrimary)
+            : I2cSensor(bus, addr) {}
+
+        /// @brief True if CHIP_ID reads back 0xD1.
+        bool probe();
+        /// @brief Command accel + gyro into normal power mode. 0 == Ok.
+        I2cResult init();
+        /// @brief Burst-read the six axis registers. False on bus error.
+        bool read(Sample& out);
+};
+
+#endif /*__bmi160_hpp__*/

--- a/modules/sensors/inc/i2c_sensor.hpp
+++ b/modules/sensors/inc/i2c_sensor.hpp
@@ -1,0 +1,43 @@
+#ifndef __i2c_sensor_hpp__
+#define __i2c_sensor_hpp__
+
+#include <cstdint>
+#include <cstddef>
+
+#include "i2c_bus.hpp"   // I2cTransport / I2cResult (modules/bcm2837)
+
+/**
+ * @file i2c_sensor.hpp
+ * @brief Common base for the mangOH Yellow I²C sensor drivers.
+ *
+ * Each chip driver holds a reference to an `I2cTransport` (the seam from
+ * modules/bcm2837) and its 7-bit address, and reads/writes 8-bit device
+ * registers through it. Depending only on the abstract transport keeps every
+ * driver host-unit-testable against a fake register file — no BSC1, no Pi.
+ */
+class I2cSensor {
+    public:
+        I2cSensor(I2cTransport& bus, std::uint8_t addr) : m_bus(bus), m_addr(addr) {}
+        virtual ~I2cSensor() = default;
+
+        std::uint8_t address() const { return m_addr; }
+
+    protected:
+        /// @brief Read `n` bytes starting at device register `reg`.
+        I2cResult read_regs(std::uint8_t reg, std::uint8_t* buf, std::size_t n) {
+            return m_bus.read_reg(m_addr, reg, buf, n);
+        }
+        /// @brief Read a single device register; returns false on bus error.
+        bool read_u8(std::uint8_t reg, std::uint8_t& out) {
+            return read_regs(reg, &out, 1) == I2cResult::Ok;
+        }
+        /// @brief Write one byte to device register `reg`.
+        I2cResult write_u8(std::uint8_t reg, std::uint8_t val) {
+            return m_bus.write_reg(m_addr, reg, val);
+        }
+
+        I2cTransport& m_bus;
+        std::uint8_t  m_addr;
+};
+
+#endif /*__i2c_sensor_hpp__*/

--- a/modules/sensors/inc/opt3001.hpp
+++ b/modules/sensors/inc/opt3001.hpp
@@ -1,0 +1,44 @@
+#ifndef __opt3001_hpp__
+#define __opt3001_hpp__
+
+#include <cstdint>
+
+#include "i2c_sensor.hpp"
+
+/**
+ * @file opt3001.hpp
+ * @brief TI OPT3001 ambient light sensor (mangOH Yellow light sensor).
+ *
+ * NOTE: the exact mangOH Yellow light-sensor part is to be confirmed on
+ * hardware (TDD open question #1); OPT3001 at 0x44 is the typical fit and the
+ * default here. OPT3001 registers are 16-bit, MSB-first. The Result register
+ * (0x00) is a 4-bit exponent + 12-bit mantissa; lux = 0.01 · 2^E · mantissa.
+ */
+class Opt3001 : public I2cSensor {
+    public:
+        static constexpr std::uint8_t  kAddr     = 0x44;
+        static constexpr std::uint8_t  kRegResult = 0x00;
+        static constexpr std::uint8_t  kRegConfig = 0x01;
+        static constexpr std::uint8_t  kRegDeviceId = 0x7F;
+        static constexpr std::uint16_t kDeviceId  = 0x3001;
+        /// @brief Config: auto full-scale range, 800 ms, continuous conversion.
+        static constexpr std::uint16_t kConfigContinuous = 0xCE10;
+
+        explicit Opt3001(I2cTransport& bus, std::uint8_t addr = kAddr)
+            : I2cSensor(bus, addr) {}
+
+        /// @brief True if the Device-ID register reads back 0x3001.
+        bool probe();
+        /// @brief Start continuous, auto-ranged conversion. 0 == Ok.
+        I2cResult init();
+        /// @brief Read the Result register and decode to lux. False on bus error.
+        bool read_lux(double& lux);
+
+    private:
+        /// @brief Read a big-endian 16-bit register.
+        bool read_u16(std::uint8_t reg, std::uint16_t& out);
+        /// @brief Write a big-endian 16-bit register.
+        I2cResult write_u16(std::uint8_t reg, std::uint16_t val);
+};
+
+#endif /*__opt3001_hpp__*/

--- a/modules/sensors/src/bme680/bme680.cpp
+++ b/modules/sensors/src/bme680/bme680.cpp
@@ -1,0 +1,177 @@
+#ifndef __bme680_cpp__
+#define __bme680_cpp__
+
+#include "bme680.hpp"
+
+namespace {
+    /* BME680 register map (datasheet §5.2). */
+    constexpr std::uint8_t REG_CHIP_ID  = 0xD0;
+    constexpr std::uint8_t REG_CTRL_HUM = 0x72;
+    constexpr std::uint8_t REG_CTRL_MEAS= 0x74;
+    constexpr std::uint8_t REG_FIELD0   = 0x1F;  /* press MSB; 8 bytes P/T/H */
+
+    /* Oversampling: humidity x1, temperature x2, pressure x16, forced mode. */
+    constexpr std::uint8_t OSRS_H_X1     = 0x01;
+    constexpr std::uint8_t CTRL_MEAS_RUN = (0x02 << 5) | (0x05 << 2) | 0x01;
+
+    std::uint16_t u16(std::uint8_t lsb, std::uint8_t msb) {
+        return static_cast<std::uint16_t>(
+            static_cast<std::uint16_t>(lsb) | (static_cast<std::uint16_t>(msb) << 8));
+    }
+}
+
+bool Bme680::probe() {
+    std::uint8_t id = 0;
+    return read_u8(REG_CHIP_ID, id) && id == kChipId;
+}
+
+bool Bme680::read_calibration() {
+    std::uint8_t e9=0,ea=0, t2l=0,t2m=0,t3=0;
+    std::uint8_t p1l=0,p1m=0,p2l=0,p2m=0,p3=0,p4l=0,p4m=0,p5l=0,p5m=0,p6=0,p7=0,
+                 p8l=0,p8m=0,p9l=0,p9m=0,p10=0;
+    std::uint8_t e1=0,e2=0,e3=0,e4=0,e5=0,e6=0,e7=0,e8=0;
+
+    bool ok = true;
+    /* Temperature coeffs. */
+    ok = ok && read_u8(0xE9, e9)  && read_u8(0xEA, ea);
+    ok = ok && read_u8(0x8A, t2l) && read_u8(0x8B, t2m) && read_u8(0x8C, t3);
+    /* Pressure coeffs. */
+    ok = ok && read_u8(0x8E, p1l) && read_u8(0x8F, p1m);
+    ok = ok && read_u8(0x90, p2l) && read_u8(0x91, p2m) && read_u8(0x92, p3);
+    ok = ok && read_u8(0x94, p4l) && read_u8(0x95, p4m);
+    ok = ok && read_u8(0x96, p5l) && read_u8(0x97, p5m);
+    ok = ok && read_u8(0x99, p6)  && read_u8(0x98, p7);
+    ok = ok && read_u8(0x9C, p8l) && read_u8(0x9D, p8m);
+    ok = ok && read_u8(0x9E, p9l) && read_u8(0x9F, p9m) && read_u8(0xA0, p10);
+    /* Humidity coeffs (packed nibbles for H1/H2). */
+    ok = ok && read_u8(0xE1, e1) && read_u8(0xE2, e2) && read_u8(0xE3, e3);
+    ok = ok && read_u8(0xE4, e4) && read_u8(0xE5, e5) && read_u8(0xE6, e6);
+    ok = ok && read_u8(0xE7, e7) && read_u8(0xE8, e8);
+    if (!ok) {
+        return false;
+    }
+
+    Calib& c = m_calib;
+    c.t1 = u16(e9, ea);
+    c.t2 = static_cast<std::int16_t>(u16(t2l, t2m));
+    c.t3 = static_cast<std::int8_t>(t3);
+
+    c.p1 = u16(p1l, p1m);
+    c.p2 = static_cast<std::int16_t>(u16(p2l, p2m));
+    c.p3 = static_cast<std::int8_t>(p3);
+    c.p4 = static_cast<std::int16_t>(u16(p4l, p4m));
+    c.p5 = static_cast<std::int16_t>(u16(p5l, p5m));
+    c.p6 = static_cast<std::int8_t>(p6);
+    c.p7 = static_cast<std::int8_t>(p7);
+    c.p8 = static_cast<std::int16_t>(u16(p8l, p8m));
+    c.p9 = static_cast<std::int16_t>(u16(p9l, p9m));
+    c.p10 = p10;
+
+    c.h1 = static_cast<std::uint16_t>((static_cast<std::uint16_t>(e3) << 4) | (e2 & 0x0F));
+    c.h2 = static_cast<std::uint16_t>((static_cast<std::uint16_t>(e1) << 4) | (e2 >> 4));
+    c.h3 = static_cast<std::int8_t>(e4);
+    c.h4 = static_cast<std::int8_t>(e5);
+    c.h5 = static_cast<std::int8_t>(e6);
+    c.h6 = e7;
+    c.h7 = static_cast<std::int8_t>(e8);
+    return true;
+}
+
+bool Bme680::init() {
+    return read_calibration();
+}
+
+std::int32_t Bme680::compensate_temperature(std::int32_t temp_adc, Calib& c) {
+    std::int32_t var1 = (temp_adc >> 3) - (static_cast<std::int32_t>(c.t1) << 1);
+    std::int32_t var2 = (var1 * static_cast<std::int32_t>(c.t2)) >> 11;
+    std::int32_t var3 = ((((var1 >> 1) * (var1 >> 1)) >> 12)
+                         * (static_cast<std::int32_t>(c.t3) << 4)) >> 14;
+    c.t_fine = var2 + var3;
+    return ((c.t_fine * 5) + 128) >> 8;   /* 0.01 °C */
+}
+
+std::int32_t Bme680::compensate_pressure(std::int32_t press_adc, const Calib& c) {
+    std::int32_t var1 = (c.t_fine >> 1) - 64000;
+    std::int32_t var2 = ((((var1 >> 2) * (var1 >> 2)) >> 11)
+                         * static_cast<std::int32_t>(c.p6)) >> 2;
+    var2 = var2 + ((var1 * static_cast<std::int32_t>(c.p5)) << 1);
+    var2 = (var2 >> 2) + (static_cast<std::int32_t>(c.p4) << 16);
+    var1 = (((((var1 >> 2) * (var1 >> 2)) >> 13)
+             * (static_cast<std::int32_t>(c.p3) << 5)) >> 3)
+           + ((static_cast<std::int32_t>(c.p2) * var1) >> 1);
+    var1 = var1 >> 18;
+    var1 = ((32768 + var1) * static_cast<std::int32_t>(c.p1)) >> 15;
+    if (var1 == 0) {
+        return 0;   /* avoid divide-by-zero on bad calibration */
+    }
+    std::int32_t press = 1048576 - press_adc;
+    press = (press - (var2 >> 12)) * 3125;
+    if (press >= 0x40000000) {
+        press = (press / var1) << 1;
+    } else {
+        press = (press << 1) / var1;
+    }
+    var1 = (static_cast<std::int32_t>(c.p9)
+            * (((press >> 3) * (press >> 3)) >> 13)) >> 12;
+    var2 = ((press >> 2) * static_cast<std::int32_t>(c.p8)) >> 13;
+    std::int32_t var3 = ((press >> 8) * (press >> 8) * (press >> 8)
+                         * static_cast<std::int32_t>(c.p10)) >> 17;
+    press = press + ((var1 + var2 + var3
+                      + (static_cast<std::int32_t>(c.p7) << 7)) >> 4);
+    return press;   /* Pa */
+}
+
+std::int32_t Bme680::compensate_humidity(std::int32_t hum_adc, const Calib& c) {
+    const std::int32_t temp_scaled = ((c.t_fine * 5) + 128) >> 8;
+    std::int32_t var1 = hum_adc - (static_cast<std::int32_t>(c.h1) << 4)
+                        - (((temp_scaled * static_cast<std::int32_t>(c.h3)) / 100) >> 1);
+    std::int32_t var2 = (static_cast<std::int32_t>(c.h2)
+        * (((temp_scaled * static_cast<std::int32_t>(c.h4)) / 100)
+           + (((temp_scaled * ((temp_scaled * static_cast<std::int32_t>(c.h5)) / 100)) >> 6) / 100)
+           + (1 << 14))) >> 10;
+    std::int32_t var3 = var1 * var2;
+    std::int32_t var4 = static_cast<std::int32_t>(c.h6) << 7;
+    var4 = (var4 + ((temp_scaled * static_cast<std::int32_t>(c.h7)) / 100)) >> 4;
+    std::int32_t var5 = ((var3 >> 14) * (var3 >> 14)) >> 10;
+    std::int32_t var6 = (var4 * var5) >> 1;
+    std::int32_t hum = (((var3 + var6) >> 10) * 1000) >> 12;   /* milli-%RH */
+    if (hum > 100000) {
+        hum = 100000;
+    } else if (hum < 0) {
+        hum = 0;
+    }
+    return hum;
+}
+
+bool Bme680::read(Sample& out) {
+    /* Humidity oversampling must be written before ctrl_meas latches the mode. */
+    if (write_u8(REG_CTRL_HUM, OSRS_H_X1) != I2cResult::Ok) {
+        return false;
+    }
+    if (write_u8(REG_CTRL_MEAS, CTRL_MEAS_RUN) != I2cResult::Ok) {
+        return false;
+    }
+    /* On hardware the sampler waits for the measurement to finish (status
+       0x1D bit7) before reading; field0 is read here in one 8-byte burst. */
+    std::uint8_t d[8] = {0};
+    if (read_regs(REG_FIELD0, d, sizeof(d)) != I2cResult::Ok) {
+        return false;
+    }
+    const std::int32_t press_adc =
+        (static_cast<std::int32_t>(d[0]) << 12) | (static_cast<std::int32_t>(d[1]) << 4) | (d[2] >> 4);
+    const std::int32_t temp_adc =
+        (static_cast<std::int32_t>(d[3]) << 12) | (static_cast<std::int32_t>(d[4]) << 4) | (d[5] >> 4);
+    const std::int32_t hum_adc =
+        (static_cast<std::int32_t>(d[6]) << 8) | d[7];
+
+    const std::int32_t t = compensate_temperature(temp_adc, m_calib);
+    const std::int32_t p = compensate_pressure(press_adc, m_calib);
+    const std::int32_t h = compensate_humidity(hum_adc, m_calib);
+
+    out.temperature_c = static_cast<double>(t) / 100.0;
+    out.pressure_pa   = static_cast<double>(p);
+    out.humidity_pct  = static_cast<double>(h) / 1000.0;
+    return true;
+}
+
+#endif /*__bme680_cpp__*/

--- a/modules/sensors/src/bmi160/bmi160.cpp
+++ b/modules/sensors/src/bmi160/bmi160.cpp
@@ -1,0 +1,52 @@
+#ifndef __bmi160_cpp__
+#define __bmi160_cpp__
+
+#include "bmi160.hpp"
+
+namespace {
+    /* BMI160 register map (datasheet §2.11). */
+    constexpr std::uint8_t REG_CHIP_ID = 0x00;
+    constexpr std::uint8_t REG_DATA    = 0x0C;  /* GYR_X_L; 12 bytes: gyro then accel */
+    constexpr std::uint8_t REG_CMD     = 0x7E;
+
+    constexpr std::uint8_t CMD_ACC_NORMAL = 0x11;  /* set accel  PMU -> normal */
+    constexpr std::uint8_t CMD_GYR_NORMAL = 0x15;  /* set gyro   PMU -> normal */
+
+    /// @brief Assemble a little-endian signed 16-bit sample.
+    std::int16_t le16(std::uint8_t lo, std::uint8_t hi) {
+        return static_cast<std::int16_t>(
+            static_cast<std::uint16_t>(lo) | (static_cast<std::uint16_t>(hi) << 8));
+    }
+}
+
+bool Bmi160::probe() {
+    std::uint8_t id = 0;
+    return read_u8(REG_CHIP_ID, id) && id == kChipId;
+}
+
+I2cResult Bmi160::init() {
+    /* Order matters per the datasheet: accel first, then gyro. On hardware each
+       command needs a few ms to settle; the sampler re-reads on a timer so a
+       transient not-yet-ready read is simply retried. */
+    const I2cResult r = write_u8(REG_CMD, CMD_ACC_NORMAL);
+    if (r != I2cResult::Ok) {
+        return r;
+    }
+    return write_u8(REG_CMD, CMD_GYR_NORMAL);
+}
+
+bool Bmi160::read(Sample& out) {
+    std::uint8_t b[12] = {0};
+    if (read_regs(REG_DATA, b, sizeof(b)) != I2cResult::Ok) {
+        return false;
+    }
+    out.gx = le16(b[0],  b[1]);
+    out.gy = le16(b[2],  b[3]);
+    out.gz = le16(b[4],  b[5]);
+    out.ax = le16(b[6],  b[7]);
+    out.ay = le16(b[8],  b[9]);
+    out.az = le16(b[10], b[11]);
+    return true;
+}
+
+#endif /*__bmi160_cpp__*/

--- a/modules/sensors/src/opt3001/opt3001.cpp
+++ b/modules/sensors/src/opt3001/opt3001.cpp
@@ -1,0 +1,46 @@
+#ifndef __opt3001_cpp__
+#define __opt3001_cpp__
+
+#include "opt3001.hpp"
+
+bool Opt3001::read_u16(std::uint8_t reg, std::uint16_t& out) {
+    std::uint8_t b[2] = {0};
+    if (read_regs(reg, b, sizeof(b)) != I2cResult::Ok) {
+        return false;
+    }
+    /* OPT3001 is MSB-first. */
+    out = static_cast<std::uint16_t>((static_cast<std::uint16_t>(b[0]) << 8) | b[1]);
+    return true;
+}
+
+I2cResult Opt3001::write_u16(std::uint8_t reg, std::uint16_t val) {
+    const std::uint8_t b[3] = {
+        reg,
+        static_cast<std::uint8_t>(val >> 8),
+        static_cast<std::uint8_t>(val & 0xFF),
+    };
+    return m_bus.write(m_addr, b, sizeof(b));
+}
+
+bool Opt3001::probe() {
+    std::uint16_t id = 0;
+    return read_u16(kRegDeviceId, id) && id == kDeviceId;
+}
+
+I2cResult Opt3001::init() {
+    return write_u16(kRegConfig, kConfigContinuous);
+}
+
+bool Opt3001::read_lux(double& lux) {
+    std::uint16_t raw = 0;
+    if (!read_u16(kRegResult, raw)) {
+        return false;
+    }
+    const std::uint32_t exponent = (raw >> 12) & 0x0F;
+    const std::uint32_t mantissa = raw & 0x0FFF;
+    /* lux = 0.01 · 2^E · mantissa (datasheet §7.3.3). */
+    lux = 0.01 * static_cast<double>(1U << exponent) * static_cast<double>(mantissa);
+    return true;
+}
+
+#endif /*__opt3001_cpp__*/

--- a/modules/sensors/test/CMakeLists.txt
+++ b/modules/sensors/test/CMakeLists.txt
@@ -1,0 +1,27 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(sensors_test CXX)
+
+find_package(GTest REQUIRED)
+
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+add_compile_options(-Wall -Wextra)
+
+# Test TUs only; the driver code comes from the sensors_driver library.
+file(GLOB TEST_SOURCES "${CMAKE_CURRENT_SOURCE_DIR}/*.cpp")
+
+add_executable(sensors_test ${TEST_SOURCES})
+target_link_libraries(sensors_test
+                        sensors_driver
+                        GTest::gtest
+                        GTest::gtest_main
+                        pthread)
+
+include(GoogleTest)
+if(SENSORS_TOP_LEVEL)
+    gtest_discover_tests(sensors_test)
+else()
+    add_test(NAME sensors_test COMMAND sensors_test)
+endif()
+
+install(TARGETS sensors_test RUNTIME DESTINATION bin)

--- a/modules/sensors/test/bme680_test.cpp
+++ b/modules/sensors/test/bme680_test.cpp
@@ -1,0 +1,109 @@
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "bme680.hpp"
+#include "fake_i2c_transport.hpp"
+
+namespace {
+    /* A realistic-ish calibration set for the pure-function tests. */
+    Bme680::Calib make_calib() {
+        Bme680::Calib c{};
+        c.t1 = 26000; c.t2 = 26400; c.t3 = 3;
+        c.p1 = 36000; c.p2 = -10500; c.p3 = 88; c.p4 = 7000; c.p5 = -150;
+        c.p6 = 30; c.p7 = 15; c.p8 = -2000; c.p9 = -2500; c.p10 = 30;
+        c.h1 = 700; c.h2 = 1000; c.h3 = 0; c.h4 = 45; c.h5 = 20; c.h6 = 120; c.h7 = -100;
+        return c;
+    }
+}
+
+TEST(Bme680Test, Probe_Matches_ChipId) {
+    FakeI2cTransport bus;
+    Bme680 env(bus);
+    bus.regs[0xD0] = Bme680::kChipId;
+    EXPECT_TRUE(env.probe());
+    bus.regs[0xD0] = 0x00;
+    EXPECT_FALSE(env.probe());
+}
+
+TEST(Bme680Test, Init_Decodes_Calibration_Packing) {
+    FakeI2cTransport bus;
+    Bme680 env(bus);
+    /* Temperature coeffs. */
+    bus.regs[0xE9] = 0x34; bus.regs[0xEA] = 0x12;   // t1 = 0x1234
+    bus.regs[0x8A] = 0x78; bus.regs[0x8B] = 0x56;   // t2 = 0x5678
+    bus.regs[0x8C] = 0xFF;                          // t3 = -1
+    bus.regs[0xA0] = 0x1E;                          // p10 = 30
+    /* Humidity packed nibbles: H1=(E3<<4)|(E2&0xF), H2=(E1<<4)|(E2>>4). */
+    bus.regs[0xE1] = 0x12; bus.regs[0xE2] = 0xCD; bus.regs[0xE3] = 0xAB;
+
+    ASSERT_TRUE(env.init());
+    const Bme680::Calib& c = env.calib();
+    EXPECT_EQ(c.t1, 0x1234u);
+    EXPECT_EQ(c.t2, 0x5678);
+    EXPECT_EQ(c.t3, -1);
+    EXPECT_EQ(c.p10, 30u);
+    EXPECT_EQ(c.h1, 0xABDu);   // (0xAB<<4)|0x0D
+    EXPECT_EQ(c.h2, 0x12Cu);   // (0x12<<4)|0x0C
+}
+
+TEST(Bme680Test, Init_Reports_Bus_Error) {
+    FakeI2cTransport bus;
+    Bme680 env(bus);
+    bus.nack = true;
+    EXPECT_FALSE(env.init());
+}
+
+TEST(Bme680Test, Temperature_Sets_TFine_And_Is_Monotonic) {
+    Bme680::Calib a = make_calib();
+    Bme680::Calib b = make_calib();
+    const std::int32_t lo = Bme680::compensate_temperature(400000, a);
+    const std::int32_t hi = Bme680::compensate_temperature(550000, b);
+    EXPECT_NE(a.t_fine, 0);
+    EXPECT_GT(hi, lo);                       // higher ADC -> higher temperature
+    EXPECT_GT(lo, -4000);                    // within the -40..85 C envelope
+    EXPECT_LT(hi, 8500);
+}
+
+TEST(Bme680Test, Pressure_Is_Deterministic_And_Guards_DivByZero) {
+    Bme680::Calib c = make_calib();
+    Bme680::compensate_temperature(500000, c);      // establish t_fine
+    const std::int32_t p1 = Bme680::compensate_pressure(400000, c);
+    const std::int32_t p2 = Bme680::compensate_pressure(400000, c);
+    EXPECT_EQ(p1, p2);                               // pure / deterministic
+
+    Bme680::Calib bad = make_calib();
+    bad.p1 = 0;                                      // forces var1 == 0
+    Bme680::compensate_temperature(500000, bad);
+    EXPECT_EQ(Bme680::compensate_pressure(400000, bad), 0);
+}
+
+TEST(Bme680Test, Humidity_Is_Clamped_To_Range) {
+    Bme680::Calib c = make_calib();
+    Bme680::compensate_temperature(500000, c);
+    const std::int32_t h = Bme680::compensate_humidity(25000, c);
+    EXPECT_GE(h, 0);
+    EXPECT_LE(h, 100000);                            // milli-%RH, clamped 0..100%
+}
+
+TEST(Bme680Test, Read_Triggers_Forced_Mode_And_Returns_Finite_Sample) {
+    FakeI2cTransport bus;
+    Bme680 env(bus);
+    bus.regs[0xD0] = Bme680::kChipId;
+    /* Seed a plausible calibration via the register file. */
+    bus.regs[0xE9] = 0x90; bus.regs[0xEA] = 0x65;   // t1
+    bus.regs[0x8A] = 0x20; bus.regs[0x8B] = 0x67;   // t2
+    bus.regs[0x8E] = 0xA0; bus.regs[0x8F] = 0x8C;   // p1
+    ASSERT_TRUE(env.init());
+
+    /* field0 @ 0x1F: press[3], temp[3], hum[2]. */
+    const std::uint8_t field[8] = {0x50,0x00,0x00, 0x7A,0x00,0x00, 0x61,0xA8};
+    for (int i = 0; i < 8; ++i) bus.regs[0x1F + i] = field[i];
+
+    Bme680::Sample s{};
+    ASSERT_TRUE(env.read(s));
+    /* ctrl_meas must have been written with forced mode (low 2 bits == 01). */
+    EXPECT_EQ(bus.regs[0x74] & 0x03, 0x01);
+    EXPECT_TRUE(std::isfinite(s.temperature_c));
+    EXPECT_TRUE(std::isfinite(s.pressure_pa));
+    EXPECT_TRUE(std::isfinite(s.humidity_pct));
+}

--- a/modules/sensors/test/bmi160_test.cpp
+++ b/modules/sensors/test/bmi160_test.cpp
@@ -1,0 +1,62 @@
+#include <gtest/gtest.h>
+
+#include "bmi160.hpp"
+#include "fake_i2c_transport.hpp"
+
+TEST(Bmi160Test, Probe_Matches_ChipId) {
+    FakeI2cTransport bus;
+    Bmi160 imu(bus);
+    bus.regs[0x00] = Bmi160::kChipId;          // CHIP_ID
+    EXPECT_TRUE(imu.probe());
+
+    bus.regs[0x00] = 0x00;
+    EXPECT_FALSE(imu.probe());
+}
+
+TEST(Bmi160Test, Probe_Honours_Address) {
+    FakeI2cTransport bus;
+    Bmi160 imu(bus, Bmi160::kAddrSecondary);
+    bus.regs[0x00] = Bmi160::kChipId;
+    EXPECT_TRUE(imu.probe());
+    EXPECT_EQ(bus.lastAddr, Bmi160::kAddrSecondary);
+}
+
+TEST(Bmi160Test, Init_Issues_Accel_Then_Gyro_Power_Commands) {
+    FakeI2cTransport bus;
+    Bmi160 imu(bus);
+    EXPECT_EQ(imu.init(), I2cResult::Ok);
+    /* Last write wins on the CMD register; gyro command is issued second. */
+    EXPECT_EQ(bus.regs[0x7E], 0x15);
+}
+
+TEST(Bmi160Test, Read_Decodes_Signed_LittleEndian_Axes) {
+    FakeI2cTransport bus;
+    Bmi160 imu(bus);
+    /* Data block at 0x0C: gyro X/Y/Z then accel X/Y/Z, LSB first. */
+    const std::uint8_t blk[12] = {
+        0x01, 0x00,   // gx = +1
+        0xFF, 0xFF,   // gy = -1
+        0x00, 0x80,   // gz = -32768
+        0xFF, 0x7F,   // ax = +32767
+        0x34, 0x12,   // ay = 0x1234
+        0x00, 0x00,   // az = 0
+    };
+    for (int i = 0; i < 12; ++i) bus.regs[0x0C + i] = blk[i];
+
+    Bmi160::Sample s{};
+    ASSERT_TRUE(imu.read(s));
+    EXPECT_EQ(s.gx, 1);
+    EXPECT_EQ(s.gy, -1);
+    EXPECT_EQ(s.gz, -32768);
+    EXPECT_EQ(s.ax, 32767);
+    EXPECT_EQ(s.ay, 0x1234);
+    EXPECT_EQ(s.az, 0);
+}
+
+TEST(Bmi160Test, Read_Reports_Bus_Error) {
+    FakeI2cTransport bus;
+    Bmi160 imu(bus);
+    bus.nack = true;
+    Bmi160::Sample s{};
+    EXPECT_FALSE(imu.read(s));
+}

--- a/modules/sensors/test/fake_i2c_transport.hpp
+++ b/modules/sensors/test/fake_i2c_transport.hpp
@@ -1,0 +1,56 @@
+#ifndef __fake_i2c_transport_hpp__
+#define __fake_i2c_transport_hpp__
+
+#include <cstdint>
+#include <cstddef>
+
+#include "i2c_bus.hpp"
+
+/**
+ * @brief In-memory I²C slave for host tests.
+ *
+ * Models a standard auto-incrementing register device: a 256-byte register
+ * file plus a pointer set by the last write. The sensor drivers only ever talk
+ * through read_reg/write_reg/write, so this is enough to exercise them without
+ * any BSC1 hardware. Tests pre-load `regs[]` with the bytes a real chip would
+ * return, then assert on the decoded result.
+ */
+class FakeI2cTransport : public I2cTransport {
+    public:
+        std::uint8_t  regs[256] = {};
+        std::uint8_t  lastAddr  = 0;
+        int           ptr       = 0;
+        bool          nack      = false;   ///< force every transfer to NACK
+
+        I2cResult write(std::uint8_t addr, const std::uint8_t* buf, std::size_t len) override {
+            if (nack)        return I2cResult::Nack;
+            if (!buf || !len) return I2cResult::BadArg;
+            lastAddr = addr;
+            ptr = buf[0];
+            for (std::size_t i = 1; i < len; ++i) {
+                regs[(ptr + static_cast<int>(i) - 1) & 0xFF] = buf[i];
+            }
+            return I2cResult::Ok;
+        }
+
+        I2cResult read(std::uint8_t addr, std::uint8_t* buf, std::size_t len) override {
+            if (nack)        return I2cResult::Nack;
+            if (!buf || !len) return I2cResult::BadArg;
+            lastAddr = addr;
+            for (std::size_t i = 0; i < len; ++i) {
+                buf[i] = regs[(ptr + static_cast<int>(i)) & 0xFF];
+            }
+            ptr = (ptr + static_cast<int>(len)) & 0xFF;
+            return I2cResult::Ok;
+        }
+
+        I2cResult write_read(std::uint8_t addr,
+                             const std::uint8_t* wbuf, std::size_t wlen,
+                             std::uint8_t* rbuf, std::size_t rlen) override {
+            const I2cResult w = write(addr, wbuf, wlen);
+            if (w != I2cResult::Ok) return w;
+            return read(addr, rbuf, rlen);
+        }
+};
+
+#endif /*__fake_i2c_transport_hpp__*/

--- a/modules/sensors/test/main_test.cpp
+++ b/modules/sensors/test/main_test.cpp
@@ -1,0 +1,6 @@
+#include <gtest/gtest.h>
+
+int main(int argc, char** argv) {
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}

--- a/modules/sensors/test/opt3001_test.cpp
+++ b/modules/sensors/test/opt3001_test.cpp
@@ -1,0 +1,54 @@
+#include <gtest/gtest.h>
+#include <cmath>
+
+#include "opt3001.hpp"
+#include "fake_i2c_transport.hpp"
+
+TEST(Opt3001Test, Probe_Matches_DeviceId) {
+    FakeI2cTransport bus;
+    Opt3001 light(bus);
+    /* Device-ID register 0x7F == 0x3001, MSB-first. */
+    bus.regs[0x7F] = 0x30;
+    bus.regs[0x80] = 0x01;   // (ptr auto-increments to 0x80 for the 2nd byte)
+    EXPECT_TRUE(light.probe());
+
+    bus.regs[0x7F] = 0x00;
+    EXPECT_FALSE(light.probe());
+}
+
+TEST(Opt3001Test, Init_Writes_Continuous_Config_BigEndian) {
+    FakeI2cTransport bus;
+    Opt3001 light(bus);
+    EXPECT_EQ(light.init(), I2cResult::Ok);
+    EXPECT_EQ(bus.regs[0x01], 0xCE);   // config MSB
+    EXPECT_EQ(bus.regs[0x02], 0x10);   // config LSB
+}
+
+TEST(Opt3001Test, ReadLux_Decodes_Exponent_Mantissa) {
+    FakeI2cTransport bus;
+    Opt3001 light(bus);
+    /* Result 0x4199: E=4, mantissa=0x199(409) -> 0.01 * 16 * 409 = 65.44 lux. */
+    bus.regs[0x00] = 0x41;
+    bus.regs[0x01] = 0x99;
+    double lux = 0.0;
+    ASSERT_TRUE(light.read_lux(lux));
+    EXPECT_NEAR(lux, 65.44, 1e-9);
+}
+
+TEST(Opt3001Test, ReadLux_Zero) {
+    FakeI2cTransport bus;
+    Opt3001 light(bus);
+    bus.regs[0x00] = 0x00;
+    bus.regs[0x01] = 0x00;
+    double lux = -1.0;
+    ASSERT_TRUE(light.read_lux(lux));
+    EXPECT_DOUBLE_EQ(lux, 0.0);
+}
+
+TEST(Opt3001Test, ReadLux_Reports_Bus_Error) {
+    FakeI2cTransport bus;
+    Opt3001 light(bus);
+    bus.nack = true;
+    double lux = 0.0;
+    EXPECT_FALSE(light.read_lux(lux));
+}


### PR DESCRIPTION
## What

Second PR of the **mangOH Yellow integration** (design: `apps/docs/tdd-mangoh-yellow-sensors.md`). Adds `modules/sensors/` — one driver per onboard chip — on top of the PR-1 (#283) I²C transaction layer.

Each driver depends only on the **`I2cTransport`** seam from `modules/bcm2837`, so it runs over real BSC1 MMIO on the Pi and over an in-memory fake on the host. No hardware needed for the suite.

## Drivers

| Chip | Class | Addr | Provides |
|------|-------|------|----------|
| Bosch BMI160 | `Bmi160` | 0x68/0x69 | accel + gyro (raw int16 ×3) |
| Bosch BME680 | `Bme680` | 0x76/0x77 | temperature, pressure, humidity¹ |
| TI OPT3001²  | `Opt3001` | 0x44 | illuminance (lux) |

¹ Gas/VOC (IPSO 3325) is a follow-up — needs heater-profile setup.
² Exact mangOH light-sensor part confirmed on hardware in PR-4; OPT3001 is the default fit.

- `I2cSensor` base: `I2cTransport&` + 7-bit addr, `read_regs`/`read_u8`/`write_u8`.
- `Bme680` decodes the packed factory calibration and applies the Bosch fixed-point T/P/H compensation (temperature first for `t_fine`).
- `Opt3001` decodes `lux = 0.01·2^E·mantissa`.

## Test

`test/` gtests over a `FakeI2cTransport` (256-byte auto-increment register file): probe/chip-id, **calibration-packing decode**, axis/lux decode, compensation **monotonicity / clamping / determinism / div-by-zero guard**, and bus-error paths.

GTest isn't installed on the dev Mac, so the real driver sources were compiled with `clang++ -std=c++20 -Wall -Wextra` against a gtest-free harness mirroring every assertion: **clean compile, all 15 scenarios pass**. The suite ships for Yocto/CI.

> BME680 compensation follows the Bosch BME68x datasheet; exact physical accuracy is cross-checked on hardware in PR-4. Host tests cover protocol + decode + math behaviour.

## Scope

New module only — **not yet linked into the iot binary** (that's PR-3: IPSO objects + ds publish + sampler). The TDD doc is also extended with §6 scoping the mangOH **cellular-WAN uplink + GPS → LwM2M Object 6** plane (all telemetry converges on the existing LwM2M/cloud-endpoints infra).

🤖 Generated with [Claude Code](https://claude.com/claude-code)