### PR TITLE
fix(systemd): drop RuntimeDirectory=iot from iot-sensord/cellular (regression)

### DIFF
--- a/packaging/systemd/iot-cellular-client.service
+++ b/packaging/systemd/iot-cellular-client.service
@@ -23,8 +23,10 @@ DeviceAllow=/dev/ttyUSB1 rw
 DeviceAllow=/dev/ttyUSB2 rw
 DeviceAllow=/dev/ttyUSB3 rw
 
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# /run/iot is owned solely by tmpfiles.d (iot.conf, 2775 root:iot) — do NOT use
+# RuntimeDirectory=iot: it resets /run/iot to root:root 0755 on start and removes
+# it on stop, clobbering the group-iot ds socket + breaking every other daemon's
+# data-store access. The daemon just reads /run/iot/data_store.sock like the rest.
 
 Restart=on-failure
 RestartSec=10s

--- a/packaging/systemd/iot-sensord.service
+++ b/packaging/systemd/iot-sensord.service
@@ -25,9 +25,10 @@ CapabilityBoundingSet=CAP_SYS_RAWIO
 DeviceAllow=/dev/mem rw
 DeviceAllow=/dev/gpiomem rw
 
-# Share /run/iot so the daemon sees the same data_store.sock as iot-ds.
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# /run/iot is owned solely by tmpfiles.d (iot.conf, 2775 root:iot) — do NOT use
+# RuntimeDirectory=iot: it resets /run/iot to root:root 0755 on start and removes
+# it on stop, clobbering the group-iot ds socket + breaking every other daemon's
+# data-store access. The daemon just reads /run/iot/data_store.sock like the rest.
 
 Restart=on-failure
 RestartSec=10s

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-cellular-client.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-cellular-client.service
@@ -21,8 +21,10 @@ DeviceAllow=/dev/ttyUSB1 rw
 DeviceAllow=/dev/ttyUSB2 rw
 DeviceAllow=/dev/ttyUSB3 rw
 
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# /run/iot is owned solely by tmpfiles.d (iot.conf, 2775 root:iot) — do NOT use
+# RuntimeDirectory=iot: it resets /run/iot to root:root 0755 on start and removes
+# it on stop, clobbering the group-iot ds socket + breaking every other daemon's
+# data-store access. The daemon just reads /run/iot/data_store.sock like the rest.
 
 Restart=on-failure
 RestartSec=10s

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-sensord.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-sensord.service
@@ -23,8 +23,10 @@ CapabilityBoundingSet=CAP_SYS_RAWIO
 DeviceAllow=/dev/mem rw
 DeviceAllow=/dev/gpiomem rw
 
-RuntimeDirectory=iot
-RuntimeDirectoryMode=0755
+# /run/iot is owned solely by tmpfiles.d (iot.conf, 2775 root:iot) — do NOT use
+# RuntimeDirectory=iot: it resets /run/iot to root:root 0755 on start and removes
+# it on stop, clobbering the group-iot ds socket + breaking every other daemon's
+# data-store access. The daemon just reads /run/iot/data_store.sock like the rest.
 
 Restart=on-failure
 RestartSec=10s


### PR DESCRIPTION
## Regression (mine, from #286 / #290)

The new **`iot-sensord`** + **`iot-cellular-client`** units declared `RuntimeDirectory=iot` — the *exact* thing every other daemon deliberately avoids (the tmpfiles `iot.conf` comment spells out why). systemd **resets `/run/iot` to `root:root 0755` on start and removes it on stop**, clobbering the tmpfiles-owned `2775 root:iot` directory and the group-`iot` ds socket inside it.

The always-on core daemons hold a `RuntimeDirectory` refcount so `/run/iot` never tears down — but sensord/cellular are **start/stop-on-demand**, so toggling one during hardware bring-up (`systemctl start/stop iot-cellular-client`) destroyed `/run/iot`. After that, the ds socket lost its group-`iot` access and **every DynamicUser daemon failed to connect**:

```
ACE_LSOCK_Connector::connect(/run/iot/data_store.sock): Permission denied
iot-wifi-client.service: ... restart counter 1→5 → Failed to start
```

`wifi-client` crash-looping took down the **WiFi uplink**, which cascaded into "device not registered to cloud-iot" + "VPN down" (the two symptoms that kicked this off).

## Fix

Remove `RuntimeDirectory=iot` + `RuntimeDirectoryMode` from both units (packaging/ + yocto/ copies — 4 files). `/run/iot` is owned **solely by tmpfiles.d**; these daemons run as root and just read `/run/iot/data_store.sock` like every other daemon. Verified: no active `RuntimeDirectory=` remains in any yocto unit.

## On-device recovery (no reflash needed)

```bash
sudo systemctl stop iot-cellular-client iot-sensord
sudo systemd-tmpfiles --create /usr/lib/tmpfiles.d/iot.conf   # recreate /run/iot 2775 root:iot
sudo systemctl restart iot-ds                                  # ds recreates the group-iot socket
sudo systemctl reset-failed
sudo systemctl restart iot-wifi-client iot-net-router iot-httpd iot-openvpn-client
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)