### PR TITLE
fix(ota): accept .tar (macOS-decompressed bundle) + wire .raucb end-to-end

### DIFF
--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -42,7 +42,7 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
         <div class="dropzone" [class.over]="dragOver" [class.busy]="uploading"
              (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)"
              (drop)="onDrop($event)" (click)="fileInput.click()">
-          <input #fileInput type="file" accept=".ipk,.tar.gz,.tgz" hidden (change)="onPick($event)" />
+          <input #fileInput type="file" accept=".ipk,.tar,.tar.gz,.tgz" hidden (change)="onPick($event)" />
           <clr-icon shape="upload-cloud" size="28"></clr-icon>
           <span *ngIf="!uploading && !pendingFile">Drag &amp; drop an <code>.ipk</code> or <code>.tar.gz</code> bundle, or click to browse</span>
           <span *ngIf="!uploading && pendingFile">{{ pendingFile?.name }} ({{ ((pendingFile?.size ?? 0)/1048576) | number:'1.0-1' }} MB) — confirm details and upload</span>
@@ -272,11 +272,13 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
 
   // Stage the file + pre-fill pkg/version/arch from its name (operator edits).
   private stageFile(f: File): void {
-    if (!/\.(ipk|tar\.gz|tgz)$/i.test(f.name)) {
-      this.toast.error('Pick a .ipk, .tar.gz or .tgz file'); return;
+    // .tar covers a .tar.gz the operator's browser auto-decompressed on
+    // download; the device detects gzip by content, so it installs the same.
+    if (!/\.(ipk|tar\.gz|tgz|tar)$/i.test(f.name)) {
+      this.toast.error('Pick a .ipk, .tar, .tar.gz or .tgz file'); return;
     }
     this.pendingFile = f;
-    const base = f.name.replace(/\.(tar\.gz|tgz|ipk)$/i, '');
+    const base = f.name.replace(/\.(tar\.gz|tgz|tar|ipk)$/i, '');
     this.upPkg = base; this.upVersion = ''; this.upArch = '';
     // .ipk = name_version_arch ; bundle = pkg-version-arch (version starts w/ a digit)
     let m = base.match(/^(.+)_([^_]+)_([^_]+)$/);

--- a/iot-ui/src/app/software-update/software-update.component.ts
+++ b/iot-ui/src/app/software-update/software-update.component.ts
@@ -134,7 +134,7 @@ import { ToastService } from '../../common/toast.service';
         <div class="dropzone" [class.over]="dragOver" [class.busy]="uploading"
              (dragover)="onDragOver($event)" (dragleave)="onDragLeave($event)"
              (drop)="onDrop($event)" (click)="fileInput.click()">
-          <input #fileInput type="file" accept=".ipk,.tar.gz,.tgz,.raucb" hidden
+          <input #fileInput type="file" accept=".ipk,.tar,.tar.gz,.tgz,.raucb" hidden
                  (change)="onPick($event)" />
           <clr-icon shape="upload-cloud" size="28"></clr-icon>
           <span *ngIf="!uploading">Drag &amp; drop a <code>.ipk</code> / <code>.tar.gz</code> / <code>.raucb</code>, or click to browse</span>
@@ -319,8 +319,11 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
 
   private uploadFile(file: File): void {
     if (this.uploading) return;
-    if (!/\.(ipk|tar\.gz|tgz|raucb)$/i.test(file.name)) {
-      this.toast.error('Pick a .ipk, .tar.gz, .tgz or .raucb file'); return;
+    // .tar covers a .tar.gz that the browser/OS auto-decompressed on download
+    // (macOS Safari/Archive Utility strips the .gz); the device detects gzip by
+    // content, so an uncompressed tar installs the same way.
+    if (!/\.(ipk|tar\.gz|tgz|tar|raucb)$/i.test(file.name)) {
+      this.toast.error('Pick a .ipk, .tar, .tar.gz, .tgz or .raucb file'); return;
     }
     this.uploading = true; this.uploadName = file.name; this.uploadPct = 0;
     const total = file.size;

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -434,9 +434,16 @@ void install_handlers(Router& router,
                 return safe.size() >= s.size() &&
                        safe.compare(safe.size() - s.size(), s.size(), s) == 0;
             };
-            if (safe.empty() || !(ends_with(".ipk") || ends_with(".tar.gz") || ends_with(".tgz"))) {
+            // Accept .tar too: macOS Safari/Archive Utility silently gunzips a
+            // downloaded .tar.gz, leaving a plain .tar the operator then drops
+            // here; the stager/swupdate detect compression by content, so an
+            // uncompressed tar is fine. .raucb is the A/B full-image bundle
+            // (iot-swupdate routes it to `rauc install`).
+            if (safe.empty() || !(ends_with(".ipk") || ends_with(".tar") ||
+                                  ends_with(".tar.gz") || ends_with(".tgz") ||
+                                  ends_with(".raucb"))) {
                 r.status = 400;
-                r.body = R"({"ok":false,"err":"name must end in .ipk, .tar.gz or .tgz"})";
+                r.body = R"({"ok":false,"err":"name must end in .ipk, .tar, .tar.gz, .tgz or .raucb"})";
                 return r;
             }
             // Chunked append: large bundles (.raucb) exceed the 8 MiB body cap,
@@ -518,8 +525,12 @@ void install_handlers(Router& router,
                 return safe.size() >= s.size() &&
                        safe.compare(safe.size() - s.size(), s.size(), s) == 0;
             };
-            if (safe.empty() || !(ends_with(".ipk") || ends_with(".tar.gz") || ends_with(".tgz"))) {
-                r.status = 400; r.body = R"({"ok":false,"err":"name must end in .ipk, .tar.gz or .tgz"})"; return r;
+            // Same accepted set as /update/upload — .tar covers a macOS-
+            // auto-decompressed .tar.gz; .raucb is the A/B full-image bundle.
+            if (safe.empty() || !(ends_with(".ipk") || ends_with(".tar") ||
+                                  ends_with(".tar.gz") || ends_with(".tgz") ||
+                                  ends_with(".raucb"))) {
+                r.status = 400; r.body = R"({"ok":false,"err":"name must end in .ipk, .tar, .tar.gz, .tgz or .raucb"})"; return r;
             }
             bool first = true, final = true;
             if (auto it = req.query.find("offset"); it != req.query.end())

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
@@ -63,7 +63,7 @@ done
 NAME="$(basename "$BASE")"
 BUNDLE=0
 case "$NAME" in
-    *.tar.gz|*.tgz) BUNDLE=1 ;;
+    *.tar.gz|*.tgz|*.tar) BUNDLE=1 ;;
     *.ipk) ;;
     *) NAME="fw.ipk" ;;
 esac
@@ -158,15 +158,18 @@ if [ -n "$SHA" ]; then
 fi
 
 # A bundle expands into the spool so iot-swupdate's `opkg install *.ipk` glob
-# applies every package atomically. Decompress via gzip|tar (busybox-safe:
-# avoids relying on tar's built-in -z) and drop the tarball.
+# applies every package atomically. Compression is detected by CONTENT (gzip -t)
+# rather than the extension, so a plain .tar (e.g. a .tar.gz auto-decompressed by
+# the operator's browser) extracts too. busybox-safe: gzip|tar (avoids relying on
+# tar's built-in -z). Drop the tarball afterwards.
 if [ "$BUNDLE" = 1 ]; then
-    if ( cd "$SPOOL" && gzip -dc "$DL" | tar -xf - ) 2>/dev/null; then
-        rm -f "$DL"
+    if gzip -t "$DL" 2>/dev/null; then
+        ok=$( ( cd "$SPOOL" && gzip -dc "$DL" | tar -xf - ) 2>/dev/null && echo 1 )
     else
-        rm -f "$DL"
-        fail 9 "bundle extract failed"
+        ok=$( ( cd "$SPOOL" && tar -xf "$DL" ) 2>/dev/null && echo 1 )
     fi
+    rm -f "$DL"
+    [ "$ok" = 1 ] || fail 9 "bundle extract failed"
     ls "$SPOOL"/*.ipk >/dev/null 2>&1 || fail 9 "no .ipk in bundle"
     log "extracted bundle $NAME -> $(ls "$SPOOL"/*.ipk | wc -l) package(s)"
 fi

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
@@ -85,15 +85,23 @@ fi
 WORK="$SPOOL/.work-$$"
 mkdir -p "$WORK"
 
-# A drag-and-drop bundle (.tar.gz/.tgz) lands here UN-extracted: the device-ui
-# /api/v1/update/upload path drops the tarball and trips us directly, bypassing
-# iot-ota-stage (which is what normally expands a bundle for the cloud/URL push).
-# Expand any bundle in the spool into its .ipks so the *.ipk snapshot below
-# installs them all. busybox-safe: gzip -dc | tar (not tar -z). On the cloud/URL
-# path iot-ota-stage already extracted + removed the tarball, so this is a no-op.
-for b in "$SPOOL"/*.tar.gz "$SPOOL"/*.tgz; do
+# A drag-and-drop bundle (.tar/.tar.gz/.tgz) lands here UN-extracted: the
+# device-ui /api/v1/update/upload path drops the tarball and trips us directly,
+# bypassing iot-ota-stage (which is what normally expands a bundle for the
+# cloud/URL push). Expand any bundle in the spool into its .ipks so the *.ipk
+# snapshot below installs them all. Compression is detected by CONTENT (gzip -t),
+# not the extension: macOS auto-decompresses a downloaded .tar.gz to a plain
+# .tar, so the name is unreliable. busybox-safe: gzip -dc | tar (not tar -z). On
+# the cloud/URL path iot-ota-stage already extracted + removed the tarball, so
+# this is a no-op.
+for b in "$SPOOL"/*.tar "$SPOOL"/*.tar.gz "$SPOOL"/*.tgz; do
     [ -e "$b" ] || continue
-    if ( cd "$SPOOL" && gzip -dc "$b" | tar -xf - ) 2>/dev/null; then
+    if gzip -t "$b" 2>/dev/null; then
+        ok=$( ( cd "$SPOOL" && gzip -dc "$b" | tar -xf - ) 2>/dev/null && echo 1 )
+    else
+        ok=$( ( cd "$SPOOL" && tar -xf "$b" ) 2>/dev/null && echo 1 )
+    fi
+    if [ "$ok" = 1 ]; then
         log "expanded bundle $(basename "$b")"
     else
         log "bundle extract FAILED: $(basename "$b")"
@@ -101,8 +109,11 @@ for b in "$SPOOL"/*.tar.gz "$SPOOL"/*.tgz; do
     rm -f "$b"
 done
 
+# Snapshot the installable artifacts. .ipk → opkg path; .raucb → A/B rauc path
+# (handled in §3). Either kind counts as "staged" so a raucb-only drop isn't
+# mistaken for an empty trigger.
 moved=0
-for f in "$SPOOL"/*.ipk; do
+for f in "$SPOOL"/*.ipk "$SPOOL"/*.raucb; do
     [ -e "$f" ] || continue
     mv "$f" "$WORK/" && moved=1
 done
@@ -110,7 +121,7 @@ done
 rm -f "$SPOOL/update"   # re-arm the .path unit
 
 if [ "$moved" = 0 ]; then
-    log "trigger but no .ipk staged; nothing to do"
+    log "trigger but no .ipk/.raucb staged; nothing to do"
     rm -rf "$WORK"
     exit 0
 fi


### PR DESCRIPTION
## Context
Investigated the report that *"CI makes a .tar but the software-update UI only accepts .tar.gz."* CI is actually correct — `iot-bundle.bb` uses `tar -czf` and every workflow references `iot-bundle-*.tar.gz` (a scoped grep for any plain `.tar` came back empty). The real causes are two upload-path mismatches:

### 1. `.tar` — macOS auto-decompression
macOS Safari / Archive Utility silently gunzips a downloaded `.tar.gz`, leaving a plain `.tar` on disk. The operator drops that `.tar` into the update page → rejected. Fixed end-to-end:
- **device-ui + cloud-ui** file `accept=` + filename validation add `.tar`
- **httpd** `/api/v1/update/upload` and `/api/v1/firmware/upload` suffix checks add `.tar`
- **iot-ota-stage + iot-swupdate** now detect compression by **content** (`gzip -t`) instead of extension, so a plain `.tar` extracts the same as a `.tar.gz` (robust to the misleading name)

### 2. `.raucb` — offered by UI, rejected by server
The device-ui already offered `.raucb`, but:
- the httpd handler rejected it (`name must end in .ipk, .tar.gz or .tgz`), **and**
- even if uploaded, `iot-swupdate`'s snapshot only moved `*.ipk` into the work dir, so a raucb-only drop bailed as *"no .ipk staged"* — the existing `rauc install` block was unreachable.

Fixed:
- httpd `/update/upload` (+ `/firmware/upload` for parity) accept `.raucb`
- `iot-swupdate` snapshots `*.raucb` too → the existing A/B `rauc install` block applies it

## Not changed
The OTA bundle stays `.tar.gz` (no recipe/CI change). This PR only widens what the **upload + install path tolerates**.

## Accepted set is now (both handlers identical)
`.ipk`, `.tar`, `.tar.gz`, `.tgz`, `.raucb`

## Testing
⚠️ **Unbuilt** (no C++/node toolchain here; image CI builds on `main`). On-device validation to do post-merge:
1. Drop a `.tar.gz` bundle → installs (regression).
2. `gunzip` it to `.tar`, drop that → installs (the macOS case; `gzip -t` falls through to `tar -xf`).
3. Drop a `.raucb` on a RAUC-enabled image → `rauc install` runs + reboots to the inactive bank.

🤖 Generated with [Claude Code](https://claude.com/claude-code)