### PR TITLE
feat(bcm2837): System Timer driver + real-µs watchdog for the interrupt I2C transport

### DIFF
--- a/modules/bcm2837/README.md
+++ b/modules/bcm2837/README.md
@@ -5,7 +5,8 @@ Raspberry Pi 3B. Each peripheral is modelled as a memory-mapped register block
 that the driver classes read/modify/write through typed, field-level accessors.
 
 Peripherals: **GPIO**, **Clock manager (CM_GPn)**, **Interrupt controller**,
-**I2C (BSC1)**, **SPI0**.
+**I2C (BSC1)**, **SPI0**, **System Timer** (1 MHz free-running counter +
+compare channels; backs the interrupt-I²C watchdog deadline).
 
 > See [`docs/DRIVER_REVIEW.md`](docs/DRIVER_REVIEW.md) for the design review,
 > the per-peripheral issue log, and what is fixed vs. still open.
@@ -33,7 +34,7 @@ GPIO gpio(buf.data());             // test/host: registers overlay a heap buffer
 ```
 
 Physical bases: GPIO `0x3F200000`, Clock `0x3F101070`*, IRQ `0x3F00B200`,
-I2C/BSC1 `0x3F804000`, SPI0 `0x3F204000`.
+I2C/BSC1 `0x3F804000`, SPI0 `0x3F204000`, System Timer `0x3F003000`.
 <sub>*Clock base is tracked as an open issue — see DRIVER_REVIEW §2.3.</sub>
 
 ---
@@ -127,7 +128,7 @@ gpio->output(17);
 gpio->GPSETn(17);                // drive GPIO17 high
 ```
 
-`map_gpio()` / `map_clock()` / `map_i2c()` / `map_spi()` use `/dev/mem` (needs
+`map_gpio()` / `map_clock()` / `map_i2c()` / `map_spi()` / `map_systimer()` use `/dev/mem` (needs
 root / `CAP_SYS_RAWIO`); `map_gpiomem()` maps **GPIO only** via the unprivileged
 `/dev/gpiomem` (group `gpio`). Each returns an RAII `Mapped<Driver>` that owns
 the mapping and unmaps on scope exit. The demo binary does this under

--- a/modules/bcm2837/docs/i2c-irq-transport-spec.md
+++ b/modules/bcm2837/docs/i2c-irq-transport-spec.md
@@ -181,9 +181,15 @@ A wedged slave (holds SCL low, never raises DONE) yields **no interrupt** → th
 thread would `WFI` forever. `wait_complete()` must bound the wait:
 - coarse: a fallback `ST`-to-now spin/iteration cap that aborts → `Timeout`
   (resets the controller: `clear_fifo()`, `clr_status(DONE|ERR|CLKT)`);
-- better: arm the ARM system timer for `N ms` and abort on expiry. (The bcm2837
-  module has no system-timer driver yet — a small dependency to add, or inject a
-  `now()`/`deadline` hook.)
+- better (**now implemented**): bound the wait by a real **microsecond deadline**
+  from the BCM2837 **System Timer** (`inc/system_timer.hpp`, a free-running 1 MHz
+  counter). Wire it with `set_time_source(&timer)`; `wait_complete()` then aborts
+  once `now_us() - start >= timeout_us` (default 50 ms), with the iteration cap
+  kept as a backstop. `now_us()` is a virtual seam (default reads the attached
+  `SystemTimer`; returns 0 = "no clock" → the cap governs), so host tests
+  simulate elapsed time. **Remaining bare-metal step:** also `arm()` a
+  System-Timer compare IRQ (channel 1 or 3) and enable it, so a wedged bus with
+  no BSC interrupt still wakes the core from `WFI` for the deadline to be acted on.
 
 ---
 
@@ -228,8 +234,11 @@ Timeout, busy-guard rejects re-entry).
    whether `DEL`/control configures them) for the large-transfer path.
 3. **Clock-stretch erratum** — pick the divider for stretch-prone slaves; the
    ISR can't paper over a bus-timing bug.
-4. **Timer dependency** — the watchdog needs a time source the module doesn't
-   ship yet (system timer driver or an injected deadline hook).
+4. **Timer dependency** — ✅ **resolved.** The `SystemTimer` driver
+   (`inc/system_timer.hpp`, phys `0x3F003000`) ships the 1 MHz `now_us()` source;
+   the watchdog uses it as a real µs deadline via `set_time_source()`. The
+   bare-metal compare-IRQ wake (`arm()` + enabling the System-Timer IRQ) is the
+   only piece still pending real silicon.
 5. **`install_IRQHandler` IVT model** — `interrupt.cpp`'s IVT placement is a
    bare-metal-only construct (see DRIVER_REVIEW §2.4); validate the vector wiring
    on real silicon, not just the host model.
@@ -243,9 +252,11 @@ Timeout, busy-guard rejects re-entry).
   `wait_complete()`/`read_status()` seams; host gtests (ISR simulated).
 - **P2 ✅** — multi-interrupt FIFO drain/fill (`handle_irq` moves all available
   bytes per call, re-reading status; the inner loop re-arms across interrupts).
-- **P3 ✅** — watchdog: `wait_complete()` bounds the wait by `max_waits`
-  `wait_for_irq()` cycles, then `abort_transfer()` → `Timeout`. (A real
-  bare-metal build must arm a timer IRQ so `WFI` wakes — §4.7.)
+- **P3 ✅** — watchdog: `wait_complete()` bounds the wait by a real **µs deadline**
+  from the `SystemTimer` (`set_time_source()`, default 50 ms) **and** an absolute
+  `max_waits` iteration backstop, then `abort_transfer()` → `Timeout`. The `now_us()`
+  seam keeps it host-testable (deadline + iteration-cap tests both green). Remaining
+  bare-metal step: `arm()` a timer compare IRQ so `WFI` wakes on a wedged bus (§4.7).
 - **P4 ⚙️ code done, silicon pending** — `bus_init()` muxes ALT0, sets the
   divider, enables BSC, `install_IRQHandler(kBsc1Irq, trampoline)` + `enable()`;
   `mem_barrier()` = `dmb sy` on ARM. Confirm `kBsc1Irq`=53, IVT wiring and the

--- a/modules/bcm2837/inc/i2c_irq.hpp
+++ b/modules/bcm2837/inc/i2c_irq.hpp
@@ -9,6 +9,8 @@
 #include "interrupt.hpp"
 #include "i2c_bus.hpp"   // I2cTransport / I2cResult
 
+class SystemTimer;       // optional watchdog time source (system_timer.hpp)
+
 /**
  * @file i2c_irq.hpp
  * @brief Interrupt-driven BSC1 I²C transport (bare-metal). See
@@ -33,17 +35,31 @@ class Bcm2837I2cIrqTransport : public I2cTransport {
         /// BSC interrupt line — BCM2837 DT `interrupts = <2 21>` ⇒ IRQ 53.
         /// CONFIRM on silicon (shared across BSC0/1/2). See spec §3.
         static constexpr std::uint8_t  kBsc1Irq         = 53;
-        /// Watchdog: max wait_for_irq() iterations before aborting → Timeout.
+        /// Watchdog: absolute cap on wait_for_irq() iterations before aborting →
+        /// Timeout. A backstop for the host / when no time source is wired; the
+        /// real bound is the µs deadline below once a SystemTimer is attached.
         static constexpr std::uint32_t kDefaultMaxWaits = 1000000U;
+
+        /// Watchdog: wall-clock deadline in microseconds (0 = disabled → fall
+        /// back to the iteration cap). Honoured only once a time source is wired
+        /// via set_time_source(); see docs/i2c-irq-transport-spec.md §4.7.
+        static constexpr std::uint32_t kDefaultTimeoutUs = 50000U;   ///< 50 ms
 
         /// Async completion callback (no captures — pass state via `user`).
         using Completion = void (*)(I2cResult result, void* user);
 
         Bcm2837I2cIrqTransport(I2C i2c, GPIO gpio, IRQ irq,
-                               std::uint16_t divider   = kDefaultDivider,
-                               std::uint32_t max_waits = kDefaultMaxWaits)
+                               std::uint16_t divider    = kDefaultDivider,
+                               std::uint32_t max_waits   = kDefaultMaxWaits,
+                               std::uint32_t timeout_us  = kDefaultTimeoutUs)
             : m_i2c(i2c), m_gpio(gpio), m_irq(irq),
-              m_divider(divider), m_max_waits(max_waits) {}
+              m_divider(divider), m_max_waits(max_waits),
+              m_timeout_us(timeout_us) {}
+
+        /// Attach a real microsecond time source for the watchdog (the BCM2837
+        /// System Timer). Without it the watchdog uses only the iteration cap.
+        /// The transport does not own the timer — the caller keeps it alive.
+        void set_time_source(SystemTimer* timer) { m_timer = timer; }
 
         /// Mux GPIO2/3 → ALT0, set the divider, enable BSC1, install the ISR and
         /// enable the BSC IRQ line. Call once before any transfer (hardware).
@@ -83,6 +99,12 @@ class Bcm2837I2cIrqTransport : public I2cTransport {
         /// I2C_IRQ_BAREMETAL) else a no-op; tests override to drive handle_irq().
         virtual void wait_for_irq();
 
+        /// Current time in microseconds for the watchdog deadline. Default:
+        /// the attached SystemTimer's free-running counter, or 0 when none is
+        /// wired (0 means "no clock" → the iteration cap governs). Virtual so
+        /// host tests can simulate the passage of time.
+        virtual std::uint64_t now_us();
+
     private:
         struct Xfer {
             const std::uint8_t* tx = nullptr; std::size_t tn = 0, ti = 0;
@@ -108,6 +130,8 @@ class Bcm2837I2cIrqTransport : public I2cTransport {
         IRQ           m_irq;
         std::uint16_t m_divider;
         std::uint32_t m_max_waits;
+        std::uint32_t m_timeout_us;
+        SystemTimer*  m_timer = nullptr;   ///< optional watchdog time source
         Xfer          m_xfer;
 };
 

--- a/modules/bcm2837/inc/memory_map.hpp
+++ b/modules/bcm2837/inc/memory_map.hpp
@@ -374,6 +374,57 @@ namespace BCM2837 {
 
     /**
      * @brief
+     *      System Timer register block. Refer Section 12 "System Timer" of
+     *      BCM2837-ARM-Peripherals.pdf. The peripheral is at bus 0x7E003000 ->
+     *      phys 0x3F003000 and exposes a free-running 1 MHz counter (so one
+     *      tick == 1 microsecond) plus four 32-bit compare channels.
+     *
+     *      The counter (CLO/CHI) is read-only; writing a compare register Cn and
+     *      enabling the matching System-Timer IRQ fires an interrupt when CLO
+     *      reaches Cn (the match latches CS bit Mn, W1C). On the Raspberry Pi
+     *      channels 0 and 2 are owned by the GPU/VideoCore firmware — only
+     *      channels 1 and 3 are free for the ARM.
+    */
+    struct SystemTimerRegistersAddress {
+
+        enum Register : std::uint32_t {
+            CS,     /* 0x00 Control / Status (match flags M0..M3, W1C) */
+            CLO,    /* 0x04 Counter Lower 32 bits (RO, 1 MHz)          */
+            CHI,    /* 0x08 Counter Higher 32 bits (RO)                */
+            C0,     /* 0x0C Compare 0 (GPU)                            */
+            C1,     /* 0x10 Compare 1 (ARM-usable)                     */
+            C2,     /* 0x14 Compare 2 (GPU)                            */
+            C3,     /* 0x18 Compare 3 (ARM-usable)                     */
+            ST_MAX
+        };
+
+        /// @brief Match bits in CS (write 1 to clear). Mn latches when CLO==Cn.
+        enum Status : std::uint32_t {
+            M0,     /* bit0 : compare-0 matched */
+            M1,     /* bit1 : compare-1 matched */
+            M2,     /* bit2 : compare-2 matched */
+            M3,     /* bit3 : compare-3 matched */
+            M_ALL
+        };
+
+        using device_register = mmio_reg;
+        SystemTimerRegistersAddress() {}
+        ~SystemTimerRegistersAddress() {}
+
+        void *operator new(std::size_t nBytes, void *region=nullptr) {
+            (void)nBytes;
+            if(nullptr == region) {
+                /* System Timer physical base (bus 0x7E003000 -> phys 0x3F003000). */
+                return reinterpret_cast<void *>(0x3F003000U);
+            }
+            return(region);
+        }
+
+        device_register m_register[Register::ST_MAX];
+    };
+
+    /**
+     * @brief
      *      SPI0 master register block. Refer Section 10 "SPI" of
      *      BCM2837-ARM-Peripherals.pdf. SPI0 is at bus 0x7E204000 ->
      *      phys 0x3F204000 and is exposed on GPIO7..11 (ALT0):

--- a/modules/bcm2837/inc/mmio.hpp
+++ b/modules/bcm2837/inc/mmio.hpp
@@ -40,6 +40,7 @@
 #include "clock.hpp"
 #include "i2c.hpp"
 #include "spi.hpp"
+#include "system_timer.hpp"
 // interrupt.hpp is intentionally NOT mapped here — see the IRQ note below.
 
 namespace BCM2837 {
@@ -51,6 +52,7 @@ namespace BCM2837 {
     inline constexpr std::uintptr_t CLOCK_PHYS  = PERIPH_BASE + 0x101070U; ///< 0x3F101070 (CM_GP0CTL)
     inline constexpr std::uintptr_t I2C1_PHYS   = PERIPH_BASE + 0x804000U; ///< 0x3F804000 (BSC1)
     inline constexpr std::uintptr_t SPI0_PHYS   = PERIPH_BASE + 0x204000U; ///< 0x3F204000
+    inline constexpr std::uintptr_t SYSTIMER_PHYS = PERIPH_BASE + 0x3000U; ///< 0x3F003000 (System Timer)
 
     /**
      * @brief RAII mapping of one peripheral register block.
@@ -140,6 +142,7 @@ namespace BCM2837 {
     inline Mapped<CLOCK> map_clock() { return Mapped<CLOCK>(CLOCK_PHYS, sizeof(ClockRegistersAddress)); }
     inline Mapped<I2C>   map_i2c()   { return Mapped<I2C>(I2C1_PHYS,   sizeof(BSCRegistersAddress)); }
     inline Mapped<SPI>   map_spi()   { return Mapped<SPI>(SPI0_PHYS,   sizeof(SPIRegistersAddress)); }
+    inline Mapped<SystemTimer> map_systimer() { return Mapped<SystemTimer>(SYSTIMER_PHYS, sizeof(SystemTimerRegistersAddress)); }
 
     // No map_irq(): the IRQ driver pairs the interrupt-enable registers with an
     // IVT (ARM exception vector table) that its region ctor places *past* the

--- a/modules/bcm2837/inc/system_timer.hpp
+++ b/modules/bcm2837/inc/system_timer.hpp
@@ -1,0 +1,72 @@
+#ifndef __system_timer_hpp__
+#define __system_timer_hpp__
+
+#include <cstdint>
+
+#include "memory_map.hpp"
+
+/**
+ * @file system_timer.hpp
+ * @brief BCM2837 System Timer driver — a free-running 1 MHz microsecond clock
+ *        plus four compare channels.
+ *
+ * Same framework as the other drivers (GPIO/CLOCK/I2C): a reference to a
+ * placement-new'd register block — live MMIO on hardware (BCM2837::map_systimer())
+ * or a std::vector-backed buffer in unit tests — with field-level accessors.
+ *
+ * It exists to give the interrupt-driven I²C transport a real time source for
+ * its watchdog (see docs/i2c-irq-transport-spec.md §4.7): `now_us()` bounds the
+ * wait by wall-clock microseconds instead of a unitless spin count, and `arm()`
+ * lets a bare-metal build schedule a compare IRQ so a wedged bus still wakes the
+ * core from `WFI`.
+ *
+ * NOTE: on the Raspberry Pi, compare channels 0 and 2 are owned by the GPU
+ * firmware — only channels 1 and 3 are free for the ARM. `arm()` defaults to
+ * channel 1.
+ */
+class SystemTimer {
+    public:
+        using value_type = std::uint32_t;
+
+        /// Channels 1 and 3 are ARM-usable (0/2 belong to the GPU).
+        static constexpr unsigned kArmChannel = 1U;
+
+        SystemTimer() : m_memory(*new BCM2837::SystemTimerRegistersAddress) {}
+
+        template<typename Region>
+        SystemTimer(Region region)
+            : m_memory(*new(region) BCM2837::SystemTimerRegistersAddress) {}
+
+        ~SystemTimer() = default;
+
+        /// @brief 64-bit free-running microsecond counter (CHI:CLO), read
+        ///        glitch-free across a low-half rollover. 1 tick == 1 µs.
+        std::uint64_t now_us() const;
+
+        /// @brief Low 32 bits of the counter (CLO). Wraps every ~71.6 min, but
+        ///        unsigned deltas over one wrap stay correct — enough for the
+        ///        millisecond-scale watchdog deadlines.
+        value_type now_lo() const;
+
+        /// @brief Arm compare channel `ch` to match when CLO reaches
+        ///        `deadline_lo`. The caller enables the System-Timer IRQ for
+        ///        that channel separately (this only programs Cn). `ch` is
+        ///        clamped to 0..3; prefer 1 or 3 on the Pi.
+        void arm(value_type deadline_lo, unsigned ch = kArmChannel);
+
+        /// @brief True if compare channel `ch` has matched (CS bit Mch set).
+        bool matched(unsigned ch = kArmChannel) const;
+
+        /// @brief Clear the match flag for channel `ch` (write-1-to-clear) so it
+        ///        can re-arm.
+        void clear_match(unsigned ch = kArmChannel);
+
+        BCM2837::SystemTimerRegistersAddress& memory() const {
+            return(m_memory);
+        }
+
+    private:
+        BCM2837::SystemTimerRegistersAddress& m_memory;
+};
+
+#endif /*__system_timer_hpp__*/

--- a/modules/bcm2837/src/i2c/i2c_irq.cpp
+++ b/modules/bcm2837/src/i2c/i2c_irq.cpp
@@ -2,6 +2,7 @@
 #define __i2c_irq_cpp__
 
 #include "i2c_irq.hpp"
+#include "system_timer.hpp"
 
 #include <atomic>
 
@@ -60,6 +61,10 @@ void Bcm2837I2cIrqTransport::wait_for_irq() {
     // Host/default: no-op. The watchdog loop in wait_complete() bounds the wait;
     // tests override this to drive handle_irq(). A real bare-metal build must
     // also arm a timer IRQ so WFI wakes for the watchdog (spec §4.7).
+}
+
+std::uint64_t Bcm2837I2cIrqTransport::now_us() {
+    return m_timer != nullptr ? m_timer->now_us() : 0;
 }
 
 I2cResult Bcm2837I2cIrqTransport::start(std::uint8_t addr,
@@ -153,14 +158,26 @@ void Bcm2837I2cIrqTransport::abort_transfer() {
 }
 
 I2cResult Bcm2837I2cIrqTransport::wait_complete() {
+    // Bound the wait two ways: a wall-clock µs deadline (the real watchdog, when
+    // a time source is wired) and an absolute iteration cap (backstop for the
+    // host / no-clock builds). Whichever trips first aborts the transfer.
+    const std::uint64_t start = now_us();
     for (std::uint32_t i = 0; i < m_max_waits; ++i) {
         mem_barrier();
         if (m_xfer.done) {
             return m_xfer.result;
         }
+        if (m_timeout_us != 0) {
+            const std::uint64_t t = now_us();
+            // now_us()==0 means no time source is wired → skip the µs check and
+            // let the iteration cap govern; otherwise abort once N µs elapse.
+            if (t != 0 && (t - start) >= m_timeout_us) {
+                break;
+            }
+        }
         wait_for_irq();
     }
-    abort_transfer();    // wedged bus / lost interrupt
+    abort_transfer();    // wedged bus / lost interrupt / deadline exceeded
     return I2cResult::Timeout;
 }
 

--- a/modules/bcm2837/src/timer/system_timer.cpp
+++ b/modules/bcm2837/src/timer/system_timer.cpp
@@ -1,0 +1,44 @@
+#ifndef __system_timer_cpp__
+#define __system_timer_cpp__
+
+#include "system_timer.hpp"
+
+namespace {
+    using R = BCM2837::SystemTimerRegistersAddress::Register;
+
+    /// Clamp a channel index to the four physical compare registers.
+    inline unsigned clamp_ch(unsigned ch) { return ch > 3U ? 3U : ch; }
+}
+
+std::uint64_t SystemTimer::now_us() const {
+    // The 64-bit counter is two 32-bit registers that tick independently, so a
+    // naive {CHI, CLO} read can straddle a low-half rollover. Re-read CHI and
+    // retry if it moved (datasheet §12) — at most one retry per ~71.6 minutes.
+    for (;;) {
+        const std::uint32_t hi  = m_memory.m_register[R::CHI];
+        const std::uint32_t lo  = m_memory.m_register[R::CLO];
+        const std::uint32_t hi2 = m_memory.m_register[R::CHI];
+        if (hi == hi2) {
+            return (static_cast<std::uint64_t>(hi) << 32) | lo;
+        }
+    }
+}
+
+SystemTimer::value_type SystemTimer::now_lo() const {
+    return m_memory.m_register[R::CLO];
+}
+
+void SystemTimer::arm(value_type deadline_lo, unsigned ch) {
+    m_memory.m_register[R::C0 + clamp_ch(ch)] = deadline_lo;
+}
+
+bool SystemTimer::matched(unsigned ch) const {
+    return (m_memory.m_register[R::CS] & (1U << clamp_ch(ch))) != 0U;
+}
+
+void SystemTimer::clear_match(unsigned ch) {
+    // CS match bits are write-1-to-clear.
+    m_memory.m_register[R::CS] = (1U << clamp_ch(ch));
+}
+
+#endif /*__system_timer_cpp__*/

--- a/modules/bcm2837/test/i2c_irq_test.cpp
+++ b/modules/bcm2837/test/i2c_irq_test.cpp
@@ -110,6 +110,34 @@ TEST_F(I2cIrqTest, Watchdog_Times_Out_When_No_Completion) {
     EXPECT_EQ(bus.write(0x68, b, 1), I2cResult::Timeout);
 }
 
+TEST_F(I2cIrqTest, Watchdog_Times_Out_On_Microsecond_Deadline) {
+    // Huge iteration cap so ONLY the µs deadline can stop the wait. The clock
+    // advances 400 µs per read; with a 1 ms deadline the watchdog fires after a
+    // few iterations — far below the 1,000,000 iteration backstop.
+    ScriptedIrqTransport bus(i2c(), gpio(), irq(), /*divider=*/2500,
+                             /*max_waits=*/1000000U, /*timeout_us=*/1000U);
+    bus.nowStep = 400;                       // 400 µs of "wall clock" per now_us()
+    const std::uint8_t b[1] = {0};
+    EXPECT_EQ(bus.write(0x68, b, 1), I2cResult::Timeout);
+    EXPECT_LT(bus.nowVal, 1000000ULL);       // stopped on time, not the iter cap
+}
+
+TEST_F(I2cIrqTest, Time_Source_Feeds_The_Watchdog_Clock) {
+    // set_time_source() wires a SystemTimer; the default now_us() then reports
+    // that timer's 64-bit (CHI:CLO) counter. Without a source it reads 0.
+    std::vector<std::uint32_t> treg(
+        BCM2837::SystemTimerRegistersAddress::Register::ST_MAX);
+    SystemTimer timer(treg.data());
+    treg[BCM2837::SystemTimerRegistersAddress::Register::CLO] = 0x12340000U;
+    treg[BCM2837::SystemTimerRegistersAddress::Register::CHI] = 0x2U;
+
+    ProbeIrqTransport bus(i2c(), gpio(), irq());
+    EXPECT_EQ(bus.probe_now_us(), 0ULL);     // no source yet → "no clock"
+    bus.set_time_source(&timer);
+    EXPECT_EQ(bus.probe_now_us(),
+              (static_cast<std::uint64_t>(0x2U) << 32) | 0x12340000U);
+}
+
 /* ---- P5: async (kick + ISR-fired callback) ---- */
 
 TEST_F(I2cIrqTest, Async_Write_Fires_Callback_On_Completion) {

--- a/modules/bcm2837/test/i2c_irq_test.hpp
+++ b/modules/bcm2837/test/i2c_irq_test.hpp
@@ -9,6 +9,7 @@
 #include "gpio.hpp"
 #include "interrupt.hpp"
 #include "i2c_irq.hpp"
+#include "system_timer.hpp"
 
 /**
  * @brief Bcm2837I2cIrqTransport driven by a scripted ISR on the host.
@@ -28,6 +29,13 @@ class ScriptedIrqTransport : public Bcm2837I2cIrqTransport {
         std::size_t scriptIdx = 0;
         std::size_t rxIdx = 0;
 
+        /// Simulated clock for the watchdog deadline. nowStep == 0 (the default)
+        /// keeps now_us() at 0 ("no clock") so the iteration cap governs — the
+        /// behaviour every other test relies on. A non-zero step advances the
+        /// clock by `nowStep` µs on each read to exercise the µs deadline.
+        std::uint64_t nowVal  = 0;
+        std::uint64_t nowStep = 0;
+
     protected:
         std::uint32_t read_status() override {
             const std::uint32_t s = (scriptIdx < script.size())
@@ -38,6 +46,15 @@ class ScriptedIrqTransport : public Bcm2837I2cIrqTransport {
             return s;
         }
         void wait_for_irq() override { handle_irq(); }    // simulate the ISR
+        std::uint64_t now_us() override { nowVal += nowStep; return nowVal; }
+};
+
+/// Exposes the (protected) default now_us() so a test can verify that
+/// set_time_source() wires a SystemTimer into the watchdog clock.
+class ProbeIrqTransport : public Bcm2837I2cIrqTransport {
+    public:
+        using Bcm2837I2cIrqTransport::Bcm2837I2cIrqTransport;
+        std::uint64_t probe_now_us() { return now_us(); }
 };
 
 class I2cIrqTest : public ::testing::Test {

--- a/modules/bcm2837/test/system_timer_test.cpp
+++ b/modules/bcm2837/test/system_timer_test.cpp
@@ -1,0 +1,50 @@
+#include "system_timer_test.hpp"
+
+TEST_F(SystemTimerTest, NowUs_Composes_Chi_Clo) {
+    poke(Reg::CHI, 0x2U);
+    poke(Reg::CLO, 0x12345678U);
+    EXPECT_EQ(m_timer.now_us(),
+              (static_cast<std::uint64_t>(0x2U) << 32) | 0x12345678U);
+    EXPECT_EQ(m_timer.now_lo(), 0x12345678U);
+}
+
+TEST_F(SystemTimerTest, NowUs_Low_Half_Only) {
+    poke(Reg::CHI, 0U);
+    poke(Reg::CLO, 0xDEADBEEFU);
+    EXPECT_EQ(m_timer.now_us(), 0xDEADBEEFULL);
+}
+
+TEST_F(SystemTimerTest, Arm_Writes_The_Arm_Usable_Compare_Channels) {
+    m_timer.arm(0xABCDU, /*ch=*/1);
+    EXPECT_EQ(peek(Reg::C1), 0xABCDU);
+    m_timer.arm(0x1111U, /*ch=*/3);
+    EXPECT_EQ(peek(Reg::C3), 0x1111U);
+    // GPU-owned channels are still addressable but not the default.
+    m_timer.arm(0x2222U, /*ch=*/0);
+    EXPECT_EQ(peek(Reg::C0), 0x2222U);
+}
+
+TEST_F(SystemTimerTest, Arm_Defaults_To_Channel_1) {
+    m_timer.arm(0x5A5AU);                       // default kArmChannel == 1
+    EXPECT_EQ(peek(Reg::C1), 0x5A5AU);
+    EXPECT_EQ(SystemTimer::kArmChannel, 1U);
+}
+
+TEST_F(SystemTimerTest, Arm_Clamps_Out_Of_Range_Channel) {
+    m_timer.arm(0x9999U, /*ch=*/7);             // clamps to channel 3
+    EXPECT_EQ(peek(Reg::C3), 0x9999U);
+}
+
+TEST_F(SystemTimerTest, Matched_Reflects_CS_Match_Bits) {
+    poke(Reg::CS, (1U << 3));                    // M3 set
+    EXPECT_TRUE(m_timer.matched(3));
+    EXPECT_FALSE(m_timer.matched(1));
+}
+
+TEST_F(SystemTimerTest, ClearMatch_Is_Write_One_To_Clear) {
+    // clear_match writes the channel's bit mask (W1C on real silicon).
+    m_timer.clear_match(1);
+    EXPECT_EQ(peek(Reg::CS), (1U << 1));
+    m_timer.clear_match(3);
+    EXPECT_EQ(peek(Reg::CS), (1U << 3));
+}

--- a/modules/bcm2837/test/system_timer_test.hpp
+++ b/modules/bcm2837/test/system_timer_test.hpp
@@ -1,0 +1,29 @@
+#ifndef __system_timer_test_hpp__
+#define __system_timer_test_hpp__
+
+#include <gtest/gtest.h>
+#include <cstdint>
+#include <vector>
+
+#include "system_timer.hpp"
+
+/**
+ * @brief SystemTimer over a std::vector-backed register block — the same
+ *        placement-new seam the other bcm2837 drivers use for host tests.
+ */
+class SystemTimerTest : public ::testing::Test {
+    public:
+        using Reg = BCM2837::SystemTimerRegistersAddress::Register;
+
+        SystemTimerTest()
+            : m_reg(Reg::ST_MAX), m_timer(m_reg.data()) {}
+
+        void poke(Reg r, std::uint32_t v) { m_reg[r] = v; }
+        std::uint32_t peek(Reg r) const   { return m_reg[r]; }
+
+    protected:
+        std::vector<std::uint32_t> m_reg;
+        SystemTimer m_timer;
+};
+
+#endif /*__system_timer_test_hpp__*/


### PR DESCRIPTION
## What

Adds the **BCM2837 System Timer** driver and uses it to give the interrupt-driven I²C transport a **real microsecond watchdog deadline** — closing the open "timer dependency" the IRQ-transport spec flagged (§4.7 / risk #4).

## Why

`Bcm2837I2cIrqTransport::wait_complete()` previously bounded the wait by a **unitless** `wait_for_irq()` iteration count (`max_waits`). There was no real time source, so the watchdog couldn't express "abort after N ms" — the documented gap (spec §4.7 "better: arm the ARM system timer … the module has no system-timer driver yet").

## Changes

- **`SystemTimer` driver** (`inc/system_timer.hpp` + `src/timer/system_timer.cpp`, phys `0x3F003000`):
  - `now_us()` — 64-bit free-running 1 MHz counter (CHI:CLO), read glitch-free across the low-half rollover; `now_lo()`.
  - `arm()` / `matched()` / `clear_match()` — the four compare channels (1 & 3 ARM-usable; 0 & 2 are GPU-owned). Channel index clamped.
  - Register model in `memory_map.hpp`; `SYSTIMER_PHYS` + `map_systimer()` in `mmio.hpp` — same placement-new seam as the other drivers.
- **Watchdog wiring** (`Bcm2837I2cIrqTransport`): injectable `now_us()` seam (default reads an attached `SystemTimer` via `set_time_source()`; `0` = "no clock") + a `timeout_us` ctor arg. `wait_complete()` now aborts on a real µs deadline (default 50 ms), with the iteration cap kept as a backstop.
- **Host-test-preserving:** with no time source `now_us()` returns 0, so the µs check is inert and **every existing test keeps its iteration-cap behaviour unchanged**.

## Tests

- 7 new `SystemTimer` gtests (counter compose, low-half, compare arm + default channel + clamp, match flag, W1C clear).
- 2 new transport gtests (µs-deadline timeout fires before the iteration cap; `set_time_source` feeds the watchdog clock).
- **Full `bcm2837` suite: 103/103 green** in podman (`ubuntu:22.04` + cmake + libgtest-dev), `-Wall -Wextra` clean.

## Scope

Bare-metal-only transport (Linux uses `/dev/i2c-1`), so no device/runtime behaviour changes here. The one remaining silicon-pending piece is the bare-metal compare-IRQ `WFI` wake (`arm()` a System-Timer IRQ on channel 1/3 + enable it) so a wedged bus with no BSC interrupt still wakes for the deadline — documented in the spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)