### PR TITLE
fix(cloud-ui): remove WAN nav (device-side concern)

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -42,16 +42,6 @@
       <!-- HTTP Server Config -->
       <app-http-config *ngIf="selectedMenu==='http'"></app-http-config>
 
-      <!-- WAN (from iot-ui) -->
-      <ng-container *ngIf="selectedMenu==='wan'">
-        <app-wan-submenu (nav)="onSubNavSelect($event)"></app-wan-submenu>
-        <div class="content-area">
-          <app-wifi-config    *ngIf="!selectedSubNav || selectedSubNav==='wifi'"></app-wifi-config>
-          <app-wifi-scan      *ngIf="selectedSubNav==='scan'"></app-wifi-scan>
-          <app-iface-priority *ngIf="selectedSubNav==='priority'"></app-iface-priority>
-        </div>
-      </ng-container>
-
       <!-- Routing (from iot-ui) -->
       <ng-container *ngIf="selectedMenu==='routing'">
         <app-routing-submenu (nav)="onSubNavSelect($event)"></app-routing-submenu>

--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -20,7 +20,6 @@ export class MainComponent implements OnInit {
     { id: 'map',       label: 'Map',       svg: 'assets/icons/map.svg' },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg' },
     { id: 'http',      label: 'HTTP',      svg: 'assets/icons/http.svg' },
-    { id: 'wan',       label: 'WAN',       svg: 'assets/icons/wan.svg' },
     { id: 'routing',   label: 'Routing',   svg: 'assets/icons/routing.svg' },
     { id: 'lwm2m',     label: 'LwM2M',     svg: 'assets/icons/lwm2m.svg' },
     { id: 'services',  label: 'Services',  svg: 'assets/icons/services.svg' },


### PR DESCRIPTION
WAN config is a device concern carried over from iot-ui; it has no meaning on the cloud dashboard. Removes the WAN sidebar item + its template block (components stay declared, unreachable).