### PR TITLE
fix(bootstrap): read cloud.dm.lifetime as integer (device got 86400, not 90)

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -227,10 +227,22 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
             };
             const std::string credsJson = str_at(0);
             const std::string dmUri     = str_at(1);
-            std::uint32_t     lifetime  = 86400;
-            if (auto s = str_at(2); !s.empty()) {
-                try { lifetime = static_cast<std::uint32_t>(std::stoul(s)); }
-                catch (...) {}
+            // cloud.dm.lifetime is INTEGER-typed in the schema (default 90, the
+            // NAT-keepalive value). Read it as an int — to_string() returns
+            // nullopt on an integer Value, which used to silently fall through to
+            // the old 86400 default so the device always registered with a 24h
+            // lifetime regardless of cloud.dm.lifetime. Tolerate a string-typed
+            // value too (legacy). Default 90 to match the schema, not 86400.
+            std::uint32_t lifetime = 90;
+            if (got.size() > 2 && got[2].has_value) {
+                if (auto n = data_store::to_uint32(got[2].value)) {
+                    lifetime = *n;
+                } else if (auto i = data_store::to_int32(got[2].value)) {
+                    if (*i > 0) lifetime = static_cast<std::uint32_t>(*i);
+                } else if (auto s = data_store::to_string(got[2].value); s && !s->empty()) {
+                    try { lifetime = static_cast<std::uint32_t>(std::stoul(*s)); }
+                    catch (...) {}
+                }
             }
             std::string binding = str_at(3);
             if (binding.empty()) binding = "U";


### PR DESCRIPTION
## Bug

The cloud Endpoints **"Next Heart Beat in"** counts down from ~24h instead of the configured 90s — because every device is bootstrapped with a **86400** registration lifetime regardless of `cloud.dm.lifetime`.

Root cause: the Bootstrap server's `provisioning_resolver` read `cloud.dm.lifetime` with `data_store::to_string()`, but the key is **integer-typed** (`default = 90`). `to_string()` returns `nullopt` for an integer `Value`, so the read was always empty and the code **silently fell back to its hard-coded `86400`**.

## Fix

Read `got[2]` as an integer (`to_uint32` → `to_int32`, with a string fallback for legacy), and default to **90** (the schema / NAT-keepalive value) rather than 86400. Now the device registers with `cloud.dm.lifetime` and the Registration Update doubles as the NAT keepalive as designed (see `apps/cloud/CLAUDE.md` → *Registration lifetime & NAT keepalive*).

> Note: `modules/server/lwm2m/BootstrapProvisioner::build_server_tlv(86400)` is **dead code** (its TLVs are built but never delivered — the real bootstrap response comes from the lwm2m-bs `provisioning_resolver` fixed here), so it doesn't affect behavior; left as-is.

## Test

podman: the `lwm2m` binary builds against real ACE (`-DIOT_ENABLE_MONGO=OFF`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)