### PR TITLE
fix(yocto): build.sh falls back to from-scratch when the builder cache image is missing

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -111,9 +111,19 @@ build_image() {
 prepare_image() {
     if [ -n "${IOT_USE_CACHE:-}" ]; then
         log_section "Pulling cache image: $CACHE_IMAGE"
-        $CR pull "$CACHE_IMAGE"
-        IMAGE_NAME="$CACHE_IMAGE"
-        log_info "Using baked sstate from $CACHE_IMAGE — only meta-iot recompiles"
+        # The published cache is an optional speedup, not a hard dependency. If
+        # it is missing/expired/unauthenticated (e.g. `manifest unknown`), fall
+        # back to building the base image locally instead of aborting the whole
+        # build — the same from-scratch path the cache-less builds already use.
+        # The `if $CR pull` guard also keeps the failed pull from tripping
+        # `set -e`.
+        if $CR pull "$CACHE_IMAGE"; then
+            IMAGE_NAME="$CACHE_IMAGE"
+            log_info "Using baked sstate from $CACHE_IMAGE — only meta-iot recompiles"
+        else
+            log_info "Cache image $CACHE_IMAGE unavailable — building the base image from scratch"
+            build_image
+        fi
     else
         build_image
     fi


### PR DESCRIPTION
## Symptom

The first real `release/**` cut (v1.2.0) failed `release-build.yml` in <30s — both the Full image and OTA bundle jobs — with:

```
Pulling cache image: docker.io/***/iot-yocto-builder:cache
Error: ... manifest unknown: manifest unknown
##[error]Process completed with exit code 125
```

## Root cause (CI infra, not release content)

`release-build.yml` is the **only** workflow that sets `IOT_USE_CACHE=1`. That makes `build.sh` `prepare_image()` pull the published builder cache (`iot-yocto-builder:cache`) and, under `set -e`, abort the whole build when the pull fails. That cache image is published by a **manual** `build.sh` step, not CI, so it's absent on Docker Hub — and the release build can never start. The `device-image.yml` / `cloud-image.yml` builds don't use the cache, so they build from scratch and pass (main was green).

## Fix

Treat the cache as the **optional speedup** it is:
- Guard the pull in an `if` (so a failed pull no longer trips `set -e`).
- On miss/expiry/auth-failure, log it and `build_image` locally — the same from-scratch path the cache-less main builds already use successfully.
- When a cache image **is** present, the fast path is unchanged.

`bash -n` clean. Unblocks `release/v1.2.0` (the fix is brought onto that branch to re-trigger the build).

🤖 Generated with [Claude Code](https://claude.com/claude-code)