### PR TITLE
ci: add ipk-bundle.yml — build + publish the OTA .ipk bundle

### DIFF
--- a/.github/workflows/ipk-bundle.yml
+++ b/.github/workflows/ipk-bundle.yml
@@ -1,0 +1,94 @@
+name: Build iot OTA .ipk bundle
+
+# Builds the single-shot OTA bundle (iot-bundle.bb): one
+# iot-bundle-<ver>-<machine>.tar.gz packing the whole iot-*.ipk feed, plus its
+# .sha256 and a paste-ready cloud.firmware.manifest row. This is what an operator
+# pushes to a device over LwM2M Object 5 (the cloud Software-Update page).
+#
+# WHERE THE BUNDLE IS KEPT:
+#   - every run → a GitHub Actions **artifact** (downloadable from the run,
+#     ~90-day retention) — for dispatch builds / testing.
+#   - on a `v*` tag → a GitHub **Release asset** (the permanent published home).
+#   Operator flow: download the .tar.gz from the release (or artifact) and
+#   drag-and-drop it into the cloud-ui Software-Update page, which publishes it to
+#   the cloud /firmware feed + adds the manifest entry (the .manifest.json here is
+#   the paste-ready row if you'd rather seed cloud.firmware.manifest by hand).
+#
+# Like rauc-bundle.yml this runs a containerized Yocto scarthgap build — heavy —
+# so it is intentional-only (tag or manual) and relies on the published sstate
+# cache image (IOT_USE_CACHE=1) to be feasible on a hosted runner.
+#
+# Secrets required:
+#   DOCKERHUB_USERNAME / DOCKERHUB_TOKEN — to pull the sstate cache image.
+
+on:
+  push:
+    tags: ['v*']
+  workflow_dispatch:
+    inputs:
+      machine:
+        description: Target MACHINE
+        default: raspberrypi3-64
+        required: false
+
+env:
+  MACHINE: ${{ github.event.inputs.machine || 'raspberrypi3-64' }}
+
+jobs:
+  build-bundle:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Free up disk space   # Yocto needs far more than a stock runner has
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          df -h /
+
+      - name: Log in to Docker Hub   # for the IOT_USE_CACHE sstate image
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build the OTA bundle
+        working-directory: yocto
+        env:
+          TARGET: iot-bundle
+          IOT_USE_CACHE: "1"
+          # Force a fresh re-clone+recompile of the iot recipe so the bundle
+          # carries the latest IOT_BRANCH commit (AUTOREV can otherwise serve a
+          # stale checkout from the git mirror / sstate → OTA pushing old code).
+          IOT_FRESH: "1"
+        run: ./build.sh "${MACHINE}"
+
+      - name: Collect bundle + sha + manifest row
+        id: collect
+        run: |
+          mkdir -p dist
+          # iot-bundle.bb deploys into images/<machine>/; search recursively to
+          # be path-robust across yocto layout tweaks.
+          found=$(find "yocto/build/${MACHINE}" -name 'iot-bundle-*.tar.gz' -type f | head -1)
+          [ -n "$found" ] || { echo "no iot-bundle tarball produced"; exit 1; }
+          base="$(basename "$found")"
+          cp -v "$found"            "dist/${base}"
+          cp -v "${found}.sha256"   "dist/${base}.sha256"        || true
+          cp -v "${found}.manifest.json" "dist/${base}.manifest.json" || true
+          ls -l dist/
+          echo "bundle=${base}" >> "$GITHUB_OUTPUT"
+
+      - name: Upload build artifact   # every run
+        uses: actions/upload-artifact@v4
+        with:
+          name: iot-bundle-${{ env.MACHINE }}
+          path: dist/
+
+      - name: Attach to release   # only on a v* tag — the permanent home
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            dist/iot-bundle-*.tar.gz
+            dist/iot-bundle-*.tar.gz.sha256
+            dist/iot-bundle-*.tar.gz.manifest.json


### PR DESCRIPTION
Closes the "nothing to update with" gap: there was no automated way to produce the `iot-bundle.tar.gz` an operator pushes over LwM2M Object 5, so the cloud Software-Update catalogue was always empty unless someone ran a manual Yocto build.

## What it does
Mirrors `rauc-bundle.yml`: a containerized Yocto build of **`TARGET=iot-bundle`** (`IOT_USE_CACHE` for speed, `IOT_FRESH` so the bundle carries the latest `IOT_BRANCH` commit — not stale OTA code). `iot-bundle.bb` already emits the `.tar.gz` + `.sha256` + a **paste-ready `cloud.firmware.manifest` row**; the job collects all three.

## Where the bundle is kept
- **Every run → a GitHub Actions artifact** (downloadable from the run, ~90-day retention) — for `workflow_dispatch` / testing.
- **On a `v*` tag → a GitHub Release asset** — the permanent published home.

Operator flow: download the `.tar.gz` from the release (or artifact) → **drag-drop into the cloud-ui Software-Update page** (publishes to the `/firmware` feed + adds the manifest entry), or seed `cloud.firmware.manifest` by hand with the provided `.manifest.json` row.

## Triggers
Intentional-only — `push: tags: ['v*']` + `workflow_dispatch` (with a `machine` input). A Yocto build is heavy, so **not** on every push. Needs `DOCKERHUB_USERNAME/TOKEN` for the `IOT_USE_CACHE` sstate image (same as `rauc-bundle.yml`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)