### PR TITLE
feat(vehicle): PR-1 — OBD-II PID decode core + gtest

### DIFF
--- a/modules/vehicle/CMakeLists.txt
+++ b/modules/vehicle/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(vehicle CXX)
+
+# Top-level (own build) vs. pulled in via add_subdirectory() from the iot tree.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(VEHICLE_TOP_LEVEL ON)
+else()
+    set(VEHICLE_TOP_LEVEL OFF)
+endif()
+
+option(VEHICLE_BUILD_TESTS  "Build the vehicle gtest suite"          ${VEHICLE_TOP_LEVEL})
+option(VEHICLE_BUILD_DAEMON "Build the iot-vehicled CAN/OBD daemon"  OFF)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# Pure OBD-II (ISO 15765-4) PID encode/decode core: no ACE, no SocketCAN, no
+# data-store — fully host-unit-testable. The CAN transport (raw + ISO-TP) and
+# ds publishing live in the iot-vehicled daemon (next PR), gated by
+# VEHICLE_BUILD_DAEMON (forced ON in the iot image build).
+add_library(vehicle_core STATIC src/obd_pid.cpp)
+target_include_directories(vehicle_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
+target_compile_options(vehicle_core PRIVATE -Wall -Wextra)
+add_library(vehicle::core ALIAS vehicle_core)
+
+if(VEHICLE_BUILD_TESTS)
+    enable_testing()
+    find_package(GTest REQUIRED)
+    add_executable(vehicle-tests test/obd_pid_test.cpp)
+    target_link_libraries(vehicle-tests vehicle_core GTest::gtest GTest::gtest_main pthread)
+    include(GoogleTest)
+    if(VEHICLE_TOP_LEVEL)
+        gtest_discover_tests(vehicle-tests)
+    else()
+        add_test(NAME vehicle-tests COMMAND vehicle-tests)
+    endif()
+endif()

--- a/modules/vehicle/README.md
+++ b/modules/vehicle/README.md
@@ -1,0 +1,43 @@
+# modules/vehicle — Vehicle telemetry over CAN (ISO 15765-4 / OBD-II)
+
+Greenfield CAN/OBD-II telemetry. See the design at
+`apps/docs/tdd-vehicle-telemetry.md`.
+
+## Layout (mirrors `modules/wan/cellular`)
+
+| Path | Role |
+| --- | --- |
+| `inc/`, `src/` | **Pure core** — OBD-II PID encode/decode + DTC formatting. No ACE / SocketCAN / data-store, so it is fully host-unit-testable (`vehicle_core`). |
+| `test/` | gtest suite (`vehicle-tests`) over the pure core. |
+| `daemon/` | *(later PR)* `iot-vehicled` — reactor-driven SocketCAN poller, publishes `vehicle.*` to the data-store. |
+| `schemas/` | *(later PR)* `vehicle.lua` ds keys. |
+
+## Build + test (host)
+
+```sh
+cmake -S modules/vehicle -B build/vehicle
+cmake --build build/vehicle
+ctest --test-dir build/vehicle --output-on-failure
+```
+
+`VEHICLE_BUILD_TESTS` defaults ON for a top-level build, OFF when the module is
+pulled into the iot image via `add_subdirectory`. `VEHICLE_BUILD_DAEMON` (OFF by
+default) gates the ACE/SocketCAN daemon, forced ON in the image build.
+
+## OBD-II decode (`vehicle::obd`, SAE J1979 Mode 01)
+
+Request on functional id `0x7DF`: `[0x02, mode, pid, pad…]`; response on
+`0x7E8..0x7EF`: `[len, mode|0x40, pid, A, B, …]`.
+
+| PID | Signal | Decode | Unit |
+| --- | --- | --- | --- |
+| `0x04` | Engine load | `A·100/255` | % |
+| `0x05` | Coolant temp | `A−40` | °C |
+| `0x0C` | RPM | `(256A+B)/4` | rpm |
+| `0x0D` | Speed | `A` | km/h |
+| `0x0F` | Intake air temp | `A−40` | °C |
+| `0x10` | MAF | `(256A+B)/100` | g/s |
+| `0x11` | Throttle | `A·100/255` | % |
+| `0x2F` | Fuel level | `A·100/255` | % |
+
+DTCs (Mode 03 / SAE J2012): `decode_dtc(hi, lo)` → `Pxxxx`/`Cxxxx`/`Bxxxx`/`Uxxxx`.

--- a/modules/vehicle/inc/obd_pid.hpp
+++ b/modules/vehicle/inc/obd_pid.hpp
@@ -1,0 +1,72 @@
+#ifndef __modules_vehicle_obd_pid_hpp__
+#define __modules_vehicle_obd_pid_hpp__
+
+/// Pure OBD-II (SAE J1979) PID encode/decode for ISO 15765-4 (CAN).
+///
+/// No ACE, no SocketCAN, no data-store — just request framing + response
+/// decoding + DTC formatting, so it is fully host-unit-testable. The CAN
+/// transport (raw + ISO-TP) and ds publishing live in the iot-vehicled daemon.
+///
+/// Wire model (11-bit OBD-II): the tester sends a single-frame request on the
+/// functional ID 0x7DF — CAN data `[0x02, mode, pid, pad…]` — and an ECU
+/// answers on 0x7E8..0x7EF with `[len, mode|0x40, pid, A, B, …]`.
+
+#include <array>
+#include <cstddef>
+#include <cstdint>
+#include <string>
+
+namespace vehicle {
+namespace obd {
+
+// SAE J1979 Mode 01 PIDs supported in v1 (core powertrain + fuel/intake).
+enum Pid : std::uint8_t {
+    kPidEngineLoad   = 0x04,
+    kPidCoolantTemp  = 0x05,
+    kPidRpm          = 0x0C,
+    kPidSpeed        = 0x0D,
+    kPidIntakeAirTmp = 0x0F,
+    kPidMaf          = 0x10,
+    kPidThrottle     = 0x11,
+    kPidFuelLevel    = 0x2F,
+};
+
+constexpr std::uint16_t kFunctionalRequestId = 0x7DF;  // 11-bit broadcast
+constexpr std::uint16_t kEcuResponseIdBase   = 0x7E8;  // 0x7E8..0x7EF
+constexpr std::uint8_t  kModeCurrentData     = 0x01;   // Mode 01 (live data)
+constexpr std::uint8_t  kModeDtc             = 0x03;   // Mode 03 (stored DTCs)
+constexpr std::uint8_t  kPositiveReplyOffset = 0x40;   // response mode = mode|0x40
+constexpr std::uint8_t  kPad                 = 0xCC;   // unused-byte padding
+
+/// Build the 8-byte CAN-data payload for a single-PID request (default Mode 01).
+/// Layout: [0x02, mode, pid, kPad, kPad, kPad, kPad, kPad].
+std::array<std::uint8_t, 8> build_request(std::uint8_t pid,
+                                          std::uint8_t mode = kModeCurrentData);
+
+/// One decoded PID reading in engineering units.
+struct ObdValue {
+    bool         valid = false;  // false → unsupported PID or malformed frame
+    std::uint8_t pid   = 0;
+    double       value = 0.0;    // engineering value in `unit`
+    const char*  unit  = "";     // "rpm" | "km/h" | "C" | "%" | "g/s"
+};
+
+/// Decode a Mode 01 positive response payload (the CAN data bytes
+/// `[len, 0x41, pid, A, B, …]`). Returns `valid=false` on a non-0x41 service
+/// id, an unsupported PID, or a frame too short for the PID's data bytes.
+ObdValue decode_response(const std::uint8_t* data, std::size_t len);
+
+/// Format an ObdValue as the decimal string published to the data-store
+/// (matches the iot.sensor.* convention: trimmed, up to 2 decimals). Empty
+/// when `!valid`.
+std::string to_ds_string(const ObdValue& v);
+
+/// Decode a 2-byte DTC word (Mode 03 / SAE J2012) to the standard
+/// `Pxxxx`/`Cxxxx`/`Bxxxx`/`Uxxxx` string. Returns "" for an all-zero word
+/// (the "no DTC" sentinel).
+std::string decode_dtc(std::uint8_t hi, std::uint8_t lo);
+
+}  // namespace obd
+}  // namespace vehicle
+
+#endif /* __modules_vehicle_obd_pid_hpp__ */

--- a/modules/vehicle/src/obd_pid.cpp
+++ b/modules/vehicle/src/obd_pid.cpp
@@ -1,0 +1,73 @@
+#include "obd_pid.hpp"
+
+#include <cstdio>
+
+namespace vehicle {
+namespace obd {
+
+std::array<std::uint8_t, 8> build_request(std::uint8_t pid, std::uint8_t mode) {
+    std::array<std::uint8_t, 8> f;
+    f.fill(kPad);
+    f[0] = 0x02;  // single frame, 2 data bytes follow (mode + pid)
+    f[1] = mode;
+    f[2] = pid;
+    return f;
+}
+
+ObdValue decode_response(const std::uint8_t* d, std::size_t len) {
+    ObdValue v;
+    // Need at least [len, 0x41, pid, A].
+    if (!d || len < 4) return v;
+    // Mode 01 positive response service id is 0x41 (mode | 0x40).
+    if (d[1] != (kModeCurrentData | kPositiveReplyOffset)) return v;
+
+    const std::uint8_t pid   = d[2];
+    const std::uint8_t A     = d[3];
+    const bool         haveB = (len >= 5);
+    const std::uint8_t B     = haveB ? d[4] : 0;
+    v.pid = pid;
+
+    switch (pid) {
+        case kPidEngineLoad:   v.value = A * 100.0 / 255.0;          v.unit = "%";    v.valid = true; break;
+        case kPidCoolantTemp:  v.value = static_cast<int>(A) - 40;   v.unit = "C";    v.valid = true; break;
+        case kPidRpm:          if (!haveB) return v;
+                               v.value = (256.0 * A + B) / 4.0;      v.unit = "rpm";  v.valid = true; break;
+        case kPidSpeed:        v.value = A;                          v.unit = "km/h"; v.valid = true; break;
+        case kPidIntakeAirTmp: v.value = static_cast<int>(A) - 40;   v.unit = "C";    v.valid = true; break;
+        case kPidMaf:          if (!haveB) return v;
+                               v.value = (256.0 * A + B) / 100.0;    v.unit = "g/s";  v.valid = true; break;
+        case kPidThrottle:     v.value = A * 100.0 / 255.0;          v.unit = "%";    v.valid = true; break;
+        case kPidFuelLevel:    v.value = A * 100.0 / 255.0;          v.unit = "%";    v.valid = true; break;
+        default:               break;  // unsupported PID → valid stays false
+    }
+    return v;
+}
+
+std::string to_ds_string(const ObdValue& v) {
+    if (!v.valid) return std::string();
+    char buf[32];
+    std::snprintf(buf, sizeof(buf), "%.2f", v.value);
+    std::string s(buf);
+    // Trim trailing zeros (and a dangling dot) so 1000.00 → "1000", 49.80 → "49.8".
+    if (s.find('.') != std::string::npos) {
+        while (!s.empty() && s.back() == '0') s.pop_back();
+        if (!s.empty() && s.back() == '.') s.pop_back();
+    }
+    return s;
+}
+
+std::string decode_dtc(std::uint8_t hi, std::uint8_t lo) {
+    if (hi == 0 && lo == 0) return std::string();  // no DTC
+    static const char kCat[4] = {'P', 'C', 'B', 'U'};
+    char buf[8];
+    std::snprintf(buf, sizeof(buf), "%c%X%X%X%X",
+                  kCat[(hi >> 6) & 0x03],
+                  (hi >> 4) & 0x03,
+                  hi & 0x0F,
+                  (lo >> 4) & 0x0F,
+                  lo & 0x0F);
+    return std::string(buf);
+}
+
+}  // namespace obd
+}  // namespace vehicle

--- a/modules/vehicle/test/obd_pid_test.cpp
+++ b/modules/vehicle/test/obd_pid_test.cpp
@@ -1,0 +1,137 @@
+#include "obd_pid.hpp"
+
+#include <gtest/gtest.h>
+
+using namespace vehicle::obd;
+
+// ── Request framing ────────────────────────────────────────────────
+TEST(ObdRequest, Mode01SinglePidFrame) {
+    auto f = build_request(kPidRpm);
+    EXPECT_EQ(0x02, f[0]);                 // single frame, 2 data bytes
+    EXPECT_EQ(kModeCurrentData, f[1]);     // 0x01
+    EXPECT_EQ(kPidRpm, f[2]);              // 0x0C
+    for (std::size_t i = 3; i < f.size(); ++i) EXPECT_EQ(kPad, f[i]);
+}
+
+TEST(ObdRequest, HonoursExplicitMode) {
+    auto f = build_request(0x00, kModeDtc);
+    EXPECT_EQ(kModeDtc, f[1]);
+}
+
+// ── Response decoding (golden frames) ──────────────────────────────
+TEST(ObdDecode, Rpm) {
+    // A=0x0F, B=0xA0 → (256*15 + 160)/4 = 1000 rpm.
+    const std::uint8_t d[] = {0x04, 0x41, 0x0C, 0x0F, 0xA0};
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_EQ(kPidRpm, v.pid);
+    EXPECT_DOUBLE_EQ(1000.0, v.value);
+    EXPECT_STREQ("rpm", v.unit);
+    EXPECT_EQ("1000", to_ds_string(v));
+}
+
+TEST(ObdDecode, Speed) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x0D, 0x50};  // 0x50 = 80 km/h
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_DOUBLE_EQ(80.0, v.value);
+    EXPECT_STREQ("km/h", v.unit);
+    EXPECT_EQ("80", to_ds_string(v));
+}
+
+TEST(ObdDecode, CoolantTempOffset) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x05, 0x5A};  // 90 - 40 = 50 C
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_DOUBLE_EQ(50.0, v.value);
+    EXPECT_STREQ("C", v.unit);
+}
+
+TEST(ObdDecode, IntakeAirTempZero) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x0F, 0x28};  // 40 - 40 = 0 C
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_DOUBLE_EQ(0.0, v.value);
+    EXPECT_EQ("0", to_ds_string(v));
+}
+
+TEST(ObdDecode, ThrottleFullScale) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x11, 0xFF};  // 255*100/255 = 100 %
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_DOUBLE_EQ(100.0, v.value);
+    EXPECT_EQ("100", to_ds_string(v));
+}
+
+TEST(ObdDecode, EngineLoadTrimmedDecimals) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x04, 0x7F};  // 127*100/255 = 49.80…
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_EQ("49.8", to_ds_string(v));
+}
+
+TEST(ObdDecode, Maf) {
+    const std::uint8_t d[] = {0x04, 0x41, 0x10, 0x01, 0xF4};  // 500/100 = 5.00
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_DOUBLE_EQ(5.0, v.value);
+    EXPECT_STREQ("g/s", v.unit);
+    EXPECT_EQ("5", to_ds_string(v));
+}
+
+TEST(ObdDecode, FuelLevel) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x2F, 0x80};  // 128*100/255 = 50.19…
+    auto v = decode_response(d, sizeof(d));
+    ASSERT_TRUE(v.valid);
+    EXPECT_EQ("50.2", to_ds_string(v));
+}
+
+// ── Malformed / unsupported ────────────────────────────────────────
+TEST(ObdDecode, UnsupportedPidInvalid) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x99, 0x00};
+    EXPECT_FALSE(decode_response(d, sizeof(d)).valid);
+}
+
+TEST(ObdDecode, WrongServiceIdInvalid) {
+    const std::uint8_t d[] = {0x03, 0x7F, 0x0D, 0x50};  // negative response
+    EXPECT_FALSE(decode_response(d, sizeof(d)).valid);
+}
+
+TEST(ObdDecode, TooShortInvalid) {
+    const std::uint8_t d[] = {0x02, 0x41};
+    EXPECT_FALSE(decode_response(d, sizeof(d)).valid);
+}
+
+TEST(ObdDecode, TwoBytepidMissingSecondByteInvalid) {
+    const std::uint8_t d[] = {0x03, 0x41, 0x0C, 0x0F};  // RPM needs B
+    EXPECT_FALSE(decode_response(d, sizeof(d)).valid);
+}
+
+TEST(ObdDecode, NullInvalid) {
+    EXPECT_FALSE(decode_response(nullptr, 8).valid);
+}
+
+TEST(ObdDecode, ToDsStringEmptyWhenInvalid) {
+    ObdValue v;  // valid == false
+    EXPECT_EQ("", to_ds_string(v));
+}
+
+// ── DTC decoding (SAE J2012) ───────────────────────────────────────
+TEST(ObdDtc, PowertrainCode) {
+    // P0301: cat P(00), digits 0,3,0,1 → hi=0x03, lo=0x01.
+    EXPECT_EQ("P0301", decode_dtc(0x03, 0x01));
+}
+
+TEST(ObdDtc, NetworkCode) {
+    // U0123: cat U(11), 0,1,2,3 → hi=0xC1, lo=0x23.
+    EXPECT_EQ("U0123", decode_dtc(0xC1, 0x23));
+}
+
+TEST(ObdDtc, ChassisCode) {
+    // C0210: cat C(01), 0,2,1,0 → hi=0x42, lo=0x10.
+    EXPECT_EQ("C0210", decode_dtc(0x42, 0x10));
+}
+
+TEST(ObdDtc, AllZeroIsNoDtc) {
+    EXPECT_EQ("", decode_dtc(0x00, 0x00));
+}


### PR DESCRIPTION
**PR-1 of `apps/docs/tdd-vehicle-telemetry.md`.** Pure OBD-II decode core — the hardware-free foundation.

- New module `modules/vehicle` (mirrors `modules/wan/cellular`): `vehicle_core` static lib (`inc/obd_pid.hpp` + `src/obd_pid.cpp`) — Mode 01 PID request framing + response decode (8 v1 signals) + ds-string formatting + SAE J2012 DTC decode. No ACE/SocketCAN/data-store → fully host-unit-testable.
- `test/obd_pid_test.cpp` — gtest golden frames (decode formulas, framing, malformed/unsupported guards, P/C/B/U DTC codes).
- `CMakeLists.txt` mirrors cellular (`VEHICLE_BUILD_TESTS` top-level; `VEHICLE_BUILD_DAEMON` OFF placeholder for PR-2).

**Build impact: none** — not referenced by any recipe or top-level CMake yet, so the device/cloud image builds don't compile it. Build-isolated by design.

> Note: no local toolchain on the dev machine, so this is written to the proven cellular-module pattern and not locally compiled; the daemon PR (PR-2) wires it into the image build where CI exercises it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)