### PR TITLE
feat(device-ui): Advanced nav — Reboot, Factory Reset, Transfer

### DIFF
--- a/iot-ui/src/app/advanced/advanced.component.ts
+++ b/iot-ui/src/app/advanced/advanced.component.ts
@@ -1,0 +1,105 @@
+import { Component, Input } from '@angular/core';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+
+/// Advanced operations: Reboot, Factory Reset, Transfer (placeholder). Each
+/// destructive action is Admin-gated + explicitly confirmed. The server arms a
+/// /run/iot trigger that a root systemd .path unit performs (iot-httpd itself
+/// is unprivileged) — see modules/http-server POST /api/v1/system/*.
+@Component({
+  selector: 'app-advanced',
+  template: `
+    <div class="page">
+      <!-- ── Reboot ───────────────────────────────────────────── -->
+      <ng-container *ngIf="panel==='reboot'">
+        <h3>Reboot</h3>
+        <p class="hint">Restart the device now. Services are briefly unavailable
+          while it comes back up; configuration and credentials are preserved.</p>
+        <label class="ck">
+          <input type="checkbox" #rc (change)="rebootOk = rc.checked">
+          I understand the device will reboot immediately.
+        </label>
+        <div class="act">
+          <button class="btn btn-warning" [disabled]="!rebootOk || busy || !isAdmin"
+                  (click)="doReboot()">{{ busy ? '…' : 'Reboot Device' }}</button>
+        </div>
+      </ng-container>
+
+      <!-- ── Factory Reset ────────────────────────────────────── -->
+      <ng-container *ngIf="panel==='factory'">
+        <h3>Factory Reset</h3>
+        <p class="warn">⚠ This <b>wipes ALL persisted configuration, credentials,
+          and network settings</b>, returning the device to first-boot (Lua
+          schema) defaults, then reboots. The device will likely drop off the
+          network and need re-setup from the console. <b>This cannot be undone.</b></p>
+        <label class="ck">
+          Type <code>RESET</code> to confirm:
+          <input type="text" #rw (input)="resetWord = rw.value"
+                 placeholder="RESET" autocomplete="off">
+        </label>
+        <div class="act">
+          <button class="btn btn-danger" [disabled]="resetWord!=='RESET' || busy || !isAdmin"
+                  (click)="doFactoryReset()">{{ busy ? '…' : 'Factory Reset' }}</button>
+        </div>
+      </ng-container>
+
+      <!-- ── Transfer (placeholder) ───────────────────────────── -->
+      <ng-container *ngIf="panel==='transfer'">
+        <h3>Transfer</h3>
+        <p class="hint">Coming soon — device configuration / credential transfer.</p>
+      </ng-container>
+
+      <p *ngIf="!isAdmin" class="warn">Admin access is required for these actions.</p>
+      <p *ngIf="msg" class="msg">{{ msg }}</p>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; max-width: 640px; }
+    h3 { font-size: 16px; font-weight: 600; color: #333; margin: 0 0 12px 0; }
+    .hint { color: #666; font-size: 13px; }
+    .warn { color: #b71c1c; font-size: 13px; background: #fdecea; border: 1px solid #f5c6cb;
+            border-radius: 4px; padding: 10px 12px; }
+    .ck { display: block; margin: 14px 0; font-size: 13px; color: #444; }
+    .ck input[type=text] { margin-left: 6px; padding: 3px 6px; }
+    .act { margin-top: 8px; }
+    .btn-warning { background: #e08e0b; color: #fff; }
+    .btn-danger  { background: #c62828; color: #fff; }
+    .btn:disabled { opacity: 0.5; cursor: not-allowed; }
+    .msg { margin-top: 14px; font-size: 13px; color: #0072a3; }
+  `]
+})
+export class AdvancedComponent {
+  @Input() panel: 'reboot' | 'factory' | 'transfer' = 'reboot';
+  rebootOk = false;
+  resetWord = '';
+  busy = false;
+  msg = '';
+
+  constructor(private http: HttpsvcService, private session: SessionService) {}
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  doReboot(): void {
+    this.busy = true; this.msg = '';
+    this.http.systemReboot().subscribe({
+      next: (r) => {
+        this.busy = false;
+        this.msg = r.ok ? 'Reboot requested — the device is restarting…'
+                        : ('Error: ' + (r.err || 'failed'));
+      },
+      error: () => { this.busy = false; this.msg = 'Request sent; the device may already be rebooting.'; }
+    });
+  }
+
+  doFactoryReset(): void {
+    this.busy = true; this.msg = '';
+    this.http.systemFactoryReset().subscribe({
+      next: (r) => {
+        this.busy = false;
+        this.msg = r.ok ? 'Factory reset requested — wiping to defaults and rebooting…'
+                        : ('Error: ' + (r.err || 'failed'));
+      },
+      error: () => { this.busy = false; this.msg = 'Request sent; the device may already be resetting.'; }
+    });
+  }
+}

--- a/iot-ui/src/app/app.module.ts
+++ b/iot-ui/src/app/app.module.ts
@@ -43,6 +43,7 @@ import { UsersComponent } from './users/users.component';
 import { SoftwareUpdateComponent } from './software-update/software-update.component';
 import { HttpConfigComponent } from './http-config/http-config.component';
 import { ShellComponent } from './shell/shell.component';
+import { AdvancedComponent } from './advanced/advanced.component';
 
 import { SsoAuthInterceptor } from '../common/sso-auth.interceptor';
 import { SessionService, initSession } from '../common/session.service';
@@ -66,6 +67,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     LogLevelComponent, LogViewerComponent, ToastComponent,
     UsersComponent, SoftwareUpdateComponent, HttpConfigComponent,
     ShellComponent,
+    AdvancedComponent,
     DsHintComponent, DsDebugDirective,
   ],
   imports: [

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -145,6 +145,12 @@
 
       <!-- Terminal (remote shell) -->
       <app-shell *ngIf="selectedMenu==='shell' && shellEnabled && isAdmin"></app-shell>
+
+      <!-- Advanced: Reboot / Factory Reset / Transfer -->
+      <ng-container *ngIf="selectedMenu==='advanced'">
+        <app-advanced [panel]="selectedSubNav==='factory' ? 'factory'
+                              : selectedSubNav==='transfer' ? 'transfer' : 'reboot'"></app-advanced>
+      </ng-container>
     </div>
   </div>
 </div>

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -45,6 +45,8 @@ export class MainComponent {
     { id: 'users',     label: 'Users',     svg: 'assets/icons/users.svg', children: [] as {id:string,label:string}[] },
     { id: 'software',  label: 'Software',  svg: 'assets/icons/software.svg', children: [] as {id:string,label:string}[] },
     { id: 'shell',     label: 'Terminal',  svg: 'assets/icons/services.svg', children: [] as {id:string,label:string}[] },
+    { id: 'advanced',  label: 'Advanced',  svg: 'assets/icons/advanced.svg',
+      children: [{id:'reboot',label:'Reboot'},{id:'factory',label:'Factory Reset'},{id:'transfer',label:'Transfer'}] },
   ];
 
   expandedMenu: string | null = null;  // which menu is expanded in sidebar

--- a/iot-ui/src/assets/icons/advanced.svg
+++ b/iot-ui/src/assets/icons/advanced.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <line x1="4" y1="21" x2="4" y2="14"/>
+  <line x1="4" y1="10" x2="4" y2="3"/>
+  <line x1="12" y1="21" x2="12" y2="12"/>
+  <line x1="12" y1="8" x2="12" y2="3"/>
+  <line x1="20" y1="21" x2="20" y2="16"/>
+  <line x1="20" y1="12" x2="20" y2="3"/>
+  <line x1="1" y1="14" x2="7" y2="14"/>
+  <line x1="9" y1="8" x2="15" y2="8"/>
+  <line x1="17" y1="16" x2="23" y2="16"/>
+</svg>

--- a/iot-ui/src/common/httpsvc.service.ts
+++ b/iot-ui/src/common/httpsvc.service.ts
@@ -44,6 +44,21 @@ export class HttpsvcService {
       { headers: this.jsonHeaders(), withCredentials: true });
   }
 
+  // ── System actions (Advanced) ─────────────────────────────────────
+  // Admin-only. The server arms a /run/iot trigger that a root systemd .path
+  // unit acts on (reboot, or wipe-to-defaults+reboot). See modules/http-server.
+  systemReboot(): Observable<{ ok: boolean; err?: string }> {
+    return this.http.post<{ ok: boolean; err?: string }>(
+      `${this.api}/api/v1/system/reboot`, {},
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
+  systemFactoryReset(): Observable<{ ok: boolean; err?: string }> {
+    return this.http.post<{ ok: boolean; err?: string }>(
+      `${this.api}/api/v1/system/factory-reset`, {},
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
   // ── Status ────────────────────────────────────────────────────────
 
   getStatus(): Observable<StatusSnapshot> {

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -489,6 +489,78 @@ void install_handlers(Router& router,
             return r;
         });
 
+    // ── POST /api/v1/system/reboot ────────────────────────────────
+    // Admin-only. iot-httpd is unprivileged (DynamicUser, group iot) so it
+    // cannot reboot directly; it arms a trigger file in /run/iot that the root
+    // iot-reboot.path systemd unit watches → iot-reboot.service runs
+    // `systemctl reboot`. Same privilege-separation pattern as the OTA stager.
+    // Yocto/systemd only (the .path/.service units live there).
+    router.add("POST", "/api/v1/system/reboot",
+        [auth](const HttpParser::Request& req) -> HttpResponse {
+            HttpResponse r;
+            std::string access_level = "Admin";
+            if (auth && auth->enabled()) {
+                std::string token = extract_session_cookie(req.headers, auth->cookie_name());
+                if (!token.empty()) {
+                    const auto* session = auth->validate(token);
+                    if (session) access_level = session->access;
+                }
+            }
+            if (access_level != "Admin") {
+                r.status = 403;
+                r.body = R"({"ok":false,"err":"admin required"})";
+                return r;
+            }
+            std::ofstream trig("/run/iot/reboot.request", std::ios::trunc);
+            if (!trig) {
+                r.status = 500;
+                r.body = R"({"ok":false,"err":"cannot arm reboot - perms or non-Yocto host"})";
+                return r;
+            }
+            trig << "reboot\n";
+            ACE_DEBUG((LM_WARNING,
+                       ACE_TEXT("%D httpd:thread:%t %M %N:%l SYSTEM REBOOT requested "
+                                "via device-ui (armed iot-reboot.path)\n")));
+            r.body = R"({"ok":true})";
+            return r;
+        });
+
+    // ── POST /api/v1/system/factory-reset ─────────────────────────
+    // Admin-only + DESTRUCTIVE. Arms the trigger that the root
+    // iot-factory-reset.service acts on: it removes the persisted data-store
+    // (/var/lib/iot/data_store.lua, the operator-override layer) + generated VPN
+    // certs, so the device falls back to the schema (Lua) defaults, then
+    // reboots into that first-boot state. Yocto/systemd only.
+    router.add("POST", "/api/v1/system/factory-reset",
+        [auth](const HttpParser::Request& req) -> HttpResponse {
+            HttpResponse r;
+            std::string access_level = "Admin";
+            if (auth && auth->enabled()) {
+                std::string token = extract_session_cookie(req.headers, auth->cookie_name());
+                if (!token.empty()) {
+                    const auto* session = auth->validate(token);
+                    if (session) access_level = session->access;
+                }
+            }
+            if (access_level != "Admin") {
+                r.status = 403;
+                r.body = R"({"ok":false,"err":"admin required"})";
+                return r;
+            }
+            std::ofstream trig("/run/iot/factory-reset.request", std::ios::trunc);
+            if (!trig) {
+                r.status = 500;
+                r.body = R"({"ok":false,"err":"cannot arm factory-reset - perms or non-Yocto host"})";
+                return r;
+            }
+            trig << "factory-reset\n";
+            ACE_DEBUG((LM_WARNING,
+                       ACE_TEXT("%D httpd:thread:%t %M %N:%l FACTORY RESET requested "
+                                "via device-ui (armed iot-factory-reset.path)\n")));
+            r.body = R"({"ok":true})";
+            return r;
+        });
+
     // ── POST /api/v1/firmware/upload?name=<f>&version=&arch=&pkg= ──
     // Cloud-side: browse / drag-drop a .ipk or .tar.gz bundle in the cloud-ui
     // straight into the firmware FEED (firmware_dir, served at /firmware/) and

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-factory-reset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-factory-reset
@@ -1,0 +1,31 @@
+#!/bin/sh
+# iot-factory-reset — DESTRUCTIVE full reset to as-flashed (first-boot) defaults.
+#
+# Armed by the device-ui: POST /api/v1/system/factory-reset writes
+# /run/iot/factory-reset.request, iot-factory-reset.path fires this (as root).
+# It removes the persisted data-store OVERRIDE layer + generated secrets so
+# ds-server restarts with ONLY the schema (Lua) defaults, then reboots into that
+# first-boot state. The device comes back UNPROVISIONED (no PSKs, no VPN, no
+# operator config — including network), so it likely drops off-network and needs
+# re-setup from the console. This is intentional ("full wipe to as-flashed").
+set -u
+
+logger -t iot-factory-reset "FACTORY RESET: wiping persisted state -> schema defaults, then reboot"
+rm -f /run/iot/factory-reset.request
+
+# Stop ds-server first so it does not rewrite the persist file as we remove it
+# (it is write-through + fsync-on-set). Dependents go down with it; we reboot
+# anyway.
+systemctl stop iot-ds 2>/dev/null || true
+
+# 1. The operator-override layer: ALL config + credentials + network. Removing
+#    it makes ds fall back to the compiled schema defaults — the .lua files in
+#    /etc/iot/ds-schemas, which are part of the image and are NOT touched.
+rm -f /var/lib/iot/data_store.lua
+
+# 2. Generated runtime secrets not held in the data-store.
+rm -rf /etc/iot/vpn
+
+sync
+logger -t iot-factory-reset "wipe done; rebooting into defaults"
+systemctl reboot

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-factory-reset.path
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-factory-reset.path
@@ -1,0 +1,12 @@
+[Unit]
+Description=Watch the factory-reset trigger (device-ui Advanced -> Factory Reset)
+Documentation=https://github.com/naushada/iot
+
+[Path]
+# iot-httpd (unprivileged) arms this; the root iot-factory-reset.service wipes
+# persisted state and reboots. DESTRUCTIVE — see iot-factory-reset.
+PathExists=/run/iot/factory-reset.request
+Unit=iot-factory-reset.service
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-factory-reset.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-factory-reset.service
@@ -1,0 +1,9 @@
+[Unit]
+Description=Factory reset — wipe persisted state to schema defaults, then reboot
+Documentation=https://github.com/naushada/iot
+# No [Install]: activated by iot-factory-reset.path, never enabled directly.
+
+[Service]
+Type=oneshot
+ExecStart=/usr/bin/iot-factory-reset
+TimeoutStartSec=120

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-reboot.path
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-reboot.path
@@ -1,0 +1,13 @@
+[Unit]
+Description=Watch the reboot trigger (device-ui Advanced -> Reboot)
+Documentation=https://github.com/naushada/iot
+
+[Path]
+# iot-httpd (unprivileged) arms this by creating the file; the root
+# iot-reboot.service then runs `systemctl reboot`. The service removes the
+# trigger to re-arm (a .path unit won't re-fire until the path is gone again).
+PathExists=/run/iot/reboot.request
+Unit=iot-reboot.service
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-reboot.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-reboot.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=Reboot the device (armed by iot-reboot.path)
+Documentation=https://github.com/naushada/iot
+# No [Install]: activated by iot-reboot.path, never enabled directly.
+
+[Service]
+Type=oneshot
+# Remove the trigger first so the .path unit re-arms, then reboot.
+ExecStartPre=/bin/rm -f /run/iot/reboot.request
+ExecStart=/bin/systemctl reboot

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -58,6 +58,11 @@ SRC_URI = "\
     file://iot-swupdate.service \
     file://iot-ota-confirm \
     file://iot-ota-confirm.service \
+    file://iot-reboot.path \
+    file://iot-reboot.service \
+    file://iot-factory-reset \
+    file://iot-factory-reset.path \
+    file://iot-factory-reset.service \
     file://iot-bank-switch \
     file://migrations/README.md \
     file://migrations/0000-template.sh.example \
@@ -261,6 +266,10 @@ do_install() {
     install -m 0755 ${WORKDIR}/iot-ota-stage    ${D}${bindir}/iot-ota-stage
     install -m 0755 ${WORKDIR}/iot-swupdate     ${D}${bindir}/iot-swupdate
     install -m 0755 ${WORKDIR}/iot-ota-confirm  ${D}${bindir}/iot-ota-confirm
+    # Factory-reset wipe script (run as root by iot-factory-reset.service, which
+    # iot-factory-reset.path fires when the unprivileged iot-httpd drops
+    # /run/iot/factory-reset.request). Reboot needs no script (systemctl reboot).
+    install -m 0755 ${WORKDIR}/iot-factory-reset ${D}${bindir}/iot-factory-reset
     install -m 0755 ${WORKDIR}/iot-bank-switch  ${D}${bindir}/iot-bank-switch
 
     # iot-dump: operator/debug tool — dumps all data-store keys + values for
@@ -300,6 +309,13 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-swupdate.path          ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-swupdate.service       ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-ota-confirm.service    ${D}${systemd_system_unitdir}/
+        # device-ui Advanced -> Reboot / Factory Reset: root .path units watch a
+        # trigger the unprivileged iot-httpd drops in /run/iot, then reboot /
+        # wipe+reboot. See modules/http-server (POST /api/v1/system/*).
+        install -m 0644 ${WORKDIR}/iot-reboot.path            ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-reboot.service         ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-factory-reset.path     ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-factory-reset.service  ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-net-router.service     ${D}${systemd_system_unitdir}/
         # iot-sensord: mangOH Yellow sensor producer (maps I2C, publishes
         # iot.sensor.*). NOT auto-enabled — it needs the mangOH board attached
@@ -522,9 +538,14 @@ FILES:${PN}-httpd = "\
     ${bindir}/iot-httpd \
     ${bindir}/iot-set-hostname \
     ${bindir}/iot-ds-seed \
+    ${bindir}/iot-factory-reset \
     ${systemd_system_unitdir}/iot-httpd.service \
     ${systemd_system_unitdir}/iot-hostname.service \
     ${systemd_system_unitdir}/iot-ds-seed.service \
+    ${systemd_system_unitdir}/iot-reboot.path \
+    ${systemd_system_unitdir}/iot-reboot.service \
+    ${systemd_system_unitdir}/iot-factory-reset.path \
+    ${systemd_system_unitdir}/iot-factory-reset.service \
     ${sysconfdir}/avahi/services/iot-http.service \
     ${datadir}/iot/www \
 "
@@ -636,7 +657,10 @@ SYSTEMD_SERVICE:${PN}-net-router = "iot-net-router.service"
 SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
 # httpd also carries the boot-time hostname unit (iot-<serial>) that makes the
 # Avahi advert resolvable — zero-touch device-UI discovery.
-SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service iot-ds-seed.service"
+# iot-reboot.path + iot-factory-reset.path are enabled (they watch the triggers
+# iot-httpd drops in /run/iot for device-ui Advanced -> Reboot/Factory Reset);
+# their .service units are path-activated, not enabled directly (no [Install]).
+SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service iot-ds-seed.service iot-reboot.path iot-factory-reset.path"
 # iot-sensord registered but NOT auto-enabled: it needs the mangOH Yellow board
 # + CAP_SYS_RAWIO, so on a board without it the daemon would Restart-loop. The
 # operator `systemctl enable --now iot-sensord` on sensor-equipped hardware.


### PR DESCRIPTION
device-ui Advanced menu: **Reboot** (config preserved), **Factory Reset** (DESTRUCTIVE full wipe → Lua schema defaults → reboot, type-RESET-to-confirm), **Transfer** (placeholder). Privilege-separated like the OTA stager: Admin-gated iot-httpd endpoints arm /run/iot triggers → root systemd .path units reboot / wipe+reboot. Ships 4 units + wipe script in ${PN}-httpd. iot-httpd compile-validated in the podman dev-build; reboot/wipe runtime is HW-verified.