### PR TITLE
fix(log): honour configured log level (DTLS + ACE per-thread + hot-reload)

### DIFF
--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -26,6 +26,7 @@ extern "C"
     #include "dtls.h"
     #include "session.h"
     #include "alert.h"
+
     /**
      * @brief This Function is invoked by tinydtls to send message to peer. The message/data will be encrypted with PSK Key.
      * @param This is a context of tinydtls which has app pointer data member which points to the instance of DTLSAdapter.
@@ -67,6 +68,21 @@ extern "C"
     */
     std::int32_t dtlsGetPskInfoCb(dtls_context_t *ctx, const session_t *session, dtls_credentials_type_t type, const unsigned char *identity, size_t identity_len, unsigned char *result, size_t result_length);
 }
+
+// C++ linkage (NOT in the extern "C" block above — these take C++ types).
+namespace data_store { class Client; }
+
+/// Map an iot log-level string ("DEBUG"/"INFO"/"WARNING"/"ERROR", any case) to
+/// the nearest tinydtls log_t. tinydtls has no ERROR level — ERROR maps to
+/// DTLS_LOG_CRIT (emerg/alert/crit only). Unknown/empty → DTLS_LOG_WARN.
+log_t dtls_level_from_string(const std::string& s);
+
+/// Resolve log.level.dtls (falling back to log.level) from ds and push it into
+/// tinydtls' GLOBAL logger via dtls_set_log_level. Call at startup (after the
+/// DTLS contexts exist) and on every log-level watch event — tinydtls logging
+/// is otherwise frozen at the value set when the first DTLSAdapter was
+/// constructed, ignoring the configured level entirely.
+void dtls_apply_log_level(data_store::Client& ds);
 
 class DTLSAdapter {
     public:

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -1,9 +1,44 @@
 #ifndef __dtls_adapter_cpp__
 #define __dtls_adapter_cpp__
 
+// data-store headers MUST precede dtls_adapter.hpp: tinydtls' numeric.h (pulled
+// in transitively by dtls_adapter.hpp) #defines a max(A,B) macro that otherwise
+// clobbers std::numeric_limits<>::max() inside data_store/value.hpp.
+#include "data_store/client.hpp"
+#include "data_store/value.hpp"
+
 #include "dtls_adapter.hpp"
 
 #include <ace/Log_Msg.h>
+#include <cctype>
+
+log_t dtls_level_from_string(const std::string& s) {
+    std::string up;
+    up.reserve(s.size());
+    for (char c : s) up.push_back(static_cast<char>(std::toupper(
+        static_cast<unsigned char>(c))));
+    if (up == "DEBUG")   return DTLS_LOG_DEBUG;   // 6 — everything
+    if (up == "INFO")    return DTLS_LOG_INFO;    // 5 — all but debug
+    if (up == "WARNING") return DTLS_LOG_WARN;    // 3
+    if (up == "ERROR")   return DTLS_LOG_CRIT;    // 2 — emerg/alert/crit
+    return DTLS_LOG_WARN;                         // quiet, production-safe default
+}
+
+void dtls_apply_log_level(data_store::Client& ds) {
+    // Per-daemon log.level.dtls wins; fall back to the global log.level.
+    std::vector<data_store::Client::GetResult> g;
+    std::string lvl;
+    if (ds.get({std::string("log.level.dtls"), std::string("log.level")}, g).ok) {
+        for (const auto& r : g) {
+            if (r.has_value) {
+                if (auto v = data_store::to_string(r.value)) {
+                    if (!v->empty()) { lvl = *v; break; }
+                }
+            }
+        }
+    }
+    dtls_set_log_level(dtls_level_from_string(lvl));
+}
 
 
 std::int32_t dtlsWriteCb(dtls_context_t *ctx, session_t *session, uint8 *data, size_t len) {
@@ -206,7 +241,11 @@ DTLSAdapter::DTLSAdapter(std::int32_t fd, log_t log_level) {
     dtlsFd = fd;
     dtls_init();
     m_dtls_ctx = dtls_new_context(this);
-    dtls_set_log_level(log_level);
+    // NOTE: do NOT set the tinydtls log level here — it's a PROCESS-GLOBAL and
+    // constructing an adapter must not clobber a level already applied from ds.
+    // dtls_apply_log_level() (driven by log.level.dtls/log.level) is the sole
+    // authority; see udp_adapter.cpp + apps/src/main.cpp.
+    (void)log_level;
     dtls_set_handler(m_dtls_ctx, &cb);
     m_coapAdapter = std::make_shared<CoAPAdapter>();
     isClient(false);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1546,7 +1546,11 @@ int main(std::int32_t argc, char *argv[]) {
     // cloud-instance key setup) just refine the level key.
     g_log.start();
     dtls_set_log_sink(&iot_dtls_log_sink);   // DTLS (tinydtls) logs → UI
-    if (auto* cli = ds.client()) { g_log.apply_level(*cli); g_log.open(*cli, 5, 1); }
+    if (auto* cli = ds.client()) {
+        g_log.apply_level(*cli);
+        dtls_apply_log_level(*cli);   // tinydtls level from log.level.dtls/log.level
+        g_log.open(*cli, 5, 1);
+    }
 
     // RPi serial auto-fill — MUST run BEFORE the provisioning park below.
     // The serial IS the endpoint + BS PSK identity, and the operator reads
@@ -1784,7 +1788,30 @@ int main(std::int32_t argc, char *argv[]) {
 
     if (auto* cli = ds.client()) {
         g_log.apply_level(*cli);
+        dtls_apply_log_level(*cli);
         g_log.flush(*cli);  // push startup logs immediately
+
+        // Hot-reload: the lwm2m binary runs its event loop inside the ACE
+        // reactor (UDPAdapter::start) and has no pull-style watch loop like
+        // cloudd/httpd, so without this a log.level change needed a restart.
+        // A callback-style watch fires on the ds notification thread; re-apply
+        // the ACE mask (bumps the generation → the reactor thread re-pins via
+        // refresh_level()) and the tinydtls level. Watch the global key, this
+        // instance's per-daemon key, and the DTLS key.
+        const std::string lvl_key = lwm2m_instance.empty()
+            ? std::string("log.level.lwm2m")
+            : ("log.level.lwm2m." + lwm2m_instance);
+        static data_store::Client::WatchHandle s_lvl_wh =
+            data_store::Client::kInvalidHandle;
+        cli->watch(
+            std::vector<std::string>{"log.level", lvl_key, "log.level.dtls"},
+            [&ds](const data_store::Client::Event&) {
+                if (auto* c = ds.client()) {
+                    g_log.apply_level(*c);
+                    dtls_apply_log_level(*c);
+                }
+            },
+            &s_lvl_wh);
     }
 
     // ── Resource telemetry (L22) ──────────────────────────────────

--- a/apps/src/udp_adapter.cpp
+++ b/apps/src/udp_adapter.cpp
@@ -26,7 +26,11 @@ ServiceContext_t::ServiceContext_t(Scheme_t scheme,
         // DTLSAdapter takes the raw fd because tinydtls' read/write
         // callbacks ::sendto/::recvfrom on it directly. The fd is filled
         // in inside open() once the socket is actually bound.
-        m_dtlsAdapter = std::make_shared<DTLSAdapter>(ACE_INVALID_HANDLE, DTLS_LOG_DEBUG);
+        // Quiet default; the real level is pushed from ds by
+        // dtls_apply_log_level() at startup + on every log.level change. Was
+        // hardcoded DTLS_LOG_DEBUG, which made tinydtls ignore the config and
+        // spew handshake DEBUG regardless of log.level / log.level.dtls.
+        m_dtlsAdapter = std::make_shared<DTLSAdapter>(ACE_INVALID_HANDLE, DTLS_LOG_WARN);
         // Share THIS context's CoAPAdapter with the DTLS read path. The
         // DTLSAdapter's dtlsReadCb dispatches deciphered datagrams via its
         // own coapAdapter(); without this it would use a private, unwired
@@ -415,6 +419,10 @@ int UDPAdapter::svc() {
     data_store::LogBuffer::attach_current_thread();
 
     while (!m_stop.load()) {
+        // Re-pin this thread's log mask if the level changed at runtime — cheap
+        // when unchanged. attach_current_thread() above only set it once, so a
+        // hot log.level change would otherwise never reach this reactor thread.
+        data_store::LogBuffer::refresh_level();
         // Reset the timeout every iteration: ACE_Reactor::handle_events()
         // decrements the passed ACE_Time_Value in place (ACE_Countdown_Time),
         // so a single shared value drains to zero after the first idle wait and

--- a/modules/data-store/inc/data_store/log_buffer.hpp
+++ b/modules/data-store/inc/data_store/log_buffer.hpp
@@ -63,6 +63,14 @@ public:
     /// Process-wide: targets the most recently start()ed LogBuffer.
     static void attach_current_thread();
 
+    /// Re-pin the CALLING thread's ACE log mask if the level changed since it
+    /// last attached. attach_current_thread() sets a thread's mask ONCE, so a
+    /// long-lived reactor/worker thread would never see a runtime log-level
+    /// change (apply_level() runs on the main thread and ACE masks are
+    /// per-thread). Call this cheaply at the top of such a thread's loop — it's
+    /// a single relaxed atomic load when nothing changed. No-op before start().
+    static void refresh_level();
+
     /// Unregister the callback. Flush one last time before destroying.
     ~LogBuffer();
 

--- a/modules/data-store/src/log_buffer.cpp
+++ b/modules/data-store/src/log_buffer.cpp
@@ -15,6 +15,7 @@
 #include <atomic>
 #include <cerrno>
 #include <ctime>
+#include <atomic>
 #include <deque>
 #include <mutex>
 #include <string>
@@ -27,8 +28,14 @@ namespace data_store {
 // honour the configured log level — ACE_Log_Msg is per-thread, so a spawned
 // reactor thread inherits neither. One LogBuffer per process in practice.
 namespace {
-    ACE_Log_Msg_Callback* s_active_cb   = nullptr;
-    unsigned long         s_active_mask = LM_INFO;
+    ACE_Log_Msg_Callback*      s_active_cb   = nullptr;
+    std::atomic<unsigned long> s_active_mask{LM_INFO};
+    // Bumped on every apply_level(): lets a long-lived worker thread (which
+    // pinned its per-thread mask once at attach_current_thread()) notice a
+    // runtime level change and re-pin via refresh_level(). ACE_Log_Msg is
+    // per-thread, so apply_level() on the main thread cannot reach it otherwise.
+    std::atomic<unsigned>      s_mask_gen{0};
+    thread_local unsigned      t_seen_gen = 0;
 }
 
 struct LogBuffer::Impl {
@@ -122,7 +129,21 @@ void LogBuffer::attach_current_thread() {
     // Also pin this thread's level to the configured mask — a freshly
     // spawned reactor thread otherwise defaults to "all levels", leaking
     // DEBUG noise that the INFO default is meant to suppress.
-    lm->priority_mask(static_cast<int>(s_active_mask), ACE_Log_Msg::THREAD);
+    lm->priority_mask(static_cast<int>(s_active_mask.load()), ACE_Log_Msg::THREAD);
+    t_seen_gen = s_mask_gen.load();
+}
+
+void LogBuffer::refresh_level() {
+    // Cheap (one relaxed atomic load) when nothing changed — safe to call
+    // every iteration of a worker thread's reactor loop. Re-pins this thread's
+    // per-thread ACE mask when apply_level() has run since we last attached,
+    // so a runtime log-level change reaches reactor/worker threads (not just
+    // the main thread that handles the watch).
+    const unsigned g = s_mask_gen.load(std::memory_order_relaxed);
+    if (g == t_seen_gen) return;
+    t_seen_gen = g;
+    ACE_Log_Msg::instance()->priority_mask(
+        static_cast<int>(s_active_mask.load()), ACE_Log_Msg::THREAD);
 }
 
 int LogBuffer::open(Client& ds, int interval_sec, std::size_t min_bytes) {
@@ -247,9 +268,16 @@ void LogBuffer::apply_level(Client& ds) {
         else if (lvl_str == "WARNING") mask = kWarn;
         else if (lvl_str == "ERROR")   mask = kErr;
     }
-    s_active_mask = mask;   // remembered for attach_current_thread()
-    ACE_Log_Msg::instance()->priority_mask(
-        static_cast<int>(mask), ACE_Log_Msg::PROCESS);
+    s_active_mask = mask;            // remembered for attach_current_thread()
+    s_mask_gen.fetch_add(1, std::memory_order_relaxed);  // wake refresh_level()
+    auto* lm = ACE_Log_Msg::instance();
+    // PROCESS seeds threads spawned LATER; THREAD fixes THIS (the calling/main)
+    // thread NOW. ACE gates logging on the per-thread mask, so without the
+    // THREAD set the main thread keeps its default "all levels" and every
+    // ACE_DEBUG it emits prints regardless of the configured level.
+    lm->priority_mask(static_cast<int>(mask), ACE_Log_Msg::PROCESS);
+    lm->priority_mask(static_cast<int>(mask), ACE_Log_Msg::THREAD);
+    t_seen_gen = s_mask_gen.load();
 }
 
 }  // namespace data_store


### PR DESCRIPTION
Setting **log.level=ERROR** (or `log.level.dtls`, etc.) still printed **DEBUG**, on both device and cloud. Three independent root causes:

### 1. DTLS hardcoded to DEBUG
`udp_adapter.cpp` built `DTLSAdapter` with `DTLS_LOG_DEBUG`. tinydtls has its **own global logger** (separate from ACE), so it spewed handshake DEBUG regardless of config.
- New `dtls_level_from_string` + `dtls_apply_log_level` (reads `log.level.dtls` → `log.level`, maps to nearest `log_t` — tinydtls has no ERROR, so **ERROR→DTLS_LOG_CRIT**).
- Driven from ds at startup + on change; the global side-effect is removed from the `DTLSAdapter` ctor so construction can't clobber it. Default is now `DTLS_LOG_WARN`.

### 2. ACE mask was PROCESS-only
`apply_level()` set only the **PROCESS** priority mask, but ACE gates on the **per-thread** mask — so the calling/main thread kept its default *all-levels* and every `ACE_DEBUG` printed.
- Set **THREAD** too, bump a generation counter, add `refresh_level()` so a long-lived reactor thread (pins its mask once in `attach_current_thread`) re-pins cheaply on change; wired into the UDP/CoAP reactor loop.

### 3. No hot-reload in the lwm2m binary
Unlike cloudd/httpd it runs inside the ACE reactor with no watch, so a level change needed a restart. Added a callback-style `ds.watch` on `log.level` / the per-daemon key / `log.level.dtls` that re-applies both the ACE mask and the tinydtls level.

**Verification:** `g++ -std=c++17 -fsyntax-only` clean for log_buffer, udp_adapter, dtls_adapter, main. Also fixes a tinydtls `numeric.h` `max()` macro clash with `data_store/value.hpp` via include ordering.

Note: `iot-cloudd`/`iot-httpd` benefit from #2 (their main thread now honours the level); the device lwm2m client + cloud lwm2m-bs/dm get all three.

🤖 Generated with [Claude Code](https://claude.com/claude-code)