### PR TITLE
feat(lwm2m): PR-31 (v2) — wire SendServer into /dp dispatch (additive)

### DIFF
--- a/apps/inc/coap_adapter.hpp
+++ b/apps/inc/coap_adapter.hpp
@@ -13,6 +13,7 @@
 
 #include "cbor_adapter.hpp"
 #include "lwm2m_adapter.hpp"
+#include "lwm2m_telemetry_pack.hpp"   // telemetry::Sample for the Send report callback
 
 extern "C" {
     #include "dtls.h"
@@ -21,6 +22,7 @@ extern "C" {
 }
 
 namespace lwm2m { class RegistrationServer; }
+namespace lwm2m { class SendServer; }
 namespace lwm2m { class RegistrationClient; }
 namespace lwm2m { class DmClient; }
 namespace lwm2m { namespace bootstrap { class Server; } }
@@ -317,6 +319,24 @@ class CoAPAdapter {
             return m_regServer;
         }
 
+        /// v2 Send: optional server-side receiver for POST /dp (LwM2M Send).
+        /// Purely additive — /dp matches no other route, so attaching this
+        /// cannot change /bs, /rd, or /push dispatch. nullptr means "no Send
+        /// support". The samples are surfaced via onSendReport(); persistence
+        /// (e.g. to a telemetry store) is the caller's choice, deferred.
+        void sendServer(std::shared_ptr<lwm2m::SendServer> ss) {
+            m_sendServer = std::move(ss);
+        }
+        /// Callback fired with the decoded samples of each accepted /dp Send
+        /// (base path = SenML bn, e.g. "/33000/0/"). The ACK is shipped
+        /// regardless; this is the report hook the wrapping context wires to
+        /// persist or log. Optional.
+        using SendReportCb = std::function<void(
+            const std::string& basePath,
+            const std::vector<lwm2m::telemetry::Sample>& samples,
+            const std::string& peerHost, std::uint16_t peerPort)>;
+        void onSendReport(SendReportCb cb) { m_sendReportCb = std::move(cb); }
+
         /// L4: optional Bootstrap server. Attached on the
         /// BootstrapServer ServiceContext_t. Same dispatch shape as
         /// `registrationServer()`.
@@ -378,6 +398,8 @@ class CoAPAdapter {
 
     private:
         std::shared_ptr<lwm2m::RegistrationServer>    m_regServer;
+        std::shared_ptr<lwm2m::SendServer>            m_sendServer;
+        SendReportCb                                  m_sendReportCb;
         std::shared_ptr<lwm2m::bootstrap::Server>     m_bsServer;
         std::shared_ptr<lwm2m::DmClient>              m_dmClient;
         std::shared_ptr<lwm2m::bootstrap::Client>     m_bsClient;

--- a/apps/src/coap_adapter.cpp
+++ b/apps/src/coap_adapter.cpp
@@ -7,6 +7,7 @@
 #include "lwm2m_dm_client.hpp"
 #include "lwm2m_registration_client.hpp"
 #include "lwm2m_registration_server.hpp"
+#include "lwm2m_send_server.hpp"
 #include "nlohmann/json.hpp"
 #include <ace/Log_Msg.h>
 
@@ -1106,6 +1107,19 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
         }
     }
 
+    // v2 Send (POST /dp). Additive: /dp matches no /rd/bs/push route, so this
+    // fires only on a Send and cannot alter existing dispatch. Decoded samples
+    // go to the optional report callback; the ACK ships regardless.
+    if (!isAmIClient && m_sendServer) {
+        auto so = m_sendServer->handle(coapmessage, *this);
+        if (so.kind != ::lwm2m::SendOutcome::None) {
+            if (so.kind == ::lwm2m::SendOutcome::Reported && m_sendReportCb)
+                m_sendReportCb(so.basePath, so.samples, std::string{}, 0);
+            if (!so.response.empty()) out.push_back(std::move(so.response));
+            return static_cast<std::int32_t>(out.size());
+        }
+    }
+
     // While bootstrapping, inbound /{oid}/{iid} frames are Bootstrap-Writes,
     // not DM Writes — let the bootstrap client (below) claim them instead of
     // the DM Write handler, which would otherwise answer 2.01 and swallow the
@@ -1325,6 +1339,21 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
         auto outcome = m_regServer->handle(coapmessage, *this, peerHost, peerPort);
         if (outcome.kind != ::lwm2m::RegistrationOutcome::None) {
             if (!outcome.response.empty()) out.push_back(std::move(outcome.response));
+            return static_cast<std::int32_t>(out.size());
+        }
+    }
+
+    // v2 Send (POST /dp) — session path, so the peer is known + passed to the
+    // report callback for endpoint attribution. Additive (see the UDP-only
+    // path above).
+    if (!isAmIClient && m_sendServer && session != nullptr) {
+        std::string peerHost(inet_ntoa(session->addr.sin.sin_addr));
+        std::uint16_t peerPort = ntohs(session->addr.sin.sin_port);
+        auto so = m_sendServer->handle(coapmessage, *this);
+        if (so.kind != ::lwm2m::SendOutcome::None) {
+            if (so.kind == ::lwm2m::SendOutcome::Reported && m_sendReportCb)
+                m_sendReportCb(so.basePath, so.samples, peerHost, peerPort);
+            if (!so.response.empty()) out.push_back(std::move(so.response));
             return static_cast<std::int32_t>(out.size());
         }
     }

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -48,6 +48,7 @@
 #include "lwm2m_registration.hpp"
 #include "lwm2m_registration_client.hpp"
 #include "lwm2m_registration_server.hpp"
+#include "lwm2m_send_server.hpp"
 
 #include "ds_config.hpp"
 #include "rpi_serial.hpp"
@@ -353,10 +354,27 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
     // both Bootstrap and Registration. A future multi-socket deploy
     // gets both handlers per socket for free.
     auto regServer = std::make_shared<::lwm2m::RegistrationServer>(registry);
+    // v2 Send (POST /dp) receiver — additive; /dp matches no existing route.
+    auto sendServer = std::make_shared<::lwm2m::SendServer>();
     auto& services = app->udpAdapter()->services();
     for (auto& [type, ctx] : services) {
         ctx->coapAdapter()->bootstrapServer(bsServer);
         ctx->coapAdapter()->registrationServer(regServer);
+        // Accept + ACK + log inbound Sends. Persistence to a telemetry store is
+        // deferred (design TBD — apps/docs/tdd-vehicle-telemetry.md §3b: feed
+        // the existing cloud.vehicle.telemetry spool vs a parallel inbox); this
+        // wiring proves the server receive path without prejudging that choice.
+        ctx->coapAdapter()->sendServer(sendServer);
+        ctx->coapAdapter()->onSendReport(
+            [](const std::string& base,
+               const std::vector<::lwm2m::telemetry::Sample>& samples,
+               const std::string& peer, std::uint16_t port) {
+                ACE_DEBUG((LM_INFO,
+                    ACE_TEXT("%D lwm2m:thread:%t %M %N:%l Send /dp report base=%C "
+                             "samples=%u peer=%C:%d (persist deferred)\n"),
+                    base.c_str(), static_cast<unsigned>(samples.size()),
+                    peer.c_str(), static_cast<int>(port)));
+            });
     }
 
     // Online/offline endpoint state. Only the DM instance sees /rd traffic,


### PR DESCRIPTION
Routes POST /dp → SendServer in CoAPAdapter::processRequest (both variants), alongside /rd and /bs. **Additive** — /dp matches no existing route, so /bs/rd/push are untouched. Adds sendServer() setter + onSendReport() hook; main.cpp attaches it server-side with a log-only callback. **Persistence deferred** (inbox-vs-spool design → HW session). Validated: full lwm2m binary compiles in the podman dev-build + Send tests green. Runtime needs a real /dp-posting device.