### PR TITLE
docs(bcm2837): rule out DMA-driven I2C transport (no BSC DREQ on BCM2837)

### DIFF
--- a/apps/docs/tdd-mangoh-yellow-sensors.md
+++ b/apps/docs/tdd-mangoh-yellow-sensors.md
@@ -31,6 +31,17 @@ left untouched.
 > 3.3 V levels and that pull-ups are present on exactly one side before
 > connecting.
 
+> **Transport variants — DMA ruled out (2026-06-20).** Three `I2cTransport`
+> implementations ship: poll (`Bcm2837I2cTransport`, #283), `/dev/i2c-N`
+> (`I2cDevTransport`, #293, the Linux shipping path), and interrupt-driven
+> (`Bcm2837I2cIrqTransport`, #296, bare-metal). A fourth, **DMA-driven**, was
+> evaluated and **rejected: the BCM2837 BSC I²C masters have no DMA DREQ**, so a
+> DMA channel can't be paced against the 16-byte FIFO (it would overrun). This
+> module's register model confirms it — BSC `Control` has no `DMAEN` bit while
+> SPI does — and it's why Linux `i2c-bcm2835` is PIO/IRQ-only. The interrupt
+> transport is the CPU-offload ceiling for BSC I²C. Details in
+> `modules/bcm2837/docs/i2c-irq-transport-spec.md` §2.
+
 ## 1. Architecture (4 layers, bottom-up)
 
 ```

--- a/modules/bcm2837/docs/i2c-irq-transport-spec.md
+++ b/modules/bcm2837/docs/i2c-irq-transport-spec.md
@@ -27,8 +27,20 @@ interrupt-vector and the BSC IRQ line (the bcm2837 `IRQ` driver in
 transport under Linux** — `/dev/mem` register poking + a userspace ISR cannot
 coexist with the kernel driver. This spec targets the no-Linux consumer only.
 
-**Non-goals:** DMA (the BSC supports a DMA DREQ path; a separate effort),
-multi-master arbitration, 10-bit addressing.
+**Non-goals:** multi-master arbitration, 10-bit addressing.
+
+> ⚠️ **DMA is NOT available for the BSC I²C masters on BCM2837** (an earlier
+> draft of this note wrongly called it "a separate effort"). The BSC0/1/2 I²C
+> masters have **no DMA DREQ line**, so a DMA channel cannot be paced against the
+> 16-byte FIFO — it would overrun immediately. Corroborated by this module's own
+> register model: `BSCRegistersAddress::Control` (`memory_map.hpp`) has no
+> `DMAEN` bit, whereas `SPIRegistersAddress::ControlStatus` does (bit 8, plus the
+> `DC` DMA-DREQ-controls register). In the BCM2835 DREQ table, entries 8/9
+> ("BSC/SPI Slave") map to the BSC **slave** peripheral (`0x7E214000`), not the
+> I²C masters. This is why mainline Linux `i2c-bcm2835` is PIO/interrupt-driven
+> only. **The interrupt-driven transport (this spec) is the CPU-offload ceiling
+> for BSC I²C.** SPI0 *does* have DMA (DREQ 6/7) — a DMA transport is viable there
+> if a future SPI peripheral ever needs it, but no mangOH Yellow sensor is SPI.
 
 ---
 


### PR DESCRIPTION
## What

Corrects the I²C IRQ transport spec and the mangOH Yellow TDD: a **DMA-driven `I2cTransport`** was evaluated and **ruled out** — it is not implementable on the BCM2837 BSC I²C masters.

## Why

The IRQ spec's non-goal note claimed *"the BSC supports a DMA DREQ path; a separate effort."* That's wrong for the BSC I²C masters:

- The BCM2837 **BSC0/1/2 masters have no DMA DREQ line**, so a DMA channel can't be paced against the 16-byte FIFO — it would overrun immediately.
- Confirmed by this module's own register model: `BSCRegistersAddress::Control` has **no `DMAEN` bit**, whereas `SPIRegistersAddress::ControlStatus` does (bit 8) plus the `DC` DMA-DREQ-controls register.
- In the BCM2835 DREQ table, entries 8/9 ("BSC/SPI Slave") map to the BSC **slave** peripheral (`0x7E214000`), not the I²C masters.
- This is why mainline Linux `i2c-bcm2835` is PIO/interrupt-driven only.

The **interrupt-driven transport (#296) is the CPU-offload ceiling** for BSC I²C. SPI0 *does* have DMA (DREQ 6/7) if a future SPI peripheral ever needs it — but no mangOH Yellow sensor is SPI.

## Changes

- `modules/bcm2837/docs/i2c-irq-transport-spec.md` §2 — replace the bogus DMA non-goal with a ⚠️ callout + register-model evidence.
- `apps/docs/tdd-mangoh-yellow-sensors.md` §0 — add a "transport variants — DMA ruled out" note so it isn't re-investigated.

**Docs only — no code changes.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)