### PR TITLE
feat(cloud): PR-23 — vehicle history read-back (map track polyline)

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -212,23 +212,27 @@ services:
     restart: unless-stopped
     profiles: ["telemetry"]
 
-  # ── Telemetry ingest (§3b) ─────────────────────────────────────
-  # iot-httpd appends each cloud.vehicle.telemetry snapshot to an NDJSON spool
-  # ({ts, endpoints:[...]} per line) — no mongo driver in the cloud C++ build.
-  # This sidecar atomically renames the spool aside and bulk-loads it into the
-  # `telemetry` collection with mongoimport, then drops the processed file.
-  # iot-httpd opens+appends+closes per snapshot, so the rename never races a
-  # held descriptor; the next snapshot recreates the spool. Reuses the mongo
-  # image for mongoimport. Opt-in with the mongo store.
+  # ── Telemetry ingest + history export (§3b) ────────────────────
+  # Two-way bridge between the iot-httpd NDJSON spool and Mongo (no mongo
+  # driver in the cloud C++ build): mongoimport loads each cloud.vehicle.
+  # telemetry snapshot iot-httpd appends, and mongoexport dumps a recent window
+  # back to history.json, which iot-httpd serves at
+  # /api/v1/cloud/telemetry/history for the map's historical-track read-back.
+  # iot-httpd opens+appends+closes per snapshot, so the spool rename never races
+  # a held descriptor. Reuses the mongo image; logic lives in the mounted
+  # iot-telemetry-ingest script (like the archiver). Opt-in with the mongo store.
   iot-telemetry-ingest:
     image: docker.io/library/mongo:5.0
     container_name: iot-telemetry-ingest
     depends_on: [mongo]
     volumes:
       - iot-telemetry-spool:/var/lib/iot/telemetry-spool
+      - ./scripts/iot-telemetry-ingest.sh:/usr/local/bin/iot-telemetry-ingest:ro
     environment:
       - MONGO_HOST=mongo
-    entrypoint: ["/bin/sh","-c","f=/var/lib/iot/telemetry-spool/spool.ndjson; while true; do if [ -s \"$$f\" ]; then mv \"$$f\" \"$$f.proc\" && mongoimport --quiet --host \"$$MONGO_HOST\" --db iot --collection telemetry --file \"$$f.proc\" && rm -f \"$$f.proc\"; fi; sleep ${TELEMETRY_INGEST_SEC:-30}; done"]
+      - TELEMETRY_INGEST_SEC=${TELEMETRY_INGEST_SEC:-30}
+      - HISTORY_WINDOW_SEC=${HISTORY_WINDOW_SEC:-86400}
+    entrypoint: ["/bin/sh","-c","exec /usr/local/bin/iot-telemetry-ingest"]
     restart: unless-stopped
     profiles: ["telemetry"]
 

--- a/apps/cloud/scripts/iot-telemetry-ingest.sh
+++ b/apps/cloud/scripts/iot-telemetry-ingest.sh
@@ -1,0 +1,43 @@
+#!/bin/sh
+# iot-telemetry-ingest — bridge between the iot-httpd NDJSON spool and Mongo,
+# in BOTH directions (§3b of apps/docs/tdd-vehicle-telemetry.md):
+#
+#   1. INGEST  spool.ndjson ──mongoimport──► Mongo `telemetry`   (write path)
+#   2. EXPORT  Mongo `telemetry` ──mongoexport──► history.json    (read path)
+#
+# Runs in the mongo:5.0 image (has mongoimport + mongoexport); no mongo driver
+# is linked into the cloud C++ build. iot-httpd appends snapshots to the spool
+# and serves history.json at /api/v1/cloud/telemetry/history. Loops every
+# TELEMETRY_INGEST_SEC. Idempotent: an empty spool or empty window is a no-op.
+
+set -u
+
+SPOOL=/var/lib/iot/telemetry-spool/spool.ndjson
+HISTORY=/var/lib/iot/telemetry-spool/history.json
+HOST="${MONGO_HOST:-mongo}"
+WINDOW="${HISTORY_WINDOW_SEC:-86400}"      # read-back window, default 24h
+INTERVAL="${TELEMETRY_INGEST_SEC:-30}"
+
+while true; do
+    # 1) INGEST — atomically claim the spool so iot-httpd's next append opens a
+    #    fresh file (it opens+appends+closes per snapshot, so the rename never
+    #    races a held descriptor), then bulk-load and drop the claimed copy.
+    if [ -s "$SPOOL" ]; then
+        if mv "$SPOOL" "$SPOOL.proc" 2>/dev/null; then
+            mongoimport --quiet --host "$HOST" --db iot --collection telemetry \
+                --file "$SPOOL.proc" && rm -f "$SPOOL.proc"
+        fi
+    fi
+
+    # 2) EXPORT — dump the last WINDOW seconds (oldest-first) as a JSON array to
+    #    a temp file, then atomically swap it in so iot-httpd never serves a
+    #    half-written file. ts is unix-seconds (set by iot-httpd at append).
+    cutoff=$(( $(date +%s) - WINDOW ))
+    if mongoexport --quiet --host "$HOST" --db iot --collection telemetry \
+            --query "{\"ts\":{\"\$gte\":$cutoff}}" --sort "{\"ts\":1}" \
+            --jsonArray --out "$HISTORY.tmp" 2>/dev/null; then
+        mv "$HISTORY.tmp" "$HISTORY"
+    fi
+
+    sleep "$INTERVAL"
+done

--- a/apps/cloud/ui/src/app/map/map.component.ts
+++ b/apps/cloud/ui/src/app/map/map.component.ts
@@ -24,6 +24,19 @@ interface Telem {
         No located vehicles yet — markers appear once devices report GPS (Object 6)
         and the telemetry pipeline populates <code>cloud.vehicle.telemetry</code>.
       </p>
+      <div class="track-bar">
+        <span class="lbl">History track:</span>
+        <select #tsel (change)="trackEp = tsel.value" [value]="trackEp">
+          <option value="">— select endpoint —</option>
+          <option *ngFor="let ep of endpointList" [value]="ep">{{ ep }}</option>
+        </select>
+        <button class="btn btn-sm" (click)="loadTrack()" [disabled]="!trackEp || loadingTrack">
+          {{ loadingTrack ? '…' : 'Show Track' }}
+        </button>
+        <button class="btn btn-sm btn-outline" *ngIf="trackLayer" (click)="clearTrack()">Clear</button>
+        <span class="tinfo" *ngIf="trackLayer">{{ trackCount }} points (last 24 h)</span>
+        <span class="tinfo" *ngIf="trackRequested && !trackLayer && !loadingTrack">no history for this endpoint yet</span>
+      </div>
       <div id="fleet-map" class="map"></div>
     </div>
   `,
@@ -31,6 +44,10 @@ interface Telem {
     .page { padding: 24px; }
     h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 12px 0; }
     .hint { color: #888; font-size: 13px; margin: 0 0 12px 0; }
+    .track-bar { display: flex; align-items: center; gap: 8px; margin: 0 0 10px 0; font-size: 13px; }
+    .track-bar .lbl { color: #555; font-weight: 600; }
+    .track-bar select { padding: 3px 6px; }
+    .track-bar .tinfo { color: #888; }
     .map { height: 70vh; width: 100%; border: 1px solid #ccc; border-radius: 4px; }
   `]
 })
@@ -38,10 +55,20 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   /// Optional endpoint to center on (set when arriving via an Endpoints link).
   @Input() focus = '';
   count = 0;
+  /// Historical-track read-back (§3b). trackEp is the selected endpoint; the
+  /// polyline is fetched on demand from /api/v1/cloud/telemetry/history.
+  trackEp = '';
+  trackCount = 0;
+  loadingTrack = false;
+  trackRequested = false;
+  trackLayer?: L.FeatureGroup;
   private map?: L.Map;
   private markers: Record<string, L.CircleMarker> = {};
   private centeredFor = '';
   private sub = new Subscription();
+
+  /// Endpoints currently on the map (track-picker options).
+  get endpointList(): string[] { return Object.keys(this.markers).sort(); }
 
   // Self-hosted tileserver (PR-10a; default :8081). Operator-configurable per
   // deployment / seeded style. Leaflet still shows markers on a blank grid if
@@ -52,6 +79,7 @@ export class MapComponent implements AfterViewInit, OnDestroy {
   constructor(private http: HttpsvcService) {}
 
   ngAfterViewInit(): void {
+    this.trackEp = this.focus || '';   // pre-select when arriving via a link
     this.map = L.map('fleet-map', { center: [20, 0], zoom: 2 });
     L.tileLayer(this.tileUrl, { maxZoom: 19, attribution: 'Self-hosted tiles' }).addTo(this.map);
     this.sub.add(
@@ -104,6 +132,46 @@ export class MapComponent implements AfterViewInit, OnDestroy {
         this.centeredFor = this.focus;
       }
     }
+  }
+
+  /// Fetch the selected endpoint's recent track and draw it as a polyline,
+  /// fitting the map to its bounds. Start (green) / end (red) dots mark the
+  /// window's extremes. Replaces any previous track.
+  loadTrack(): void {
+    if (!this.trackEp || !this.map) return;
+    this.loadingTrack = true;
+    this.trackRequested = true;
+    this.http.getVehicleHistory(this.trackEp).subscribe(track => {
+      this.loadingTrack = false;
+      this.clearTrack();
+      const map = this.map;
+      if (!map) return;
+      const pts: L.LatLngExpression[] = [];
+      for (const p of track) {
+        const lat = parseFloat(String(p['lat'] ?? ''));
+        const lon = parseFloat(String(p['lon'] ?? ''));
+        if (isNaN(lat) || isNaN(lon)) continue;
+        pts.push([lat, lon]);
+      }
+      this.trackCount = pts.length;
+      if (!pts.length) return;
+      const line = L.polyline(pts, { color: '#d35400', weight: 3, opacity: 0.85 });
+      const start = L.circleMarker(pts[0],
+        { radius: 6, color: '#2e7d32', fillColor: '#43a047', fillOpacity: 0.9 }).bindPopup('Track start');
+      const end = L.circleMarker(pts[pts.length - 1],
+        { radius: 6, color: '#c62828', fillColor: '#e53935', fillOpacity: 0.9 }).bindPopup('Track end');
+      // Group polyline + endpoint dots so Clear removes them together.
+      const group = L.featureGroup([line, start, end]).addTo(map);
+      this.trackLayer = group;
+      map.fitBounds(group.getBounds(), { padding: [30, 30] });
+    });
+  }
+
+  /// Remove the current track polyline (+ its endpoint dots).
+  clearTrack(): void {
+    if (this.trackLayer && this.map) this.map.removeLayer(this.trackLayer);
+    this.trackLayer = undefined;
+    this.trackCount = 0;
   }
 
   ngOnDestroy(): void {

--- a/apps/cloud/ui/src/common/httpsvc.service.ts
+++ b/apps/cloud/ui/src/common/httpsvc.service.ts
@@ -116,6 +116,17 @@ export class HttpsvcService {
       { withCredentials: true });
   }
 
+  /// Historical vehicle track for one endpoint (§3b read-back). iot-httpd
+  /// serves the recent window the iot-telemetry-ingest sidecar mongoexports;
+  /// `track` is oldest-first [{ts,lat,lon,speed,...}]. Empty until the
+  /// telemetry profile is up and the sidecar has exported once.
+  getVehicleHistory(ep: string): Observable<Array<Record<string, string|number>>> {
+    return this.http.get<{ok:boolean;track:Array<Record<string,string|number>>}>(
+      `${this.api}/api/v1/cloud/telemetry/history?ep=${encodeURIComponent(ep)}`,
+      { withCredentials: true })
+      .pipe(map(r => r.track || []), catchError(() => of([])));
+  }
+
   // ── User management ───────────────────────────────────────────────
 
   listUsers(): Observable<UserListResponse> {

--- a/apps/docs/tdd-vehicle-telemetry.md
+++ b/apps/docs/tdd-vehicle-telemetry.md
@@ -53,8 +53,13 @@ Needs a build-and-run loop + new deps:**
   ingest: `iot-httpd` links mongocxx behind a new `IOT_HTTPD_MONGO` flag,
   watches `cloud.telemetry.inbox`, writes the cloud `telemetry` collection
   (normal coll + TTL backstop; the **mongo service from PR-10a** is ready).
-- ⬜ PR-11 — Map history/replay + **time-series charts** (Chart.js) over a new
-  `iot-httpd` Mongo query endpoint. (Leaflet dep + pattern already in PR-4.)
+- ✅ PR-11 (read-back) — Map **history track**: the iot-telemetry-ingest sidecar
+  `mongoexport`s a recent window to `history.json`; `iot-httpd` serves it at
+  `GET /api/v1/cloud/telemetry/history?ep=<ep>` (file-served, no mongo driver);
+  the cloud-ui Map draws the selected endpoint's track as a Leaflet polyline
+  (start/end dots, fit-to-bounds) — reuses the PR-4 Leaflet dep, **no charting
+  library**. ⬜ Time-series **charts** (speed/rpm over time, Chart.js/ECharts)
+  remain an optional future add over the same endpoint.
 
 Greenfield baseline: no CAN code existed in the repo before PR-1.
 
@@ -286,7 +291,10 @@ device ──Send(SenML)──► lwm2m-dm ──ds inbox key──► iot-httpd
 - **ACK-then-prune end to end:** device prunes a point only after the Send it
   rode in got a 2.04; the cloud's dedup makes an un-acked re-send safe.
 - cloud-ui Map reads **live** position from `cloud.vehicle.telemetry` (volatile)
-  and **history/replay** from Mongo via a new `iot-httpd` query endpoint.
+  and **history/replay** via `GET /api/v1/cloud/telemetry/history?ep=` — which
+  iot-httpd serves straight from `history.json` (the sidecar's periodic
+  `mongoexport` of the recent window), drawn as a Leaflet track polyline.
+  ✅ **Implemented** — see the §3b IMPLEMENTED note above.
 
 ## 3c. Cold-storage archiver (offload after 60 days → external HDD)
 

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -1146,6 +1146,60 @@ void install_handlers(Router& router,
             return r;
         });
 
+    // ── GET /api/v1/cloud/telemetry/history?ep=<ep> ──────────────────
+    // Vehicle history read-back (§3b). The iot-telemetry-ingest sidecar
+    // periodically mongoexports a recent window of the Mongo `telemetry`
+    // collection to /var/lib/iot/telemetry-spool/history.json — a JSON array
+    // of {ts, endpoints:[...]} snapshots, oldest-first. Served straight from
+    // that file (no mongo driver in this build). With ?ep= we flatten it to
+    // that endpoint's track [{ts,lat,lon,speed,...}] for the map polyline;
+    // without, the raw snapshots. Empty array until the sidecar has run once.
+    router.add("GET", "/api/v1/cloud/telemetry/history",
+        [](const HttpParser::Request& req) -> HttpResponse {
+            HttpResponse r;
+            json resp;
+            resp["ok"] = true;
+            json snaps = json::array();
+            {
+                std::ifstream f("/var/lib/iot/telemetry-spool/history.json");
+                if (f) {
+                    std::string s((std::istreambuf_iterator<char>(f)),
+                                  std::istreambuf_iterator<char>());
+                    if (!s.empty()) {
+                        try {
+                            auto parsed = json::parse(s);
+                            if (parsed.is_array()) snaps = parsed;
+                        } catch (const std::exception&) { /* leave empty */ }
+                    }
+                }
+            }
+            auto it = req.query.find("ep");
+            if (it != req.query.end()) {
+                const std::string& ep = it->second;
+                json track = json::array();
+                for (const auto& snap : snaps) {
+                    if (!snap.contains("endpoints") || !snap["endpoints"].is_array())
+                        continue;
+                    auto tsIt = snap.find("ts");
+                    for (const auto& e : snap["endpoints"]) {
+                        if (e.value("endpoint", std::string()) != ep) continue;
+                        json pt = e;
+                        if (tsIt != snap.end()) pt["ts"] = *tsIt;
+                        track.push_back(pt);
+                        break;   // one entry per snapshot
+                    }
+                }
+                resp["endpoint"] = ep;
+                resp["count"]    = track.size();
+                resp["track"]    = track;
+            } else {
+                resp["count"]     = snaps.size();
+                resp["snapshots"] = snaps;
+            }
+            r.body = resp.dump();
+            return r;
+        });
+
     // ── GET /api/v1/cloud/endpoint?ep=<ep> ─────────────────────────
     router.add("GET", "/api/v1/cloud/endpoint",
         [ds](const HttpParser::Request& req) -> HttpResponse {


### PR DESCRIPTION
The READ side of the 60-day pipeline, mirroring PR-22's write side — **no mongo driver in the cloud build**. The ingest sidecar also `mongoexport`s a recent window to history.json; iot-httpd serves it at `GET /api/v1/cloud/telemetry/history?ep=`; the cloud-ui Map draws the endpoint's track as a Leaflet polyline (start/end dots, fit-to-bounds) — reuses the existing Leaflet dep, no charting lib. Time-series charts left as an optional future add.