### PR TITLE
feat(vehicle): PR-6b — device-ui MQTT config page

### DIFF
--- a/iot-ui/src/app/app.module.ts
+++ b/iot-ui/src/app/app.module.ts
@@ -25,6 +25,7 @@ import { CellularConfigComponent } from './wan/cellular-config/cellular-config.c
 import { SensorsStatusComponent } from './sensors/sensors-status/sensors-status.component';
 import { GpsStatusComponent } from './sensors/gps-status/gps-status.component';
 import { VehicleStatusComponent } from './vehicle/vehicle-status.component';
+import { MqttConfigComponent } from './mqtt/mqtt-config.component';
 
 import { RoutingSubmenuComponent } from './routing/routing-submenu/routing-submenu.component';
 import { PortForwardComponent } from './routing/port-forward/port-forward.component';
@@ -58,7 +59,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     VpnSubmenuComponent, VpnConfigComponent, VpnStatusComponent,
     WanSubmenuComponent, WifiConfigComponent, WifiScanComponent, IfacePriorityComponent,
     CellularStatusComponent, CellularConfigComponent, SensorsStatusComponent, GpsStatusComponent,
-    VehicleStatusComponent,
+    VehicleStatusComponent, MqttConfigComponent,
     RoutingSubmenuComponent, PortForwardComponent, CustomRulesComponent,
     Lwm2mSubmenuComponent, Lwm2mConfigComponent,
     ServicesSubmenuComponent, ServicesListComponent,

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -113,6 +113,11 @@
         <app-vehicle-status></app-vehicle-status>
       </ng-container>
 
+      <!-- MQTT mirror -->
+      <ng-container *ngIf="selectedMenu==='mqtt'">
+        <app-mqtt-config></app-mqtt-config>
+      </ng-container>
+
       <!-- Routing -->
       <ng-container *ngIf="selectedMenu==='routing'">
         <app-port-forward [view]="selectedSubNav==='dnat' ? 'dnat' : 'ports'" *ngIf="!selectedSubNav || selectedSubNav==='ports' || selectedSubNav==='dnat'"></app-port-forward>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -34,6 +34,7 @@ export class MainComponent {
     { id: 'sensors',   label: 'Sensors',   svg: 'assets/icons/sensor.svg',
       children: [{id:'env',label:'Sensors'},{id:'gps',label:'Location (GPS)'}] },
     { id: 'vehicle',   label: 'Vehicle',   svg: 'assets/icons/sensor.svg', children: [] as {id:string,label:string}[] },
+    { id: 'mqtt',      label: 'MQTT',      svg: 'assets/icons/services.svg', children: [] as {id:string,label:string}[] },
     { id: 'routing',   label: 'Routing',   svg: 'assets/icons/routing.svg',
       children: [{id:'ports',label:'Port Forward'},{id:'dnat',label:'DNAT Target'},{id:'rules',label:'Firewall Rules'}] },
     { id: 'lwm2m',     label: 'LwM2M',     svg: 'assets/icons/lwm2m.svg',

--- a/iot-ui/src/app/mqtt/mqtt-config.component.ts
+++ b/iot-ui/src/app/mqtt/mqtt-config.component.ts
@@ -1,0 +1,113 @@
+import { Component, OnInit } from '@angular/core';
+import { FormBuilder, FormGroup } from '@angular/forms';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+import { ToastService } from '../../common/toast.service';
+
+/// MQTT mirror config — broker + topic + "mirror telemetry" toggle, written to
+/// mqtt.* (read by the iot-mqttd daemon). A SEPARATE, VPN-independent plane
+/// (device → broker over the WAN). The password is write-only: blank on save
+/// keeps the stored value.
+@Component({
+  selector: 'app-mqtt-config',
+  template: `
+    <div class="page">
+      <h3>MQTT Mirror</h3>
+      <p class="hint">
+        Publish vehicle telemetry to your own MQTT broker. Topic:
+        <code>&lt;serial&gt;/{{ form.value.suffix || 'telemetry' }}</code>. The
+        client stays parked until a broker host is set.
+      </p>
+      <form [formGroup]="form" (ngSubmit)="save()">
+        <div class="form-grid">
+          <clr-input-container>
+            <label>Broker Host</label>
+            <input clrInput formControlName="host" [disabled]="!isAdmin" placeholder="mqtt.example.com" />
+          </clr-input-container>
+          <clr-input-container>
+            <label>Port</label>
+            <input clrInput type="number" formControlName="port" [disabled]="!isAdmin" />
+          </clr-input-container>
+          <clr-input-container>
+            <label>Username</label>
+            <input clrInput formControlName="user" [disabled]="!isAdmin" placeholder="(optional)" />
+          </clr-input-container>
+          <clr-input-container>
+            <label>Password</label>
+            <input clrInput type="password" formControlName="pass" [disabled]="!isAdmin"
+                   autocomplete="new-password" placeholder="(unchanged)" />
+          </clr-input-container>
+          <clr-input-container>
+            <label>Topic Suffix</label>
+            <input clrInput formControlName="suffix" [disabled]="!isAdmin" placeholder="telemetry" />
+          </clr-input-container>
+        </div>
+        <clr-checkbox-container>
+          <clr-checkbox-wrapper>
+            <input type="checkbox" clrCheckbox formControlName="mirror" [disabled]="!isAdmin" />
+            <label>Mirror vehicle telemetry to the broker</label>
+          </clr-checkbox-wrapper>
+        </clr-checkbox-container>
+        <div style="margin-top:16px;" *ngIf="isAdmin">
+          <button type="submit" class="btn btn-primary" [disabled]="saving">
+            {{ saving ? 'Saving…' : 'Save' }}
+          </button>
+        </div>
+      </form>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; }
+    h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 12px 0; }
+    .hint { color: #888; font-size: 13px; margin: 0 0 16px 0; }
+  `]
+})
+export class MqttConfigComponent implements OnInit {
+  form: FormGroup;
+  saving = false;
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpsvcService, fb: FormBuilder,
+              private session: SessionService, private toast: ToastService) {
+    this.form = fb.group({
+      host: [''], port: [1883], user: [''], pass: [''], suffix: ['telemetry'], mirror: [false],
+    });
+  }
+
+  ngOnInit(): void {
+    this.http.dbGet(['mqtt.broker.host', 'mqtt.broker.port', 'mqtt.broker.user',
+                     'mqtt.topic.suffix', 'mqtt.mirror.enable'])
+      .subscribe(r => {
+        if (!r.ok || !r.data) return;
+        const d = r.data;
+        this.form.patchValue({
+          host:   (d['mqtt.broker.host'] as string) || '',
+          port:   (d['mqtt.broker.port'] as number) || 1883,
+          user:   (d['mqtt.broker.user'] as string) || '',
+          suffix: (d['mqtt.topic.suffix'] as string) || 'telemetry',
+          mirror: d['mqtt.mirror.enable'] === true,
+        });
+      });
+  }
+
+  save(): void {
+    if (!this.isAdmin) return;
+    const v = this.form.value;
+    const pairs: { key: string; value: unknown }[] = [
+      { key: 'mqtt.broker.host',   value: v.host || '' },
+      { key: 'mqtt.broker.port',   value: Number(v.port) || 1883 },
+      { key: 'mqtt.broker.user',   value: v.user || '' },
+      { key: 'mqtt.topic.suffix',  value: v.suffix || 'telemetry' },
+      { key: 'mqtt.mirror.enable', value: !!v.mirror },
+    ];
+    if (v.pass) pairs.push({ key: 'mqtt.broker.pass', value: v.pass });  // only when entered
+    this.saving = true;
+    this.http.dbSet(pairs).subscribe({
+      next: (r) => {
+        this.saving = false;
+        if (r.ok) this.toast.success('MQTT settings saved'); else this.toast.error(r.err || 'Save failed');
+      },
+      error: () => { this.saving = false; this.toast.error('Save failed'); }
+    });
+  }
+}


### PR DESCRIPTION
Broker + topic + 'mirror telemetry' toggle → `mqtt.*` (read by iot-mqttd). Mirrors the config-form pattern (FormGroup + dbGet/dbSet), write-only password. Registered in app.module + 'MQTT' nav + render. No new deps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)