### PR TITLE
fix(cloud-ui): keep device selection across the 5s poll (software update)

### DIFF
--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -196,7 +196,20 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   private pollEndpoints(): void {
     if (!this.active) return;
     this.http.getCloudEndpoints().subscribe({
-      next: (eps) => { this.endpoints = eps as Ep[]; if (this.active) setTimeout(() => this.pollEndpoints(), 5000); },
+      next: (eps) => {
+        const fresh = eps as Ep[];
+        // The 5s poll replaces `endpoints` with fresh objects; Clarity's
+        // clrDgSelected tracks selection by object REFERENCE, so without this
+        // the operator's selection is silently dropped on every refresh (and
+        // appears to vanish when they click the upload area mid-poll). Re-point
+        // `selected` at the new row objects that share the same endpoint id.
+        if (this.selected.length) {
+          const selKeys = new Set(this.selected.map(e => e.endpoint));
+          this.selected = fresh.filter(e => selKeys.has(e.endpoint));
+        }
+        this.endpoints = fresh;
+        if (this.active) setTimeout(() => this.pollEndpoints(), 5000);
+      },
       error: () => { if (this.active) setTimeout(() => this.pollEndpoints(), 5000); }
     });
   }


### PR DESCRIPTION
## Bug

On the cloud-ui **Software Update** page, selecting a target device and then clicking the upload area (or just waiting ~5s) **dropped the selection**.

## Cause

`pollEndpoints()` reassigns `this.endpoints` to **fresh objects every 5s**, and Clarity's `[(clrDgSelected)]` tracks selection by **object reference** — so after a poll the selected rows no longer match any item in the new array and Clarity clears the selection. Clicking the upload area opens the native file dialog, which holds the page while a poll tick fires, so it *looked* like the click deselected the row.

## Fix

Reconcile across each refresh: before swapping in the fresh list, re-point `selected` at the new row objects sharing the same `endpoint` id. Selection now survives the periodic poll and the upload-area click.

## Test

cloud-ui production build (node:18) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)