### PR TITLE
feat(cellular): cellular WAN + GPS parsing/state core + schema (PR-A)

### DIFF
--- a/apps/docs/tdd-mangoh-yellow-sensors.md
+++ b/apps/docs/tdd-mangoh-yellow-sensors.md
@@ -135,46 +135,53 @@ SH
 ## 6. WAN plane — mangOH cellular uplink + GPS over LwM2M
 
 The mangOH Yellow's CF3 cellular module (Sierra Wireless WP-series) is the Pi's
-**primary WAN** and the **GPS/GNSS** source. This is a separate workstream from
-the I²C sensor drivers (PRs 1–4) — it touches `modules/wan` and the LwM2M object
-set, not `modules/sensors` — but shares the same destination: **cloud-iot over
-LwM2M**, on the infrastructure that already exists (DTLS/PSK bootstrap+register,
-ClientRegistry → `cloud.lwm2m.registrations` → EndpointRegistry → `cloud.endpoints`,
-observe/notify, IPSO objects). See `[[reference_cloud_endpoints_dataflow]]`.
+**primary WAN** and the **GPS/GNSS** source. Separate workstream from the I²C
+sensor drivers (PRs 1–4) — it touches `modules/wan` + the LwM2M object set — but
+shares the same destination: **cloud-iot over LwM2M**, on the infrastructure that
+already exists (DTLS/PSK bootstrap+register, ClientRegistry →
+`cloud.lwm2m.registrations` → EndpointRegistry → `cloud.endpoints`, observe/notify).
+See `[[reference_cloud_endpoints_dataflow]]`. net-router already routes the
+cellular slot (`net.iface.cellular.name` default `wwan0`,
+`net.iface.priority="eth,wifi,cellular"`), so once the daemon brings up `wwan0`
+with a default route, bootstrap→register→observe flow unchanged.
 
-### 6.1 Cellular WAN
-- The WP module presents to the Pi over USB as a network interface (QMI/MBIM or
-  RNDIS/ECM) plus an AT control channel. Bring-up = enumerate modem → set APN →
-  connect (ModemManager/`mmcli` or a `qmicli`/`pppd` path) → default route.
-- Add a **`modules/wan/cellular/`** daemon as a sibling of `modules/wan/wifi/`
-  (mirrors the wifi-client structure): manage the connection, publish
-  `wan.cellular.*` state into the data-store (operator, RSSI/RSRP, APN, IP,
-  up/down), and integrate with the existing online-gate / route preference so
-  cellular is the uplink when wired/WiFi is absent. Reuse the `vpn.state` /
-  `iot.conn.state` lifecycle pattern, not a new bespoke key
-  (`[[feedback_ds_key_reuse]]`).
-- The VPN/LwM2M client already binds to "whatever the default route is", so once
-  cellular provides the route, bootstrap→register→observe flows unchanged.
+### 6.A Task breakdown
 
-### 6.2 GPS / GNSS → LwM2M Object 6 (Location)
-- GPS comes off the **same WP module** (AT `+GPS`/`+QGPS` or QMI LOC / a gnss
-  NMEA device), **not** I²C — so it lives in the cellular daemon, which parses
-  fix → publishes `gps.*` (lat/lon/alt/speed/ts) into ds.
-- Surface to the cloud as **LwM2M Object 6 (Location)**: RIDs 0 Latitude,
-  1 Longitude, 2 Altitude, 5 Timestamp, 6 Speed. Install it next to the IPSO
-  sensor objects (PR-3 `install_sensors` sibling, e.g. `install_location`), with
-  read-closures bound to the `gps.*` ds keys and observe/notify on position
-  change. The cloud Endpoints table can then show device location.
+| Task | PR | State | Notes |
+| --- | --- | --- | --- |
+| **A — cellular core** | A | ✅ **DONE** | `modules/wan/cellular/` (`cellular_core` lib): pure `at_parser` (`+CSQ`→dBm/bars, `+COPS`→operator+tech, `+CREG/CGREG/CEREG`→reg, `+CGPADDR`→IP, ICCID), `nmea_parser` (GGA/RMC + XOR checksum → signed decimal-degree fix, knots→km/h), `CellularState` cache → `cell.*`/`gps.*` `to_kv()` batch. `schemas/cell.lua`. **17 gtests pass in podman.** No I/O — host-testable. |
+| **B — GPS → Object 6** | B | ⬜ TODO | Replace the static `install_location` (OID 6) with ds-backed read closures (like `install_sensors`): RID 0 Lat, 1 Lon, 2 Alt, 5 Timestamp, 6 Speed bound to `gps.*` keys; wire `LocationHooks` in `main.cpp`. Client-side, unprivileged, host-testable. |
+| **C — cellular-client daemon** | C | ⬜ TODO | Privileged producer in `modules/wan/cellular/` (sibling of wifi-client): drive the modem, connect the data context, run GNSS, publish `cell.*`/`gps.*`. **Reactor-driven, ACE-only I/O** (see 6.B). Connect FSM publishes `cell.state` (reuse the lifecycle-token convention, `[[feedback_ds_key_reuse]]`). Yocto `${PN}-cellular` package + `cellular-client.service` (NOT auto-enabled — needs the WP module). |
 
-### 6.3 Telemetry transport recap
-Everything converges on LwM2M: sensors → IPSO 33xx, GPS → Object 6, device
-health → Object 3 + existing `iot.*` keys. No new cloud ingestion path is
-needed — the device just registers more objects, and the cloud observes them.
+### 6.B Daemon I/O design — ACE only, reactor-driven (decided)
 
-### 6.4 Open questions (WAN)
-1. Modem stack on the Yocto image: ModemManager vs. raw `qmicli`/`pppd` — pick
-   per image size / WP firmware (QMI vs MBIM).
-2. USB enumeration: which interface the WP exposes to the Pi (composition may
-   need a `usb_modeswitch` / mode set).
-3. SIM/APN provisioning path (operator profile via device-ui vs. preconfigured).
-4. Power: the WP + Pi current draw on the mangOH supply during TX peaks.
+Per `[[feedback_ace_over_posix]]`, the daemon (PR-C) uses **ACE for all I/O — no
+raw POSIX** `open/read/write/select`:
+- The AT control channel and the GNSS NMEA stream are **serial ttys**
+  (`/dev/ttyUSB*`), opened via **`ACE_TTY_IO`/`ACE_DEV_IO`** (termios setup
+  through ACE), not `::open`.
+- Each device's `ACE_HANDLE` is **registered with the `ACE_Reactor`** through an
+  `ACE_Event_Handler` (`get_handle()` returns the fd; `handle_input()` fires on
+  readable) — i.e. yes, a driver's fd is fed to the reactor; no polling loop.
+  `handle_input()` line-buffers and feeds complete lines to the **pure PR-A
+  parsers**. A reactor **timer** (`schedule_timer`) drives the periodic AT polls
+  (`+CSQ/+COPS/+CREG`) and the GNSS query. Any sockets use `ACE_SOCK_*`; sleeps
+  `ACE_OS::sleep`; logging `ACE_DEBUG/ACE_ERROR`.
+- This keeps the daemon a thin reactor shell around the already-tested parsing/
+  state core.
+
+### 6.C GPS / GNSS source
+GPS comes off the **same WP module** (a GNSS NMEA tty, or `+QGPSLOC` over AT),
+**not** I²C. The daemon parses the fix (PR-A `nmea_parser`/`at_parser`) →
+publishes `gps.*` → PR-B mirrors into **LwM2M Object 6 (Location)** RIDs 0/1/2/5/6
+with observe/notify on position change, so the cloud Endpoints table can show
+device location.
+
+### 6.D Open questions (WAN — need hardware)
+1. Modem stack: ModemManager/`mmcli` vs. raw `qmicli`/`pppd` (or pure-AT
+   `+CGACT`/`+QNETDEVCTL`) — pick per image size / WP firmware (QMI vs MBIM).
+2. USB enumeration: which interfaces the WP exposes (AT vs DIAG vs NMEA vs net),
+   composition may need `usb_modeswitch`.
+3. SIM/APN provisioning path (operator profile via device-ui vs. preconfigured
+   `cell.apn`).
+4. Power: WP + Pi draw on the mangOH supply during TX peaks.

--- a/modules/wan/cellular/CMakeLists.txt
+++ b/modules/wan/cellular/CMakeLists.txt
@@ -1,0 +1,48 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(cellular CXX)
+
+# Top-level (own build) vs. pulled in via add_subdirectory() from the iot tree.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CELLULAR_TOP_LEVEL ON)
+else()
+    set(CELLULAR_TOP_LEVEL OFF)
+endif()
+
+option(CELLULAR_BUILD_TESTS  "Build the cellular gtest suite"            ${CELLULAR_TOP_LEVEL})
+option(CELLULAR_BUILD_DAEMON "Build the cellular-client modem daemon"    OFF)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Pure parsing/state core: no ACE, no data-store — fully host-unit-testable.
+# The serial/AT modem control + ds publishing live in the daemon (PR-C).
+add_library(cellular_core STATIC
+    src/at_parser.cpp
+    src/nmea_parser.cpp
+    src/cell_state.cpp)
+target_include_directories(cellular_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+target_compile_options(cellular_core PRIVATE -Wall -Wextra)
+add_library(cellular::core ALIAS cellular_core)
+
+# ── Install the cell.* / gps.* schema (operator + daemon contract) ──
+include(GNUInstallDirs)
+if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+    install(FILES schemas/cell.lua
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+endif()
+
+if(CELLULAR_BUILD_TESTS)
+    enable_testing()
+    find_package(GTest REQUIRED)
+    add_executable(cellular-tests
+        test/at_parser_test.cpp
+        test/nmea_parser_test.cpp
+        test/cell_state_test.cpp)
+    target_link_libraries(cellular-tests cellular_core GTest::gtest GTest::gtest_main pthread)
+    include(GoogleTest)
+    if(CELLULAR_TOP_LEVEL)
+        gtest_discover_tests(cellular-tests)
+    else()
+        add_test(NAME cellular-tests COMMAND cellular-tests)
+    endif()
+endif()

--- a/modules/wan/cellular/README.md
+++ b/modules/wan/cellular/README.md
@@ -1,0 +1,39 @@
+# cellular — mangOH Yellow cellular WAN + GPS
+
+Drives the mangOH Yellow's CF3 cellular module (Sierra Wireless WP / Quectel) as
+the Pi's **primary WAN uplink** and its **GPS/GNSS** source, publishing status to
+the data-store. Sibling of `modules/wan/wifi/client`. Part of the WAN plane in
+[`apps/docs/tdd-mangoh-yellow-sensors.md`](../../../apps/docs/tdd-mangoh-yellow-sensors.md) §6.
+
+## Layout
+
+```
+inc/at_parser.hpp    pure +CSQ/+COPS/+CREG/+CGPADDR/ICCID parsers
+inc/nmea_parser.hpp  pure $--GGA / $--RMC NMEA parsers (+ XOR checksum)
+inc/cell_state.hpp   CellularState cache → cell.* / gps.* to_kv() batch
+src/                 implementations (no I/O — host-testable)
+schemas/cell.lua     cell.* (modem status) + gps.* (location) ds keys
+test/                gtests over the parsers + state (run in podman)
+daemon/              cellular-client — the privileged producer (PR-C)
+```
+
+`cellular_core` (the lib) is **pure** — no ACE, no data-store — so the AT/NMEA
+parsing and state are fully host-unit-tested. The serial/modem control and ds
+publishing live in the `cellular-client` daemon (PR-C), which is **reactor-driven
+and ACE-only**: the AT + GNSS ttys are `ACE_TTY_IO`/`ACE_DEV_IO` handles
+registered with the `ACE_Reactor` (`handle_input` → parsers), with a reactor
+timer for the periodic `+CSQ/+COPS/+CREG` polls — no raw POSIX I/O.
+
+## Build & test
+
+```bash
+cmake -S modules/wan/cellular -B modules/wan/cellular/build -DCELLULAR_BUILD_TESTS=ON
+cmake --build modules/wan/cellular/build
+ctest --test-dir modules/wan/cellular/build
+```
+
+## Data flow
+
+`cellular-client` → `cell.*` / `gps.*` in ds → device-ui (local) + the lwm2m
+client mirrors `gps.*` into **LwM2M Object 6 (Location)** for the cloud (PR-B).
+net-router already routes the cellular slot (`net.iface.cellular.name`/`wwan0`).

--- a/modules/wan/cellular/inc/at_parser.hpp
+++ b/modules/wan/cellular/inc/at_parser.hpp
@@ -1,0 +1,63 @@
+#ifndef __cellular_at_parser_hpp__
+#define __cellular_at_parser_hpp__
+
+#include <string>
+
+/**
+ * @file at_parser.hpp
+ * @brief Pure parsers for the AT-command responses the cellular daemon needs.
+ *
+ * The mangOH Yellow's CF3 module (Sierra Wireless WP / Quectel) is driven over
+ * an AT control channel (/dev/ttyUSB*). These free functions turn the common
+ * status responses into typed values; they touch no hardware so they are fully
+ * host-unit-testable. The daemon (PR-C) does the serial I/O and feeds the
+ * response lines here.
+ */
+
+namespace cellular {
+
+/// Signal quality from `+CSQ: <rssi>,<ber>`.
+struct Signal {
+    bool valid = false;
+    int  dbm   = 0;   ///< RSSI in dBm (-113..-51); 0 when unknown
+    int  bars  = 0;   ///< 0..5 derived from dbm for the UI
+};
+
+/// Operator + access technology from `+COPS: <mode>,<format>,"<oper>"[,<act>]`.
+struct Operator {
+    bool        valid = false;
+    std::string name;          ///< e.g. "Vodafone"
+    std::string tech;          ///< "2G" / "3G" / "4G" / "" (unknown)
+};
+
+/// Network registration state from `+CREG/+CGREG/+CEREG`.
+enum class Reg {
+    Unknown,
+    NotRegistered,
+    Searching,
+    Denied,
+    Home,
+    Roaming,
+};
+
+/// `+CSQ: <rssi>,<ber>` → Signal. rssi 0..31 maps to -113..-51 dBm; 99 = unknown.
+Signal parse_csq(const std::string& line);
+
+/// `+COPS: ...` → Operator. The quoted name and optional <act> are extracted.
+Operator parse_cops(const std::string& line);
+
+/// `+CREG/+CGREG/+CEREG: [<n>,]<stat>` → Reg (uses the <stat> field).
+Reg parse_creg(const std::string& line);
+
+/// Canonical lowercase token for a Reg ("home", "roaming", "searching", …).
+const char* reg_str(Reg r);
+
+/// `+CGPADDR: <cid>,"<ip>"` (or unquoted) → the IPv4/IPv6 string, or "".
+std::string parse_cgpaddr(const std::string& line);
+
+/// ICCID from `+QCCID: <iccid>` / `+CCID: <iccid>` / a bare digit line → "".
+std::string parse_iccid(const std::string& line);
+
+} // namespace cellular
+
+#endif /*__cellular_at_parser_hpp__*/

--- a/modules/wan/cellular/inc/cell_state.hpp
+++ b/modules/wan/cellular/inc/cell_state.hpp
@@ -1,0 +1,58 @@
+#ifndef __cellular_cell_state_hpp__
+#define __cellular_cell_state_hpp__
+
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "at_parser.hpp"
+#include "nmea_parser.hpp"
+
+/**
+ * @file cell_state.hpp
+ * @brief Latest cellular + GPS state, and the ds key batch it publishes.
+ *
+ * Pure/ACE-free (host-testable), mirroring SensorCache: the daemon feeds it the
+ * parsed AT/NMEA values and calls `to_kv()` to publish `cell.*` (modem status)
+ * and `gps.*` (location) into the data-store. The lwm2m client mirrors `gps.*`
+ * into LwM2M Object 6 (Location); the device-ui shows `cell.*` locally.
+ */
+
+namespace cellular {
+
+struct KV {
+    std::string key;
+    std::string value;
+};
+
+class CellularState {
+    public:
+        /// Connection lifecycle token: "absent" / "init" / "sim-missing" /
+        /// "searching" / "registered" / "connecting" / "connected" / "failed".
+        void set_state(const std::string& token);
+        void set_signal(const Signal& s);
+        void set_operator(const Operator& op);
+        void set_reg(Reg r);
+        void set_ip(const std::string& ip);
+        void set_iccid(const std::string& iccid);
+        void set_gps(const GpsFix& fix);
+
+        /// `cell.*` + `gps.*` batch (only populated fields are emitted), plus a
+        /// per-domain version counter for the device-ui long-poll.
+        std::vector<KV> to_kv() const;
+
+    private:
+        mutable std::mutex m_mtx;
+        std::string m_state;
+        std::string m_operator, m_tech, m_reg, m_ip, m_iccid;
+        int  m_dbm = 0, m_bars = 0;
+        bool m_haveSignal = false, m_haveCell = false;
+        GpsFix m_gps;
+        bool m_haveGps = false;
+        std::uint64_t m_cellVersion = 0, m_gpsVersion = 0;
+};
+
+} // namespace cellular
+
+#endif /*__cellular_cell_state_hpp__*/

--- a/modules/wan/cellular/inc/nmea_parser.hpp
+++ b/modules/wan/cellular/inc/nmea_parser.hpp
@@ -1,0 +1,44 @@
+#ifndef __cellular_nmea_parser_hpp__
+#define __cellular_nmea_parser_hpp__
+
+#include <string>
+
+/**
+ * @file nmea_parser.hpp
+ * @brief Pure NMEA-0183 GNSS sentence parsers (GGA + RMC).
+ *
+ * The WP module's GNSS emits NMEA on a dedicated port (or QGPSLOC over AT).
+ * These parsers turn `$GxGGA` (altitude/quality/sats) and `$GxRMC`
+ * (position/speed/course/validity) into a typed fix. No hardware — fully
+ * host-unit-testable. Latitude/longitude are converted to signed decimal
+ * degrees; speed to km/h.
+ */
+
+namespace cellular {
+
+struct GpsFix {
+    bool        valid = false;     ///< a usable 2D/3D position was parsed
+    std::string quality;           ///< "none" / "2d" / "3d"
+    double      lat = 0.0;         ///< decimal degrees, +N / -S
+    double      lon = 0.0;         ///< decimal degrees, +E / -W
+    double      alt_m = 0.0;       ///< altitude above MSL, metres (GGA)
+    double      speed_kmh = 0.0;   ///< ground speed, km/h (RMC)
+    double      course_deg = 0.0;  ///< course over ground, degrees (RMC)
+    int         sats = 0;          ///< satellites used (GGA)
+    std::string utc;               ///< raw UTC hhmmss[.sss] field
+};
+
+/// Validate the `*HH` XOR checksum of a full NMEA sentence (between '$' and '*').
+bool nmea_checksum_ok(const std::string& sentence);
+
+/// Parse a `$--GGA` sentence into `out` (lat/lon/alt/sats/quality). Returns
+/// false on a malformed sentence or bad checksum; `out` is updated in place so
+/// a GGA+RMC pair can be merged into one fix.
+bool parse_gga(const std::string& sentence, GpsFix& out);
+
+/// Parse a `$--RMC` sentence into `out` (lat/lon/speed/course/validity).
+bool parse_rmc(const std::string& sentence, GpsFix& out);
+
+} // namespace cellular
+
+#endif /*__cellular_nmea_parser_hpp__*/

--- a/modules/wan/cellular/schemas/cell.lua
+++ b/modules/wan/cellular/schemas/cell.lua
@@ -1,0 +1,73 @@
+-- cell.* / gps.* schema for the cellular-client modem daemon (mangOH Yellow
+-- CF3 / WP module over an AT control channel + GNSS).
+--
+-- Read keys (operator → daemon):
+--   cell.apn                - APN to activate the data context (default "";
+--                             operator/SIM-specific, set via ds-cli / cloud-ui)
+--   cell.modem.tty          - AT control device (default "/dev/ttyUSB2")
+--   cell.gps.tty            - NMEA device; empty → poll GNSS over AT (QGPSLOC)
+--   cell.poll.interval.sec  - status poll cadence (+CSQ/+COPS/+CREG) (default 30)
+--   cell.gps.enable         - enable GNSS reads (default true)
+--
+-- Write keys (daemon → operator / device-ui / lwm2m client). All string-typed
+-- so the daemon publishes the cache batch verbatim; the device-ui and the
+-- client's Object-6 mirror parse as needed. Numeric values are decimal strings.
+--   cell.state       - "absent"/"init"/"sim-missing"/"searching"/"registered"/
+--                      "connecting"/"connected"/"failed"
+--   cell.operator    - registered operator name
+--   cell.tech        - "2G"/"3G"/"4G"
+--   cell.reg         - "home"/"roaming"/"searching"/"denied"/"not-registered"/
+--                      "unknown"
+--   cell.signal.dbm  - RSSI in dBm
+--   cell.signal.bars - 0..5 signal bars (UI)
+--   cell.ip          - IP assigned to the data context (wwan0)
+--   cell.iccid       - SIM ICCID
+--   cell.version     - bump-on-change counter for the device-ui long-poll
+--   gps.fix          - "none"/"2d"/"3d"
+--   gps.lat/lon      - decimal degrees (signed)
+--   gps.alt          - altitude (m)
+--   gps.speed        - ground speed (km/h)
+--   gps.course       - course over ground (deg)
+--   gps.sats         - satellites used
+--   gps.utc          - raw UTC field from the fix
+--   gps.version      - bump-on-change counter
+--
+-- The lwm2m client mirrors gps.* into LwM2M Object 6 (Location); net-router
+-- already routes the cellular slot (net.iface.cellular.name default "wwan0").
+
+local function viewer_str()  return { access = "Viewer", type = "string",  default = "" } end
+local function admin_str(d)  return { access = "Admin",  type = "string",  default = d } end
+
+return {
+  namespace = "cell",
+  keys = {
+    -- read (operator-set)
+    ["cell.apn"]               = admin_str(""),
+    ["cell.modem.tty"]         = admin_str("/dev/ttyUSB2"),
+    ["cell.gps.tty"]           = admin_str(""),
+    ["cell.poll.interval.sec"] = { access = "Admin", type = "integer", default = 30, min = 5, max = 3600 },
+    ["cell.gps.enable"]        = { access = "Admin", type = "boolean", default = true },
+
+    -- write (daemon-published status)
+    ["cell.state"]       = viewer_str(),
+    ["cell.operator"]    = viewer_str(),
+    ["cell.tech"]        = viewer_str(),
+    ["cell.reg"]         = viewer_str(),
+    ["cell.signal.dbm"]  = viewer_str(),
+    ["cell.signal.bars"] = viewer_str(),
+    ["cell.ip"]          = viewer_str(),
+    ["cell.iccid"]       = viewer_str(),
+    ["cell.version"]     = viewer_str(),
+
+    -- GPS / GNSS (daemon-published)
+    ["gps.fix"]     = viewer_str(),
+    ["gps.lat"]     = viewer_str(),
+    ["gps.lon"]     = viewer_str(),
+    ["gps.alt"]     = viewer_str(),
+    ["gps.speed"]   = viewer_str(),
+    ["gps.course"]  = viewer_str(),
+    ["gps.sats"]    = viewer_str(),
+    ["gps.utc"]     = viewer_str(),
+    ["gps.version"] = viewer_str(),
+  },
+}

--- a/modules/wan/cellular/src/at_parser.cpp
+++ b/modules/wan/cellular/src/at_parser.cpp
@@ -1,0 +1,159 @@
+#include "at_parser.hpp"
+
+#include <cctype>
+#include <cstdlib>
+#include <vector>
+
+namespace cellular {
+
+namespace {
+
+/// Return the substring after the first ':' (the AT response payload), trimmed
+/// of leading spaces. Returns "" if there is no ':'.
+std::string after_colon(const std::string& line) {
+    const auto pos = line.find(':');
+    if (pos == std::string::npos) return {};
+    std::size_t i = pos + 1;
+    while (i < line.size() && line[i] == ' ') ++i;
+    return line.substr(i);
+}
+
+/// Split on commas at top level (commas inside double quotes are kept).
+std::vector<std::string> split_csv(const std::string& s) {
+    std::vector<std::string> out;
+    std::string cur;
+    bool inq = false;
+    for (char c : s) {
+        if (c == '"') { inq = !inq; cur.push_back(c); }
+        else if (c == ',' && !inq) { out.push_back(cur); cur.clear(); }
+        else cur.push_back(c);
+    }
+    out.push_back(cur);
+    return out;
+}
+
+std::string strip_quotes(std::string s) {
+    if (s.size() >= 2 && s.front() == '"' && s.back() == '"') {
+        s = s.substr(1, s.size() - 2);
+    }
+    return s;
+}
+
+/// Map a 3GPP <act> access-technology code to a coarse generation label.
+const char* act_to_tech(int act) {
+    switch (act) {
+        case 0: case 1: case 3:           return "2G";   // GSM / GSM Compact / EGPRS
+        case 2: case 4: case 5: case 6:   return "3G";   // UTRAN / HSDPA / HSUPA / HSPA
+        case 7: case 8: case 9:           return "4G";   // E-UTRAN (LTE) families
+        default:                          return "";
+    }
+}
+
+} // namespace
+
+Signal parse_csq(const std::string& line) {
+    Signal s;
+    const std::string body = after_colon(line);
+    if (body.empty()) return s;
+    const auto parts = split_csv(body);
+    if (parts.empty()) return s;
+    char* end = nullptr;
+    const long rssi = std::strtol(parts[0].c_str(), &end, 10);
+    if (end == parts[0].c_str() || rssi < 0 || rssi == 99 || rssi > 31) {
+        return s;   // 99 = "not known or not detectable"
+    }
+    s.valid = true;
+    s.dbm = static_cast<int>(-113 + 2 * rssi);
+    // 5 bars across the usable RSSI window (roughly -109..-53 dBm).
+    if      (s.dbm >= -65) s.bars = 5;
+    else if (s.dbm >= -75) s.bars = 4;
+    else if (s.dbm >= -85) s.bars = 3;
+    else if (s.dbm >= -95) s.bars = 2;
+    else if (s.dbm >= -105) s.bars = 1;
+    else                    s.bars = 0;
+    return s;
+}
+
+Operator parse_cops(const std::string& line) {
+    Operator op;
+    const std::string body = after_colon(line);
+    if (body.empty()) return op;
+    const auto parts = split_csv(body);
+    // +COPS: <mode>,<format>,"<oper>"[,<act>] — name is field index 2.
+    if (parts.size() >= 3) {
+        op.name = strip_quotes(parts[2]);
+        if (!op.name.empty()) op.valid = true;
+    }
+    if (parts.size() >= 4) {
+        char* end = nullptr;
+        const long act = std::strtol(parts[3].c_str(), &end, 10);
+        if (end != parts[3].c_str()) op.tech = act_to_tech(static_cast<int>(act));
+    }
+    return op;
+}
+
+Reg parse_creg(const std::string& line) {
+    const std::string body = after_colon(line);
+    if (body.empty()) return Reg::Unknown;
+    const auto parts = split_csv(body);
+    // Response form is "<n>,<stat>", solicited query "<stat>". Use the last
+    // purely-numeric field that looks like a <stat> (0..5).
+    long stat = -1;
+    for (const auto& p : parts) {
+        char* end = nullptr;
+        const long v = std::strtol(p.c_str(), &end, 10);
+        if (end != p.c_str() && *end == '\0') stat = v;   // numeric field
+        if (parts.size() == 1) break;
+    }
+    // When two numeric fields are present (<n>,<stat>), the loop above leaves
+    // `stat` = the last one, which is <stat>. For a single field it's <stat>.
+    switch (stat) {
+        case 1:  return Reg::Home;
+        case 2:  return Reg::Searching;
+        case 3:  return Reg::Denied;
+        case 5:  return Reg::Roaming;
+        case 0:  return Reg::NotRegistered;
+        default: return Reg::Unknown;
+    }
+}
+
+const char* reg_str(Reg r) {
+    switch (r) {
+        case Reg::Home:          return "home";
+        case Reg::Roaming:       return "roaming";
+        case Reg::Searching:     return "searching";
+        case Reg::Denied:        return "denied";
+        case Reg::NotRegistered: return "not-registered";
+        case Reg::Unknown:       default: return "unknown";
+    }
+}
+
+std::string parse_cgpaddr(const std::string& line) {
+    const std::string body = after_colon(line);
+    if (body.empty()) return {};
+    const auto parts = split_csv(body);
+    // +CGPADDR: <cid>,<address>  — address is field 1, may be quoted.
+    if (parts.size() >= 2) {
+        std::string ip = strip_quotes(parts[1]);
+        if (ip != "0.0.0.0" && !ip.empty()) return ip;
+    }
+    return {};
+}
+
+std::string parse_iccid(const std::string& line) {
+    std::string body = after_colon(line);
+    if (body.empty()) {
+        // A bare ICCID line (no "+CCID:" prefix).
+        body = line;
+    }
+    std::string digits;
+    for (char c : body) {
+        if (std::isdigit(static_cast<unsigned char>(c)) || c == 'F' || c == 'f') {
+            digits.push_back(c);
+        }
+    }
+    // ICCIDs are 19–20 chars; reject obviously-too-short noise.
+    return digits.size() >= 18 ? digits : std::string{};
+}
+
+} // namespace cellular

--- a/modules/wan/cellular/src/cell_state.cpp
+++ b/modules/wan/cellular/src/cell_state.cpp
@@ -1,0 +1,87 @@
+#include "cell_state.hpp"
+
+#include <cstdio>
+
+namespace cellular {
+
+namespace {
+    std::string fmt(double v, int decimals) {
+        char buf[40];
+        std::snprintf(buf, sizeof(buf), "%.*f", decimals, v);
+        return buf;
+    }
+}
+
+void CellularState::set_state(const std::string& token) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    m_state = token; m_haveCell = true; ++m_cellVersion;
+}
+
+void CellularState::set_signal(const Signal& s) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    if (!s.valid) return;
+    m_dbm = s.dbm; m_bars = s.bars; m_haveSignal = true; m_haveCell = true; ++m_cellVersion;
+}
+
+void CellularState::set_operator(const Operator& op) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    if (!op.valid) return;
+    m_operator = op.name;
+    if (!op.tech.empty()) m_tech = op.tech;
+    m_haveCell = true; ++m_cellVersion;
+}
+
+void CellularState::set_reg(Reg r) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    m_reg = reg_str(r); m_haveCell = true; ++m_cellVersion;
+}
+
+void CellularState::set_ip(const std::string& ip) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    m_ip = ip; m_haveCell = true; ++m_cellVersion;
+}
+
+void CellularState::set_iccid(const std::string& iccid) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    if (iccid.empty()) return;
+    m_iccid = iccid; m_haveCell = true; ++m_cellVersion;
+}
+
+void CellularState::set_gps(const GpsFix& fix) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    m_gps = fix; m_haveGps = true; ++m_gpsVersion;
+}
+
+std::vector<KV> CellularState::to_kv() const {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    std::vector<KV> kv;
+    if (m_haveCell) {
+        if (!m_state.empty())    kv.push_back({"cell.state", m_state});
+        if (!m_operator.empty()) kv.push_back({"cell.operator", m_operator});
+        if (!m_tech.empty())     kv.push_back({"cell.tech", m_tech});
+        if (!m_reg.empty())      kv.push_back({"cell.reg", m_reg});
+        if (!m_ip.empty())       kv.push_back({"cell.ip", m_ip});
+        if (!m_iccid.empty())    kv.push_back({"cell.iccid", m_iccid});
+        if (m_haveSignal) {
+            kv.push_back({"cell.signal.dbm",  std::to_string(m_dbm)});
+            kv.push_back({"cell.signal.bars", std::to_string(m_bars)});
+        }
+        kv.push_back({"cell.version", std::to_string(m_cellVersion)});
+    }
+    if (m_haveGps) {
+        kv.push_back({"gps.fix", m_gps.quality.empty() ? "none" : m_gps.quality});
+        if (m_gps.valid) {
+            kv.push_back({"gps.lat",    fmt(m_gps.lat, 6)});
+            kv.push_back({"gps.lon",    fmt(m_gps.lon, 6)});
+            kv.push_back({"gps.alt",    fmt(m_gps.alt_m, 1)});
+            kv.push_back({"gps.speed",  fmt(m_gps.speed_kmh, 1)});
+            kv.push_back({"gps.course", fmt(m_gps.course_deg, 1)});
+            kv.push_back({"gps.sats",   std::to_string(m_gps.sats)});
+            if (!m_gps.utc.empty()) kv.push_back({"gps.utc", m_gps.utc});
+        }
+        kv.push_back({"gps.version", std::to_string(m_gpsVersion)});
+    }
+    return kv;
+}
+
+} // namespace cellular

--- a/modules/wan/cellular/src/nmea_parser.cpp
+++ b/modules/wan/cellular/src/nmea_parser.cpp
@@ -1,0 +1,115 @@
+#include "nmea_parser.hpp"
+
+#include <cstdlib>
+#include <vector>
+
+namespace cellular {
+
+namespace {
+
+/// Split a sentence body on commas (NMEA has no quoting). Trailing checksum is
+/// stripped by the caller before splitting.
+std::vector<std::string> split_fields(const std::string& s) {
+    std::vector<std::string> out;
+    std::string cur;
+    for (char c : s) {
+        if (c == ',') { out.push_back(cur); cur.clear(); }
+        else cur.push_back(c);
+    }
+    out.push_back(cur);
+    return out;
+}
+
+double to_double(const std::string& s) {
+    if (s.empty()) return 0.0;
+    return std::strtod(s.c_str(), nullptr);
+}
+
+/// NMEA latitude/longitude come as ddmm.mmmm / dddmm.mmmm. Convert to signed
+/// decimal degrees using the hemisphere field (N/E +, S/W -).
+double dm_to_deg(const std::string& dm, const std::string& hemi, int deg_digits) {
+    if (dm.size() < static_cast<std::size_t>(deg_digits)) return 0.0;
+    const double whole = to_double(dm.substr(0, deg_digits));
+    const double minutes = to_double(dm.substr(deg_digits));
+    double deg = whole + minutes / 60.0;
+    if (hemi == "S" || hemi == "W") deg = -deg;
+    return deg;
+}
+
+/// Return the sentence type token (e.g. "GGA") from "$GPGGA" / "$GNGGA".
+std::string talker_type(const std::string& sentence) {
+    // "$ttSSS,..." → the 3 chars after the 2-char talker id.
+    if (sentence.size() < 6 || sentence[0] != '$') return {};
+    return sentence.substr(3, 3);
+}
+
+} // namespace
+
+bool nmea_checksum_ok(const std::string& sentence) {
+    const auto star = sentence.find('*');
+    if (sentence.empty() || sentence[0] != '$' || star == std::string::npos) {
+        return false;
+    }
+    if (star + 3 > sentence.size()) return false;   // need 2 hex chars
+    unsigned char sum = 0;
+    for (std::size_t i = 1; i < star; ++i) {
+        sum ^= static_cast<unsigned char>(sentence[i]);
+    }
+    const long given = std::strtol(sentence.substr(star + 1, 2).c_str(), nullptr, 16);
+    return static_cast<long>(sum) == given;
+}
+
+namespace {
+/// Common front-matter for both parsers: validate checksum + type, return the
+/// comma-split fields (body between '$' and '*').
+bool fields_for(const std::string& sentence, const char* want,
+                std::vector<std::string>& fields) {
+    if (!nmea_checksum_ok(sentence)) return false;
+    if (talker_type(sentence) != want) return false;
+    const auto star = sentence.find('*');
+    fields = split_fields(sentence.substr(1, star - 1));   // drop '$' and '*..'
+    return true;
+}
+} // namespace
+
+bool parse_gga(const std::string& sentence, GpsFix& out) {
+    std::vector<std::string> f;
+    if (!fields_for(sentence, "GGA", f)) return false;
+    // 0:type 1:utc 2:lat 3:N/S 4:lon 5:E/W 6:qual 7:sats 8:hdop 9:alt 10:M ...
+    if (f.size() < 10) return false;
+    const int qual = static_cast<int>(std::strtol(f[6].c_str(), nullptr, 10));
+    out.utc  = f[1];
+    out.sats = static_cast<int>(std::strtol(f[7].c_str(), nullptr, 10));
+    out.alt_m = to_double(f[9]);
+    if (qual > 0 && !f[2].empty() && !f[4].empty()) {
+        out.lat = dm_to_deg(f[2], f[3], 2);
+        out.lon = dm_to_deg(f[4], f[5], 3);
+        out.valid = true;
+        out.quality = "3d";          // GGA with a fix; RMC refines 2d vs 3d if needed
+    } else {
+        out.quality = "none";
+    }
+    return true;
+}
+
+bool parse_rmc(const std::string& sentence, GpsFix& out) {
+    std::vector<std::string> f;
+    if (!fields_for(sentence, "RMC", f)) return false;
+    // 0:type 1:utc 2:status 3:lat 4:N/S 5:lon 6:E/W 7:speed(kn) 8:course 9:date
+    if (f.size() < 9) return false;
+    out.utc = f[1];
+    const bool active = (f[2] == "A");
+    if (active && !f[3].empty() && !f[5].empty()) {
+        out.lat = dm_to_deg(f[3], f[4], 2);
+        out.lon = dm_to_deg(f[5], f[6], 3);
+        out.speed_kmh = to_double(f[7]) * 1.852;   // knots → km/h
+        out.course_deg = to_double(f[8]);
+        out.valid = true;
+        if (out.quality.empty() || out.quality == "none") out.quality = "2d";
+    } else if (out.quality.empty()) {
+        out.quality = "none";
+    }
+    return true;
+}
+
+} // namespace cellular

--- a/modules/wan/cellular/test/at_parser_test.cpp
+++ b/modules/wan/cellular/test/at_parser_test.cpp
@@ -1,0 +1,60 @@
+#include <gtest/gtest.h>
+
+#include "at_parser.hpp"
+
+using namespace cellular;
+
+TEST(AtCsq, MidScale) {
+    Signal s = parse_csq("+CSQ: 24,0");
+    EXPECT_TRUE(s.valid);
+    EXPECT_EQ(s.dbm, -113 + 2 * 24);   // -65 dBm
+    EXPECT_EQ(s.bars, 5);
+}
+
+TEST(AtCsq, WeakAndUnknown) {
+    Signal weak = parse_csq("+CSQ: 2,0");
+    EXPECT_TRUE(weak.valid);
+    EXPECT_EQ(weak.dbm, -109);
+    EXPECT_EQ(weak.bars, 0);
+
+    EXPECT_FALSE(parse_csq("+CSQ: 99,99").valid);   // not detectable
+    EXPECT_FALSE(parse_csq("garbage").valid);
+}
+
+TEST(AtCops, NameAndTech) {
+    Operator op = parse_cops("+COPS: 0,0,\"Vodafone\",7");
+    EXPECT_TRUE(op.valid);
+    EXPECT_EQ(op.name, "Vodafone");
+    EXPECT_EQ(op.tech, "4G");
+
+    Operator g3 = parse_cops("+COPS: 0,0,\"O2 - UK\",2");
+    EXPECT_EQ(g3.name, "O2 - UK");
+    EXPECT_EQ(g3.tech, "3G");
+
+    EXPECT_FALSE(parse_cops("+COPS: 0").valid);     // not registered to an operator
+}
+
+TEST(AtCreg, States) {
+    EXPECT_EQ(parse_creg("+CREG: 0,1"), Reg::Home);
+    EXPECT_EQ(parse_creg("+CREG: 2,5"), Reg::Roaming);
+    EXPECT_EQ(parse_creg("+CEREG: 1,2"), Reg::Searching);
+    EXPECT_EQ(parse_creg("+CGREG: 0,3"), Reg::Denied);
+    EXPECT_EQ(parse_creg("+CEREG: 5"), Reg::Roaming);     // solicited, single field
+    EXPECT_EQ(parse_creg("+CREG: 0,0"), Reg::NotRegistered);
+    EXPECT_STREQ(reg_str(Reg::Home), "home");
+    EXPECT_STREQ(reg_str(Reg::Roaming), "roaming");
+}
+
+TEST(AtCgpaddr, ExtractsIp) {
+    EXPECT_EQ(parse_cgpaddr("+CGPADDR: 1,\"10.181.22.7\""), "10.181.22.7");
+    EXPECT_EQ(parse_cgpaddr("+CGPADDR: 1,100.92.3.44"), "100.92.3.44");
+    EXPECT_EQ(parse_cgpaddr("+CGPADDR: 1,\"0.0.0.0\""), "");   // no context yet
+    EXPECT_EQ(parse_cgpaddr("+CGPADDR: 1"), "");
+}
+
+TEST(AtIccid, AcceptsLongDigits) {
+    EXPECT_EQ(parse_iccid("+QCCID: 8944500207123456789"), "8944500207123456789");
+    EXPECT_EQ(parse_iccid("+CCID: 8901234567890123456F"), "8901234567890123456F");
+    EXPECT_EQ(parse_iccid("8944500207123456789"), "8944500207123456789");  // bare
+    EXPECT_EQ(parse_iccid("ERROR"), "");
+}

--- a/modules/wan/cellular/test/cell_state_test.cpp
+++ b/modules/wan/cellular/test/cell_state_test.cpp
@@ -1,0 +1,74 @@
+#include <gtest/gtest.h>
+#include <algorithm>
+
+#include "cell_state.hpp"
+
+using namespace cellular;
+
+static std::string val(const std::vector<KV>& kv, const std::string& k) {
+    for (auto& e : kv) if (e.key == k) return e.value;
+    return "<absent>";
+}
+static bool has(const std::vector<KV>& kv, const std::string& k) {
+    return std::any_of(kv.begin(), kv.end(), [&](const KV& e){ return e.key == k; });
+}
+
+TEST(CellState, EmptyEmitsNothing) {
+    CellularState st;
+    EXPECT_TRUE(st.to_kv().empty());
+}
+
+TEST(CellState, CellularFieldsPublished) {
+    CellularState st;
+    st.set_state("connected");
+    st.set_signal(parse_csq("+CSQ: 20,0"));        // -73 dBm
+    st.set_operator(parse_cops("+COPS: 0,0,\"Telekom\",7"));
+    st.set_reg(parse_creg("+CREG: 0,5"));          // roaming
+    st.set_ip("10.20.30.40");
+    st.set_iccid(parse_iccid("+QCCID: 8944500207123456789"));
+
+    auto kv = st.to_kv();
+    EXPECT_EQ(val(kv, "cell.state"), "connected");
+    EXPECT_EQ(val(kv, "cell.operator"), "Telekom");
+    EXPECT_EQ(val(kv, "cell.tech"), "4G");
+    EXPECT_EQ(val(kv, "cell.reg"), "roaming");
+    EXPECT_EQ(val(kv, "cell.signal.dbm"), "-73");
+    EXPECT_EQ(val(kv, "cell.ip"), "10.20.30.40");
+    EXPECT_EQ(val(kv, "cell.iccid"), "8944500207123456789");
+    EXPECT_TRUE(has(kv, "cell.version"));
+    // no GPS set → no gps.* keys
+    EXPECT_FALSE(has(kv, "gps.fix"));
+}
+
+TEST(CellState, GpsFixPublished) {
+    CellularState st;
+    GpsFix fix;
+    parse_gga("$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47", fix);
+    st.set_gps(fix);
+
+    auto kv = st.to_kv();
+    EXPECT_EQ(val(kv, "gps.fix"), "3d");
+    EXPECT_EQ(val(kv, "gps.sats"), "8");
+    EXPECT_NE(val(kv, "gps.lat"), "<absent>");
+    EXPECT_NE(val(kv, "gps.lon"), "<absent>");
+    EXPECT_TRUE(has(kv, "gps.version"));
+    // no cellular set → no cell.* keys
+    EXPECT_FALSE(has(kv, "cell.state"));
+}
+
+TEST(CellState, VersionBumpsOnChange) {
+    CellularState st;
+    st.set_state("init");
+    const std::string v1 = val(st.to_kv(), "cell.version");
+    st.set_state("connected");
+    const std::string v2 = val(st.to_kv(), "cell.version");
+    EXPECT_NE(v1, v2);
+}
+
+TEST(CellState, InvalidSignalIgnored) {
+    CellularState st;
+    st.set_state("searching");
+    st.set_signal(parse_csq("+CSQ: 99,99"));   // unknown → not stored
+    auto kv = st.to_kv();
+    EXPECT_FALSE(has(kv, "cell.signal.dbm"));
+}

--- a/modules/wan/cellular/test/nmea_parser_test.cpp
+++ b/modules/wan/cellular/test/nmea_parser_test.cpp
@@ -1,0 +1,75 @@
+#include <gtest/gtest.h>
+#include <cmath>
+#include <cstdio>
+#include <string>
+
+#include "nmea_parser.hpp"
+
+using namespace cellular;
+
+// Wrap a sentence body in "$<body>*HH" with the correct XOR checksum.
+static std::string framed(const std::string& body) {
+    unsigned char sum = 0;
+    for (char c : body) sum ^= static_cast<unsigned char>(c);
+    char cs[8];
+    std::snprintf(cs, sizeof(cs), "*%02X", sum);
+    return "$" + body + cs;
+}
+
+// Canonical NMEA examples with documented checksums.
+static const char* kGGA =
+    "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*47";
+static const char* kRMC =
+    "$GPRMC,123519,A,4807.038,N,01131.000,E,022.4,084.4,230394,003.1,W*6A";
+
+TEST(Nmea, ChecksumValidation) {
+    EXPECT_TRUE(nmea_checksum_ok(kGGA));
+    EXPECT_TRUE(nmea_checksum_ok(kRMC));
+    // corrupt a payload byte → checksum mismatch
+    EXPECT_FALSE(nmea_checksum_ok(
+        "$GPGGA,123519,4807.038,N,01131.000,E,1,08,0.9,545.4,M,46.9,M,,*48"));
+    EXPECT_FALSE(nmea_checksum_ok("no dollar sign"));
+}
+
+TEST(Nmea, GgaPositionAltitudeSats) {
+    GpsFix fix;
+    ASSERT_TRUE(parse_gga(kGGA, fix));
+    EXPECT_TRUE(fix.valid);
+    EXPECT_NEAR(fix.lat, 48.1173, 1e-3);
+    EXPECT_NEAR(fix.lon, 11.51667, 1e-3);
+    EXPECT_NEAR(fix.alt_m, 545.4, 1e-3);
+    EXPECT_EQ(fix.sats, 8);
+    EXPECT_EQ(fix.quality, "3d");
+}
+
+TEST(Nmea, RmcSpeedCourse) {
+    GpsFix fix;
+    ASSERT_TRUE(parse_rmc(kRMC, fix));
+    EXPECT_TRUE(fix.valid);
+    EXPECT_NEAR(fix.lat, 48.1173, 1e-3);
+    EXPECT_NEAR(fix.speed_kmh, 22.4 * 1.852, 1e-3);
+    EXPECT_NEAR(fix.course_deg, 84.4, 1e-3);
+}
+
+TEST(Nmea, GgaThenRmcMerge) {
+    GpsFix fix;
+    ASSERT_TRUE(parse_gga(kGGA, fix));   // alt + sats + 3d
+    ASSERT_TRUE(parse_rmc(kRMC, fix));   // speed + course, keeps 3d
+    EXPECT_EQ(fix.quality, "3d");
+    EXPECT_NEAR(fix.alt_m, 545.4, 1e-3);
+    EXPECT_GT(fix.speed_kmh, 0.0);
+}
+
+TEST(Nmea, NoFixRmcVoid) {
+    GpsFix fix;
+    // status 'V' (void) — no position
+    ASSERT_TRUE(parse_rmc(framed("GPRMC,123519,V,,,,,,,230394,,"), fix));
+    EXPECT_FALSE(fix.valid);
+    EXPECT_EQ(fix.quality, "none");
+}
+
+TEST(Nmea, RejectsWrongTypeOrChecksum) {
+    GpsFix fix;
+    EXPECT_FALSE(parse_gga(kRMC, fix));   // RMC fed to GGA parser
+    EXPECT_FALSE(parse_rmc(kGGA, fix));   // GGA fed to RMC parser
+}


### PR DESCRIPTION
## What

Starts the **mangOH Yellow cellular WAN + GPS plane** (design: `apps/docs/tdd-mangoh-yellow-sensors.md` §6). This is the host-testable **foundation** — pure parsers + state cache, **no I/O** — that the reactor-driven modem daemon (PR-C) and the Object-6 Location mirror (PR-B) build on.

The CF3 cellular module (Sierra Wireless WP / Quectel) is the Pi's primary WAN uplink + GNSS source. net-router already routes the cellular slot (`net.iface.cellular.name`/`wwan0`), so once the daemon brings up `wwan0` the existing bootstrap→register→observe flow is unchanged.

## Changes — `modules/wan/cellular/` (`cellular_core` lib)

- **`at_parser`** — `+CSQ`→dBm/bars, `+COPS`→operator + access tech, `+CREG/+CGREG/+CEREG`→registration state, `+CGPADDR`→IP, ICCID.
- **`nmea_parser`** — `$--GGA`/`$--RMC` with XOR-checksum validation; `ddmm.mmmm`→signed decimal degrees, knots→km/h; GGA+RMC merge into one fix.
- **`CellularState`** — thread-safe cache → `cell.*` (modem status) + `gps.*` (location) `to_kv()` batch with per-domain version counters for the device-ui long-poll.
- **`schemas/cell.lua`** — `cell.*` + `gps.*` keys (status string-typed so the daemon publishes the batch verbatim).

## Test (real, in podman)

`ubuntu:22.04` + `libgtest-dev`: **17 gtests** across `at_parser` / `nmea_parser` / `cell_state` — all pass. The core is pure (no ACE/ds), so it runs anywhere.

## Design note (ACE I/O)

PR-C will be **reactor-driven and ACE-only**: the AT + GNSS ttys are `ACE_TTY_IO`/`ACE_DEV_IO` handles **registered with the `ACE_Reactor`** (`handle_input` feeds these parsers), with a reactor timer for periodic polls — **no raw POSIX** `open/read/write/select`. Baked into the doc §6.B.

## Next
- **PR-B** — `gps.*` → LwM2M Object 6 (Location) in the client (ds-backed read closures, like `install_sensors`).
- **PR-C** — the privileged `cellular-client` daemon (modem control + GNSS + publish) + Yocto packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)