### PR TITLE
feat(lwm2m): PR-25 (v2) — SenML bt/t time fields

### DIFF
--- a/apps/inc/lwm2m_codec_senml.hpp
+++ b/apps/inc/lwm2m_codec_senml.hpp
@@ -12,10 +12,12 @@
  * Closes REQ-ENC-003 and REQ-ENC-004 per RFC 8428 §5 / §6.
  *
  * Scope: the LwM2M-relevant subset of SenML — Base Name (`bn`), Name
- * (`n`), Numeric Value (`v`), String Value (`vs`), Boolean Value
- * (`vb`), Data Value (`vd`). Time fields (`bt`, `t`, `ut`), Unit
- * (`u`, `bu`), Sum (`s`, `bs`), and Value-Sum aggregation are out of
- * v1 scope — Core spec doesn't require them on a 1.1 device.
+ * (`n`), Base Time (`bt`), Time (`t`), Numeric Value (`v`), String
+ * Value (`vs`), Boolean Value (`vb`), Data Value (`vd`). `bt`/`t` carry
+ * per-record timestamps for batched telemetry (LwM2M Send backfill).
+ * Unix-Time (`ut`), Unit (`u`, `bu`), Sum (`s`, `bs`), and Value-Sum
+ * aggregation remain out of v1 scope — Core spec doesn't require them on
+ * a 1.1 device.
  *
  * The codec produces / consumes a flat `std::vector<Record>`. Base
  * Name accumulation (RFC 8428 §4.5: subsequent records inherit the
@@ -63,6 +65,23 @@ struct Record {
     /// Raw binary for `vd`. The codec handles base64url encode/decode
     /// for SenML JSON; SenML CBOR carries it as a byte-string directly.
     std::string dataValue;
+
+    /// Base Time (`bt`, RFC 8428 §4.5.2). Like `bn`, it is carried by the
+    /// first record on the wire and kept on every output record so resolving
+    /// a record's absolute time is an addition, not a state machine. A
+    /// record's effective time is `baseTime + time`. Needed for timestamped
+    /// telemetry batches (LwM2M Send backfill); absent on plain reads.
+    double baseTime{0.0};
+    bool   hasBaseTime{false};
+    /// Per-record Time (`t`), a relative offset added to `baseTime` (or an
+    /// absolute time when no `bt` is present, per §4.5.3). Absent → hasTime
+    /// false (a 0 offset).
+    double time{0.0};
+    bool   hasTime{false};
+
+    /// Effective absolute time = baseTime + time. Only meaningful when
+    /// hasBaseTime || hasTime.
+    double effectiveTime() const { return baseTime + time; }
 };
 
 /* ────────── JSON (RFC 8428 §5) ────────── */

--- a/apps/src/lwm2m_codec_senml.cpp
+++ b/apps/src/lwm2m_codec_senml.cpp
@@ -84,12 +84,21 @@ std::string encode_json(const std::vector<Record>& records) {
         if (r.baseName != bn) return {};      // bn must be consistent
     }
 
+    // Base Time, like bn, is the first record's and must be consistent.
+    const bool   hasBt = records.front().hasBaseTime;
+    const double bt    = records.front().baseTime;
+    for (const auto& r : records) {
+        if (r.hasBaseTime != hasBt || (hasBt && r.baseTime != bt)) return {};
+    }
+
     json out = json::array();
     for (std::size_t i = 0; i < records.size(); ++i) {
         const auto& r = records[i];
         json rec = json::object();
         if (i == 0 && !bn.empty()) rec["bn"] = bn;
+        if (i == 0 && hasBt)       rec["bt"] = bt;
         if (!r.name.empty()) rec["n"] = r.name;
+        if (r.hasTime)       rec["t"] = r.time;
         switch (r.kind) {
             case ValueKind::Numeric:
                 if (r.isFloat) rec["v"] = r.numericValue;
@@ -116,6 +125,8 @@ int decode_json(const std::string& bytes, std::vector<Record>& out) {
     if (!doc.is_array()) return -1;
 
     std::string bn;
+    double bt = 0.0;
+    bool   hasBt = false;
     for (std::size_t i = 0; i < doc.size(); ++i) {
         const auto& rec = doc.at(i);
         if (!rec.is_object()) return -1;
@@ -124,12 +135,24 @@ int decode_json(const std::string& bytes, std::vector<Record>& out) {
             if (i != 0 || !rec["bn"].is_string()) return -1;
             bn = rec["bn"].get<std::string>();
         }
+        if (rec.contains("bt")) {
+            if (i != 0 || !rec["bt"].is_number()) return -1;
+            bt = rec["bt"].get<double>();
+            hasBt = true;
+        }
 
         Record r;
         r.baseName = bn;
+        r.baseTime = bt;
+        r.hasBaseTime = hasBt;
         if (rec.contains("n")) {
             if (!rec["n"].is_string()) return -1;
             r.name = rec["n"].get<std::string>();
+        }
+        if (rec.contains("t")) {
+            if (!rec["t"].is_number()) return -1;
+            r.time = rec["t"].get<double>();
+            r.hasTime = true;
         }
 
         int valueCount = 0;
@@ -185,7 +208,9 @@ constexpr std::uint8_t CBOR_F64      = 0xFB;
 
 /* SenML CBOR integer labels per RFC 8428 §6. */
 constexpr int LBL_BN = -2;
+constexpr int LBL_BT = -3;
 constexpr int LBL_N  =  0;
+constexpr int LBL_T  =  6;
 constexpr int LBL_V  =  2;
 constexpr int LBL_VS =  3;
 constexpr int LBL_VB =  4;
@@ -243,6 +268,18 @@ void emit_double(std::string& out, double v) {
     std::memcpy(&bits, &v, sizeof(bits));
     for (int s = 56; s >= 0; s -= 8) {
         out.push_back(static_cast<char>((bits >> s) & 0xFF));
+    }
+}
+
+/// Time (`bt`/`t`): emit as a compact CBOR unsigned int when the value is a
+/// non-negative whole number (the usual unix-seconds case), else as a float64.
+/// Round-trips losslessly either way (decode reads both via read_number).
+void emit_time(std::string& out, double t) {
+    std::int64_t it = static_cast<std::int64_t>(t);
+    if (it >= 0 && static_cast<double>(it) == t) {
+        emit_head(out, CBOR_UINT, static_cast<std::uint64_t>(it));
+    } else {
+        emit_double(out, t);
     }
 }
 
@@ -338,6 +375,16 @@ bool read_signed_int(CborCursor& c, std::int64_t& out) {
     return false;
 }
 
+/// Read a SenML time/number that may be encoded as a CBOR int OR a float64
+/// (emit_time picks the compact form). Always yields a double.
+bool read_number(CborCursor& c, double& out) {
+    if (c.peek_is_double()) return c.read_double(out);
+    std::int64_t v;
+    if (!read_signed_int(c, v)) return false;
+    out = static_cast<double>(v);
+    return true;
+}
+
 bool skip_value(CborCursor& c) {
     std::uint8_t major;
     std::uint64_t arg;
@@ -378,6 +425,12 @@ std::string encode_cbor(const std::vector<Record>& records) {
     for (const auto& r : records) {
         if (r.baseName != bn) return {};
     }
+    // Base Time, like bn, is the first record's and must be consistent.
+    const bool   hasBt = records.front().hasBaseTime;
+    const double bt    = records.front().baseTime;
+    for (const auto& r : records) {
+        if (r.hasBaseTime != hasBt || (hasBt && r.baseTime != bt)) return {};
+    }
 
     std::string out;
     emit_head(out, CBOR_ARRAY, records.size());
@@ -386,7 +439,9 @@ std::string encode_cbor(const std::vector<Record>& records) {
         const auto& r = records[i];
         std::size_t entries = 0;
         if (i == 0 && !bn.empty()) ++entries;
+        if (i == 0 && hasBt)       ++entries;
         if (!r.name.empty()) ++entries;
+        if (r.hasTime)       ++entries;
         if (r.kind != ValueKind::None) ++entries;
 
         emit_head(out, CBOR_MAP, entries);
@@ -394,8 +449,14 @@ std::string encode_cbor(const std::vector<Record>& records) {
         if (i == 0 && !bn.empty()) {
             emit_int(out, LBL_BN); emit_text(out, bn);
         }
+        if (i == 0 && hasBt) {
+            emit_int(out, LBL_BT); emit_time(out, bt);
+        }
         if (!r.name.empty()) {
             emit_int(out, LBL_N); emit_text(out, r.name);
+        }
+        if (r.hasTime) {
+            emit_int(out, LBL_T); emit_time(out, r.time);
         }
         switch (r.kind) {
             case ValueKind::Numeric:
@@ -433,6 +494,8 @@ int decode_cbor(const std::string& bytes, std::vector<Record>& out) {
     if (major != CBOR_ARRAY) return -1;
 
     std::string bn;
+    double bt = 0.0;
+    bool   hasBt = false;
     for (std::uint64_t i = 0; i < nRecs; ++i) {
         std::uint8_t m;
         std::uint64_t nFields;
@@ -450,6 +513,16 @@ int decode_cbor(const std::string& bytes, std::vector<Record>& out) {
                     if (!read_text(c, bn)) return -1;
                     break;
                 }
+                case LBL_BT: {
+                    if (i != 0) return -1;
+                    if (!read_number(c, bt)) return -1;
+                    hasBt = true;
+                    break;
+                }
+                case LBL_T:
+                    if (!read_number(c, r.time)) return -1;
+                    r.hasTime = true;
+                    break;
                 case LBL_N:
                     if (!read_text(c, r.name)) return -1;
                     break;
@@ -496,6 +569,8 @@ int decode_cbor(const std::string& bytes, std::vector<Record>& out) {
         }
         if (valueCount > 1) return -1;
         r.baseName = bn;
+        r.baseTime = bt;
+        r.hasBaseTime = hasBt;
         out.push_back(std::move(r));
     }
     return 0;

--- a/apps/test/senml_test.cpp
+++ b/apps/test/senml_test.cpp
@@ -96,6 +96,55 @@ TEST(SenmlJson, REQ_ENC_003_decode_rejects_non_array) {
     EXPECT_EQ(-1, s::decode_json("not json", out));
 }
 
+/* ───── SenML time fields (bt/t) — timestamped telemetry batches ───── */
+
+TEST(SenmlJson, time_roundtrip_bt_and_per_record_t) {
+    // A 3-sample batch of /33000/0/10 (speed): base time + per-record offsets.
+    std::vector<s::Record> in;
+    for (int k = 0; k < 3; ++k) {
+        s::Record r;
+        r.baseName = "/33000/0/"; r.name = "10";
+        r.kind = s::ValueKind::Numeric; r.numericValue = 60 + k; r.isFloat = false;
+        r.hasBaseTime = true; r.baseTime = 1718000000.0;   // bt on first record only
+        r.hasTime = true;     r.time = k * 2.0;             // +0, +2, +4 s
+        in.push_back(r);
+    }
+
+    auto wire = s::encode_json(in);
+    EXPECT_NE(std::string::npos, wire.find("\"bt\":1718000000"));
+    EXPECT_NE(std::string::npos, wire.find("\"t\":4"));
+
+    std::vector<s::Record> out;
+    ASSERT_EQ(0, s::decode_json(wire, out));
+    ASSERT_EQ(3u, out.size());
+    for (int k = 0; k < 3; ++k) {
+        EXPECT_TRUE(out[k].hasBaseTime);
+        EXPECT_EQ(1718000000.0, out[k].baseTime);    // bt accumulates to all
+        EXPECT_TRUE(out[k].hasTime);
+        EXPECT_EQ(k * 2.0, out[k].time);
+        EXPECT_EQ(1718000000.0 + k * 2.0, out[k].effectiveTime());
+    }
+}
+
+TEST(SenmlJson, time_decode_rejects_bt_not_on_first) {
+    std::vector<s::Record> out;
+    EXPECT_EQ(-1, s::decode_json(R"([{"n":"0","v":1},{"bt":1,"n":"1","v":2}])", out));
+}
+
+TEST(SenmlJson, time_absent_means_no_time_flags) {
+    std::vector<s::Record> in;
+    s::Record a; a.baseName = "/3/0/"; a.name = "9";
+    a.kind = s::ValueKind::Numeric; a.numericValue = 42;
+    in.push_back(a);
+    auto wire = s::encode_json(in);
+    EXPECT_EQ(std::string::npos, wire.find("\"bt\""));   // no time emitted
+    EXPECT_EQ(std::string::npos, wire.find("\"t\""));
+    std::vector<s::Record> out;
+    ASSERT_EQ(0, s::decode_json(wire, out));
+    EXPECT_FALSE(out[0].hasBaseTime);
+    EXPECT_FALSE(out[0].hasTime);
+}
+
 /* ─────────────────────────── REQ-ENC-004 SenML CBOR ───────────────── */
 
 TEST(SenmlCbor, REQ_ENC_004_roundtrip_numeric_int) {
@@ -128,6 +177,30 @@ TEST(SenmlCbor, REQ_ENC_004_roundtrip_float) {
     ASSERT_EQ(0, s::decode_cbor(wire, out));
     EXPECT_TRUE(out[0].isFloat);
     EXPECT_EQ(1.5, out[0].numericValue);
+}
+
+TEST(SenmlCbor, time_roundtrip_bt_and_t) {
+    // Same timestamped batch as the JSON test, over CBOR. Integral times are
+    // emitted as compact CBOR uints (emit_time) and read back via read_number.
+    std::vector<s::Record> in;
+    for (int k = 0; k < 3; ++k) {
+        s::Record r;
+        r.baseName = "/33000/0/"; r.name = "10";
+        r.kind = s::ValueKind::Numeric; r.numericValue = 60 + k;
+        r.hasBaseTime = true; r.baseTime = 1718000000.0;
+        r.hasTime = true;     r.time = k * 2.0;
+        in.push_back(r);
+    }
+    auto wire = s::encode_cbor(in);
+    std::vector<s::Record> out;
+    ASSERT_EQ(0, s::decode_cbor(wire, out));
+    ASSERT_EQ(3u, out.size());
+    for (int k = 0; k < 3; ++k) {
+        EXPECT_TRUE(out[k].hasBaseTime);
+        EXPECT_EQ(1718000000.0, out[k].baseTime);
+        EXPECT_EQ(k * 2.0, out[k].time);
+        EXPECT_EQ(1718000000.0 + k * 2.0, out[k].effectiveTime());
+    }
 }
 
 TEST(SenmlCbor, REQ_ENC_004_roundtrip_string_bool_data) {


### PR DESCRIPTION
First v2 Send-backfill piece: per-record timestamps in the SenML codec (RFC 8428 bt=§4.5.2/-3, t=6). JSON + CBOR encode/decode, bt accumulates like bn, compact-uint for integral times. No-time records are byte-for-byte unchanged. **Validated locally** — codec builds standalone against the vendored nlohmann header; JSON+CBOR round-trips + rejection cases all pass.