### PR TITLE
fix(cert-obj): demote per-chunk reassembly traces INFO → DEBUG

### DIFF
--- a/apps/src/lwm2m_object_cert.cpp
+++ b/apps/src/lwm2m_object_cert.cpp
@@ -157,14 +157,14 @@ ObjectInstance make_instance(std::uint32_t iid,
                     type.c_str()), -1);
             }
             if (rc == 0) {
-                ACE_DEBUG((LM_INFO,
+                ACE_DEBUG((LM_DEBUG,
                     ACE_TEXT("%D [cert-obj] %M %N:%l buffered %C chunk (waiting "
                              "for more)\n"), type.c_str()));
                 return 0;   // more chunks to come
             }
             auto& s = (*staging)[type];
             s.pem = std::move(pem); s.present = true;
-            ACE_DEBUG((LM_INFO,
+            ACE_DEBUG((LM_DEBUG,
                 ACE_TEXT("%D [cert-obj] %M %N:%l reassembled %C (%d bytes)\n"),
                 type.c_str(), static_cast<int>(s.pem.size())));
             return 0;
@@ -198,7 +198,7 @@ ObjectInstance make_instance(std::uint32_t iid,
                 for (auto* t : kFamilyTypes) {
                     auto it = staging->find(t);
                     if (it == staging->end() || !it->second.present) {
-                        ACE_DEBUG((LM_INFO,
+                        ACE_DEBUG((LM_DEBUG,
                             ACE_TEXT("%D [cert-obj] %M %N:%l apply deferred: '%C' "
                                      "not staged yet; retaining partial family\n"),
                             t));


### PR DESCRIPTION
Spotted in a real device log during VPN cert push:

```
lwm2m: [cert-obj] LM_INFO .../lwm2m_object_cert.cpp:160 buffered ca chunk (waiting for more)
```

The Object-2048 cert push logged its internal chunk-reassembly mechanics at **LM_INFO** — "buffered <type> chunk (waiting for more)" per DTLS chunk, "reassembled <type> (N bytes)" per artifact, and "apply deferred: not staged yet" during normal multi-write family delivery. That's verbose internal detail flooding the operator INFO log on every push.

Demote the three to **LM_DEBUG**. INFO now carries only the operator-facing milestones: `wrote /etc/iot/vpn/<file>`, `applied VPN endpoint`, `applied N artifact(s) … reload rc=0`.

Log-level only — no behaviour change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)