### PR TITLE
fix(ui): http-config workers form default 4, not 0

### DIFF
--- a/apps/cloud/ui/src/app/http-config/http-config.component.ts
+++ b/apps/cloud/ui/src/app/http-config/http-config.component.ts
@@ -133,7 +133,9 @@ export class HttpConfigComponent implements OnInit, OnDestroy {
       ip:      ['0.0.0.0'],
       port:    [8080],
       scheme:  ['http'],
-      workers: [0],
+      workers: [4],   // match the schema default (http.lua). A 0 fallback here
+                      // clobbered http.workers to 0 on save whenever ds had no
+                      // explicit value (the daemon's effective default is 4).
       cert:    [''],
       key:     [''],
       ca:      [''],

--- a/iot-ui/src/app/http-config/http-config.component.ts
+++ b/iot-ui/src/app/http-config/http-config.component.ts
@@ -162,7 +162,9 @@ export class HttpConfigComponent implements OnInit, OnDestroy {
       ip:      ['0.0.0.0'],
       port:    [8080],
       scheme:  ['http'],
-      workers: [0],
+      workers: [4],   // match the schema default (http.lua). A 0 fallback here
+                      // clobbered http.workers to 0 on save whenever ds had no
+                      // explicit value (the daemon's effective default is 4).
       cert:    [''],
       key:     [''],
       ca:      [''],


### PR DESCRIPTION
The HTTP config form defaulted workers:[0]; when ds had no explicit http.workers, the '?? form.value' fallback wrote 0 on save — dropping iot-httpd to inline despite the schema default of 4. Default the form to 4 (both cloud-ui + device-ui).