### PR TITLE
fix(cloud-vpn): operator proto is "tcp"; add "-server" only for the listen socket

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -523,7 +523,10 @@ int main(int argc, char** argv) {
     // ── OpenVPN server — spawn + supervise (config from cloud.vpn.*) ──
     server::openvpn::OpenVpnServerConfig ovpn_cfg;
     ovpn_cfg.subnet    = ds_str(ds, "cloud.vpn.subnet",     "10.9.0.0/24");
-    ovpn_cfg.proto     = ds_str(ds, "cloud.vpn.proto",      "tcp-server");
+    // Operator-facing base form ("tcp"/"udp") — build_server_config adds the
+    // "-server" suffix for the TCP listen socket, and the device push uses the
+    // base as-is (client). Default "tcp"; legacy "tcp-server" still normalizes.
+    ovpn_cfg.proto     = ds_str(ds, "cloud.vpn.proto",      "tcp");
     ovpn_cfg.ca_path   = ds_str(ds, "cloud.vpn.ca.crt",     "/etc/iot/vpn/ca/ca.crt");
     ovpn_cfg.cert_path = ds_str(ds, "cloud.vpn.server.crt", "/etc/iot/vpn/server.crt");
     ovpn_cfg.key_path  = ds_str(ds, "cloud.vpn.server.key", "/etc/iot/vpn/server.key");

--- a/modules/server/openvpn/src/openvpn_server.cpp
+++ b/modules/server/openvpn/src/openvpn_server.cpp
@@ -50,7 +50,16 @@ std::string build_server_config(const OpenVpnServerConfig& c) {
     ss << "mode server\n";
     ss << "tls-server\n";
     ss << "dev "   << c.dev   << "\n";
-    ss << "proto " << c.proto << "\n";
+    // The operator-facing proto is the plain base form ("tcp"/"udp") — that's
+    // also what the device/client uses. But OpenVPN's TCP *server socket* needs
+    // the explicit "-server" form to LISTEN (mode server + tls-server set the
+    // TLS role, not the socket direction), so add it here for TCP. udp needs no
+    // suffix; an already-suffixed value (legacy "tcp-server") passes through.
+    auto server_socket_proto = [](const std::string& p) -> std::string {
+        if (p == "tcp" || p == "tcp4" || p == "tcp6") return p + "-server";
+        return p;
+    };
+    ss << "proto " << server_socket_proto(c.proto) << "\n";
     ss << "port "  << c.port  << "\n";
     ss << "topology subnet\n";
     ss << "server " << net << " " << mask << "\n";

--- a/modules/server/openvpn/test/openvpn_server_test.cpp
+++ b/modules/server/openvpn/test/openvpn_server_test.cpp
@@ -49,6 +49,34 @@ TEST(BuildServerConfig, badSubnetReturnsEmpty) {
     EXPECT_TRUE(build_server_config(c).empty());
 }
 
+TEST(BuildServerConfig, tcpProtoGetsServerSuffix) {
+    // Operator-facing proto is the base form "tcp"; the server *socket* must
+    // LISTEN, so the config must render "proto tcp-server" (not bare "proto tcp",
+    // which OpenVPN treats as a client and never listens).
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";
+    c.proto  = "tcp";
+    const std::string conf = build_server_config(c);
+    EXPECT_NE(conf.find("proto tcp-server"), std::string::npos);
+    EXPECT_EQ(conf.find("proto tcp\n"), std::string::npos);   // never the bare form
+}
+
+TEST(BuildServerConfig, udpProtoUnchanged) {
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";
+    c.proto  = "udp";
+    EXPECT_NE(build_server_config(c).find("proto udp\n"), std::string::npos);
+}
+
+TEST(BuildServerConfig, legacyTcpServerPassesThrough) {
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";
+    c.proto  = "tcp-server";                 // legacy stored value
+    const std::string conf = build_server_config(c);
+    EXPECT_NE(conf.find("proto tcp-server"), std::string::npos);
+    EXPECT_EQ(conf.find("tcp-server-server"), std::string::npos);   // not doubled
+}
+
 TEST(BuildServerConfig, pushesDnsWhenSet) {
     OpenVpnServerConfig c;
     c.subnet = "10.9.0.0/24";


### PR DESCRIPTION
## Bug (caught on the live device)

`cloud.vpn.proto` feeds **two** consumers that need **different** forms: the OpenVPN **server socket** needs `tcp-server` to *listen*, but the **device/client** (and the operator) want plain `tcp`. One key/value can't satisfy both.

So setting the natural `tcp` in the cloud-ui VPN page produced `proto tcp` in the **server** config — which OpenVPN treats as a *client* (never listens) → the server stopped accepting tunnels → every device showed **VPN down**. (Empty worked only because the code fell back to `tcp-server`.)

## Fix

The operator-facing value is the **base form** (`tcp`/`udp`) — also what the client/device uses. `build_server_config` adds the `-server` suffix **only for the TCP listen socket** (`mode server`+`tls-server` set the TLS role, not socket direction); `udp` and legacy `tcp-server` pass through unchanged. Default `tcp-server` → `tcp`. The device push already maps to the client form (`apps/src/main.cpp:584`), so it stays correct.

So @naushada's instinct was right — **it should be just `tcp`**; the `-server` is a server-socket detail the code now owns.

## Test

3 new `BuildServerConfig` cases (`tcp`→`tcp-server`, `udp` unchanged, legacy `tcp-server` not doubled) — **7/7 green** in podman. (Full iot-cloudd compiles 100%; only the ad-hoc link needs the prebuilt `datastore_client`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)