### PR TITLE
fix(cloud-ui): give Map nav its own icon (was reusing endpoints.svg)

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -17,7 +17,7 @@ export class MainComponent implements OnInit {
   menus = [
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg' },
     { id: 'endpoints', label: 'Endpoints', svg: 'assets/icons/endpoints.svg' },
-    { id: 'map',       label: 'Map',       svg: 'assets/icons/endpoints.svg' },
+    { id: 'map',       label: 'Map',       svg: 'assets/icons/map.svg' },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg' },
     { id: 'http',      label: 'HTTP',      svg: 'assets/icons/http.svg' },
     { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg' },

--- a/apps/cloud/ui/src/assets/icons/map.svg
+++ b/apps/cloud/ui/src/assets/icons/map.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <polygon points="1 6 1 22 8 18 16 22 23 18 23 2 16 6 8 2 1 6"/>
+  <line x1="8" y1="2" x2="8" y2="18"/>
+  <line x1="16" y1="6" x2="16" y2="22"/>
+</svg>


### PR DESCRIPTION
Map and Endpoints showed the same sidebar icon — Map pointed at endpoints.svg. Adds a folded-map icon (matching line-art style) and points Map at it.