### PR TITLE
ci: add cache-publish.yml to bootstrap + publish the Yocto builder cache

### DIFF
--- a/.github/workflows/cache-publish.yml
+++ b/.github/workflows/cache-publish.yml
@@ -1,0 +1,71 @@
+name: Publish Yocto builder cache image
+
+# One-time / occasional: build a FULL Yocto image from scratch to populate the
+# sstate + downloads volumes, then bake them into the builder cache image
+#   docker.io/naushada/iot-yocto-builder:cache
+# and push it. Once published, every IOT_USE_CACHE=1 build (release-build.yml,
+# ipk-bundle.yml, rauc-bundle.yml) pulls this as an sstate floor and only
+# recompiles meta-iot — so the full image fits the 6h hosted-runner ceiling.
+#
+# WHY THIS EXISTS: a from-scratch full image does NOT finish within 6h on the
+# default 2-core ubuntu-22.04 runner (it timed out cutting v1.2.0). The fix is a
+# published cache — but producing it needs one full build to complete first.
+# This workflow runs that build on a LARGER runner (more cores → bitbake
+# parallelism finishes well under 6h), then publishes.
+#
+# Manual only. Secrets: DOCKERHUB_USERNAME / DOCKERHUB_TOKEN (push the cache).
+
+on:
+  workflow_dispatch:
+    inputs:
+      runner:
+        description: >-
+          Runner label. Use a LARGER runner (e.g. an 8/16-core label configured
+          on the account) so the from-scratch full build fits in the 6h job cap.
+          The default 2-core ubuntu-22.04 will likely time out.
+        default: ubuntu-22.04
+        required: true
+      machine:
+        description: Target MACHINE (its sstate floor also covers the OTA bundle)
+        default: raspberrypi3-64
+        required: false
+      branch:
+        description: IOT_BRANCH to fetch + build the cache from (sstate is broadly reusable)
+        default: main
+        required: false
+
+jobs:
+  publish-cache:
+    name: Build full image + publish builder cache
+    runs-on: ${{ github.event.inputs.runner }}
+    timeout-minutes: 360   # 6h hosted cap — a larger runner must finish under it
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Free up disk space
+        run: |
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache
+          df -h /
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      # Build the full image WITHOUT IOT_USE_CACHE — we are creating the cache,
+      # so this run populates the iot-yocto-sstate / -downloads volumes from
+      # scratch. build.sh falls back to a local base-image build automatically.
+      - name: Build full image from scratch (populate sstate + downloads)
+        working-directory: yocto
+        env:
+          TARGET: iot-image
+          IOT_BRANCH: ${{ github.event.inputs.branch || 'main' }}
+          IOT_FRESH: "1"
+        run: ./build.sh "${{ github.event.inputs.machine || 'raspberrypi3-64' }}"
+
+      # Snapshot the now-populated volumes into the builder image and push it.
+      # The volumes are runner-local, so this MUST run in the same job.
+      - name: Publish builder cache image
+        working-directory: yocto
+        run: ./build.sh publish


### PR DESCRIPTION
## Why

A from-scratch full Yocto image doesn't finish within GitHub's **6h** hosted-runner cap on the default 2-core `ubuntu-22.04` — it timed out cutting **v1.2.0**, so no flashable `.wic.bz2` could be produced. Every `IOT_USE_CACHE=1` build (`release-build`, `ipk-bundle`, `rauc-bundle`) relies on the published sstate **cache image** `docker.io/naushada/iot-yocto-builder:cache` as an sstate floor, but that image is produced by a **manual** `build.sh publish` step and was absent. Bootstrap deadlock: you can't cut the full image without the cache, and you can't make the cache without one full build completing.

## What

A manual `workflow_dispatch` that breaks the bootstrap:
1. On a **larger runner** (input — more cores → bitbake parallelism finishes under 6h), build the full image **from scratch** (no `IOT_USE_CACHE`) to populate the `iot-yocto-sstate` / `iot-yocto-downloads` volumes.
2. `./build.sh publish` — bake those volumes into the cache image and push via the existing `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets.

Build + publish share one job (the podman volumes are runner-local). Inputs: `runner` (label — **use a larger one**, default `ubuntu-22.04` will likely time out), `machine`, `branch`.

## After this

Dispatch it once with your larger-runner label → cache image is published → re-run `release-build.yml` on `release/v1.2.0`; the full image now builds via `IOT_USE_CACHE=1` within 6h, and we can attach the `.wic.bz2` to the v1.2.0 release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)