### PR TITLE
feat(lwm2m): PR-33 (v2) — bounded SampleBuffer with ACK-then-prune

### DIFF
--- a/apps/inc/lwm2m_sample_buffer.hpp
+++ b/apps/inc/lwm2m_sample_buffer.hpp
@@ -1,0 +1,75 @@
+#ifndef __lwm2m_sample_buffer_hpp__
+#define __lwm2m_sample_buffer_hpp__
+
+#include <cstddef>
+#include <deque>
+#include <vector>
+
+#include "lwm2m_telemetry_pack.hpp"
+
+/**
+ * @file lwm2m_sample_buffer.hpp
+ * @brief Bounded FIFO of telemetry Samples awaiting LwM2M Send, with
+ *        ACK-then-prune (§3b) delivery semantics.
+ *
+ * The client uploader accumulates timestamped readings here while the cloud
+ * link is available; it `take()`s an oldest-first batch to Send, and either
+ * drops it on a 2.04 ACK or `requeue()`s it on failure so it retries first.
+ * Bounded: when full, the oldest queued sample is evicted (recent telemetry
+ * wins; the deep history is the cloud spool's job, PR-22/23). Pure — no ACE /
+ * CoAP — so it is fully unit-testable; the transmit/timer wiring lives in the
+ * registered client session.
+ */
+
+namespace lwm2m { namespace telemetry {
+
+class SampleBuffer {
+public:
+    /// `capacity` samples max (clamped to >= 1).
+    explicit SampleBuffer(std::size_t capacity)
+        : m_cap(capacity ? capacity : 1) {}
+
+    /// Append a reading; evicts the oldest when full (counts it in dropped()).
+    void push(const Sample& s) {
+        if (m_q.size() >= m_cap) { m_q.pop_front(); ++m_dropped; }
+        m_q.push_back(s);
+    }
+
+    std::size_t size() const { return m_q.size(); }
+    bool        empty() const { return m_q.empty(); }
+    /// Total samples evicted by overflow (here + requeue), for telemetry.
+    std::size_t dropped() const { return m_dropped; }
+
+    /// Remove and return up to `n` oldest samples — the batch to Send.
+    std::vector<Sample> take(std::size_t n) {
+        std::vector<Sample> out;
+        const std::size_t k = n < m_q.size() ? n : m_q.size();
+        out.reserve(k);
+        for (std::size_t i = 0; i < k; ++i) {
+            out.push_back(std::move(m_q.front()));
+            m_q.pop_front();
+        }
+        return out;
+    }
+
+    /// Return a taken batch to the FRONT after a failed Send (nack/timeout) so
+    /// it retries first, preserving order. Honours capacity: if the buffer
+    /// filled while the batch was in flight, the oldest overflow is dropped
+    /// (newest-wins), counted in dropped().
+    void requeue(std::vector<Sample>&& batch) {
+        for (auto it = batch.rbegin(); it != batch.rend(); ++it) {
+            if (m_q.size() >= m_cap) { ++m_dropped; continue; }
+            m_q.push_front(std::move(*it));
+        }
+        batch.clear();
+    }
+
+private:
+    std::deque<Sample> m_q;
+    std::size_t        m_cap;
+    std::size_t        m_dropped{0};
+};
+
+}} // namespace lwm2m::telemetry
+
+#endif /*__lwm2m_sample_buffer_hpp__*/

--- a/apps/test/sample_buffer_test.cpp
+++ b/apps/test/sample_buffer_test.cpp
@@ -1,0 +1,85 @@
+#include <gtest/gtest.h>
+
+#include "lwm2m_sample_buffer.hpp"
+
+namespace tp = ::lwm2m::telemetry;
+
+namespace {
+tp::Sample mk(double t, double v) {
+    tp::Sample s;
+    s.timeUnix = t;
+    s.values = { {"10", v} };
+    return s;
+}
+} // namespace
+
+TEST(SampleBuffer, push_and_take_is_fifo_oldest_first) {
+    tp::SampleBuffer buf(10);
+    for (int k = 0; k < 5; ++k) buf.push(mk(1000 + k, 60 + k));
+    EXPECT_EQ(5u, buf.size());
+    EXPECT_FALSE(buf.empty());
+
+    auto batch = buf.take(3);
+    ASSERT_EQ(3u, batch.size());
+    EXPECT_EQ(1000.0, batch[0].timeUnix);   // oldest first
+    EXPECT_EQ(1002.0, batch[2].timeUnix);
+    EXPECT_EQ(2u, buf.size());              // 2 left
+}
+
+TEST(SampleBuffer, take_more_than_present_returns_all) {
+    tp::SampleBuffer buf(10);
+    buf.push(mk(1, 1));
+    buf.push(mk(2, 2));
+    auto batch = buf.take(100);
+    EXPECT_EQ(2u, batch.size());
+    EXPECT_TRUE(buf.empty());
+    EXPECT_TRUE(buf.take(5).empty());       // empty buffer → empty batch
+}
+
+TEST(SampleBuffer, overflow_evicts_oldest_and_counts_dropped) {
+    tp::SampleBuffer buf(3);
+    for (int k = 0; k < 5; ++k) buf.push(mk(1000 + k, k));  // 0,1,2 then evict for 3,4
+    EXPECT_EQ(3u, buf.size());
+    EXPECT_EQ(2u, buf.dropped());
+    auto batch = buf.take(3);
+    EXPECT_EQ(1002.0, batch[0].timeUnix);   // 1000,1001 evicted; 1002 is oldest kept
+    EXPECT_EQ(1004.0, batch[2].timeUnix);
+}
+
+TEST(SampleBuffer, requeue_restores_order_and_retries_first) {
+    tp::SampleBuffer buf(10);
+    for (int k = 0; k < 4; ++k) buf.push(mk(1000 + k, k));
+    auto batch = buf.take(2);               // [1000, 1001]
+    EXPECT_EQ(2u, buf.size());              // [1002, 1003] remain
+    buf.requeue(std::move(batch));          // failed Send → back to front
+    EXPECT_EQ(4u, buf.size());
+    auto again = buf.take(4);
+    ASSERT_EQ(4u, again.size());
+    EXPECT_EQ(1000.0, again[0].timeUnix);   // requeued batch retries first
+    EXPECT_EQ(1001.0, again[1].timeUnix);
+    EXPECT_EQ(1002.0, again[2].timeUnix);
+    EXPECT_EQ(1003.0, again[3].timeUnix);
+}
+
+TEST(SampleBuffer, requeue_over_capacity_drops_oldest) {
+    tp::SampleBuffer buf(3);
+    buf.push(mk(1, 1));
+    buf.push(mk(2, 2));
+    auto batch = buf.take(2);               // hold [1,2]; buffer empty
+    buf.push(mk(3, 3));
+    buf.push(mk(4, 4));
+    buf.push(mk(5, 5));                      // buffer full [3,4,5]
+    buf.requeue(std::move(batch));          // no room → both requeued samples dropped
+    EXPECT_EQ(3u, buf.size());
+    EXPECT_EQ(2u, buf.dropped());
+    auto out = buf.take(3);
+    EXPECT_EQ(3.0, out[0].timeUnix);        // newest-wins: 3,4,5 kept
+}
+
+TEST(SampleBuffer, capacity_zero_clamps_to_one) {
+    tp::SampleBuffer buf(0);
+    buf.push(mk(1, 1));
+    buf.push(mk(2, 2));
+    EXPECT_EQ(1u, buf.size());
+    EXPECT_EQ(2.0, buf.take(1)[0].timeUnix);
+}


### PR DESCRIPTION
The client uploader's core data structure: a bounded FIFO of telemetry Samples. push() each reading, take() an oldest-first batch to Send, drop on 2.04 or requeue() on failure (retries first) — the §3b ACK-then-prune contract. Bounded (drop-oldest on overflow, dropped() counter). Pure + header-only → **validated 6/6** in the podman dev-build. Transmit/timer wiring around it is the HW step.