### PR TITLE
fix(ui): cache-bust favicon (?v=2) so the node-mesh mark shows

### DIFF
--- a/apps/cloud/ui/src/index.html
+++ b/apps/cloud/ui/src/index.html
@@ -5,7 +5,7 @@
   <title>IoT Cloud</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg?v=2">
 </head>
 <body>
   <app-root></app-root>

--- a/iot-ui/src/index.html
+++ b/iot-ui/src/index.html
@@ -5,7 +5,7 @@
   <title>IoT Manager</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" type="image/svg+xml" href="favicon.svg">
+  <link rel="icon" type="image/svg+xml" href="favicon.svg?v=2">
 </head>
 <body>
   <app-root></app-root>


### PR DESCRIPTION
The `favicon.svg` source is already the current node-mesh mark (#f4105589), but Angular copies it verbatim with **no content hash**, so the URL never changes and browsers cache the *old* favicon indefinitely → the tab keeps showing the pre-change icon.

Adds `?v=2` to the `<link rel="icon">` href in both `iot-ui` and `apps/cloud/ui` so browsers re-fetch. Bump on future favicon changes.

> Also rebuild/redeploy the UI image + hard-refresh (Shift-Reload) if the running container predates #f4105589 — the served file must be the new one for the cache-bust to fetch it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)