### PR TITLE
feat(cloud): PR-22 — 60-day telemetry history ingest (spool → mongoimport)

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -145,6 +145,7 @@ services:
       - iot-run:/var/run/iot
       - iot-firmware:/var/lib/iot/firmware      # OTA .ipk feed (served at /firmware/; RW so the cloud-ui can upload bundles via POST /api/v1/firmware/upload)
       - iot-tls:/etc/iot/tls                    # self-signed cert — auto-provisioned by the image entrypoint
+      - iot-telemetry-spool:/var/lib/iot/telemetry-spool  # NDJSON spool: iot-httpd appends cloud.vehicle.telemetry snapshots; iot-telemetry-ingest bulk-loads → Mongo (§3b)
     environment:
       - TLS_HOST=${TLS_HOST:-}                  # cert CN/SAN for https (run.sh passes the host IP)
     depends_on:
@@ -166,8 +167,9 @@ services:
   # iot-etc config volume, so a release that changes ds *schemas* still
   # needs a manual `./run.sh` on the host. Code/UI-only releases are fine.
   # ── Telemetry store (60-day vehicle history; §3b of the TDD) ────
-  # x86 VM → mongod 5.0 supports native time-series collections. iot-httpd will
-  # ingest LwM2M-Send telemetry here (IOT_HTTPD_MONGO build, a later PR); the
+  # x86 VM → mongod 5.0 supports native time-series collections. The
+  # iot-telemetry-ingest sidecar bulk-loads vehicle snapshots here from the
+  # NDJSON spool iot-httpd writes (no mongo driver in the cloud C++ build); the
   # cold-storage archiver (§3c) mongodumps + prunes aged data. Idle until wired.
   mongo:
     image: docker.io/library/mongo:5.0
@@ -210,6 +212,26 @@ services:
     restart: unless-stopped
     profiles: ["telemetry"]
 
+  # ── Telemetry ingest (§3b) ─────────────────────────────────────
+  # iot-httpd appends each cloud.vehicle.telemetry snapshot to an NDJSON spool
+  # ({ts, endpoints:[...]} per line) — no mongo driver in the cloud C++ build.
+  # This sidecar atomically renames the spool aside and bulk-loads it into the
+  # `telemetry` collection with mongoimport, then drops the processed file.
+  # iot-httpd opens+appends+closes per snapshot, so the rename never races a
+  # held descriptor; the next snapshot recreates the spool. Reuses the mongo
+  # image for mongoimport. Opt-in with the mongo store.
+  iot-telemetry-ingest:
+    image: docker.io/library/mongo:5.0
+    container_name: iot-telemetry-ingest
+    depends_on: [mongo]
+    volumes:
+      - iot-telemetry-spool:/var/lib/iot/telemetry-spool
+    environment:
+      - MONGO_HOST=mongo
+    entrypoint: ["/bin/sh","-c","f=/var/lib/iot/telemetry-spool/spool.ndjson; while true; do if [ -s \"$$f\" ]; then mv \"$$f\" \"$$f.proc\" && mongoimport --quiet --host \"$$MONGO_HOST\" --db iot --collection telemetry --file \"$$f.proc\" && rm -f \"$$f.proc\"; fi; sleep ${TELEMETRY_INGEST_SEC:-30}; done"]
+    restart: unless-stopped
+    profiles: ["telemetry"]
+
   watchtower:
     image: containrrr/watchtower
     container_name: iot-watchtower
@@ -229,5 +251,6 @@ volumes:
   iot-firmware: # OTA .ipk packages (seeded by operator; served by iot-httpd)
   iot-tls:    # self-signed https cert (auto-provisioned by the image entrypoint)
   iot-mongo:    # 60-day vehicle telemetry time-series store (§3b)
+  iot-telemetry-spool:  # NDJSON hand-off: iot-httpd writer → iot-telemetry-ingest reader (§3b)
   iot-archive:  # cold-storage telemetry archives (mongodump, §3c → external HDD)
   iot-tiles:    # self-hosted map tiles (region .mbtiles + style, §3d)

--- a/apps/docs/tdd-vehicle-telemetry.md
+++ b/apps/docs/tdd-vehicle-telemetry.md
@@ -194,6 +194,26 @@ fills in `RegistryMirror`'s currently-stubbed `persist()` by example.
 
 ## 3b. Cloud telemetry pipeline — LwM2M Send → cloud MongoDB (60-day)
 
+> ✅ **IMPLEMENTED (v1, snapshot-derived) — no mongocxx, no LwM2M Send.**
+> The live map already populates `cloud.vehicle.telemetry` from `lwm2m-dm`'s
+> token-tagged **server-Reads** of Object 6 + 33000 (§5). v1 history simply
+> **persists that stream**: `iot-httpd` watches `cloud.vehicle.telemetry` and
+> appends one NDJSON line per poll cycle — `{ts, endpoints:[…]}` — to a spool
+> file on a dedicated `iot-telemetry-spool` volume (plain `ofstream`, so the
+> **cloud C++ build keeps `IOT_ENABLE_MONGO=OFF` — no mongocxx, no new build
+> flag**). The `iot-telemetry-ingest` sidecar (mongo image) atomically renames
+> the spool aside and `mongoimport`s it into the `telemetry` collection, then
+> the §3c archiver prunes. This deliberately **does not need client-side Send +
+> SenML codec** (the critical-path item below) because the server already pulls
+> the data live. The Send/SenML/Block-Wise path below remains the **v2
+> upgrade** — it adds *device-buffered backfill with true per-point
+> timestamps + offline catch-up*, which the snapshot stream can't (it only
+> records what the server polled while the device was registered).
+>
+> Wiring: `iot-httpd` watch+spool in `modules/http-server/src/main.cpp`;
+> `iot-telemetry-ingest` + `iot-telemetry-spool` volume in
+> `apps/cloud/docker-compose.yml` (`profiles: [telemetry]`).
+
 **Transport: LwM2M 1.1 Send (client-initiated batch push).** The device drains
 its buffer oldest-first and pushes batches as a **SenML pack** via LwM2M **Send**
 (CoAP POST to `/dp`) — multiple timestamped records in one message, exactly what

--- a/modules/http-server/src/main.cpp
+++ b/modules/http-server/src/main.cpp
@@ -29,6 +29,7 @@
 #include <csignal>
 #include <cstdlib>
 #include <ctime>
+#include <fstream>
 #include <memory>
 #include <string>
 #include <string_view>
@@ -308,6 +309,27 @@ int main(int argc, char** argv) {
     if (!wwwDir.empty()) router.set_static_dir(wwwDir);
     if (!fwDir.empty()) router.set_firmware_dir("/firmware/", fwDir);
     http_server::install_handlers(router, &ds, &auth_store, fwDir);
+
+    // ── Telemetry history spool (cloud-only, §3b) ─────────────
+    // Mirror each cloud.vehicle.telemetry snapshot to an append-only NDJSON
+    // spool that the iot-telemetry-ingest sidecar bulk-loads into Mongo (the
+    // 60-day store). One doc per poll cycle — {ts, endpoints:[...]} — built by
+    // string-wrapping the raw ds array value, so no JSON re-parse here. The key
+    // exists only on the cloud, so on a device this watch simply never fires
+    // (same binary, no #ifdef). The callback runs on the ds listener thread;
+    // each fire opens+appends+closes (O_APPEND), so the sidecar can safely
+    // rename the spool out from under us between fires.
+    data_store::Client::WatchHandle wh_telem = data_store::Client::kInvalidHandle;
+    ds.watch(std::string("cloud.vehicle.telemetry"),
+        [](const data_store::Client::Event& e) {
+            auto sv = data_store::to_string(e.value);
+            if (!sv || sv->empty() || *sv == "[]") return;  // skip empties
+            std::ofstream f("/var/lib/iot/telemetry-spool/spool.ndjson",
+                            std::ios::app);
+            if (f) f << "{\"ts\":" << static_cast<long>(::time(nullptr))
+                     << ",\"endpoints\":" << *sv << "}\n";
+        }, &wh_telem);
+
     // Per-device UI reverse proxy at /dev/<ep>/ (cloud-only effect; on a device
     // there is no cloud.endpoints so any /dev/ hit just 502s).
     http_server::install_proxy_handler(router, &ds, &auth_store);


### PR DESCRIPTION
Persists the live cloud.vehicle.telemetry stream into the cloud Mongo 60-day store via an NDJSON spool (iot-httpd ofstream) + a mongoimport sidecar — **no mongocxx in the cloud build, no LwM2M Send dependency**. Reuses the data lwm2m-dm already server-Reads for the map. `profiles:[telemetry]`, opt-in. The Send/SenML path is reframed as the v2 upgrade (device-buffered backfill w/ true per-point timestamps).