### PR TITLE
fix(yocto): enable iot-ota-stage.path in 90-iot.preset (OTA stager never fired)

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
@@ -18,6 +18,7 @@ enable iot-wifi-client.service
 enable iot-lwm2m-client.service
 enable iot-openvpn-client.service
 enable iot-net-router.service
+enable iot-ota-stage.path
 enable iot-swupdate.path
 enable iot-vpn-cert.path
 enable iot-ota-confirm.service


### PR DESCRIPTION
## Symptom

Software Update stuck at **90% forever**, even after #311 (\"complete the OTA job\"). Verified on hardware (device `000000006556e041`, build `1.1.0+28234ae`).

## Root cause — the device's updater never runs

#280 fixed the *client* side of the privilege bug: the unprivileged lwm2m client (`User=engineer`) can't `systemd-run` a system unit, so it now drops the package URL into `/run/iot/update/stage.req` and a **root** `iot-ota-stage.path` unit fires the stager. #280 added `iot-ota-stage.path` to `SYSTEMD_SERVICE:${PN}-lwm2m` + `FILES` + the install step — **but never added the matching `enable iot-ota-stage.path` line to `90-iot.preset`.**

The image runs `systemctl preset-all` on first boot. Any unit with **no** preset rule defaults to `disable`, undoing the build-time `SYSTEMD_AUTO_ENABLE` symlink — exactly the failure mode this preset file's own header warns about. So on a freshly flashed device:

| Unit | In preset? | State on device |
|---|---|---|
| `iot-swupdate.path` | ✓ | **enabled** |
| `iot-vpn-cert.path` | ✓ | **enabled** |
| `iot-ota-stage.path` | ✗ (missing) | **disabled / inactive** |

(Same package, same `AUTO_ENABLE=enable` — the only difference was the preset omission.)

### On-device evidence
- Client correctly wrote `/run/iot/update/stage.req` → `https://65.20.74.23/firmware/iot-bundle-1.1.0-raspberrypi3-64.tar.gz?sha256=fbd31d50…&version=1.1.0` (so blocker #1 base.url + sha are fine).
- `systemctl is-enabled iot-ota-stage.path` → `disabled`; no `multi-user.target.wants/` symlink.
- Nothing watches the spool → stager never fires → `iot.update.{state,result,progress}` all `0`, **no `iot-ota-stage`/`iot-swupdate` journal entries**, version unchanged.
- Cloud shows 90% only because `lwm2m-dm` optimistically sets `state=3` on push and never gets a completion (correctly — nothing happened device-side).

## Fix

One line — add `enable iot-ota-stage.path` to `90-iot.preset`, next to `iot-swupdate.path`. Keeps the preset in sync with `SYSTEMD_AUTO_ENABLE:${PN}-lwm2m` as the file header instructs.

Needs a CI image build + reflash to validate on hardware (no local compiler).

> Note: the cloud-side completion logic (baseline-change in `reconcile_registrations`) is blind to a *same-build* reinstall — a separate latent gap, not the cause here. Tracked for a follow-up (read Object 5 `/5/0/5` Update Result on re-Register).

🤖 Generated with [Claude Code](https://claude.com/claude-code)