### PR TITLE
fix(yocto): correct iot-bundle path in build.sh summary + README

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -257,8 +257,8 @@ print_summary() {
   ── OTA the whole iot-* userspace over LwM2M (one shot, many devices) ─
     # Copy the bundle into the cloud firmware feed + add its manifest row,
     # then push from the cloud-ui Software Update page (multi-select devices).
-    scp $OUT_DIR/raspberrypi3-64/images/iot-bundle-*.tar.gz* <cloud>:/firmware/
-    # Paste images/iot-bundle-*.tar.gz.manifest.json into cloud.firmware.manifest
+    scp $OUT_DIR/raspberrypi3-64/images/raspberrypi3-64/iot-bundle-*.tar.gz* <cloud>:/firmware/
+    # Paste images/raspberrypi3-64/iot-bundle-*.tar.gz.manifest.json into cloud.firmware.manifest
 EOF
     fi
     echo ""

--- a/yocto/meta-iot/README.md
+++ b/yocto/meta-iot/README.md
@@ -19,7 +19,7 @@ first source fetch. All commands run from the `yocto/` directory.
 | **Full image** (bootable SD card — first flash / OS change) | `./build.sh` | `build/<machine>/images/<machine>/*.wic.bz2` (+ the `ipk/` feed as a byproduct) |
 | **iot apps only** (just the C++/UI recipe — fast iterate, no full image) | `TARGET=iot ./build.sh` | `build/<machine>/ipk/**/iot-*.ipk` |
 | **Full `.ipk` feed** (every iot package: ds/lwm2m/httpd/sensord/cellular/…) | `TARGET=packagegroup-iot ./build.sh` | `build/<machine>/ipk/` (opkg feed) |
-| **OTA bundle** (one `.tar.gz` of the whole feed, for the LwM2M Object-5 push) | `TARGET=iot-bundle ./build.sh` | `build/<machine>/.../iot-bundle-<ver>-<arch>.tar.gz` |
+| **OTA bundle** (one `.tar.gz` of the whole feed, for the LwM2M Object-5 push) | `TARGET=iot-bundle ./build.sh` | `build/<machine>/images/<machine>/iot-bundle-<ver>-<arch>.tar.gz` (+ `.sha256`, `.manifest.json`) — **NOT** built by the default image target |
 | **A/B dual-bank image** (RAUC update flow) | `IOT_AB=1 ./build.sh` | u-boot + 4-partition `.wic` + signed `update-bundle-*.raucb` |
 
 ```sh


### PR DESCRIPTION
build.sh's "OTA over LwM2M" summary printed the bundle at `build/<machine>/images/iot-bundle-*.tar.gz` — **missing the `/<machine>/` subdir**. The bundle (like the `.wic.bz2`) deploys to `images/<machine>/`, so the printed `scp`/manifest paths pointed at an empty dir → "I don't see it anywhere."

(The detection `find` is recursive so the summary still *listed* `iot-bundle-…tar.gz`; only the example paths were wrong.)

Fix the heredoc to `images/raspberrypi3-64/iot-bundle-*` (matching the wic line), and make the README target table show the exact `build/<machine>/images/<machine>/` path + note the bundle is **not** built by the default image target.

🤖 Generated with [Claude Code](https://claude.com/claude-code)