### PR TITLE
chore(build): podman dev-build for apps/ gtest suite + fix link rot

### DIFF
--- a/apps/test/CMakeLists.txt
+++ b/apps/test/CMakeLists.txt
@@ -63,6 +63,7 @@ file(GLOB SOURCES "*.cpp"
                     "../src/lwm2m_object_3_device.cpp"
                     "../src/lwm2m_object_sensors.cpp"
                     "../src/lwm2m_object_stubs.cpp"
+                    "../src/lwm2m_object_firmware.cpp"
                     "../src/lwm2m_object_cert.cpp"
                     "../src/lwm2m_cert_chunk.cpp"
                     "../src/lua_config.cpp"
@@ -78,6 +79,8 @@ target_link_libraries(lwm2m_test
     ACE
     pthread
     z
+    ssl
+    crypto
     ${LUA_LINK_LIBS})
 
 add_test(NAME lwm2m_gtests COMMAND lwm2m_test)

--- a/docker/Dockerfile.devbuild
+++ b/docker/Dockerfile.devbuild
@@ -1,0 +1,37 @@
+# Dev-build image: compile + run the apps/ gtest suite (lwm2m_test) against a
+# locally-mounted working tree, WITHOUT cloning from GitHub or building the
+# mongo/device runtime. Lines 1–31 are byte-identical to docker/Dockerfile so
+# podman reuses its cached ACE/apt layers (no ~15-min ACE rebuild).
+#
+# Usage (from repo root):
+#   podman build -t localhost/iot-devbuild:latest -f docker/Dockerfile.devbuild docker/
+#   podman run --rm -v "$PWD":/src:Z -w /src localhost/iot-devbuild:latest \
+#       bash docker/devbuild.sh
+FROM ubuntu:jammy
+RUN apt-get update && apt-get -y upgrade && \
+    apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev python3-dev autoconf wget pkg-config \
+                       openvpn netcat-openbsd nftables iproute2 \
+                       wpasupplicant udhcpc wireless-tools
+
+ENV ACE_SRC=/root/ACE_wrappers ACE_PREFIX=/usr/local/ACE_TAO-7.0.0
+WORKDIR /root
+RUN wget -q https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_0/ACE+TAO-7.0.0.tar.gz \
+    && tar -xzf ACE+TAO-7.0.0.tar.gz \
+    && rm ACE+TAO-7.0.0.tar.gz \
+    && echo '#include "ace/config-linux.h"' > /root/ACE_wrappers/ace/config.h \
+    && echo 'include $(ACE_SRC)/include/makeinclude/platform_linux.GNU' \
+          > /root/ACE_wrappers/include/makeinclude/platform_macros.GNU
+WORKDIR /root/ACE_wrappers
+RUN make install ssl=1 INSTALL_PREFIX=${ACE_PREFIX} ACE_ROOT=${ACE_SRC} SSL_ROOT=/usr/include/openssl \
+    && echo "${ACE_PREFIX}/lib" > /etc/ld.so.conf.d/ace-tao.conf \
+    && ldconfig
+
+# googletest (find_package(GTest) for apps/test). Separate layer so it caches
+# independently of the source tree.
+WORKDIR /tmp
+RUN git clone --depth 1 https://github.com/google/googletest/ && \
+    cd /tmp/googletest && mkdir build && cd build && cmake .. && make -j"$(nproc)" install && \
+    ldconfig
+
+WORKDIR /src
+CMD ["bash"]

--- a/docker/devbuild.sh
+++ b/docker/devbuild.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Compile + run the apps/ gtest suite (lwm2m_test) from a mounted working tree,
+# inside the localhost/iot-devbuild image. No GitHub clone, no mongo — the test
+# suite omits the mongo/UDP/DTLS-bring-up wiring (see apps/test/CMakeLists.txt).
+#
+#   podman run --rm -v "$PWD":/src:Z -w /src localhost/iot-devbuild:latest \
+#       bash docker/devbuild.sh [gtest_filter]
+#
+# Optional arg = a --gtest_filter (e.g. 'Senml*'). Builds out-of-tree under
+# /tmp/iot-build so the mounted tree stays clean.
+set -euo pipefail
+
+SRC=/src
+BUILD=/tmp/iot-build
+FILTER="${1:-*}"
+
+echo "== tinydtls (in-tree, required by apps link) =="
+cd "$SRC/apps/3rdparty/tinydtls"
+if [ ! -f libtinydtls.a ]; then
+    autoconf && autoheader && ./configure >/dev/null && make >/dev/null 2>&1
+fi
+
+echo "== cmake configure (BUILD_APPS_TESTS=ON, IOT_ENABLE_MONGO=OFF) =="
+rm -rf "$BUILD"
+mkdir -p "$BUILD"
+cd "$BUILD"
+cmake "$SRC/apps" -DBUILD_APPS_TESTS=ON -DIOT_ENABLE_MONGO=OFF >/tmp/cmake.log 2>&1 \
+    || { echo "!! cmake failed"; tail -40 /tmp/cmake.log; exit 1; }
+
+echo "== build lwm2m_test =="
+make -j"$(nproc)" lwm2m_test 2>/tmp/make.log \
+    || { echo "!! build failed"; tail -60 /tmp/make.log; exit 1; }
+
+echo "== run: --gtest_filter=$FILTER =="
+./test/lwm2m_test --gtest_filter="$FILTER"


### PR DESCRIPTION
Local full-fidelity validation for ACE-dependent apps/ C++ (image CI only builds, never runs apps/test). Deps-only podman image (cache-hits the ACE layer) + a script that compiles+runs lwm2m_test against the mounted tree. Also repairs the suite's link rot (missing lwm2m_object_firmware.cpp in the glob; ssl/crypto link for psk_gen EVP) → 200/202 pass. The 2 cert failures are a pre-existing umask file-mode check, fixed separately. Test-subdir + docker only; image builds unaffected.