### PR TITLE
feat(vehicle): PR-4 — cloud-ui Fleet Map (Leaflet, self-hosted tiles)

### DIFF
--- a/apps/cloud/ui/angular.json
+++ b/apps/cloud/ui/angular.json
@@ -21,6 +21,7 @@
             "styles": [
               "node_modules/@clr/ui/clr-ui.min.css",
               "node_modules/@clr/icons/clr-icons.min.css",
+              "node_modules/leaflet/dist/leaflet.css",
               "src/styles.scss"
             ],
             "scripts": [

--- a/apps/cloud/ui/package.json
+++ b/apps/cloud/ui/package.json
@@ -26,6 +26,7 @@
     "@clr/ui": "^13.8.0",
     "@webcomponents/custom-elements": "^1.0.0",
     "@webcomponents/webcomponentsjs": "^2.6.0",
+    "leaflet": "^1.9.4",
     "rxjs": "~7.5.0",
     "tslib": "^2.3.0",
     "zone.js": "~0.11.4"
@@ -35,6 +36,7 @@
     "@angular/cli": "^14.1.0",
     "@angular/compiler-cli": "^14.1.0",
     "@types/jasmine": "~4.0.0",
+    "@types/leaflet": "^1.9.0",
     "jasmine-core": "~4.3.0",
     "karma": "~6.4.0",
     "karma-chrome-launcher": "~3.1.0",

--- a/apps/cloud/ui/src/app/app.module.ts
+++ b/apps/cloud/ui/src/app/app.module.ts
@@ -11,6 +11,7 @@ import { MainComponent } from './main/main.component';
 import { LoginComponent } from './login/login.component';
 import { DashboardComponent } from './dashboard/dashboard.component';
 import { EndpointListComponent } from './endpoint-list/endpoint-list.component';
+import { MapComponent } from './map/map.component';
 import { StatusBadgeComponent } from './common/status-badge/status-badge.component';
 import { ToastComponent } from './common/toast/toast.component';
 import { LogViewerComponent } from './log-level/log-viewer.component';
@@ -43,7 +44,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
 @NgModule({
   declarations: [
     AppComponent, MainComponent, LoginComponent,
-    DashboardComponent, EndpointListComponent, StatusBadgeComponent, ToastComponent, LogViewerComponent,
+    DashboardComponent, EndpointListComponent, MapComponent, StatusBadgeComponent, ToastComponent, LogViewerComponent,
     VpnSubmenuComponent, VpnConfigComponent, VpnStatusComponent,
     WanSubmenuComponent, WifiConfigComponent, WifiScanComponent, IfacePriorityComponent,
     RoutingSubmenuComponent, CustomRulesComponent, DeviceForwardingComponent,

--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -28,6 +28,7 @@
     <div class="content">
       <app-dashboard *ngIf="selectedMenu==='dashboard'"></app-dashboard>
       <app-endpoint-list *ngIf="selectedMenu==='endpoints'"></app-endpoint-list>
+      <app-map *ngIf="selectedMenu==='map'"></app-map>
 
       <!-- VPN (server-side) -->
       <ng-container *ngIf="selectedMenu==='vpn'">

--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -17,6 +17,7 @@ export class MainComponent implements OnInit {
   menus = [
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg' },
     { id: 'endpoints', label: 'Endpoints', svg: 'assets/icons/endpoints.svg' },
+    { id: 'map',       label: 'Map',       svg: 'assets/icons/endpoints.svg' },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg' },
     { id: 'http',      label: 'HTTP',      svg: 'assets/icons/http.svg' },
     { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg' },

--- a/apps/cloud/ui/src/app/map/map.component.ts
+++ b/apps/cloud/ui/src/app/map/map.component.ts
@@ -1,0 +1,94 @@
+import { Component, AfterViewInit, OnDestroy } from '@angular/core';
+import { Subscription, timer } from 'rxjs';
+import { switchMap } from 'rxjs/operators';
+import * as L from 'leaflet';
+import { HttpsvcService } from '../../common/httpsvc.service';
+
+interface Telem {
+  endpoint: string;
+  lat?: string; lon?: string;
+  speed?: string; rpm?: string; coolant?: string; link?: string;
+}
+
+/// Fleet map — plots each endpoint's latest position from cloud.vehicle.telemetry
+/// (live, polled). Client-side Leaflet (no plotting daemon); tiles come from the
+/// self-hosted tileserver (compose service). circleMarkers avoid the Leaflet
+/// default-marker-icon webpack pitfall. See §3d of the TDD.
+@Component({
+  selector: 'app-map',
+  template: `
+    <div class="page">
+      <h3>Fleet Map</h3>
+      <p class="hint" *ngIf="!count">
+        No located vehicles yet — markers appear once devices report GPS (Object 6)
+        and the telemetry pipeline populates <code>cloud.vehicle.telemetry</code>.
+      </p>
+      <div id="fleet-map" class="map"></div>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; }
+    h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 12px 0; }
+    .hint { color: #888; font-size: 13px; margin: 0 0 12px 0; }
+    .map { height: 70vh; width: 100%; border: 1px solid #ccc; border-radius: 4px; }
+  `]
+})
+export class MapComponent implements AfterViewInit, OnDestroy {
+  count = 0;
+  private map?: L.Map;
+  private markers: Record<string, L.CircleMarker> = {};
+  private sub = new Subscription();
+
+  // Self-hosted tileserver (PR-10a; default :8081). Operator-configurable per
+  // deployment / seeded style. Leaflet still shows markers on a blank grid if
+  // tiles 404, so the map is useful even before tiles are seeded.
+  private readonly tileUrl =
+    `${location.protocol}//${location.hostname}:8081/styles/basic/{z}/{x}/{y}.png`;
+
+  constructor(private http: HttpsvcService) {}
+
+  ngAfterViewInit(): void {
+    this.map = L.map('fleet-map', { center: [20, 0], zoom: 2 });
+    L.tileLayer(this.tileUrl, { maxZoom: 19, attribution: 'Self-hosted tiles' }).addTo(this.map);
+    this.sub.add(
+      timer(0, 5000).pipe(switchMap(() => this.http.dbGet(['cloud.vehicle.telemetry'])))
+        .subscribe(r => this.apply(r)));
+  }
+
+  private apply(r: { ok: boolean; data?: Record<string, unknown> }): void {
+    const map = this.map;
+    if (!r || !r.ok || !r.data || !map) return;
+    let arr: Telem[] = [];
+    try { arr = JSON.parse((r.data['cloud.vehicle.telemetry'] as string) || '[]'); }
+    catch { arr = []; }
+
+    let n = 0;
+    for (const t of arr) {
+      const lat = parseFloat(t.lat || '');
+      const lon = parseFloat(t.lon || '');
+      if (isNaN(lat) || isNaN(lon)) continue;
+      n++;
+      const popup =
+        `<b>${t.endpoint}</b><br>` +
+        `speed ${t.speed ?? '—'} km/h<br>rpm ${t.rpm ?? '—'}<br>` +
+        `coolant ${t.coolant ?? '—'} °C<br>link ${t.link ?? '—'}`;
+      const existing = this.markers[t.endpoint];
+      if (existing) {
+        existing.setLatLng([lat, lon]);
+        existing.bindPopup(popup);
+      } else {
+        this.markers[t.endpoint] =
+          L.circleMarker([lat, lon],
+            { radius: 7, color: '#0072a3', fillColor: '#0095d3', fillOpacity: 0.8 })
+            .bindPopup(popup)
+            .addTo(map);
+      }
+    }
+    this.count = n;
+  }
+
+  ngOnDestroy(): void {
+    this.sub.unsubscribe();
+    this.map?.remove();
+  }
+}


### PR DESCRIPTION
Client-side Leaflet map plotting endpoints from `cloud.vehicle.telemetry` (circleMarkers + popups), tiles from the self-hosted tileserver. Adds leaflet to package.json (npm-install fallback) + leaflet.css to angular.json + 'Map' nav. Bundle under the 5mb budget. Empty until plumbing populates the key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)