### PR TITLE
fix(yocto): sync iot-bundle.bb PV to 1.2.0 (was stale 1.1.0)

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
@@ -11,7 +11,7 @@ LIC_FILES_CHKSUM = "file://${COMMON_LICENSE_DIR}/MIT;md5=0835ade698e0bcf8506ecda
 
 # Keep the leading semver in sync with the repo-root /VERSION (same source of
 # truth as iot_git.bb's PV and the baked-in iot.version).
-PV = "1.1.0"
+PV = "1.2.0"
 
 # No source to fetch/compile — this recipe only repackages the already-built
 # feed in do_deploy. nopackages skips the empty packaging tasks; deploy gives


### PR DESCRIPTION
## What

`iot-bundle.bb` carries its **own** `PV` (the OTA bundle's advertised semver), separate from `iot_git.bb`'s `PV`. The recipe comment says to keep it in sync with the repo-root `/VERSION`, but the v1.2.0 release cut bumped `/VERSION` + `iot_git.bb` and **missed this one**.

## Impact (caught while publishing v1.2.0)

The release-branch build produced a bundle whose **`.ipk`s were correctly `1.2.0+git<sha>`** but whose **wrapper + manifest said `1.1.0`** (`iot-bundle-1.1.0-….tar.gz`, `"version": "1.1.0"`). An OTA push of that bundle would advertise a stale `1.1.0` to the fleet — devices already on 1.1.0 wouldn't register a version change (the baseline-stuck symptom).

## Fix

Bump `iot-bundle.bb` `PV` `1.1.0 → 1.2.0`. Future bundle builds emit `iot-bundle-1.2.0-…` with a matching manifest.

> The published **v1.2.0** GitHub Release asset was relabeled to 1.2.0 by hand from the verified payload (the `.ipk`s were already 1.2.0; renaming didn't change the tarball bytes, so its sha256 is unchanged). This recipe fix is for correctness of future builds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)