### PR TITLE
feat(vehicle): PR-6 — iot-mqttd MQTT mirror + fix Yocto unit paths

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -153,6 +153,13 @@ set(VEHICLE_BUILD_DAEMON ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/vehicle
                  ${CMAKE_BINARY_DIR}/vehicle)
 
+# mqtt module (iot-mqttd MQTT mirror). Daemon OFF by default here — only the
+# device Yocto build enables it (-DMQTT_BUILD_DAEMON=ON in the recipe), since the
+# cloud Docker builder has no libmosquitto. This add_subdirectory just exposes
+# the option + installs the mqtt.lua schema. See modules/mqtt + Phase 3 of the TDD.
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/mqtt
+                 ${CMAKE_BINARY_DIR}/iotmqtt)
+
 include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../modules/data-store/inc)
 
 link_directories(${CMAKE_CURRENT_SOURCE_DIR}/3rdparty/tinydtls)
@@ -272,6 +279,7 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-cellular-client.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-vehicled.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-can0-up.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-mqttd.service
             DESTINATION lib/systemd/system)
 
     # tmpfiles.d fallback for hosts where RuntimeDirectory= doesn't

--- a/modules/mqtt/CMakeLists.txt
+++ b/modules/mqtt/CMakeLists.txt
@@ -1,0 +1,43 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(iotmqtt CXX)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# OFF by default: only the device (Yocto) build enables this (it has
+# libmosquitto from meta-networking). The cloud Docker builder has no
+# libmosquitto, so apps/CMakeLists must NOT force this ON — the recipe passes
+# -DMQTT_BUILD_DAEMON=ON. A plain add_subdirectory just installs the schema.
+option(MQTT_BUILD_DAEMON "Build the iot-mqttd MQTT mirror daemon" OFF)
+
+include(GNUInstallDirs)
+if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+    install(FILES schemas/mqtt.lua
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+endif()
+
+if(MQTT_BUILD_DAEMON)
+    if(NOT DEFINED ACE_ROOT)
+        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
+    endif()
+    if(NOT TARGET datastore_client)
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../data-store
+                         ${CMAKE_BINARY_DIR}/data-store)
+    endif()
+
+    add_executable(iot-mqttd
+        daemon/main.cpp
+        daemon/mqtt_mirror.cpp)
+    target_include_directories(iot-mqttd PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/daemon
+        ${CMAKE_CURRENT_SOURCE_DIR}/../data-store/inc
+        ${ACE_ROOT}/include)
+    target_link_directories(iot-mqttd PRIVATE ${ACE_ROOT}/lib)
+    # libmosquitto (meta-networking) provides -lmosquitto.
+    target_link_libraries(iot-mqttd PRIVATE
+        datastore_client ACE mosquitto pthread)
+
+    if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+        install(TARGETS iot-mqttd RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
+endif()

--- a/modules/mqtt/daemon/main.cpp
+++ b/modules/mqtt/daemon/main.cpp
@@ -1,0 +1,54 @@
+/// iot-mqttd — mirror device telemetry to an operator-owned MQTT broker.
+///
+/// Reactor-driven (ACE): an ACE timer drives libmosquitto's network loop, and a
+/// second timer publishes vehicle.* to `<iot.serial>/<mqtt.topic.suffix>`. A
+/// SEPARATE, VPN-independent plane (device → broker over the WAN). Parks until
+/// mqtt.broker.host is configured. See apps/docs/tdd-vehicle-telemetry.md.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "mqtt_mirror.hpp"
+
+namespace {
+
+void usage() {
+    std::cout <<
+        "iot-mqttd — MQTT telemetry mirror\n"
+        "\n"
+        "Usage: iot-mqttd [--ds-sock=PATH] [--interval=MS] [--help]\n"
+        "\n"
+        "  --ds-sock=PATH   ds-server unix socket (default: ds built-in).\n"
+        "  --interval=MS    telemetry publish cadence (default 1000).\n"
+        "  --help           show this and exit.\n"
+        "\n"
+        "Broker host/port/creds + topic + mirror toggle come from mqtt.* in ds\n"
+        "(set via the device-ui). The daemon parks until mqtt.broker.host is set.\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    mqtt::MqttMirror::Config cfg;
+    try {
+        for (int i = 1; i < argc; ++i) {
+            std::string a = argv[i];
+            if      (a.rfind("--ds-sock=", 0)  == 0) cfg.ds_sock = a.substr(10);
+            else if (a.rfind("--interval=", 0) == 0) cfg.publish_ms = static_cast<unsigned>(std::stoul(a.substr(11)));
+            else if (a == "--help" || a == "-h")     { usage(); return 0; }
+            else {
+                std::cerr << "iot-mqttd: unknown argument '" << a << "'\n";
+                usage();
+                return 2;
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "iot-mqttd: bad argument: " << e.what() << "\n";
+        return 2;
+    }
+    if (cfg.publish_ms == 0) cfg.publish_ms = 1000;
+
+    mqtt::MqttMirror client(std::move(cfg));
+    return client.run();
+}

--- a/modules/mqtt/daemon/mqtt_mirror.cpp
+++ b/modules/mqtt/daemon/mqtt_mirror.cpp
@@ -1,0 +1,169 @@
+#include "mqtt_mirror.hpp"
+
+#include <cstring>
+#include <string>
+#include <vector>
+
+#include <mosquitto.h>
+
+#include <ace/Log_Msg.h>
+#include <ace/Reactor.h>
+#include <ace/Time_Value.h>
+
+#include "data_store/value.hpp"
+
+namespace mqtt {
+
+namespace {
+const void* const kLoopAct = reinterpret_cast<const void*>(1);  // mosquitto_loop
+const void* const kPubAct  = reinterpret_cast<const void*>(2);  // publish telemetry
+
+// vehicle.* keys mirrored to the broker. "vehicle." (8 chars) is stripped for
+// the JSON field name; vehicle.dtc is already a JSON array (embedded raw).
+const char* const kVehicleKeys[] = {
+    "vehicle.link", "vehicle.speed", "vehicle.rpm", "vehicle.coolant",
+    "vehicle.throttle", "vehicle.load", "vehicle.fuel", "vehicle.iat",
+    "vehicle.maf", "vehicle.dtc",
+};
+} // namespace
+
+MqttMirror::~MqttMirror() {
+    if (m_mosq) {
+        mosquitto_disconnect(m_mosq);
+        mosquitto_destroy(m_mosq);
+    }
+    mosquitto_lib_cleanup();
+}
+
+std::string MqttMirror::read_key(const char* key) {
+    std::vector<data_store::Client::GetResult> got;
+    if (m_ds.get({std::string(key)}, got).ok && !got.empty() && got[0].has_value)
+        if (auto s = data_store::to_string(got[0].value)) return *s;
+    return std::string();
+}
+
+void MqttMirror::reload_config() {
+    m_host = read_key("mqtt.broker.host");
+    std::vector<data_store::Client::GetResult> got;
+    if (m_ds.get({std::string("mqtt.broker.port")}, got).ok && !got.empty() && got[0].has_value)
+        if (auto n = data_store::to_int32(got[0].value)) m_port = *n;
+    if (m_port <= 0) m_port = 1883;
+    got.clear();
+    if (m_ds.get({std::string("mqtt.qos")}, got).ok && !got.empty() && got[0].has_value)
+        if (auto n = data_store::to_int32(got[0].value)) m_qos = *n;
+    got.clear();
+    if (m_ds.get({std::string("mqtt.mirror.enable")}, got).ok && !got.empty() && got[0].has_value)
+        if (auto b = data_store::to_bool(got[0].value)) m_mirror = *b;
+
+    std::string serial = read_key("iot.serial");
+    std::string suffix = read_key("mqtt.topic.suffix");
+    if (suffix.empty()) suffix = "telemetry";
+    if (serial.empty()) serial = "device";
+    m_topic = serial + "/" + suffix;
+}
+
+void MqttMirror::ensure_connected() {
+    if (m_connected) return;
+    reload_config();
+    if (m_host.empty()) return;   // unconfigured → stay parked (effectively off)
+
+    if (!m_mosq) {
+        std::string cid = read_key("mqtt.client.id");
+        m_mosq = mosquitto_new(cid.empty() ? nullptr : cid.c_str(), true, this);
+        if (!m_mosq) {
+            ACE_ERROR((LM_ERROR, ACE_TEXT("%D [mqtt] mosquitto_new failed\n")));
+            return;
+        }
+        std::string user = read_key("mqtt.broker.user");
+        std::string pass = read_key("mqtt.broker.pass");
+        if (!user.empty())
+            mosquitto_username_pw_set(m_mosq, user.c_str(),
+                                      pass.empty() ? nullptr : pass.c_str());
+    }
+
+    int rc = mosquitto_connect(m_mosq, m_host.c_str(), m_port, 60);
+    if (rc == MOSQ_ERR_SUCCESS) {
+        m_connected = true;
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [mqtt] connected %C:%d topic=%C\n"),
+                   m_host.c_str(), m_port, m_topic.c_str()));
+    } else {
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D [mqtt] connect %C:%d failed rc=%d (retry)\n"),
+                   m_host.c_str(), m_port, rc));
+    }
+}
+
+void MqttMirror::publish_telemetry() {
+    if (!m_connected || !m_mosq) return;
+    // Re-read the mirror toggle live so an operator flip applies without restart.
+    std::vector<data_store::Client::GetResult> g;
+    if (m_ds.get({std::string("mqtt.mirror.enable")}, g).ok && !g.empty() && g[0].has_value)
+        if (auto b = data_store::to_bool(g[0].value)) m_mirror = *b;
+    if (!m_mirror) return;
+
+    std::string json = "{";
+    bool first = true;
+    for (const char* k : kVehicleKeys) {
+        std::string v = read_key(k);
+        if (v.empty()) continue;
+        if (!first) json += ",";
+        first = false;
+        const char* field = k + 8;          // strip "vehicle."
+        json += "\"";
+        json += field;
+        json += "\":";
+        if (std::strcmp(field, "dtc") == 0) {
+            json += v;                        // already a JSON array
+        } else {
+            json += "\"";
+            json += v;
+            json += "\"";
+        }
+    }
+    json += "}";
+
+    mosquitto_publish(m_mosq, nullptr, m_topic.c_str(),
+                      static_cast<int>(json.size()), json.data(), m_qos, true /*retain*/);
+}
+
+int MqttMirror::handle_timeout(const ACE_Time_Value&, const void* act) {
+    if (act == kLoopAct) {
+        if (m_mosq && m_connected) {
+            int rc = mosquitto_loop(m_mosq, 0, 1);
+            if (rc != MOSQ_ERR_SUCCESS) {
+                if (mosquitto_reconnect(m_mosq) != MOSQ_ERR_SUCCESS) m_connected = false;
+            }
+        } else {
+            // Parked / disconnected: retry every ~5 s (not every 100 ms tick),
+            // so an unconfigured device doesn't hammer ds.
+            if (++m_loop_ticks % 50 == 0) ensure_connected();
+        }
+    } else if (act == kPubAct) {
+        publish_telemetry();
+    }
+    return 0;
+}
+
+int MqttMirror::run() {
+    if (!m_ds.connect(m_cfg.ds_sock).ok) {
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%D [mqtt] ds connect failed\n")), 1);
+    }
+    mosquitto_lib_init();
+    reload_config();
+
+    // Loop timer (100 ms): drives mosquitto network read/write + reconnect.
+    ACE_Reactor::instance()->schedule_timer(this, kLoopAct,
+        ACE_Time_Value(1), ACE_Time_Value(0, 100 * 1000));
+    // Publish timer: mirror vehicle.* to the broker at the configured cadence.
+    ACE_Time_Value pub(m_cfg.publish_ms / 1000, (m_cfg.publish_ms % 1000) * 1000);
+    ACE_Reactor::instance()->schedule_timer(this, kPubAct, ACE_Time_Value(2), pub);
+
+    ACE_DEBUG((LM_INFO,
+        ACE_TEXT("%D [mqtt] up: broker=%C:%d topic=%C (parks until host set)\n"),
+        m_host.empty() ? "(unset)" : m_host.c_str(), m_port, m_topic.c_str()));
+
+    ACE_Reactor::instance()->run_reactor_event_loop();
+    return 0;
+}
+
+} // namespace mqtt

--- a/modules/mqtt/daemon/mqtt_mirror.hpp
+++ b/modules/mqtt/daemon/mqtt_mirror.hpp
@@ -1,0 +1,62 @@
+#ifndef __mqtt_mirror_hpp__
+#define __mqtt_mirror_hpp__
+
+#include <cstdint>
+#include <string>
+
+#include <ace/Event_Handler.h>
+
+#include "data_store/client.hpp"
+
+struct mosquitto;  // libmosquitto opaque handle (fwd-decl)
+
+/// iot-mqttd — mirror device telemetry to an operator-owned MQTT broker.
+///
+/// A SEPARATE, VPN-independent plane: device → broker over the WAN (NOT the
+/// cloud LwM2M pipeline, NOT the tunnel). Reactor-driven: an ACE timer drives
+/// `mosquitto_loop()` (read/write/keepalive/reconnect in one call — simpler and
+/// more robust than fd-reactor integration across reconnects), and a second
+/// timer reads vehicle.* from ds, builds a JSON payload, and publishes it to
+/// `<iot.serial>/<mqtt.topic.suffix>`. The daemon parks (no connection) until
+/// mqtt.broker.host is configured, so it is effectively off by default.
+
+namespace mqtt {
+
+class MqttMirror : public ACE_Event_Handler {
+    public:
+        struct Config {
+            std::string ds_sock;            ///< "" → ds default socket
+            unsigned    publish_ms = 1000;  ///< telemetry publish cadence
+        };
+
+        explicit MqttMirror(Config cfg) : m_cfg(std::move(cfg)) {}
+        ~MqttMirror() override;
+
+        /// Connect ds, init libmosquitto, run the reactor. Process exit code.
+        int run();
+
+        /// Two timers, distinguished by `act`: kLoopAct drives mosquitto_loop,
+        /// kPubAct drives the telemetry publish.
+        int handle_timeout(const ACE_Time_Value&, const void* act) override;
+
+    private:
+        std::string read_key(const char* key);
+        void        reload_config();        ///< re-read mqtt.* (host/creds/topic)
+        void        ensure_connected();
+        void        publish_telemetry();
+
+        Config             m_cfg;
+        data_store::Client m_ds;
+        struct mosquitto*  m_mosq = nullptr;
+        bool               m_connected = false;
+        std::string        m_host;
+        int                m_port = 1883;
+        std::string        m_topic;          ///< <serial>/<suffix>
+        bool               m_mirror = false;
+        int                m_qos = 0;
+        unsigned           m_loop_ticks = 0; ///< paces reconnect attempts while parked
+};
+
+} // namespace mqtt
+
+#endif /*__mqtt_mirror_hpp__*/

--- a/modules/mqtt/schemas/mqtt.lua
+++ b/modules/mqtt/schemas/mqtt.lua
@@ -1,0 +1,28 @@
+-- mqtt.* schema for the iot-mqttd mirror daemon — publishes vehicle.* (and
+-- future telemetry) to an operator-owned MQTT broker. See
+-- apps/docs/tdd-vehicle-telemetry.md (Phase 3). This is a SEPARATE,
+-- VPN-independent plane (device → broker over the WAN), not the cloud pipeline.
+--
+-- Read keys (operator → daemon). The daemon parks (no broker connection) while
+-- mqtt.broker.host is empty, and connects as soon as it is set + saved, so it is
+-- effectively disabled by default until configured. mqtt.mirror.enable gates
+-- whether telemetry is actually published once connected.
+--   mqtt.broker.host    - broker hostname/IP (empty → daemon parks)
+--   mqtt.broker.port    - broker port (default 1883; 8883 for TLS)
+--   mqtt.broker.user    - username (optional)
+--   mqtt.broker.pass    - password (optional, write-only)
+--   mqtt.client.id      - MQTT client id (empty → derived from iot.serial)
+--   mqtt.mirror.enable  - publish vehicle telemetry when true (default false)
+--   mqtt.topic.suffix   - topic = "<iot.serial>/<suffix>" (default "telemetry")
+--   mqtt.qos            - publish QoS 0/1/2 (default 0)
+return {
+    ["mqtt.broker.host"]   = { access = "Admin", type = "string",  default = "" },
+    ["mqtt.broker.port"]   = { access = "Admin", type = "integer", default = 1883 },
+    ["mqtt.broker.user"]   = { access = "Admin", type = "string",  default = "" },
+    ["mqtt.broker.pass"]   = { access = "Admin", type = "string",  default = "",
+                               write_acl = {"gid:engineer"}, read_acl = {"gid:engineer"} },
+    ["mqtt.client.id"]     = { access = "Admin", type = "string",  default = "" },
+    ["mqtt.mirror.enable"] = { access = "Admin", type = "boolean", default = false },
+    ["mqtt.topic.suffix"]  = { access = "Admin", type = "string",  default = "telemetry" },
+    ["mqtt.qos"]           = { access = "Admin", type = "integer", default = 0 },
+}

--- a/packaging/systemd/iot-mqttd.service
+++ b/packaging/systemd/iot-mqttd.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=IoT MQTT mirror (vehicle.* → operator MQTT broker)
+Documentation=file:///usr/local/share/doc/iot/tdd-vehicle-telemetry.md
+# Network + ds only. VPN-independent (device → broker over the WAN).
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/iot-mqttd
+# No special privileges. The daemon parks (no connection) until mqtt.broker.host
+# is configured, so enabling it on every device is harmless until set up.
+Restart=on-failure
+RestartSec=10s
+StandardOutput=journal
+StandardError=journal
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-mqttd.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-mqttd.service
@@ -1,0 +1,26 @@
+[Unit]
+Description=IoT MQTT mirror (vehicle.* → operator MQTT broker)
+Documentation=file:///usr/local/share/doc/iot/tdd-vehicle-telemetry.md
+# Network + ds only. VPN-independent (device → broker over the WAN).
+After=network-online.target iot-ds.service
+Wants=network-online.target iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/iot-mqttd
+# No special privileges. The daemon parks (no connection) until mqtt.broker.host
+# is configured, so enabling it on every device is harmless until set up.
+Restart=on-failure
+RestartSec=10s
+StandardOutput=journal
+StandardError=journal
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vehicled.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-vehicled.service
@@ -9,7 +9,7 @@ StartLimitIntervalSec=60s
 
 [Service]
 Type=simple
-ExecStart=/usr/local/bin/iot-vehicled
+ExecStart=/usr/bin/iot-vehicled
 
 # SocketCAN is a netdev (no /dev node), so the daemon needs CAP_NET_RAW to open
 # the PF_CAN socket — but nothing else.

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -38,6 +38,7 @@ SRC_URI = "\
     file://iot-cellular-client.service \
     file://iot-vehicled.service \
     file://iot-can0-up.service \
+    file://iot-mqttd.service \
     file://10-iot-wired.network \
     file://iot-wifi-client.service \
     file://iot-httpd.service \
@@ -109,6 +110,7 @@ DEPENDS = "\
     readline \
     nlohmann-json \
     nodejs-native \
+    mosquitto \
 "
 
 # ── PACKAGECONFIG ──────────────────────────────────────────────────
@@ -212,6 +214,7 @@ EXTRA_OECMAKE = "\
     -DACE_LIBRARY=${STAGING_LIBDIR}/libACE.so \
     -DBSONCXX_LIBRARY=${STAGING_LIBDIR}/libbsoncxx.so \
     -DMONGOCXX_LIBRARY=${STAGING_LIBDIR}/libmongocxx.so \
+    -DMQTT_BUILD_DAEMON=ON \
     -DCMAKE_INSTALL_PREFIX=/usr \
 "
 
@@ -311,6 +314,9 @@ do_install() {
         # vehicle/CAN-equipped units. iot-vehicled Wants= iot-can0-up (brings up can0).
         install -m 0644 ${WORKDIR}/iot-vehicled.service        ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-can0-up.service         ${D}${systemd_system_unitdir}/
+        # iot-mqttd: MQTT telemetry mirror. Enabled by default but parks until a
+        # broker is configured (mqtt.broker.host), so it is harmless when unused.
+        install -m 0644 ${WORKDIR}/iot-mqttd.service           ${D}${systemd_system_unitdir}/
         # networkd wired profile: RequiredForOnline=no so a cable-less eth0 does
         # not pin the system "offline" and park systemd-timesyncd on a WiFi-only
         # unit (no-RTC clock would stay stale → TLS/VPN fails). See the file header.
@@ -391,6 +397,7 @@ PACKAGE_BEFORE_PN = "\
     ${PN}-sensord \
     ${PN}-cellular \
     ${PN}-vehicle \
+    ${PN}-mqtt \
     ${PN}-config \
     ${PN}-bcm2837-selftest \
 "
@@ -570,6 +577,19 @@ RRECOMMENDS:${PN}-vehicle = "\
     ${PN}-ds-server \
     ${PN}-config \
 "
+
+# mqtt — iot-mqttd telemetry mirror to an operator MQTT broker (libmosquitto).
+# Enabled by default; parks until mqtt.broker.host is configured. mqtt.lua
+# schema ships in ${PN}-config.
+FILES:${PN}-mqtt = "\
+    ${bindir}/iot-mqttd \
+    ${systemd_system_unitdir}/iot-mqttd.service \
+"
+RDEPENDS:${PN}-mqtt = "ace-tao mosquitto"
+RRECOMMENDS:${PN}-mqtt = "\
+    ${PN}-ds-server \
+    ${PN}-config \
+"
 # A real data path also wants a modem manager + tools on the image; left to the
 # integrator per WP firmware (ModemManager / libqmi / usb-modeswitch).
 RRECOMMENDS:${PN}-cellular = "\
@@ -632,6 +652,9 @@ SYSTEMD_AUTO_ENABLE:${PN}-cellular = "disable"
 # enables it on vehicle/CAN-equipped hardware (Wants= pulls in iot-can0-up).
 SYSTEMD_SERVICE:${PN}-vehicle = "iot-vehicled.service iot-can0-up.service"
 SYSTEMD_AUTO_ENABLE:${PN}-vehicle = "disable"
+# mqtt mirror enabled by default — it parks (no broker connection) until
+# mqtt.broker.host is configured, so it is a no-op until the operator sets it up.
+SYSTEMD_SERVICE:${PN}-mqtt = "iot-mqttd.service"
 
 # ds-server and wifi-client auto-start. wifi-client comes up on every boot
 # and reads wifi.networks from the data-store (schema default seeds a


### PR DESCRIPTION
New `iot-mqttd` daemon (modules/mqtt): mirrors `vehicle.*` to an operator MQTT broker over the WAN (VPN-independent). ACE-timer-driven `mosquitto_loop` (robust reconnect), publishes one JSON object to `<serial>/<suffix>` (retain), parks until `mqtt.broker.host` set. Build-gated so only the device Yocto build links libmosquitto (cloud builder has none): `MQTT_BUILD_DAEMON` OFF in apps/CMakeLists, recipe passes `-DMQTT_BUILD_DAEMON=ON` + `DEPENDS mosquitto` + `${PN}-mqtt` package.

Also fixes a latent path bug: Yocto `iot-vehicled.service` (PR-2b) + new `iot-mqttd.service` used `/usr/local/bin` but the Yocto prefix is `/usr` → corrected to `/usr/bin` (matches httpd/lwm2m/cellular units).

🤖 Generated with [Claude Code](https://claude.com/claude-code)