### PR TITLE
feat(bcm2837): interrupt-driven BSC1 I2C transport (P1–P5)

### DIFF
--- a/modules/bcm2837/docs/DRIVER_REVIEW.md
+++ b/modules/bcm2837/docs/DRIVER_REVIEW.md
@@ -215,8 +215,9 @@ The I2C (BSC1) and SPI0 drivers (`inc/i2c.hpp`, `inc/spi.hpp`, `src/i2c`,
 > the build/toolchain fixes in 2.1 before they run on a Pi.
 
 The shipped `Bcm2837I2cTransport` (`inc/i2c_bus.hpp`) is **poll-based** (bounded
-spin on the status register); the BSC `INTD`/`INTT`/`INTR` interrupt-enable bits
-are addressable but unused. An **interrupt-driven** bare-metal variant is
-designed in [`i2c-irq-transport-spec.md`](i2c-irq-transport-spec.md) (not yet
-implemented). On Linux the interrupt-driven path is already provided by the
-kernel via `inc/i2c_dev.hpp` (`/dev/i2c-1`).
+spin on the status register). The **interrupt-driven** bare-metal variant
+`Bcm2837I2cIrqTransport` (`inc/i2c_irq.hpp` + `src/i2c/i2c_irq.cpp`) is
+**implemented** (DONE/TXW/RXR-driven, watchdog, async) and host-tested; see
+[`i2c-irq-transport-spec.md`](i2c-irq-transport-spec.md) — on-silicon validation
+(P4) is the only open item. On Linux the interrupt-driven path is already
+provided by the kernel via `inc/i2c_dev.hpp` (`/dev/i2c-1`).

--- a/modules/bcm2837/docs/i2c-irq-transport-spec.md
+++ b/modules/bcm2837/docs/i2c-irq-transport-spec.md
@@ -1,8 +1,12 @@
 # Spec — Interrupt-driven BSC1 I²C transport (`Bcm2837I2cIrqTransport`)
 
-Status: **DESIGN / not implemented.** A bare-metal follow-up to the polling
-`Bcm2837I2cTransport` (`inc/i2c_bus.hpp`). Implements the same `I2cTransport`
-seam so it is a drop-in for the sensor drivers and stays host-unit-testable.
+Status: **IMPLEMENTED (P1–P5)** in `inc/i2c_irq.hpp` + `src/i2c/i2c_irq.cpp`,
+host-tested in `test/i2c_irq_test.{hpp,cpp}` (11 gtests — DONE path, multi-
+interrupt drain, watchdog, error classes, bus_init/IRQ-arm, async callback).
+A bare-metal follow-up to the polling `Bcm2837I2cTransport` (`inc/i2c_bus.hpp`)
+on the same `I2cTransport` seam — a drop-in for the sensor drivers, host-unit-
+testable by simulating the ISR. **On-silicon validation (P4) is pending real
+hardware** (the `kBsc1Irq`=53 line, IVT wiring, barriers, clock-stretch divider).
 
 ---
 
@@ -222,11 +226,20 @@ Timeout, busy-guard rejects re-entry).
 
 ---
 
-## 9. Phased plan
-- **P1** — `Bcm2837I2cIrqTransport` skeleton + `Xfer` ctx + small-transfer
-  DONE-only path + `wait_complete()` seam; full host gtest suite (ISR simulated).
-- **P2** — large-transfer TXW/RXR refill-drain + tests.
-- **P3** — watchdog (inject a deadline hook; host-test the Timeout path).
-- **P4** — real-silicon bring-up: confirm `kBsc1Irq`, IVT wiring, barriers,
-  divider vs the clock-stretch erratum; A/B against the poll transport.
-- **P5 (optional)** — async/callback API for an event-loop consumer.
+## 9. Phased plan — status
+- **P1 ✅** — `Bcm2837I2cIrqTransport` + `Xfer` ctx + small-transfer DONE path +
+  `wait_complete()`/`read_status()` seams; host gtests (ISR simulated).
+- **P2 ✅** — multi-interrupt FIFO drain/fill (`handle_irq` moves all available
+  bytes per call, re-reading status; the inner loop re-arms across interrupts).
+- **P3 ✅** — watchdog: `wait_complete()` bounds the wait by `max_waits`
+  `wait_for_irq()` cycles, then `abort_transfer()` → `Timeout`. (A real
+  bare-metal build must arm a timer IRQ so `WFI` wakes — §4.7.)
+- **P4 ⚙️ code done, silicon pending** — `bus_init()` muxes ALT0, sets the
+  divider, enables BSC, `install_IRQHandler(kBsc1Irq, trampoline)` + `enable()`;
+  `mem_barrier()` = `dmb sy` on ARM. Confirm `kBsc1Irq`=53, IVT wiring and the
+  clock-stretch divider **on hardware**; A/B against the poll transport.
+- **P5 ✅** — `write_async`/`read_async` (kick + return; the ISR fires the
+  `Completion` callback); a busy guard rejects a second in-flight transfer.
+
+> **Build note:** the bare-metal `WFI` in `wait_for_irq()` is gated behind
+> `-DI2C_IRQ_BAREMETAL` (+ ARM) so the hosted/test build is a safe no-op.

--- a/modules/bcm2837/inc/i2c_irq.hpp
+++ b/modules/bcm2837/inc/i2c_irq.hpp
@@ -1,0 +1,114 @@
+#ifndef __i2c_irq_hpp__
+#define __i2c_irq_hpp__
+
+#include <cstdint>
+#include <cstddef>
+
+#include "i2c.hpp"
+#include "gpio.hpp"
+#include "interrupt.hpp"
+#include "i2c_bus.hpp"   // I2cTransport / I2cResult
+
+/**
+ * @file i2c_irq.hpp
+ * @brief Interrupt-driven BSC1 I²C transport (bare-metal). See
+ *        docs/i2c-irq-transport-spec.md.
+ *
+ * Same `I2cTransport` seam as the polling Bcm2837I2cTransport, so it is a
+ * drop-in for the sensor drivers and host-unit-testable the same way (simulate
+ * the ISR over a vector-backed register block). The transfer is driven by the
+ * BSC DONE/TXW/RXR interrupts instead of a status-register spin:
+ *
+ *   start() programs A/DLEN, enables the INT* bits, kicks ST, then blocks in
+ *   wait_complete(); the installed ISR (handle_irq) moves FIFO bytes and
+ *   finalizes on DONE/ERR/CLKT; a watchdog bounds the wait for a wedged bus.
+ *
+ * BARE-METAL ONLY. On Linux use I2cDevTransport (/dev/i2c-1) — the kernel
+ * already drives the BSC by interrupt; a userspace ISR cannot coexist with it.
+ */
+class Bcm2837I2cIrqTransport : public I2cTransport {
+    public:
+        /// ~100 kHz from a 250 MHz core clock (tune for clock-stretch slaves).
+        static constexpr std::uint16_t kDefaultDivider  = 2500;
+        /// BSC interrupt line — BCM2837 DT `interrupts = <2 21>` ⇒ IRQ 53.
+        /// CONFIRM on silicon (shared across BSC0/1/2). See spec §3.
+        static constexpr std::uint8_t  kBsc1Irq         = 53;
+        /// Watchdog: max wait_for_irq() iterations before aborting → Timeout.
+        static constexpr std::uint32_t kDefaultMaxWaits = 1000000U;
+
+        /// Async completion callback (no captures — pass state via `user`).
+        using Completion = void (*)(I2cResult result, void* user);
+
+        Bcm2837I2cIrqTransport(I2C i2c, GPIO gpio, IRQ irq,
+                               std::uint16_t divider   = kDefaultDivider,
+                               std::uint32_t max_waits = kDefaultMaxWaits)
+            : m_i2c(i2c), m_gpio(gpio), m_irq(irq),
+              m_divider(divider), m_max_waits(max_waits) {}
+
+        /// Mux GPIO2/3 → ALT0, set the divider, enable BSC1, install the ISR and
+        /// enable the BSC IRQ line. Call once before any transfer (hardware).
+        void bus_init();
+
+        /* ---- I2cTransport (synchronous: start + block) ---- */
+        I2cResult write(std::uint8_t addr,
+                        const std::uint8_t* buf, std::size_t len) override;
+        I2cResult read(std::uint8_t addr,
+                       std::uint8_t* buf, std::size_t len) override;
+        I2cResult write_read(std::uint8_t addr,
+                             const std::uint8_t* wbuf, std::size_t wlen,
+                             std::uint8_t* rbuf, std::size_t rlen) override;
+
+        /* ---- P5: async (kick + return; the ISR fires `cb`) ---- */
+        /// Begin a write and return immediately (Ok = in flight). `cb` is
+        /// invoked from the ISR on completion. Returns BadArg on bad args or if
+        /// a transfer is already in flight (one controller, one transfer).
+        I2cResult write_async(std::uint8_t addr, const std::uint8_t* buf,
+                              std::size_t len, Completion cb, void* user);
+        I2cResult read_async(std::uint8_t addr, std::uint8_t* buf,
+                             std::size_t len, Completion cb, void* user);
+
+        /// ISR body: move available FIFO bytes, finalize on DONE/ERR/CLKT.
+        /// Public so the static trampoline and host tests can invoke it.
+        void handle_irq();
+
+        I2C&  i2c()  { return m_i2c; }
+        GPIO& gpio() { return m_gpio; }
+        IRQ&  irq()  { return m_irq; }
+
+    protected:
+        /// Live Status (S) register snapshot. Virtual: tests script it and stage
+        /// RX bytes; production reads the register.
+        virtual std::uint32_t read_status();
+        /// Block the caller until the next interrupt. Production: WFI (with
+        /// I2C_IRQ_BAREMETAL) else a no-op; tests override to drive handle_irq().
+        virtual void wait_for_irq();
+
+    private:
+        struct Xfer {
+            const std::uint8_t* tx = nullptr; std::size_t tn = 0, ti = 0;
+            std::uint8_t*       rx = nullptr; std::size_t rn = 0, ri = 0;
+            bool                reading = false;
+            volatile bool       done    = false;
+            volatile I2cResult  result  = I2cResult::Timeout;
+            Completion          cb      = nullptr;
+            void*               user    = nullptr;
+            bool                active  = false;
+        };
+
+        I2cResult start(std::uint8_t addr,
+                        const std::uint8_t* tx, std::size_t tn,
+                        std::uint8_t* rx, std::size_t rn, bool reading,
+                        Completion cb, void* user);
+        I2cResult wait_complete();      ///< watchdog loop over wait_for_irq()
+        void      finalize(I2cResult r);
+        void      abort_transfer();
+
+        I2C           m_i2c;
+        GPIO          m_gpio;
+        IRQ           m_irq;
+        std::uint16_t m_divider;
+        std::uint32_t m_max_waits;
+        Xfer          m_xfer;
+};
+
+#endif /*__i2c_irq_hpp__*/

--- a/modules/bcm2837/src/i2c/i2c_irq.cpp
+++ b/modules/bcm2837/src/i2c/i2c_irq.cpp
@@ -1,0 +1,207 @@
+#ifndef __i2c_irq_cpp__
+#define __i2c_irq_cpp__
+
+#include "i2c_irq.hpp"
+
+#include <atomic>
+
+namespace {
+    /* BSC Status (S) register bit masks — see memory_map.hpp / i2c_bus.cpp. */
+    constexpr std::uint32_t S_DONE = 1U << 1;
+    constexpr std::uint32_t S_TXD  = 1U << 4;   ///< FIFO can accept data
+    constexpr std::uint32_t S_RXD  = 1U << 5;   ///< FIFO contains data
+    constexpr std::uint32_t S_ERR  = 1U << 8;   ///< slave NACK
+    constexpr std::uint32_t S_CLKT = 1U << 9;   ///< clock-stretch timeout
+
+    constexpr std::uint8_t  ADDR_MAX = 0x7F;
+
+    using C = BCM2837::BSCRegistersAddress::Control;
+    using S = BCM2837::BSCRegistersAddress::Status;
+
+    /// Cross-context (ISR ↔ thread) + cross-peripheral ordering. Real DMB on
+    /// ARM (safe in userspace); a compiler/seq-cst fence elsewhere (host tests).
+    inline void mem_barrier() {
+#if defined(__aarch64__) || defined(__arm__)
+        __asm__ volatile("dmb sy" ::: "memory");
+#else
+        std::atomic_thread_fence(std::memory_order_seq_cst);
+#endif
+    }
+
+    /// The active instance the static IRQ trampoline dispatches to (one BSC
+    /// controller ⇒ one instance services its line).
+    Bcm2837I2cIrqTransport* s_instance = nullptr;
+
+    /// Installed via IRQ::install_IRQHandler (which takes a bare void(*)()).
+    void bsc_isr_trampoline() {
+        if (s_instance != nullptr) s_instance->handle_irq();
+    }
+}
+
+void Bcm2837I2cIrqTransport::bus_init() {
+    m_gpio.write(2, BCM2837::GPIORegistersAddress::Config::AlternateFunction0);
+    m_gpio.write(3, BCM2837::GPIORegistersAddress::Config::AlternateFunction0);
+    m_i2c.clock_divider(m_divider);
+    m_i2c.enable();
+    s_instance = this;
+    m_irq.install_IRQHandler(kBsc1Irq, &bsc_isr_trampoline);
+    m_irq.enable(kBsc1Irq);
+    mem_barrier();
+}
+
+std::uint32_t Bcm2837I2cIrqTransport::read_status() {
+    return m_i2c.memory().m_register[BCM2837::BSCRegistersAddress::Register::S];
+}
+
+void Bcm2837I2cIrqTransport::wait_for_irq() {
+#if defined(I2C_IRQ_BAREMETAL) && (defined(__aarch64__) || defined(__arm__))
+    __asm__ volatile("wfi");   // sleep until an interrupt; the ISR sets done.
+#endif
+    // Host/default: no-op. The watchdog loop in wait_complete() bounds the wait;
+    // tests override this to drive handle_irq(). A real bare-metal build must
+    // also arm a timer IRQ so WFI wakes for the watchdog (spec §4.7).
+}
+
+I2cResult Bcm2837I2cIrqTransport::start(std::uint8_t addr,
+                                        const std::uint8_t* tx, std::size_t tn,
+                                        std::uint8_t* rx, std::size_t rn,
+                                        bool reading, Completion cb, void* user) {
+    m_xfer = Xfer{};
+    m_xfer.tx = tx; m_xfer.tn = tn;
+    m_xfer.rx = rx; m_xfer.rn = rn;
+    m_xfer.reading = reading;
+    m_xfer.cb = cb; m_xfer.user = user;
+    m_xfer.active = true;
+
+    m_i2c.clear_fifo();
+    m_i2c.clr_status(S::DONE);
+    m_i2c.clr_status(S::ERR);
+    m_i2c.clr_status(S::CLKT_TO);
+    m_i2c.slave_address(addr);
+    m_i2c.data_length(static_cast<I2C::value_type>(reading ? rn : tn));
+
+    if (reading) {
+        m_i2c.set_control(C::INTR, 1);   // RX FIFO needs reading
+        m_i2c.set_control(C::INTD, 1);   // transfer done
+        m_i2c.start_read();
+    } else {
+        m_i2c.set_control(C::INTT, 1);   // TX FIFO needs writing
+        m_i2c.set_control(C::INTD, 1);
+        m_i2c.start_write();             // empty FIFO + TA → TXW fires → ISR fills
+    }
+    mem_barrier();
+    return I2cResult::Ok;
+}
+
+void Bcm2837I2cIrqTransport::handle_irq() {
+    mem_barrier();
+    for (;;) {
+        const std::uint32_t s = read_status();
+        if (s & S_ERR)  { finalize(I2cResult::Nack);         return; }
+        if (s & S_CLKT) { finalize(I2cResult::ClockTimeout); return; }
+
+        if (m_xfer.reading) {
+            if ((s & S_RXD) && m_xfer.ri < m_xfer.rn) {
+                m_xfer.rx[m_xfer.ri++] =
+                    static_cast<std::uint8_t>(m_i2c.read_byte() & 0xFFU);
+                continue;
+            }
+        } else {
+            if ((s & S_TXD) && m_xfer.ti < m_xfer.tn) {
+                m_i2c.write_byte(m_xfer.tx[m_xfer.ti++]);
+                continue;
+            }
+        }
+
+        if (s & S_DONE) {
+            const bool ok = m_xfer.reading ? (m_xfer.ri == m_xfer.rn) : true;
+            finalize(ok ? I2cResult::Ok : I2cResult::Timeout);
+            return;
+        }
+        return;   // nothing to move and not done — wait for the next interrupt
+    }
+}
+
+void Bcm2837I2cIrqTransport::finalize(I2cResult r) {
+    m_i2c.clr_status(S::DONE);
+    m_i2c.clr_status(S::ERR);
+    m_i2c.clr_status(S::CLKT_TO);
+    m_i2c.clr_control(C::INTD);
+    m_i2c.clr_control(C::INTT);
+    m_i2c.clr_control(C::INTR);
+    m_xfer.result = r;
+    mem_barrier();
+    m_xfer.done = true;
+    m_xfer.active = false;
+    if (m_xfer.cb != nullptr) {
+        const Completion cb = m_xfer.cb;
+        void* const user = m_xfer.user;
+        m_xfer.cb = nullptr;
+        cb(r, user);
+    }
+}
+
+void Bcm2837I2cIrqTransport::abort_transfer() {
+    m_i2c.clr_control(C::INTD);
+    m_i2c.clr_control(C::INTT);
+    m_i2c.clr_control(C::INTR);
+    m_i2c.clear_fifo();
+    m_i2c.clr_status(S::DONE);
+    m_i2c.clr_status(S::ERR);
+    m_i2c.clr_status(S::CLKT_TO);
+    m_xfer.active = false;
+}
+
+I2cResult Bcm2837I2cIrqTransport::wait_complete() {
+    for (std::uint32_t i = 0; i < m_max_waits; ++i) {
+        mem_barrier();
+        if (m_xfer.done) {
+            return m_xfer.result;
+        }
+        wait_for_irq();
+    }
+    abort_transfer();    // wedged bus / lost interrupt
+    return I2cResult::Timeout;
+}
+
+I2cResult Bcm2837I2cIrqTransport::write(std::uint8_t addr,
+                                        const std::uint8_t* buf, std::size_t len) {
+    if (buf == nullptr || len == 0 || addr > ADDR_MAX) return I2cResult::BadArg;
+    start(addr, buf, len, nullptr, 0, /*reading=*/false, nullptr, nullptr);
+    return wait_complete();
+}
+
+I2cResult Bcm2837I2cIrqTransport::read(std::uint8_t addr,
+                                       std::uint8_t* buf, std::size_t len) {
+    if (buf == nullptr || len == 0 || addr > ADDR_MAX) return I2cResult::BadArg;
+    start(addr, nullptr, 0, buf, len, /*reading=*/true, nullptr, nullptr);
+    return wait_complete();
+}
+
+I2cResult Bcm2837I2cIrqTransport::write_read(std::uint8_t addr,
+                                             const std::uint8_t* wbuf, std::size_t wlen,
+                                             std::uint8_t* rbuf, std::size_t rlen) {
+    const I2cResult w = write(addr, wbuf, wlen);   // BSC has no repeated-START
+    if (w != I2cResult::Ok) return w;
+    return read(addr, rbuf, rlen);
+}
+
+I2cResult Bcm2837I2cIrqTransport::write_async(std::uint8_t addr,
+                                              const std::uint8_t* buf, std::size_t len,
+                                              Completion cb, void* user) {
+    if (buf == nullptr || len == 0 || addr > ADDR_MAX || m_xfer.active) {
+        return I2cResult::BadArg;
+    }
+    return start(addr, buf, len, nullptr, 0, /*reading=*/false, cb, user);
+}
+
+I2cResult Bcm2837I2cIrqTransport::read_async(std::uint8_t addr,
+                                             std::uint8_t* buf, std::size_t len,
+                                             Completion cb, void* user) {
+    if (buf == nullptr || len == 0 || addr > ADDR_MAX || m_xfer.active) {
+        return I2cResult::BadArg;
+    }
+    return start(addr, nullptr, 0, buf, len, /*reading=*/true, cb, user);
+}
+
+#endif /*__i2c_irq_cpp__*/

--- a/modules/bcm2837/test/i2c_irq_test.cpp
+++ b/modules/bcm2837/test/i2c_irq_test.cpp
@@ -1,0 +1,148 @@
+#ifndef __i2c_irq_test_cpp__
+#define __i2c_irq_test_cpp__
+
+#include "i2c_irq_test.hpp"
+
+namespace {
+    struct CbRec { I2cResult r = I2cResult::Timeout; int n = 0; };
+    void rec_cb(I2cResult r, void* user) {
+        auto* c = static_cast<CbRec*>(user);
+        c->r = r; c->n++;
+    }
+}
+
+/* ---- P4: bus_init wires pin-mux + clock + the BSC IRQ ---- */
+
+TEST_F(I2cIrqTest, BusInit_Muxes_Clocks_Enables_And_Arms_Irq) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq(), /*divider=*/2500);
+    bus.bus_init();
+    EXPECT_EQ((gpfsel0() >> 6) & 0b111U, 0b100U);   // GPIO2 → ALT0
+    EXPECT_EQ((gpfsel0() >> 9) & 0b111U, 0b100U);   // GPIO3 → ALT0
+    EXPECT_EQ(i2c().clock_divider(), 2500U);
+    EXPECT_EQ(i2c().get_control(BCM2837::BSCRegistersAddress::Control::I2CEN), 1U);
+    EXPECT_TRUE(irq().isEnabled(Bcm2837I2cIrqTransport::kBsc1Irq));  // IRQ 53 armed
+}
+
+/* ---- argument validation ---- */
+
+TEST_F(I2cIrqTest, Rejects_Bad_Arguments) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    const std::uint8_t b[1] = {0};
+    std::uint8_t r[1] = {0};
+    EXPECT_EQ(bus.write(0x68, nullptr, 1), I2cResult::BadArg);
+    EXPECT_EQ(bus.write(0x68, b, 0),       I2cResult::BadArg);
+    EXPECT_EQ(bus.write(0x80, b, 1),       I2cResult::BadArg);
+    EXPECT_EQ(bus.read(0x68, nullptr, 1),  I2cResult::BadArg);
+}
+
+/* ---- P1: small-transfer DONE path ---- */
+
+TEST_F(I2cIrqTest, Write_Completes_On_Done) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    bus.script = {TXD, TXD, DONE};
+    const std::uint8_t payload[2] = {0x11, 0x22};
+
+    EXPECT_EQ(bus.write(0x68, payload, sizeof(payload)), I2cResult::Ok);
+    EXPECT_EQ(i2c().slave_address(), 0x68U);
+    EXPECT_EQ(i2c().data_length(),   2U);
+    EXPECT_EQ(i2c().get_control(BCM2837::BSCRegistersAddress::Control::READ), 0U);
+    EXPECT_EQ(i2c().read_byte(), 0x22U);   // last byte the ISR pushed
+}
+
+TEST_F(I2cIrqTest, Read_Completes_On_Done) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    bus.script = {RXD, RXD, DONE};
+    bus.rx     = {0xDE, 0xAD};
+    std::uint8_t buf[2] = {0, 0};
+
+    EXPECT_EQ(bus.read(0x76, buf, sizeof(buf)), I2cResult::Ok);
+    EXPECT_EQ(buf[0], 0xDEU);
+    EXPECT_EQ(buf[1], 0xADU);
+    EXPECT_EQ(i2c().get_control(BCM2837::BSCRegistersAddress::Control::READ), 1U);
+}
+
+/* ---- P2: larger transfer — ISR drains/fills across several interrupts ---- */
+
+TEST_F(I2cIrqTest, Read_Drains_Across_Multiple_Interrupts) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    // Each "interrupt" delivers one byte then yields (a 0 word), then DONE.
+    bus.script = {RXD, 0, RXD, 0, RXD, DONE};
+    bus.rx     = {0x01, 0x02, 0x03};
+    std::uint8_t buf[3] = {0, 0, 0};
+
+    EXPECT_EQ(bus.read(0x50, buf, sizeof(buf)), I2cResult::Ok);
+    EXPECT_EQ(buf[0], 0x01U);
+    EXPECT_EQ(buf[1], 0x02U);
+    EXPECT_EQ(buf[2], 0x03U);
+}
+
+/* ---- error classification ---- */
+
+TEST_F(I2cIrqTest, Reports_Nack_On_Err) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    bus.script = {ERR};
+    const std::uint8_t b[1] = {0};
+    EXPECT_EQ(bus.write(0x68, b, 1), I2cResult::Nack);
+}
+
+TEST_F(I2cIrqTest, Reports_ClockTimeout_On_Clkt) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    bus.script = {CLKT};
+    std::uint8_t b[1] = {0};
+    EXPECT_EQ(bus.read(0x68, b, 1), I2cResult::ClockTimeout);
+}
+
+TEST_F(I2cIrqTest, Short_Read_Is_Timeout) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    bus.script = {RXD, DONE};   // DONE with a byte still owed
+    bus.rx     = {0xDE};
+    std::uint8_t buf[2] = {0, 0};
+    EXPECT_EQ(bus.read(0x76, buf, sizeof(buf)), I2cResult::Timeout);
+    EXPECT_EQ(buf[0], 0xDEU);
+}
+
+/* ---- P3: watchdog ---- */
+
+TEST_F(I2cIrqTest, Watchdog_Times_Out_When_No_Completion) {
+    // Empty script → read_status() returns 0 forever; DONE never arrives.
+    ScriptedIrqTransport bus(i2c(), gpio(), irq(), /*divider=*/2500, /*max_waits=*/5);
+    const std::uint8_t b[1] = {0};
+    EXPECT_EQ(bus.write(0x68, b, 1), I2cResult::Timeout);
+}
+
+/* ---- P5: async (kick + ISR-fired callback) ---- */
+
+TEST_F(I2cIrqTest, Async_Write_Fires_Callback_On_Completion) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    bus.script = {TXD, TXD, DONE};
+    const std::uint8_t payload[2] = {0xAA, 0xBB};
+    CbRec rec;
+
+    EXPECT_EQ(bus.write_async(0x68, payload, sizeof(payload), rec_cb, &rec), I2cResult::Ok);
+    EXPECT_EQ(rec.n, 0);                       // not finished yet — in flight
+    // A second transfer while one is active is rejected.
+    EXPECT_EQ(bus.write_async(0x69, payload, 1, rec_cb, &rec), I2cResult::BadArg);
+
+    bus.handle_irq();                          // simulate the interrupt firing
+    EXPECT_EQ(rec.n, 1);
+    EXPECT_EQ(rec.r, I2cResult::Ok);
+    // Controller is free again.
+    EXPECT_EQ(bus.write_async(0x68, payload, 1, rec_cb, &rec), I2cResult::Ok);
+}
+
+TEST_F(I2cIrqTest, Async_Read_Delivers_Bytes_Then_Callback) {
+    ScriptedIrqTransport bus(i2c(), gpio(), irq());
+    bus.script = {RXD, RXD, DONE};
+    bus.rx     = {0x7E, 0x01};
+    std::uint8_t buf[2] = {0, 0};
+    CbRec rec;
+
+    EXPECT_EQ(bus.read_async(0x68, buf, sizeof(buf), rec_cb, &rec), I2cResult::Ok);
+    bus.handle_irq();
+    EXPECT_EQ(rec.n, 1);
+    EXPECT_EQ(rec.r, I2cResult::Ok);
+    EXPECT_EQ(buf[0], 0x7EU);
+    EXPECT_EQ(buf[1], 0x01U);
+}
+
+#endif /*__i2c_irq_test_cpp__*/

--- a/modules/bcm2837/test/i2c_irq_test.hpp
+++ b/modules/bcm2837/test/i2c_irq_test.hpp
@@ -1,0 +1,73 @@
+#ifndef __i2c_irq_test_hpp__
+#define __i2c_irq_test_hpp__
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <vector>
+
+#include "i2c.hpp"
+#include "gpio.hpp"
+#include "interrupt.hpp"
+#include "i2c_irq.hpp"
+
+/**
+ * @brief Bcm2837I2cIrqTransport driven by a scripted ISR on the host.
+ *
+ * Same idea as the poll transport's ScriptedTransport: `read_status()` returns
+ * a caller-supplied sequence of S-register words and stages the next `rx` byte
+ * into the FIFO whenever it reports S.RXD, and `wait_for_irq()` drives one
+ * handle_irq() (simulating an interrupt firing) — so the whole interrupt path
+ * is exercised without real interrupts.
+ */
+class ScriptedIrqTransport : public Bcm2837I2cIrqTransport {
+    public:
+        using Bcm2837I2cIrqTransport::Bcm2837I2cIrqTransport;
+
+        std::vector<std::uint32_t> script;   ///< S-register word per read_status()
+        std::vector<std::uint8_t>  rx;        ///< bytes fed when S.RXD is reported
+        std::size_t scriptIdx = 0;
+        std::size_t rxIdx = 0;
+
+    protected:
+        std::uint32_t read_status() override {
+            const std::uint32_t s = (scriptIdx < script.size())
+                                        ? script[scriptIdx++] : 0U;
+            if ((s & (1U << 5)) && rxIdx < rx.size()) {   // S.RXD → stage a byte
+                i2c().write_byte(rx[rxIdx++]);
+            }
+            return s;
+        }
+        void wait_for_irq() override { handle_irq(); }    // simulate the ISR
+};
+
+class I2cIrqTest : public ::testing::Test {
+    public:
+        I2cIrqTest()
+            : m_i2cReg(BCM2837::BSCRegistersAddress::Register::BSC_MAX),
+              m_gpioReg(BCM2837::GPIORegistersAddress::BCM2837_MAX),
+              m_irqReg(1024),
+              m_i2c(m_i2cReg.data()),
+              m_gpio(m_gpioReg.data()),
+              m_irq(m_irqReg.data()) {}
+
+        static constexpr std::uint32_t DONE = 1U << 1;
+        static constexpr std::uint32_t TXD  = 1U << 4;
+        static constexpr std::uint32_t RXD  = 1U << 5;
+        static constexpr std::uint32_t ERR  = 1U << 8;
+        static constexpr std::uint32_t CLKT = 1U << 9;
+
+        I2C&  i2c()  { return m_i2c; }
+        GPIO& gpio() { return m_gpio; }
+        IRQ&  irq()  { return m_irq; }
+        std::uint32_t gpfsel0() const { return m_gpioReg[0]; }
+
+    protected:
+        std::vector<std::uint32_t> m_i2cReg;
+        std::vector<std::uint32_t> m_gpioReg;
+        std::vector<std::uint32_t> m_irqReg;
+        I2C  m_i2c;
+        GPIO m_gpio;
+        IRQ  m_irq;
+};
+
+#endif /*__i2c_irq_test_hpp__*/


### PR DESCRIPTION
## What

Implements **`Bcm2837I2cIrqTransport`** — the interrupt-driven counterpart to the polling `Bcm2837I2cTransport` — per `docs/i2c-irq-transport-spec.md` (#295). Same `I2cTransport` seam, so it's a **drop-in** for the sensor drivers and host-unit-testable by simulating the ISR. **Bare-metal only** (on Linux, `I2cDevTransport`/`/dev/i2c-1` already gets kernel interrupts).

## All five phases

- **P1** — `start()` programs `A`/`DLEN`, enables `INTD`/`INTT`/`INTR`, kicks `ST`; the ISR (`handle_irq`) moves FIFO bytes and finalizes on `DONE`; `wait_complete()` blocks via the `wait_for_irq()` / `read_status()` seams.
- **P2** — `handle_irq` drains/fills **all available FIFO bytes per call** (re-reading status), so a transfer spans multiple interrupts correctly.
- **P3** — **watchdog**: `wait_complete()` bounds the wait by `max_waits` `wait_for_irq()` cycles, then `abort_transfer()` → `Timeout` (wedged bus / lost interrupt).
- **P4** — `bus_init()` muxes GPIO2/3→ALT0, sets the divider, enables BSC, `install_IRQHandler(kBsc1Irq=53, trampoline)` + `enable()`; `mem_barrier()` = `dmb sy` on ARM / seq-cst fence on host. **On-silicon validation pending** (IRQ line `<2 21>`⇒53, IVT wiring, clock-stretch divider).
- **P5** — `write_async`/`read_async` (kick + return; the ISR fires a `Completion` callback); a busy guard rejects a second in-flight transfer.

A file-static trampoline dispatches the bare `void(*)()` IRQ callback to the active instance. The bare-metal `WFI` is gated behind `-DI2C_IRQ_BAREMETAL` so the hosted/test build is a safe no-op; barriers are arch-guarded.

## Test (real, podman)

`ubuntu:22.04` (aarch64) + `libgtest-dev`: **11 new `I2cIrq` gtests pass** (DONE path, multi-interrupt drain, error classes, short-read Timeout, watchdog, `bus_init`+IRQ-arm, async write/read callbacks + busy-reject), and the **full bcm2837 suite is 94/94 green**.

## Scope

Not wired into `iot-sensord` (Linux → i2c-dev). It's for a bare-metal/RTOS consumer that constructs the transport directly. The poll transport stays as the simplest model + the no-IRQ fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)