### PR TITLE
feat(vehicle): PR-2 — iot-vehicled SocketCAN/OBD-II daemon

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -145,6 +145,14 @@ set(CELLULAR_BUILD_DAEMON ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/wan/cellular
                  ${CMAKE_BINARY_DIR}/cellular)
 
+# vehicle module (CAN/OBD-II telemetry). Builds iot-vehicled, the privileged
+# producer that drives the SocketCAN bus, decodes OBD-II PIDs (vehicle::obd),
+# and publishes vehicle.* to ds. Reuses the datastore_client target added above.
+# See modules/vehicle/README.md + apps/docs/tdd-vehicle-telemetry.md.
+set(VEHICLE_BUILD_DAEMON ON CACHE BOOL "" FORCE)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/vehicle
+                 ${CMAKE_BINARY_DIR}/vehicle)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store/inc)
 
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)

--- a/modules/vehicle/CMakeLists.txt
+++ b/modules/vehicle/CMakeLists.txt
@@ -23,6 +23,43 @@ target_include_directories(vehicle_core PUBLIC ${CMAKE_CURRENT_SOURCE_DIR}/inc)
 target_compile_options(vehicle_core PRIVATE -Wall -Wextra)
 add_library(vehicle::core ALIAS vehicle_core)
 
+# ── Install the vehicle.* schema (operator + daemon contract) ──
+include(GNUInstallDirs)
+if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+    install(FILES schemas/vehicle.lua
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+endif()
+
+# ── iot-vehicled daemon (privileged producer; reactor-driven, ACE-only) ──
+# Built when VEHICLE_BUILD_DAEMON=ON (forced on in the iot image build). Off by
+# default for a plain `cmake modules/vehicle` core/test build.
+if(VEHICLE_BUILD_DAEMON)
+    if(NOT DEFINED ACE_ROOT)
+        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
+    endif()
+    if(NOT TARGET datastore_client)
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../data-store
+                         ${CMAKE_BINARY_DIR}/data-store)
+    endif()
+
+    add_executable(iot-vehicled
+        daemon/main.cpp
+        daemon/vehicle_client.cpp
+        daemon/can_socket.cpp)
+    target_include_directories(iot-vehicled PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/daemon
+        ${CMAKE_CURRENT_SOURCE_DIR}/inc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../data-store/inc
+        ${ACE_ROOT}/include)
+    target_link_directories(iot-vehicled PRIVATE ${ACE_ROOT}/lib)
+    target_link_libraries(iot-vehicled PRIVATE
+        vehicle_core datastore_client ACE pthread)
+
+    if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+        install(TARGETS iot-vehicled RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
+endif()
+
 if(VEHICLE_BUILD_TESTS)
     enable_testing()
     find_package(GTest REQUIRED)

--- a/modules/vehicle/daemon/can_socket.cpp
+++ b/modules/vehicle/daemon/can_socket.cpp
@@ -1,0 +1,112 @@
+#include "can_socket.hpp"
+
+#include <cstring>
+
+#include <net/if.h>
+#include <sys/ioctl.h>
+#include <sys/socket.h>
+#include <unistd.h>
+
+#include <linux/can.h>
+#include <linux/can/raw.h>
+
+#include <ace/Log_Msg.h>
+#include <ace/Reactor.h>
+
+#include "obd_pid.hpp"
+
+namespace vehicle {
+
+int CanSocket::open(const std::string& iface, ACE_Reactor* reactor) {
+    m_fd = ::socket(PF_CAN, SOCK_RAW, CAN_RAW);
+    if (m_fd < 0) {
+        ACE_ERROR_RETURN((LM_ERROR,
+            ACE_TEXT("%D [veh] socket(PF_CAN) failed: %m\n")), -1);
+    }
+
+    struct ifreq ifr;
+    std::memset(&ifr, 0, sizeof(ifr));
+    std::strncpy(ifr.ifr_name, iface.c_str(), IFNAMSIZ - 1);
+    if (::ioctl(m_fd, SIOCGIFINDEX, &ifr) < 0) {
+        ACE_ERROR((LM_ERROR,
+            ACE_TEXT("%D [veh] SIOCGIFINDEX(%C) failed: %m\n"), iface.c_str()));
+        close();
+        return -1;
+    }
+
+    struct sockaddr_can addr;
+    std::memset(&addr, 0, sizeof(addr));
+    addr.can_family  = AF_CAN;
+    addr.can_ifindex = ifr.ifr_ifindex;
+    if (::bind(m_fd, reinterpret_cast<struct sockaddr*>(&addr), sizeof(addr)) < 0) {
+        ACE_ERROR((LM_ERROR,
+            ACE_TEXT("%D [veh] bind(%C) failed: %m\n"), iface.c_str()));
+        close();
+        return -1;
+    }
+
+    // Only deliver OBD-II ECU responses (0x7E8..0x7EF): id & mask == 0x7E8.
+    struct can_filter rf;
+    rf.can_id   = obd::kEcuResponseIdBase;
+    rf.can_mask = 0x7F8;
+    if (::setsockopt(m_fd, SOL_CAN_RAW, CAN_RAW_FILTER, &rf, sizeof(rf)) < 0) {
+        ACE_ERROR((LM_WARNING,
+            ACE_TEXT("%D [veh] CAN_RAW_FILTER failed: %m (continuing unfiltered)\n")));
+    }
+
+    if (reactor->register_handler(this, ACE_Event_Handler::READ_MASK) == -1) {
+        ACE_ERROR((LM_ERROR,
+            ACE_TEXT("%D [veh] register_handler(%C) failed\n"), iface.c_str()));
+        close();
+        return -1;
+    }
+    return 0;
+}
+
+void CanSocket::close() {
+    if (m_fd >= 0 && reactor()) {
+        reactor()->remove_handler(this,
+            ACE_Event_Handler::READ_MASK | ACE_Event_Handler::DONT_CALL);
+    }
+    if (m_fd >= 0) {
+        ::close(m_fd);
+        m_fd = -1;
+    }
+}
+
+int CanSocket::send(std::uint32_t can_id, const std::array<std::uint8_t, 8>& data) {
+    if (m_fd < 0) return -1;
+    struct can_frame f;
+    std::memset(&f, 0, sizeof(f));
+    f.can_id  = can_id;
+    f.can_dlc = 8;
+    std::memcpy(f.data, data.data(), 8);
+    const ssize_t n = ::write(m_fd, &f, sizeof(f));
+    return static_cast<int>(n);
+}
+
+ACE_HANDLE CanSocket::get_handle() const {
+    return static_cast<ACE_HANDLE>(m_fd);
+}
+
+int CanSocket::handle_input(ACE_HANDLE) {
+    struct can_frame f;
+    const ssize_t n = ::read(m_fd, &f, sizeof(f));
+    if (n < static_cast<ssize_t>(sizeof(struct can_frame))) {
+        return -1;  // short read / error → reactor calls handle_close
+    }
+    if (m_on_frame) {
+        m_on_frame(f.can_id & CAN_EFF_MASK, f.data, f.can_dlc);
+    }
+    return 0;
+}
+
+int CanSocket::handle_close(ACE_HANDLE, ACE_Reactor_Mask) {
+    if (m_fd >= 0) {
+        ::close(m_fd);
+        m_fd = -1;
+    }
+    return 0;
+}
+
+} // namespace vehicle

--- a/modules/vehicle/daemon/can_socket.hpp
+++ b/modules/vehicle/daemon/can_socket.hpp
@@ -1,0 +1,52 @@
+#ifndef __vehicle_can_socket_hpp__
+#define __vehicle_can_socket_hpp__
+
+#include <array>
+#include <cstdint>
+#include <functional>
+#include <string>
+
+#include <ace/Event_Handler.h>
+
+/// Reactor-driven SocketCAN (raw CAN) channel.
+///
+/// SocketCAN is a Linux netdev with no ACE wrapper, so we open the raw PF_CAN
+/// socket ourselves and feed its fd to the ACE_Reactor (the project rule:
+/// "never raw POSIX event loops — feed the driver fd to ACE_Reactor"). Each
+/// readable burst is one `struct can_frame`; we hand `(id, data, dlc)` to the
+/// caller's callback. `send()` transmits an 8-byte OBD request frame.
+
+namespace vehicle {
+
+class CanSocket : public ACE_Event_Handler {
+    public:
+        /// frame callback: (can_id, data[dlc], dlc).
+        using FrameFn = std::function<void(std::uint32_t,
+                                           const std::uint8_t*,
+                                           std::uint8_t)>;
+
+        explicit CanSocket(FrameFn on_frame) : m_on_frame(std::move(on_frame)) {}
+        ~CanSocket() override { close(); }
+
+        /// Open + bind the raw CAN socket on `iface` (e.g. "can0"), install a
+        /// filter for the OBD response id range, and register with `reactor`
+        /// for READ events. Returns 0 / -1.
+        int open(const std::string& iface, ACE_Reactor* reactor);
+        void close();
+
+        /// Transmit an 8-byte data frame on `can_id`. Returns bytes sent / -1.
+        int send(std::uint32_t can_id, const std::array<std::uint8_t, 8>& data);
+
+        /* ACE_Event_Handler */
+        ACE_HANDLE get_handle() const override;
+        int handle_input(ACE_HANDLE) override;
+        int handle_close(ACE_HANDLE, ACE_Reactor_Mask) override;
+
+    private:
+        FrameFn m_on_frame;
+        int     m_fd = -1;
+};
+
+} // namespace vehicle
+
+#endif /*__vehicle_can_socket_hpp__*/

--- a/modules/vehicle/daemon/main.cpp
+++ b/modules/vehicle/daemon/main.cpp
@@ -1,0 +1,56 @@
+/// iot-vehicled — vehicle telemetry over CAN (ISO 15765-4 / OBD-II) producer.
+///
+/// Reactor-driven (ACE): opens a SocketCAN interface, polls OBD-II Mode 01 PIDs
+/// on a timer, decodes them via the pure vehicle::obd core, and publishes
+/// `vehicle.*` to the data-store (volatile live keys). Config keys
+/// (vehicle.can.iface / vehicle.poll.interval.ms) override the argv defaults
+/// when present in ds. See apps/docs/tdd-vehicle-telemetry.md.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "vehicle_client.hpp"
+
+namespace {
+
+void usage() {
+    std::cout <<
+        "iot-vehicled — CAN/OBD-II vehicle telemetry producer\n"
+        "\n"
+        "Usage: iot-vehicled [--ds-sock=PATH] [--iface=can0] [--interval=MS] [--help]\n"
+        "\n"
+        "  --ds-sock=PATH   ds-server unix socket (default: ds built-in).\n"
+        "  --iface=NAME     SocketCAN interface (default can0;\n"
+        "                   overridden by vehicle.can.iface in ds).\n"
+        "  --interval=MS    full-poll cadence in ms (default 1000 /\n"
+        "                   vehicle.poll.interval.ms).\n"
+        "  --help           show this and exit.\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    vehicle::VehicleClient::Config cfg;
+    try {
+        for (int i = 1; i < argc; ++i) {
+            std::string a = argv[i];
+            if      (a.rfind("--ds-sock=", 0)  == 0) cfg.ds_sock = a.substr(10);
+            else if (a.rfind("--iface=", 0)    == 0) cfg.iface = a.substr(8);
+            else if (a.rfind("--interval=", 0) == 0) cfg.interval_ms = static_cast<unsigned>(std::stoul(a.substr(11)));
+            else if (a == "--help" || a == "-h")     { usage(); return 0; }
+            else {
+                std::cerr << "iot-vehicled: unknown argument '" << a << "'\n";
+                usage();
+                return 2;
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "iot-vehicled: bad argument: " << e.what() << "\n";
+        return 2;
+    }
+    if (cfg.interval_ms == 0) cfg.interval_ms = 1000;
+
+    vehicle::VehicleClient client(std::move(cfg));
+    return client.run();
+}

--- a/modules/vehicle/daemon/vehicle_client.cpp
+++ b/modules/vehicle/daemon/vehicle_client.cpp
@@ -1,0 +1,114 @@
+#include "vehicle_client.hpp"
+
+#include <ace/Log_Msg.h>
+#include <ace/Reactor.h>
+#include <ace/Time_Value.h>
+
+#include "data_store/value.hpp"
+
+#include "obd_pid.hpp"
+
+namespace vehicle {
+
+namespace {
+
+// PID → data-store key. Only the supported v1 signals map; everything else is
+// ignored. Keep in sync with schemas/vehicle.lua + vehicle::obd.
+const char* ds_key_for_pid(std::uint8_t pid) {
+    switch (pid) {
+        case obd::kPidEngineLoad:   return "vehicle.load";
+        case obd::kPidCoolantTemp:  return "vehicle.coolant";
+        case obd::kPidRpm:          return "vehicle.rpm";
+        case obd::kPidSpeed:        return "vehicle.speed";
+        case obd::kPidIntakeAirTmp: return "vehicle.iat";
+        case obd::kPidMaf:          return "vehicle.maf";
+        case obd::kPidThrottle:     return "vehicle.throttle";
+        case obd::kPidFuelLevel:    return "vehicle.fuel";
+        default:                    return nullptr;
+    }
+}
+
+} // namespace
+
+void VehicleClient::load_config_from_ds() {
+    std::vector<data_store::Client::GetResult> got;
+    if (m_ds.get({std::string("vehicle.can.iface")}, got).ok && !got.empty() && got[0].has_value)
+        if (auto s = data_store::to_string(got[0].value)) if (!s->empty()) m_cfg.iface = *s;
+    got.clear();
+    if (m_ds.get({std::string("vehicle.poll.interval.ms")}, got).ok && !got.empty() && got[0].has_value)
+        if (auto n = data_store::to_int32(got[0].value)) if (*n > 0) m_cfg.interval_ms = static_cast<unsigned>(*n);
+}
+
+void VehicleClient::publish_link(const char* state) {
+    if (m_link == state) return;     // only on change
+    m_link = state;
+    m_ds.set_volatile(std::string("vehicle.link"), data_store::Value{std::string(state)});
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [veh] link=%C\n"), state));
+}
+
+void VehicleClient::on_frame(std::uint32_t id, const std::uint8_t* data, std::uint8_t dlc) {
+    if (id < obd::kEcuResponseIdBase || id > (obd::kEcuResponseIdBase + 7)) return;
+    auto v = obd::decode_response(data, dlc);
+    if (!v.valid) return;
+    const char* key = ds_key_for_pid(v.pid);
+    if (!key) return;
+    m_any_reply = true;
+    m_ds.set_volatile(std::string(key), data_store::Value{obd::to_ds_string(v)});
+}
+
+int VehicleClient::handle_timeout(const ACE_Time_Value&, const void*) {
+    if (m_pids.empty() || !m_can) return 0;
+
+    // A completed round with no reply means the bus is up but no ECU answered
+    // (engine off / wrong bitrate); any reply this round means it's live.
+    if (m_next == 0) {
+        publish_link(m_any_reply ? "up" : "no-ecu");
+        m_any_reply = false;
+    }
+
+    const std::uint8_t pid = m_pids[m_next];
+    if (m_can->send(obd::kFunctionalRequestId, obd::build_request(pid)) < 0) {
+        publish_link("down");
+    }
+    m_next = (m_next + 1) % m_pids.size();
+    return 0;
+}
+
+int VehicleClient::run() {
+    if (!m_ds.connect(m_cfg.ds_sock).ok) {
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%D [veh] ds connect failed\n")), 1);
+    }
+    load_config_from_ds();
+
+    m_pids = {
+        obd::kPidEngineLoad, obd::kPidCoolantTemp, obd::kPidRpm, obd::kPidSpeed,
+        obd::kPidIntakeAirTmp, obd::kPidMaf, obd::kPidThrottle, obd::kPidFuelLevel,
+    };
+
+    m_can.reset(new CanSocket(
+        [this](std::uint32_t id, const std::uint8_t* d, std::uint8_t dlc) { on_frame(id, d, dlc); }));
+    if (m_can->open(m_cfg.iface, ACE_Reactor::instance()) == -1) {
+        publish_link("down");
+        ACE_ERROR_RETURN((LM_ERROR,
+            ACE_TEXT("%D [veh] CAN iface %C unavailable (is it up? "
+                     "`ip link set %C up type can`)\n"),
+            m_cfg.iface.c_str(), m_cfg.iface.c_str()), 2);
+    }
+
+    // Spread the per-PID requests across the poll interval so we don't burst all
+    // eight at once: one request per (interval / N) tick.
+    unsigned tick_ms = m_cfg.interval_ms / static_cast<unsigned>(m_pids.size());
+    if (tick_ms == 0) tick_ms = 1;
+    ACE_Time_Value period(tick_ms / 1000, (tick_ms % 1000) * 1000);
+    ACE_Reactor::instance()->schedule_timer(this, nullptr, ACE_Time_Value(1), period);
+
+    ACE_DEBUG((LM_INFO,
+        ACE_TEXT("%D [veh] up: iface=%C poll=%ums (%u PIDs, %ums/PID)\n"),
+        m_cfg.iface.c_str(), m_cfg.interval_ms,
+        static_cast<unsigned>(m_pids.size()), tick_ms));
+
+    ACE_Reactor::instance()->run_reactor_event_loop();
+    return 0;
+}
+
+} // namespace vehicle

--- a/modules/vehicle/daemon/vehicle_client.hpp
+++ b/modules/vehicle/daemon/vehicle_client.hpp
@@ -1,0 +1,61 @@
+#ifndef __vehicle_client_hpp__
+#define __vehicle_client_hpp__
+
+#include <cstdint>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <ace/Event_Handler.h>
+
+#include "data_store/client.hpp"
+
+#include "can_socket.hpp"
+
+/// iot-vehicled — reactor-driven OBD-II (ISO 15765-4) telemetry producer.
+///
+/// Opens the SocketCAN interface as a reactor-registered CanSocket, and on a
+/// periodic ACE timer sends the next Mode 01 PID request (round-robin over the
+/// supported set) on the functional id 0x7DF. ECU responses arrive on the
+/// reactor thread, are decoded by the pure vehicle::obd core, and published to
+/// the data-store as VOLATILE `vehicle.*` keys (transient per-tick readings —
+/// no SD-card fsync). `vehicle.link` reflects bus health. All I/O is ACE; the
+/// only raw-POSIX is opening the CAN fd, which is then driven by the reactor.
+
+namespace vehicle {
+
+class VehicleClient : public ACE_Event_Handler {
+    public:
+        struct Config {
+            std::string  ds_sock;              ///< "" → ds default socket
+            std::string  iface       = "can0";
+            unsigned     interval_ms = 1000;
+        };
+
+        explicit VehicleClient(Config cfg) : m_cfg(std::move(cfg)) {}
+        ~VehicleClient() override = default;
+
+        /// Connect ds, read config overrides, open the CAN socket, run the
+        /// reactor. Returns a process exit code.
+        int run();
+
+        /// Poll timer: send the next PID request + refresh vehicle.link.
+        int handle_timeout(const ACE_Time_Value&, const void*) override;
+
+    private:
+        void load_config_from_ds();
+        void on_frame(std::uint32_t id, const std::uint8_t* data, std::uint8_t dlc);
+        void publish_link(const char* state);
+
+        Config                       m_cfg;
+        data_store::Client           m_ds;
+        std::unique_ptr<CanSocket>   m_can;
+        std::vector<std::uint8_t>    m_pids;        ///< round-robin poll list
+        std::size_t                  m_next = 0;    ///< index into m_pids
+        bool                         m_any_reply = false;
+        std::string                  m_link;        ///< last published link state
+};
+
+} // namespace vehicle
+
+#endif /*__vehicle_client_hpp__*/

--- a/modules/vehicle/schemas/vehicle.lua
+++ b/modules/vehicle/schemas/vehicle.lua
@@ -1,0 +1,38 @@
+-- vehicle.* schema for the iot-vehicled CAN/OBD-II (ISO 15765-4) daemon.
+-- See apps/docs/tdd-vehicle-telemetry.md.
+--
+-- Read keys (operator -> daemon):
+--   vehicle.can.iface        - SocketCAN interface (default "can0")
+--   vehicle.can.bitrate      - CAN bitrate (default 500000; 250000 variant)
+--   vehicle.poll.interval.ms - PID poll cadence in ms (default 1000)
+--
+-- Write keys (daemon -> device-ui / lwm2m client). All string-typed; numeric
+-- values are decimal strings (matches the iot.sensor.* / cell.* convention).
+-- The live telemetry keys are written VOLATILE (in-memory, no fsync) since they
+-- are transient per-tick readings; vehicle.dtc is persisted (on-change, low rate).
+--   vehicle.rpm       - engine RPM
+--   vehicle.speed     - vehicle speed (km/h)
+--   vehicle.coolant   - coolant temperature (deg C)
+--   vehicle.throttle  - throttle position (%)
+--   vehicle.load      - calculated engine load (%)
+--   vehicle.fuel      - fuel tank level (%)
+--   vehicle.iat       - intake air temperature (deg C)
+--   vehicle.maf       - mass air flow (g/s)
+--   vehicle.dtc       - JSON array of active DTCs (Mode 03)
+--   vehicle.link      - bus health: "up" / "down" / "no-ecu"
+return {
+    ["vehicle.can.iface"]        = { access = "Admin",  type = "string",  default = "can0" },
+    ["vehicle.can.bitrate"]      = { access = "Admin",  type = "integer", default = 500000 },
+    ["vehicle.poll.interval.ms"] = { access = "Admin",  type = "integer", default = 1000 },
+
+    ["vehicle.rpm"]      = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.speed"]    = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.coolant"]  = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.throttle"] = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.load"]     = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.fuel"]     = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.iat"]      = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.maf"]      = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.dtc"]      = { access = "Viewer", type = "string", default = "" },
+    ["vehicle.link"]     = { access = "Viewer", type = "string", default = "down" },
+}

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -383,6 +383,7 @@ PACKAGE_BEFORE_PN = "\
     ${PN}-httpd \
     ${PN}-sensord \
     ${PN}-cellular \
+    ${PN}-vehicle \
     ${PN}-config \
     ${PN}-bcm2837-selftest \
 "
@@ -545,6 +546,15 @@ FILES:${PN}-cellular = "\
     ${systemd_system_unitdir}/iot-cellular-client.service \
 "
 RDEPENDS:${PN}-cellular = "ace-tao"
+
+# vehicle — iot-vehicled CAN/OBD-II (ISO 15765-4) telemetry producer.
+# Publishes vehicle.* to ds; the lwm2m client mirrors them into a Vehicle
+# object + GPS Object 6 for the cloud map. vehicle.lua schema ships in
+# ${PN}-config (${sysconfdir}/iot). systemd unit + can0 bring-up land in a
+# follow-up PR; for now the binary ships and is run manually / on demand.
+# See apps/docs/tdd-vehicle-telemetry.md.
+FILES:${PN}-vehicle = "${bindir}/iot-vehicled"
+RDEPENDS:${PN}-vehicle = "ace-tao"
 # A real data path also wants a modem manager + tools on the image; left to the
 # integrator per WP firmware (ModemManager / libqmi / usb-modeswitch).
 RRECOMMENDS:${PN}-cellular = "\


### PR DESCRIPTION
PR-2 of `apps/docs/tdd-vehicle-telemetry.md`. Reactor-driven CAN/OBD-II producer mirroring `cellular-client`: `can_socket` (PF_CAN raw fd → ACE_Reactor), `vehicle_client` (timer round-robins Mode 01 PIDs, decodes via the pure `vehicle::obd` core from PR-1, publishes `vehicle.*` volatile), `vehicle.lua` schema. Wired into `apps/CMakeLists` (image build compiles it) + a minimal `${PN}-vehicle` package. systemd unit + can0 bring-up + ServiceGate deferred to a follow-up.

> Written to the proven cellular pattern; not locally compiled (no toolchain). Watching device-image CI post-merge to fix-forward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)