### PR TITLE
feat(vehicle): PR-3 — Vehicle LwM2M object 33000 + reader hooks

### DIFF
--- a/apps/inc/lwm2m_object_stubs.hpp
+++ b/apps/inc/lwm2m_object_stubs.hpp
@@ -46,6 +46,27 @@ struct LocationHooks {
 /// Resources are observable; unset hooks serve static "0".
 int install_location(ObjectStore& store, LocationHooks hooks = {});
 
+/// Live readers for the custom Vehicle Telemetry object (OID 33000). Each
+/// returns text/plain; an unset hook serves a static default. Bound to the
+/// vehicle.* ds keys (published by iot-vehicled) in the client build.
+struct VehicleHooks {
+    std::function<std::string()> speed;     ///< /33000/0 (km/h)
+    std::function<std::string()> rpm;       ///< /33000/1
+    std::function<std::string()> coolant;   ///< /33000/2 (deg C)
+    std::function<std::string()> throttle;  ///< /33000/3 (%)
+    std::function<std::string()> load;      ///< /33000/4 (%)
+    std::function<std::string()> fuel;      ///< /33000/5 (%)
+    std::function<std::string()> iat;       ///< /33000/6 (deg C)
+    std::function<std::string()> maf;       ///< /33000/7 (g/s)
+    std::function<std::string()> dtc;       ///< /33000/8 (JSON DTC list)
+    std::function<std::string()> link;      ///< /33000/10 (up/down/no-ecu)
+};
+
+/// Vehicle Telemetry (OID 33000, private-use range) — OBD-II signals mirrored
+/// from vehicle.* ds keys. Observable; unset hooks serve a static default.
+/// Custom (not OMA) → installed separately from install_canonical_objects.
+int install_vehicle(ObjectStore& store, VehicleHooks hooks = {});
+
 /// Connectivity Statistics (OID 7) — counters.
 int install_connstats(ObjectStore& store);
 

--- a/apps/src/lwm2m_object_stubs.cpp
+++ b/apps/src/lwm2m_object_stubs.cpp
@@ -153,6 +153,32 @@ int install_connstats(ObjectStore& store) {
     return 0;
 }
 
+int install_vehicle(ObjectStore& store, VehicleHooks h) {
+    ObjectDescriptor d;
+    d.oid = 33000; d.name = "Vehicle Telemetry";
+    d.urn = "urn:oma:lwm2m:x:33000";          // private-use range (no OMA reg)
+    d.mandatory = false; d.multipleInstance = false;
+
+    auto inst = instance_with(0);
+    // Bound to vehicle.* (iot-vehicled / OBD-II) in the client build; unset →
+    // static default. A server Read/Observe /33000/0/* surfaces live vehicle
+    // telemetry to the cloud (map + dashboards). RID 8 (DTC) is fed once the
+    // ISO-TP Mode 03 path lands; RID 9 (MIL) is reserved.
+    inst.resources[0]  = live_or_static(0,  "Speed",           ResourceType::Float,  std::move(h.speed),    "0");
+    inst.resources[1]  = live_or_static(1,  "RPM",             ResourceType::Float,  std::move(h.rpm),      "0");
+    inst.resources[2]  = live_or_static(2,  "Coolant",         ResourceType::Float,  std::move(h.coolant),  "0");
+    inst.resources[3]  = live_or_static(3,  "Throttle",        ResourceType::Float,  std::move(h.throttle), "0");
+    inst.resources[4]  = live_or_static(4,  "Engine Load",     ResourceType::Float,  std::move(h.load),     "0");
+    inst.resources[5]  = live_or_static(5,  "Fuel Level",      ResourceType::Float,  std::move(h.fuel),     "0");
+    inst.resources[6]  = live_or_static(6,  "Intake Air Temp", ResourceType::Float,  std::move(h.iat),      "0");
+    inst.resources[7]  = live_or_static(7,  "MAF",             ResourceType::Float,  std::move(h.maf),      "0");
+    inst.resources[8]  = live_or_static(8,  "DTC List",        ResourceType::String, std::move(h.dtc),      "");
+    inst.resources[10] = live_or_static(10, "Link",            ResourceType::String, std::move(h.link),     "down");
+    d.instances[0] = std::move(inst);
+    store.add_object(std::move(d));
+    return 0;
+}
+
 // The Security (OID 0) and Server (OID 1) objects are NOT seeded from static
 // config — they are delivered entirely by the Bootstrap server at /bs and
 // created in the live store by the Bootstrap client's apply_commit (which

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1024,6 +1024,34 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
                                                 std::move(fwHooks), std::move(certHooks),
                                                 std::move(locHooks));
 
+    // Vehicle Telemetry (custom OID 33000): bind OBD-II signals to the vehicle.*
+    // ds keys published by iot-vehicled (it owns the CAN bus). A server
+    // Read/Observe /33000/0/* surfaces live vehicle data to the cloud map. Each
+    // hook reuses the same ds reader as gps.* above; empty → static default.
+    ::lwm2m::objects::VehicleHooks vehHooks;
+    {
+        auto vehVal = [dsc](const char* key) -> std::string {
+            std::string v;
+            if (dsc) {
+                std::vector<data_store::Client::GetResult> got;
+                if (dsc->get({std::string(key)}, got).ok && !got.empty() && got[0].has_value)
+                    if (auto s = data_store::to_string(got[0].value)) v = *s;
+            }
+            return v;
+        };
+        vehHooks.speed    = [vehVal]() { return vehVal("vehicle.speed"); };
+        vehHooks.rpm      = [vehVal]() { return vehVal("vehicle.rpm"); };
+        vehHooks.coolant  = [vehVal]() { return vehVal("vehicle.coolant"); };
+        vehHooks.throttle = [vehVal]() { return vehVal("vehicle.throttle"); };
+        vehHooks.load     = [vehVal]() { return vehVal("vehicle.load"); };
+        vehHooks.fuel     = [vehVal]() { return vehVal("vehicle.fuel"); };
+        vehHooks.iat      = [vehVal]() { return vehVal("vehicle.iat"); };
+        vehHooks.maf      = [vehVal]() { return vehVal("vehicle.maf"); };
+        vehHooks.dtc      = [vehVal]() { return vehVal("vehicle.dtc"); };
+        vehHooks.link     = [vehVal]() { return vehVal("vehicle.link"); };
+    }
+    ::lwm2m::objects::install_vehicle(*plumb.store, std::move(vehHooks));
+
     // ── IPSO sensor objects (mangOH Yellow) ───────────────────────────────
     // Sensor values are produced by the privileged iot-sensord daemon (it owns
     // the I2C bus / mangOH board) and published to iot.sensor.* in the


### PR DESCRIPTION
PR-3 of the vehicle plan. Custom **Vehicle Telemetry object (OID 33000)** mirroring the Object-6/`LocationHooks` pattern: `VehicleHooks` + `install_vehicle()` (one observable resource per OBD-II signal), bound in `main.cpp` to the `vehicle.*` ds keys (same ds reader as gps.*). Server Read/Observe `/33000/0/*` surfaces live telemetry to the cloud map. Mirrors `install_location` line-for-line; not locally compiled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)