### PR TITLE
fix(wifi-client): clear stale assoc/lease state on link drop

### DIFF
--- a/modules/wan/wifi/client/src/supervisor.cpp
+++ b/modules/wan/wifi/client/src/supervisor.cpp
@@ -524,13 +524,30 @@ int Supervisor::run() {
             m_dhcp.terminate();
             m_ds.set_dhcp_state("exited");
             m_ds.set_pid_dhcp(0u);
+            publish_disconnected();   // clear the stale assoc + lease
         } else if (ev->kind == ctrl::CtrlEvent::Kind::Terminating) {
+            m_dhcp.terminate();
+            m_ds.set_dhcp_state("exited");
+            m_ds.set_pid_dhcp(0u);
+            publish_disconnected();   // wpa_supplicant going away → not associated
             return 0;
         } else if (ev->kind == ctrl::CtrlEvent::Kind::AssocReject
                 || ev->kind == ctrl::CtrlEvent::Kind::AuthReject) {
             m_ds.set_last_error("reject:" + ev->reason);
         }
     }
+}
+
+void Supervisor::publish_disconnected() {
+    // Mirror the real link state so the device UI / cloud stop showing a ghost
+    // "connected" at the last IP once WiFi drops. assoc.state is the badge the
+    // dashboard reads; the rest are the per-field values it shows.
+    m_ds.set_assoc_state("disconnected");
+    m_ds.set_assoc_ssid("");
+    m_ds.set_assoc_bssid("");
+    m_ds.set_signal_rssi(0);
+    m_ds.set_dhcp_ip("");
+    m_assoc_bssid.clear();
 }
 
 } // namespace wifi_client

--- a/modules/wan/wifi/client/src/supervisor.hpp
+++ b/modules/wan/wifi/client/src/supervisor.hpp
@@ -161,6 +161,12 @@ public:
     int run();
 
 private:
+    /// Publish a clean "not associated" snapshot to ds when the link drops
+    /// (CTRL-EVENT-DISCONNECTED / TERMINATING): assoc.state=disconnected and
+    /// clear ssid/bssid/rssi/dhcp.ip so the device UI doesn't keep showing a
+    /// ghost "connected" at the last IP after WiFi goes away.
+    void publish_disconnected();
+
     DsBridge&             m_ds;
     SupervisorOptions     m_opt;
     SystemClock           m_clock;


### PR DESCRIPTION
## Bug

The `CTRL-EVENT-DISCONNECTED` handler terminated DHCP and set `dhcp.state=exited`, but **never cleared** `wifi.assoc.state` / `wifi.assoc.ssid` / `wifi.assoc.bssid` / `wifi.signal.rssi` / `wifi.dhcp.ip`. So after WiFi dropped, the data-store (and the device-ui + cloud reading it) kept showing a **ghost "connected" at the last IP** — exactly what we hit on hardware (`iot-dump` said `connected` / `192.168.1.2` while `ip addr` showed `wlan0` DOWN).

## Fix

Add `Supervisor::publish_disconnected()` — sets `assoc.state=disconnected` and clears `ssid`/`bssid`/`rssi`/`dhcp.ip` — called on both `CTRL-EVENT-DISCONNECTED` and `CTRL-EVENT-TERMINATING` (wpa_supplicant going away). The dashboard now reflects the real link state.

**Scope note:** this covers a graceful disassoc/terminate while the daemon is alive. A *hard crash* of wifi-client itself still can't self-clear — but that path was the `RuntimeDirectory` regression (#299), now fixed.

## Test

podman: wifi-client builds and **112/112 tests pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)