### PR TITLE
feat(vehicle): PR-2b — iot-vehicled systemd units + can0 bring-up

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -270,6 +270,8 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-wifi-client.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-sensord.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-cellular-client.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-vehicled.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-can0-up.service
             DESTINATION lib/systemd/system)
 
     # tmpfiles.d fallback for hosts where RuntimeDirectory= doesn't

--- a/packaging/systemd/iot-can0-up.service
+++ b/packaging/systemd/iot-can0-up.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Bring up the SocketCAN interface (can0) for OBD-II
+Documentation=file:///usr/local/share/doc/iot/tdd-vehicle-telemetry.md
+After=network-pre.target
+Before=iot-vehicled.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Bring can0 up at the ISO 15765-4 bitrate (500 kbps; some vehicles use 250k —
+# adjust per fleet). The leading "-" makes systemd ignore failure, so a board
+# with no CAN controller (or a different `ip` path) does not fault the boot;
+# iot-vehicled then reports vehicle.link=down until the bus is present.
+ExecStart=-/sbin/ip link set can0 up type can bitrate 500000
+ExecStop=-/sbin/ip link set can0 down
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/iot-vehicled.service
+++ b/packaging/systemd/iot-vehicled.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=IoT vehicle telemetry (CAN/OBD-II ISO 15765-4 → ds vehicle.*)
+Documentation=file:///usr/local/share/doc/iot/tdd-vehicle-telemetry.md
+# Needs ds-server up (publishes vehicle.* on connect) and can0 brought up first.
+After=network-online.target iot-ds.service iot-can0-up.service
+Wants=iot-ds.service iot-can0-up.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/iot-vehicled
+
+# SocketCAN is a netdev (no /dev node), so the daemon needs CAP_NET_RAW to open
+# the PF_CAN socket — but nothing else.
+AmbientCapabilities=CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_RAW
+
+# /run/iot is owned solely by tmpfiles.d (iot.conf, 2775 root:iot) — do NOT use
+# RuntimeDirectory=iot: it resets /run/iot on start/stop, clobbering the
+# group-iot ds socket. The daemon just reads /run/iot/data_store.sock.
+
+Restart=on-failure
+RestartSec=10s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-can0-up.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-can0-up.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Bring up the SocketCAN interface (can0) for OBD-II
+Documentation=file:///usr/local/share/doc/iot/tdd-vehicle-telemetry.md
+After=network-pre.target
+Before=iot-vehicled.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+# Bring can0 up at the ISO 15765-4 bitrate (500 kbps; some vehicles use 250k —
+# adjust per fleet). The leading "-" makes systemd ignore failure, so a board
+# with no CAN controller (or a different `ip` path) does not fault the boot;
+# iot-vehicled then reports vehicle.link=down until the bus is present.
+ExecStart=-/sbin/ip link set can0 up type can bitrate 500000
+ExecStop=-/sbin/ip link set can0 down
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vehicled.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vehicled.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=IoT vehicle telemetry (CAN/OBD-II ISO 15765-4 → ds vehicle.*)
+Documentation=file:///usr/local/share/doc/iot/tdd-vehicle-telemetry.md
+# Needs ds-server up (publishes vehicle.* on connect) and can0 brought up first.
+After=network-online.target iot-ds.service iot-can0-up.service
+Wants=iot-ds.service iot-can0-up.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/iot-vehicled
+
+# SocketCAN is a netdev (no /dev node), so the daemon needs CAP_NET_RAW to open
+# the PF_CAN socket — but nothing else.
+AmbientCapabilities=CAP_NET_RAW
+CapabilityBoundingSet=CAP_NET_RAW
+
+# /run/iot is owned solely by tmpfiles.d (iot.conf, 2775 root:iot) — do NOT use
+# RuntimeDirectory=iot: it resets /run/iot on start/stop, clobbering the
+# group-iot ds socket. The daemon just reads /run/iot/data_store.sock.
+
+Restart=on-failure
+RestartSec=10s
+
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -36,6 +36,8 @@ SRC_URI = "\
     file://iot-net-router.service \
     file://iot-sensord.service \
     file://iot-cellular-client.service \
+    file://iot-vehicled.service \
+    file://iot-can0-up.service \
     file://10-iot-wired.network \
     file://iot-wifi-client.service \
     file://iot-httpd.service \
@@ -304,6 +306,11 @@ do_install() {
         # auto-enabled — needs the WP module + serial ports, so an operator
         # enables it on cellular-equipped units.
         install -m 0644 ${WORKDIR}/iot-cellular-client.service ${D}${systemd_system_unitdir}/
+        # iot-vehicled + iot-can0-up: CAN/OBD-II telemetry producer. NOT
+        # auto-enabled — needs a CAN controller, so an operator enables it on
+        # vehicle/CAN-equipped units. iot-vehicled Wants= iot-can0-up (brings up can0).
+        install -m 0644 ${WORKDIR}/iot-vehicled.service        ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-can0-up.service         ${D}${systemd_system_unitdir}/
         # networkd wired profile: RequiredForOnline=no so a cable-less eth0 does
         # not pin the system "offline" and park systemd-timesyncd on a WiFi-only
         # unit (no-RTC clock would stay stale → TLS/VPN fails). See the file header.
@@ -553,8 +560,16 @@ RDEPENDS:${PN}-cellular = "ace-tao"
 # ${PN}-config (${sysconfdir}/iot). systemd unit + can0 bring-up land in a
 # follow-up PR; for now the binary ships and is run manually / on demand.
 # See apps/docs/tdd-vehicle-telemetry.md.
-FILES:${PN}-vehicle = "${bindir}/iot-vehicled"
+FILES:${PN}-vehicle = "\
+    ${bindir}/iot-vehicled \
+    ${systemd_system_unitdir}/iot-vehicled.service \
+    ${systemd_system_unitdir}/iot-can0-up.service \
+"
 RDEPENDS:${PN}-vehicle = "ace-tao"
+RRECOMMENDS:${PN}-vehicle = "\
+    ${PN}-ds-server \
+    ${PN}-config \
+"
 # A real data path also wants a modem manager + tools on the image; left to the
 # integrator per WP firmware (ModemManager / libqmi / usb-modeswitch).
 RRECOMMENDS:${PN}-cellular = "\
@@ -612,6 +627,11 @@ SYSTEMD_AUTO_ENABLE:${PN}-sensord = "disable"
 # cellular-equipped hardware.
 SYSTEMD_SERVICE:${PN}-cellular = "iot-cellular-client.service"
 SYSTEMD_AUTO_ENABLE:${PN}-cellular = "disable"
+# vehicle (iot-vehicled + can0 bring-up) registered but NOT auto-enabled: needs a
+# CAN controller, so it would Restart-loop on a board without one. Operator
+# enables it on vehicle/CAN-equipped hardware (Wants= pulls in iot-can0-up).
+SYSTEMD_SERVICE:${PN}-vehicle = "iot-vehicled.service iot-can0-up.service"
+SYSTEMD_AUTO_ENABLE:${PN}-vehicle = "disable"
 
 # ds-server and wifi-client auto-start. wifi-client comes up on every boot
 # and reads wifi.networks from the data-store (schema default seeds a


### PR DESCRIPTION
Makes `iot-vehicled` deployable. `iot-vehicled.service` (CAP_NET_RAW, ds+can0 ordering, no RuntimeDirectory=iot) + `iot-can0-up.service` oneshot (`ip link set can0 up type can bitrate 500000`, '-' tolerates no-CAN boards). Recipe packages both into `${PN}-vehicle`, registered but AUTO_ENABLE=disable (operator enables on CAN hardware, like cellular/sensord). Mirrors the cellular unit/recipe wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)