### PR TITLE
test(cert): assert key mode 0640 (group-readable by design)

### DIFF
--- a/apps/test/dm_test.cpp
+++ b/apps/test/dm_test.cpp
@@ -409,7 +409,7 @@ TEST(CertPush, server_push_materializes_family_on_device) {
     EXPECT_EQ(cert, slurp_file(certDir + "/client.crt"));
     EXPECT_EQ(key,  slurp_file(certDir + "/client.key"));
     ASSERT_EQ(0, ::stat((certDir + "/client.key").c_str(), &st));
-    EXPECT_EQ(0600, st.st_mode & 0777);                            // key private
+    EXPECT_EQ(0640, st.st_mode & 0777);            // key 0640: group-readable by design
 
     for (auto* f : {"/ca.crt", "/client.crt", "/client.key"})
         std::remove((certDir + f).c_str());

--- a/apps/test/objects_test.cpp
+++ b/apps/test/objects_test.cpp
@@ -314,9 +314,12 @@ TEST(CertObject, write_then_apply_materializes_cert_family) {
     EXPECT_EQ("-----CERT PEM-----\n", slurp(certDir + "/client.crt"));
     EXPECT_EQ("-----KEY PEM-----\n",  slurp(certDir + "/client.key"));
 
-    // Private key must be 0600; cert/CA world-readable.
+    // Private key is 0640 — group-readable by design so the openvpn-client
+    // DynamicUser (sharing group `iot` via the certDir) can read it; world has
+    // no access. Cert/CA are world-readable. See default_store() in
+    // lwm2m_object_cert.cpp.
     ASSERT_EQ(0, ::stat((certDir + "/client.key").c_str(), &stbuf));
-    EXPECT_EQ(0600, stbuf.st_mode & 0777);
+    EXPECT_EQ(0640, stbuf.st_mode & 0777);
     ASSERT_EQ(0, ::stat((certDir + "/client.crt").c_str(), &stbuf));
     EXPECT_EQ(0644, stbuf.st_mode & 0777);
 


### PR DESCRIPTION
Two cert tests asserted the private key is 0600, but default_store() intentionally writes 0640 (group-readable so openvpn-client's DynamicUser in group 'iot' can read it; world has none). Update the stale assertions to 0640. Full apps/ gtest suite now 202/202 in the podman dev-build (PR-26).