### PR TITLE
ci: build full image + OTA bundle on a release-branch cut (IOT_BRANCH-aware)

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -1,0 +1,103 @@
+name: Release build (full image + OTA bundle)
+
+# Cuts the device-side release artifacts when a release branch is pushed:
+#   - the FULL bootable Yocto image  (iot-image → *.wic.bz2, flash to SD)
+#   - the OTA .ipk bundle            (iot-bundle → *.tar.gz, push over LwM2M Obj 5)
+# Both carry the RELEASE BRANCH's code: the iot recipe fetches its source from
+# IOT_BRANCH, so we pin it to the triggering branch (github.ref_name) — without
+# this the build would ship `main` (the recipe default).
+#
+# Triggered when a `release/**` branch is pushed (i.e. when you cut/update a
+# release branch), or manually via workflow_dispatch from that branch. v* TAGS
+# are handled by the existing ipk-bundle.yml / rauc-bundle.yml / release-image.yml
+# (which attach RELEASE ASSETS) — kept separate so a tag doesn't double-build.
+#
+# Heavy containerized Yocto build → relies on the published sstate cache image
+# (IOT_USE_CACHE=1). Secrets: DOCKERHUB_USERNAME / DOCKERHUB_TOKEN.
+
+on:
+  push:
+    branches: ['release/**']
+  workflow_dispatch:
+    inputs:
+      machine:
+        description: Target MACHINE
+        default: raspberrypi3-64
+        required: false
+
+env:
+  MACHINE: ${{ github.event.inputs.machine || 'raspberrypi3-64' }}
+  # The branch this run is on (the release branch). The iot recipe fetches its
+  # source from here, so the artifacts carry release code, not main.
+  IOT_BRANCH: ${{ github.ref_name }}
+
+jobs:
+  full-image:
+    name: Full image (iot-image → .wic.bz2)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          df -h /
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build full bootable image
+        working-directory: yocto
+        env:
+          TARGET: iot-image
+          IOT_USE_CACHE: "1"
+          IOT_FRESH: "1"     # clean re-fetch of the release branch (no stale mirror)
+        run: ./build.sh "${MACHINE}"
+      - name: Collect image
+        run: |
+          mkdir -p dist
+          found=$(find "yocto/build/${MACHINE}" -name '*.wic.bz2' -type f | head -1)
+          [ -n "$found" ] || { echo "no *.wic.bz2 produced"; exit 1; }
+          cp -v "$found" "dist/"
+          ( cd dist && sha256sum *.wic.bz2 > SHA256SUMS )
+          ls -l dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: iot-image-${{ env.MACHINE }}
+          path: dist/
+
+  iot-bundle:
+    name: OTA bundle (iot-bundle → .tar.gz)
+    runs-on: ubuntu-22.04
+    steps:
+      - uses: actions/checkout@v4
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          df -h /
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build OTA bundle
+        working-directory: yocto
+        env:
+          TARGET: iot-bundle
+          IOT_USE_CACHE: "1"
+          IOT_FRESH: "1"
+        run: ./build.sh "${MACHINE}"
+      - name: Collect bundle + sha + manifest row
+        run: |
+          mkdir -p dist
+          found=$(find "yocto/build/${MACHINE}" -name 'iot-bundle-*.tar.gz' -type f | head -1)
+          [ -n "$found" ] || { echo "no iot-bundle tarball produced"; exit 1; }
+          base="$(basename "$found")"
+          cp -v "$found"                 "dist/${base}"
+          cp -v "${found}.sha256"        "dist/${base}.sha256"        || true
+          cp -v "${found}.manifest.json" "dist/${base}.manifest.json" || true
+          ls -l dist/
+      - uses: actions/upload-artifact@v4
+        with:
+          name: iot-bundle-${{ env.MACHINE }}
+          path: dist/

--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -23,6 +23,11 @@
 # iot recipe (deps still restore from sstate, so it stays fast):
 #   IOT_FRESH=1 ./build.sh
 #
+# Build a non-`main` ref of the iot recipe (e.g. a release branch) — the recipe
+# fetches its source from IOT_BRANCH, so the image/feed/bundle carries THAT
+# branch's code (combine with IOT_FRESH=1 to force a clean re-fetch):
+#   IOT_BRANCH=release/v1.1.0 IOT_FRESH=1 ./build.sh
+#
 # Build the RAUC A/B (dual-bank) image instead of the single-rootfs one:
 #   IOT_AB=1 ./build.sh        # raspberrypi*: u-boot + 4-partition wic +
 #                              # signed update-bundle-*.raucb. See
@@ -187,6 +192,7 @@ build_machine() {
         -e "MACHINE=$machine" \
         -e "IOT_FRESH=${IOT_FRESH:-}" \
         -e "IOT_AB=${IOT_AB:-}" \
+        -e "IOT_BRANCH=${IOT_BRANCH:-}" \
         -v "$SCRIPT_DIR/meta-iot:/home/builduser/yocto/meta-iot:ro" \
         -v "${DOWNLOADS_VOLUME}:/home/builduser/yocto/build/downloads:U" \
         -v "${SSTATE_VOLUME}:/home/builduser/yocto/build/sstate-cache:U" \

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -135,6 +135,14 @@ if [ "$MACHINE" != "qemux86-64" ]; then
     echo "MACHINE = \"$MACHINE\"" >> conf/local.conf
 fi
 
+# Pin the iot recipe's source branch (the recipe defaults IOT_BRANCH ?= "main").
+# Set by CI for a release-branch build so the image/feed/bundle carries that
+# branch's code instead of main. Unset → recipe default (main).
+if [ -n "${IOT_BRANCH:-}" ]; then
+    echo "→ IOT_BRANCH set: building iot from '${IOT_BRANCH}'"
+    echo "IOT_BRANCH = \"${IOT_BRANCH}\"" >> conf/local.conf
+fi
+
 # Raspberry Pi tunables: serial console on the GPIO header for headless
 # bring-up debugging. (No-op on the qemu machines.)
 case "$MACHINE" in


### PR DESCRIPTION
When you **cut a release branch** (`release/**`), build the two device-side release artifacts:
- **Full bootable image** — `iot-image` → `*.wic.bz2` (flash to SD)
- **OTA bundle** — `iot-bundle` → `*.tar.gz` (+ `.sha256` + paste-ready manifest row, push over LwM2M Object 5)

New `release-build.yml` — `push: branches: ['release/**']` + `workflow_dispatch`, two parallel jobs.

## The important bit — IOT_BRANCH
The `iot` recipe **fetches its source from `IOT_BRANCH`** (default `main`), *not* the checked-out ref — so a naive release-branch build would ship **main's** code in the image. Fixed by plumbing `IOT_BRANCH` end-to-end:
- `build.sh` forwards `-e IOT_BRANCH` into the build container (+ usage note for local `IOT_BRANCH=release/v1.1.0 ./build.sh`)
- `entrypoint.sh` writes `IOT_BRANCH = "<ref>"` into `local.conf` when set
- the workflow sets `IOT_BRANCH=${{ github.ref_name }}` (with `IOT_FRESH=1` for a clean re-fetch)

So both artifacts carry the **release branch's** code.

## Where the artifacts go
Per-run **GitHub Actions artifacts** (`iot-image-<machine>`, `iot-bundle-<machine>`). `v*` **tags** stay with `ipk-bundle.yml` / `rauc-bundle.yml` / `release-image.yml` (which attach *release assets*) — kept separate so a tag doesn't double-build.

Heavy Yocto build → uses `IOT_USE_CACHE` (needs `DOCKERHUB_USERNAME/TOKEN`, same as the other Yocto workflows).

## Note on "full image"
I read **"full image" = the Yocto bootable `.wic.bz2`** (paired with the OTA bundle, both `build.sh` device artifacts) — *not* the Docker device-image (which `device-image.yml` builds on `main`). Shout if you meant the Docker images on release branches instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)