### PR TITLE
feat(vehicle): PR-21 — StatsPublisher for vehicle + mqtt

### DIFF
--- a/modules/data-store/schemas/services.lua
+++ b/modules/data-store/schemas/services.lua
@@ -128,6 +128,8 @@ local stats_services = {
   "services.lwm2m.client",
   "services.lwm2m.server",
   "services.wifi.client",
+  "services.vehicle",
+  "services.mqtt",
   "services.cloud.iot.cloudd",
   "services.cloud.iot.httpd",
   "services.cloud.openvpn.server",

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -746,6 +746,12 @@ void install_handlers(Router& router,
                 "services.wifi.client.cpu.permille", "services.wifi.client.cpu.count",
                 "services.wifi.client.mem.rss.kb",
                 "services.wifi.client.fd.count", "services.wifi.client.threads",
+                "services.vehicle.cpu.permille", "services.vehicle.cpu.count",
+                "services.vehicle.mem.rss.kb",
+                "services.vehicle.fd.count", "services.vehicle.threads",
+                "services.mqtt.cpu.permille", "services.mqtt.cpu.count",
+                "services.mqtt.mem.rss.kb",
+                "services.mqtt.fd.count", "services.mqtt.threads",
                 // ── Cloud service states/enables + telemetry (cloud UI
                 // Services page reads these via the shared status poll) ──
                 "services.cloud.iot.cloudd.enable", "services.cloud.iot.cloudd.state",
@@ -939,6 +945,16 @@ void install_handlers(Router& router,
                 else if (k == "services.wifi.client.mem.rss.kb")      services["wifi_client"]["mem_kb"] = iv();
                 else if (k == "services.wifi.client.fd.count")        services["wifi_client"]["fd_count"] = iv();
                 else if (k == "services.wifi.client.threads")         services["wifi_client"]["threads"] = iv();
+                else if (k == "services.vehicle.cpu.permille")        services["vehicle"]["cpu_permille"] = iv();
+                else if (k == "services.vehicle.cpu.count")           services["vehicle"]["cpu_count"] = iv();
+                else if (k == "services.vehicle.mem.rss.kb")          services["vehicle"]["mem_kb"] = iv();
+                else if (k == "services.vehicle.fd.count")            services["vehicle"]["fd_count"] = iv();
+                else if (k == "services.vehicle.threads")             services["vehicle"]["threads"] = iv();
+                else if (k == "services.mqtt.cpu.permille")           services["mqtt"]["cpu_permille"] = iv();
+                else if (k == "services.mqtt.cpu.count")              services["mqtt"]["cpu_count"] = iv();
+                else if (k == "services.mqtt.mem.rss.kb")             services["mqtt"]["mem_kb"] = iv();
+                else if (k == "services.mqtt.fd.count")               services["mqtt"]["fd_count"] = iv();
+                else if (k == "services.mqtt.threads")                services["mqtt"]["threads"] = iv();
 
                 // Cloud Service rows + bump keys: pass through verbatim under
                 // their ds key, typed by suffix (state→string, enable→bool,

--- a/modules/mqtt/daemon/mqtt_mirror.cpp
+++ b/modules/mqtt/daemon/mqtt_mirror.cpp
@@ -11,6 +11,7 @@
 #include <ace/Time_Value.h>
 
 #include "data_store/log_buffer.hpp"
+#include "data_store/stats_publisher.hpp"
 #include "data_store/value.hpp"
 
 namespace mqtt {
@@ -174,6 +175,12 @@ int MqttMirror::run() {
     g_log.open(m_ds, 5, 1);
     // Self-report for the Services page.
     m_ds.set(std::string("services.mqtt.state"), data_store::Value{std::string("running")});
+
+    // L22 resource telemetry → services.mqtt.{cpu,mem,fd,threads}. Singleton
+    // reactor is pumped in-thread here, so schedule on it (no extra thread).
+    data_store::StatsPublisher stats("services.mqtt",
+        [this](const std::vector<data_store::KV>& kv) { m_ds.set(kv); });
+    stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC, false);
 
     ACE_DEBUG((LM_INFO,
         ACE_TEXT("%D [mqtt] up: broker=%C:%d topic=%C (parks until host set)\n"),

--- a/modules/vehicle/daemon/vehicle_client.cpp
+++ b/modules/vehicle/daemon/vehicle_client.cpp
@@ -5,6 +5,7 @@
 #include <ace/Time_Value.h>
 
 #include "data_store/log_buffer.hpp"
+#include "data_store/stats_publisher.hpp"
 #include "data_store/value.hpp"
 
 #include "obd_pid.hpp"
@@ -147,6 +148,12 @@ int VehicleClient::run() {
     g_log.open(m_ds, 5, 1);
     // Self-report for the Services page.
     m_ds.set(std::string("services.vehicle.state"), data_store::Value{std::string("running")});
+
+    // L22 resource telemetry → services.vehicle.{cpu,mem,fd,threads}. This daemon
+    // pumps the singleton reactor in-thread, so schedule on it (no extra thread).
+    data_store::StatsPublisher stats("services.vehicle",
+        [this](const std::vector<data_store::KV>& kv) { m_ds.set(kv); });
+    stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC, false);
 
     ACE_DEBUG((LM_INFO,
         ACE_TEXT("%D [veh] up: iface=%C poll=%ums (%u PIDs, %ums/PID)\n"),


### PR DESCRIPTION
Per-daemon cpu/mem/fd/threads for iot-vehicled + iot-mqttd: stats_services list entries (auto-gen schema keys) + StatsPublisher(open(false)) in each daemon (singleton reactor, in-thread) + /status fetch+map. Completes the Services-page telemetry (was '—').