### PR TITLE
feat(vehicle): PR-18 — Services state + per-daemon log level + RAII mosquitto

### DIFF
--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -373,6 +373,17 @@ return {
       type    = "string",
       default = "",
     },
+    -- iot-vehicled (CAN/OBD-II) + iot-mqttd (MQTT mirror) per-daemon levels.
+    ["log.level.vehicle"] = {
+        access  = "Admin",
+      type    = "string",
+      default = "",
+    },
+    ["log.level.mqtt"] = {
+        access  = "Admin",
+      type    = "string",
+      default = "",
+    },
     -- Bumped by every daemon on log flush so the cloud UI can long-poll
     -- a single key instead of round-robining through all log.*.text keys.
     ["log.version"] = {
@@ -410,6 +421,16 @@ return {
       default = "",
     },
     ["log.lwm2m.dm.text"] = {
+        access  = "Viewer",
+      type    = "string",
+      default = "",
+    },
+    ["log.vehicled.text"] = {
+        access  = "Viewer",
+      type    = "string",
+      default = "",
+    },
+    ["log.mqttd.text"] = {
         access  = "Viewer",
       type    = "string",
       default = "",

--- a/modules/data-store/schemas/services.lua
+++ b/modules/data-store/schemas/services.lua
@@ -60,6 +60,19 @@ local keys = {
     ["services.lwm2m.server.state"]        = {
         access  = "Viewer", type = "string",  default = "stopped" },
 
+    -- vehicle (iot-vehicled, CAN/OBD-II) + mqtt (iot-mqttd mirror). Optional
+    -- producer daemons; enable defaults true but they park until configured
+    -- (CAN bus present / mqtt.broker.host set), so they are no-ops until set up.
+    -- The daemons self-report .state on startup.
+    ["services.vehicle.enable"]            = {
+        access  = "Admin", type = "boolean", default = true, write_acl = {"uid:0"} },
+    ["services.vehicle.state"]             = {
+        access  = "Viewer", type = "string",  default = "stopped" },
+    ["services.mqtt.enable"]               = {
+        access  = "Admin", type = "boolean", default = true, write_acl = {"uid:0"} },
+    ["services.mqtt.state"]                = {
+        access  = "Viewer", type = "string",  default = "stopped" },
+
     -- wifi-client — the WAN uplink, so NO dependency on net.router (routing
     -- layers on top of the uplink; the inverse dep deadlocked WiFi whenever
     -- net-router was down). Matches the (lack of) DepWatch in supervisor.cpp.

--- a/modules/mqtt/daemon/mqtt_mirror.cpp
+++ b/modules/mqtt/daemon/mqtt_mirror.cpp
@@ -10,9 +10,18 @@
 #include <ace/Reactor.h>
 #include <ace/Time_Value.h>
 
+#include "data_store/log_buffer.hpp"
 #include "data_store/value.hpp"
 
 namespace mqtt {
+
+// Owns the libmosquitto handle via std::unique_ptr (no raw owning pointer).
+void MosqDeleter::operator()(::mosquitto* m) const noexcept { if (m) mosquitto_destroy(m); }
+
+// Captures this daemon's ACE log output to log.mqttd.text and applies the
+// per-daemon level from log.level.mqtt (falls back to log.level). See
+// data_store::LogBuffer.
+static data_store::LogBuffer g_log("mqttd", "log.mqttd.text", "log.level.mqtt");
 
 namespace {
 const void* const kLoopAct = reinterpret_cast<const void*>(1);  // mosquitto_loop
@@ -29,8 +38,8 @@ const char* const kVehicleKeys[] = {
 
 MqttMirror::~MqttMirror() {
     if (m_mosq) {
-        mosquitto_disconnect(m_mosq);
-        mosquitto_destroy(m_mosq);
+        mosquitto_disconnect(m_mosq.get());
+        m_mosq.reset();   // deleter → mosquitto_destroy
     }
     mosquitto_lib_cleanup();
 }
@@ -69,7 +78,7 @@ void MqttMirror::ensure_connected() {
 
     if (!m_mosq) {
         std::string cid = read_key("mqtt.client.id");
-        m_mosq = mosquitto_new(cid.empty() ? nullptr : cid.c_str(), true, this);
+        m_mosq.reset(mosquitto_new(cid.empty() ? nullptr : cid.c_str(), true, this));
         if (!m_mosq) {
             ACE_ERROR((LM_ERROR, ACE_TEXT("%D [mqtt] mosquitto_new failed\n")));
             return;
@@ -77,11 +86,11 @@ void MqttMirror::ensure_connected() {
         std::string user = read_key("mqtt.broker.user");
         std::string pass = read_key("mqtt.broker.pass");
         if (!user.empty())
-            mosquitto_username_pw_set(m_mosq, user.c_str(),
+            mosquitto_username_pw_set(m_mosq.get(), user.c_str(),
                                       pass.empty() ? nullptr : pass.c_str());
     }
 
-    int rc = mosquitto_connect(m_mosq, m_host.c_str(), m_port, 60);
+    int rc = mosquitto_connect(m_mosq.get(), m_host.c_str(), m_port, 60);
     if (rc == MOSQ_ERR_SUCCESS) {
         m_connected = true;
         ACE_DEBUG((LM_INFO, ACE_TEXT("%D [mqtt] connected %C:%d topic=%C\n"),
@@ -122,16 +131,16 @@ void MqttMirror::publish_telemetry() {
     }
     json += "}";
 
-    mosquitto_publish(m_mosq, nullptr, m_topic.c_str(),
+    mosquitto_publish(m_mosq.get(), nullptr, m_topic.c_str(),
                       static_cast<int>(json.size()), json.data(), m_qos, true /*retain*/);
 }
 
 int MqttMirror::handle_timeout(const ACE_Time_Value&, const void* act) {
     if (act == kLoopAct) {
         if (m_mosq && m_connected) {
-            int rc = mosquitto_loop(m_mosq, 0, 1);
+            int rc = mosquitto_loop(m_mosq.get(), 0, 1);
             if (rc != MOSQ_ERR_SUCCESS) {
-                if (mosquitto_reconnect(m_mosq) != MOSQ_ERR_SUCCESS) m_connected = false;
+                if (mosquitto_reconnect(m_mosq.get()) != MOSQ_ERR_SUCCESS) m_connected = false;
             }
         } else {
             // Parked / disconnected: retry every ~5 s (not every 100 ms tick),
@@ -157,6 +166,14 @@ int MqttMirror::run() {
     // Publish timer: mirror vehicle.* to the broker at the configured cadence.
     ACE_Time_Value pub(m_cfg.publish_ms / 1000, (m_cfg.publish_ms % 1000) * 1000);
     ACE_Reactor::instance()->schedule_timer(this, kPubAct, ACE_Time_Value(2), pub);
+
+    // ACE is initialised now (the reactor was used above): capture logs to
+    // log.mqttd.text, apply log.level.mqtt, and drive the flush timer.
+    g_log.start();
+    g_log.apply_level(m_ds);
+    g_log.open(m_ds, 5, 1);
+    // Self-report for the Services page.
+    m_ds.set(std::string("services.mqtt.state"), data_store::Value{std::string("running")});
 
     ACE_DEBUG((LM_INFO,
         ACE_TEXT("%D [mqtt] up: broker=%C:%d topic=%C (parks until host set)\n"),

--- a/modules/mqtt/daemon/mqtt_mirror.hpp
+++ b/modules/mqtt/daemon/mqtt_mirror.hpp
@@ -2,6 +2,7 @@
 #define __mqtt_mirror_hpp__
 
 #include <cstdint>
+#include <memory>
 #include <string>
 
 #include <ace/Event_Handler.h>
@@ -9,6 +10,12 @@
 #include "data_store/client.hpp"
 
 struct mosquitto;  // libmosquitto opaque handle (fwd-decl)
+
+namespace mqtt {
+/// Custom deleter so the libmosquitto handle is owned by a std::unique_ptr
+/// (no raw owning pointer). Defined in the .cpp where mosquitto.h is visible.
+struct MosqDeleter { void operator()(::mosquitto* m) const noexcept; };
+}
 
 /// iot-mqttd — mirror device telemetry to an operator-owned MQTT broker.
 ///
@@ -45,10 +52,10 @@ class MqttMirror : public ACE_Event_Handler {
         void        ensure_connected();
         void        publish_telemetry();
 
-        Config             m_cfg;
-        data_store::Client m_ds;
-        struct mosquitto*  m_mosq = nullptr;
-        bool               m_connected = false;
+        Config                                   m_cfg;
+        data_store::Client                       m_ds;
+        std::unique_ptr<::mosquitto, MosqDeleter> m_mosq;  // owns the handle (RAII)
+        bool                                     m_connected = false;
         std::string        m_host;
         int                m_port = 1883;
         std::string        m_topic;          ///< <serial>/<suffix>

--- a/modules/vehicle/daemon/vehicle_client.cpp
+++ b/modules/vehicle/daemon/vehicle_client.cpp
@@ -4,11 +4,16 @@
 #include <ace/Reactor.h>
 #include <ace/Time_Value.h>
 
+#include "data_store/log_buffer.hpp"
 #include "data_store/value.hpp"
 
 #include "obd_pid.hpp"
 
 namespace vehicle {
+
+// Captures this daemon's ACE log output to log.vehicled.text and applies the
+// per-daemon level from log.level.vehicle (falls back to log.level).
+static data_store::LogBuffer g_log("vehicled", "log.vehicled.text", "log.level.vehicle");
 
 namespace {
 
@@ -134,6 +139,14 @@ int VehicleClient::run() {
     if (tick_ms == 0) tick_ms = 1;
     ACE_Time_Value period(tick_ms / 1000, (tick_ms % 1000) * 1000);
     ACE_Reactor::instance()->schedule_timer(this, nullptr, ACE_Time_Value(1), period);
+
+    // ACE is initialised now (reactor used above): capture logs to
+    // log.vehicled.text, apply log.level.vehicle, drive the flush timer.
+    g_log.start();
+    g_log.apply_level(m_ds);
+    g_log.open(m_ds, 5, 1);
+    // Self-report for the Services page.
+    m_ds.set(std::string("services.vehicle.state"), data_store::Value{std::string("running")});
 
     ACE_DEBUG((LM_INFO,
         ACE_TEXT("%D [veh] up: iface=%C poll=%ums (%u PIDs, %ums/PID)\n"),


### PR DESCRIPTION
vehicle/mqtt daemons: services.{vehicle,mqtt}.{enable,state} + log.level.{vehicle,mqtt} + log.{vehicled,mqttd}.text schema; both use data_store::LogBuffer (log-text + per-daemon level via apply_level) + self-report state. MQTT handle refactored to std::unique_ptr<mosquitto,MosqDeleter> (no raw owning pointer).