### PR TITLE
feat(cellular): GPS over the AT channel via +QGPSLOC (no NMEA tty needed)

### DIFF
--- a/apps/docs/tdd-mangoh-yellow-sensors.md
+++ b/apps/docs/tdd-mangoh-yellow-sensors.md
@@ -171,11 +171,16 @@ raw POSIX** `open/read/write/select`:
   state core.
 
 ### 6.C GPS / GNSS source
-GPS comes off the **same WP module** (a GNSS NMEA tty, or `+QGPSLOC` over AT),
-**not** I²C. The daemon parses the fix (PR-A `nmea_parser`/`at_parser`) →
-publishes `gps.*` → PR-B mirrors into **LwM2M Object 6 (Location)** RIDs 0/1/2/5/6
-with observe/notify on position change, so the cloud Endpoints table can show
-device location.
+GPS comes off the **same WP module**, **not** I²C, by either route — both wired:
+- **NMEA tty** (`cell.gps.tty` set): the daemon opens a second `SerialChannel`
+  and routes `$--GGA`/`$--RMC` through `nmea_parser`.
+- **AT channel** (`cell.gps.tty` empty): the daemon issues `AT+QGPS=1` once then
+  `AT+QGPSLOC=2` each poll; `parse_qgpsloc` decodes the decimal-degree fix
+  (`+QGPSLOC: utc,lat,lon,hdop,alt,fix,cog,spkm,spkn,date,nsat`). A no-fix
+  `+CME ERROR 516` is ignored. **So GPS works with no dedicated NMEA port.**
+
+Either way the fix → `gps.*` → PR-B mirrors into **LwM2M Object 6 (Location)**
+RIDs 0/1/2/5/6 with observe/notify on position change.
 
 ### 6.D Open questions (WAN — need hardware)
 1. Modem stack: ModemManager/`mmcli` vs. raw `qmicli`/`pppd` (or pure-AT

--- a/modules/wan/cellular/daemon/cellular_client.cpp
+++ b/modules/wan/cellular/daemon/cellular_client.cpp
@@ -37,6 +37,8 @@ int CellularClient::run() {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%D [cell] ds connect failed\n")), 1);
     }
     load_config_from_ds();
+    // No dedicated NMEA tty → read GNSS over the AT channel (AT+QGPSLOC).
+    m_gps_via_at = m_cfg.gps_enable && m_cfg.gps_tty.empty();
 
     m_at.reset(new SerialChannel([this](const std::string& l){ on_at_line(l); }));
     if (m_at->open(m_cfg.modem_tty, ACE_Reactor::instance()) == -1) {
@@ -68,7 +70,7 @@ int CellularClient::run() {
     ACE_DEBUG((LM_INFO,
         ACE_TEXT("%D [cell] up: AT=%C GNSS=%C apn=%C every %us\n"),
         m_cfg.modem_tty.c_str(),
-        m_gnss ? m_cfg.gps_tty.c_str() : "(none)",
+        m_gnss ? m_cfg.gps_tty.c_str() : (m_gps_via_at ? "AT+QGPSLOC" : "(none)"),
         m_cfg.apn.empty() ? "(unset)" : m_cfg.apn.c_str(),
         m_cfg.interval_sec));
 
@@ -93,6 +95,15 @@ void CellularClient::poll_modem() {
     m_at->write_line("AT+CEREG?");
     m_at->write_line("AT+CGPADDR=1");
     m_at->write_line("AT+QCCID");
+    if (m_gps_via_at) {
+        // Turn the GNSS engine on once, then query a fix each tick. A no-fix
+        // reply (+CME ERROR 516) is simply ignored by the parser.
+        if (!m_qgps_on) {
+            m_at->write_line("AT+QGPS=1");
+            m_qgps_on = true;
+        }
+        m_at->write_line("AT+QGPSLOC=2");
+    }
 }
 
 void CellularClient::on_at_line(const std::string& line) {

--- a/modules/wan/cellular/daemon/cellular_client.hpp
+++ b/modules/wan/cellular/daemon/cellular_client.hpp
@@ -63,6 +63,8 @@ class CellularClient : public ACE_Event_Handler {
         bool                            m_apn_sent = false;
         Reg                             m_lastReg = Reg::Unknown;
         bool                            m_haveIp = false;
+        bool                            m_gps_via_at = false;  ///< GNSS over AT+QGPSLOC (no NMEA tty)
+        bool                            m_qgps_on = false;     ///< AT+QGPS=1 issued
 };
 
 } // namespace cellular

--- a/modules/wan/cellular/inc/nmea_parser.hpp
+++ b/modules/wan/cellular/inc/nmea_parser.hpp
@@ -39,6 +39,13 @@ bool parse_gga(const std::string& sentence, GpsFix& out);
 /// Parse a `$--RMC` sentence into `out` (lat/lon/speed/course/validity).
 bool parse_rmc(const std::string& sentence, GpsFix& out);
 
+/// Parse a Quectel `+QGPSLOC: <utc>,<lat>,<lon>,<hdop>,<alt>,<fix>,<cog>,<spkm>,
+/// <spkn>,<date>,<nsat>` response — the `AT+QGPSLOC=2` decimal-degree form, so
+/// lat/lon are already signed decimal degrees. Lets GPS work over the AT
+/// channel alone (no dedicated NMEA tty). Returns false on a no-fix/malformed
+/// line (e.g. the modem replies `+CME ERROR: 516` until it has a fix).
+bool parse_qgpsloc(const std::string& sentence, GpsFix& out);
+
 } // namespace cellular
 
 #endif /*__cellular_nmea_parser_hpp__*/

--- a/modules/wan/cellular/src/line_router.cpp
+++ b/modules/wan/cellular/src/line_router.cpp
@@ -54,6 +54,12 @@ bool dispatch_at_line(const std::string& line, CellularState& st) {
         st.set_iccid(parse_iccid(line));
         return true;
     }
+    if (starts_with(line, "+QGPSLOC:")) {
+        // GPS over the AT channel (AT+QGPSLOC=2) — one complete fix per line.
+        GpsFix fix;
+        if (parse_qgpsloc(line, fix)) st.set_gps(fix);
+        return true;
+    }
     return false;
 }
 

--- a/modules/wan/cellular/src/nmea_parser.cpp
+++ b/modules/wan/cellular/src/nmea_parser.cpp
@@ -92,6 +92,31 @@ bool parse_gga(const std::string& sentence, GpsFix& out) {
     return true;
 }
 
+bool parse_qgpsloc(const std::string& sentence, GpsFix& out) {
+    const auto colon = sentence.find(':');
+    if (colon == std::string::npos) return false;
+    std::size_t i = colon + 1;
+    while (i < sentence.size() && sentence[i] == ' ') ++i;
+    const std::vector<std::string> f = split_fields(sentence.substr(i));
+    // 0:utc 1:lat 2:lon 3:hdop 4:alt 5:fix 6:cog 7:spkm 8:spkn 9:date 10:nsat
+    if (f.size() < 8) return false;
+    const int fix = static_cast<int>(std::strtol(f[5].c_str(), nullptr, 10));
+    if ((fix != 2 && fix != 3) || f[1].empty() || f[2].empty()) {
+        out.quality = "none";
+        return false;
+    }
+    out.utc        = f[0];
+    out.lat        = to_double(f[1]);   // already signed decimal degrees (mode 2)
+    out.lon        = to_double(f[2]);
+    out.alt_m      = to_double(f[4]);
+    out.quality    = (fix == 3) ? "3d" : "2d";
+    out.course_deg = to_double(f[6]);
+    out.speed_kmh  = to_double(f[7]);
+    if (f.size() > 10) out.sats = static_cast<int>(std::strtol(f[10].c_str(), nullptr, 10));
+    out.valid = true;
+    return true;
+}
+
 bool parse_rmc(const std::string& sentence, GpsFix& out) {
     std::vector<std::string> f;
     if (!fields_for(sentence, "RMC", f)) return false;

--- a/modules/wan/cellular/test/line_router_test.cpp
+++ b/modules/wan/cellular/test/line_router_test.cpp
@@ -62,6 +62,20 @@ TEST(DispatchNmea, MergesGgaAndRmc) {
     EXPECT_NE(val(kv, "gps.speed"), "<absent>");
 }
 
+TEST(DispatchAt, RoutesQgpslocToGps) {
+    CellularState st;
+    EXPECT_TRUE(dispatch_at_line(
+        "+QGPSLOC: 092204.0,31.22246,121.35372,1.2,57.1,3,45.0,12.5,6.7,200520,06", st));
+    auto kv = st.to_kv();
+    EXPECT_EQ(val(kv, "gps.fix"), "3d");
+    EXPECT_EQ(val(kv, "gps.sats"), "6");
+    EXPECT_NE(val(kv, "gps.lat"), "<absent>");
+    // a no-fix +QGPSLOC is still "handled" (returns true) but sets no fix
+    CellularState st2;
+    EXPECT_TRUE(dispatch_at_line("+QGPSLOC: 0.0,,,,,0", st2));
+    EXPECT_TRUE(st2.to_kv().empty());
+}
+
 TEST(DispatchNmea, RejectsBadChecksum) {
     CellularState st;
     GpsFix acc;

--- a/modules/wan/cellular/test/nmea_parser_test.cpp
+++ b/modules/wan/cellular/test/nmea_parser_test.cpp
@@ -73,3 +73,32 @@ TEST(Nmea, RejectsWrongTypeOrChecksum) {
     EXPECT_FALSE(parse_gga(kRMC, fix));   // RMC fed to GGA parser
     EXPECT_FALSE(parse_rmc(kGGA, fix));   // GGA fed to RMC parser
 }
+
+TEST(Qgpsloc, DecimalModeFix) {
+    GpsFix fix;
+    ASSERT_TRUE(parse_qgpsloc(
+        "+QGPSLOC: 092204.0,31.22246,121.35372,1.2,57.1,3,45.0,12.5,6.7,200520,06", fix));
+    EXPECT_TRUE(fix.valid);
+    EXPECT_EQ(fix.quality, "3d");
+    EXPECT_NEAR(fix.lat, 31.22246, 1e-5);
+    EXPECT_NEAR(fix.lon, 121.35372, 1e-5);
+    EXPECT_NEAR(fix.alt_m, 57.1, 1e-3);
+    EXPECT_NEAR(fix.course_deg, 45.0, 1e-3);
+    EXPECT_NEAR(fix.speed_kmh, 12.5, 1e-3);
+    EXPECT_EQ(fix.sats, 6);
+}
+
+TEST(Qgpsloc, NegativeDecimalDegrees) {
+    GpsFix fix;
+    ASSERT_TRUE(parse_qgpsloc(
+        "+QGPSLOC: 010101.0,-33.86880,-151.20930,0.8,15.0,2,0.0,0.0,0.0,010120,05", fix));
+    EXPECT_EQ(fix.quality, "2d");
+    EXPECT_NEAR(fix.lat, -33.86880, 1e-5);
+    EXPECT_NEAR(fix.lon, -151.20930, 1e-5);
+}
+
+TEST(Qgpsloc, NoFixIsRejected) {
+    GpsFix fix;
+    EXPECT_FALSE(parse_qgpsloc("+CME ERROR: 516", fix));   // not fixed yet
+    EXPECT_FALSE(parse_qgpsloc("+QGPSLOC: 0.0,,,,,0", fix));
+}


### PR DESCRIPTION
## What

Adds the Quectel **`AT+QGPSLOC`** path so GPS works over the AT control channel alone — no dedicated NMEA tty required. (Previously GNSS needed `cell.gps.tty` pointing at a separate NMEA port.)

## Changes

- **`parse_qgpsloc`** (`nmea_parser`) — decodes the `AT+QGPSLOC=2` decimal-degree reply `+QGPSLOC: utc,lat,lon,hdop,alt,fix,cog,spkm,spkn,date,nsat` into a `GpsFix` (signed decimal degrees, km/h speed, 2d/3d from `<fix>`). Rejects no-fix / `+CME ERROR 516` lines.
- **`dispatch_at_line`** routes `+QGPSLOC` → `CellularState.set_gps` (one complete fix per line, no accumulator).
- **`cellular_client`** — when `cell.gps.tty` is empty and GPS is enabled, the daemon issues `AT+QGPS=1` once then `AT+QGPSLOC=2` each poll; with a NMEA tty it keeps the `SerialChannel` path. Startup log shows the active GNSS source (`AT+QGPSLOC` vs the tty).

Both GPS routes are now wired (doc §6.C updated).

## Test (real, podman)

`ubuntu:22.04` + `libace-dev`: **cellular-tests 26/26 pass** (new `Qgpsloc.*` incl. negative decimal degrees + no-fix rejection, and `DispatchAt.RoutesQgpslocToGps`), and **`cellular-client` still links against real ACE + datastore_client**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)