### PR TITLE
feat(cloud): ISP IP from LwM2M registration (VPN-independent + retained) + last-seen

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -185,6 +185,7 @@ bool reconcile_registrations(data_store::Client& ds,
     std::unordered_map<std::string, std::int64_t> online;  // ep → last_seen_unix
     std::unordered_map<std::string, std::string>  versions;  // ep → /3/0/3
     std::unordered_map<std::string, std::string>  lanIps;    // ep → /4/0/4
+    std::unordered_map<std::string, std::string>  ispIps;    // ep → DTLS peer (public/ISP)
     std::unordered_map<std::string, std::uint32_t> lifetimes; // ep → lifetime(s)
     std::unordered_map<std::string, std::string>  locations;  // ep → /rd/<id>
     try {
@@ -199,6 +200,8 @@ bool reconcile_registrations(data_store::Client& ds,
                 if (!ver.empty()) versions[ep] = std::move(ver);
                 auto lan = e.value("lan_ip", std::string());
                 if (!lan.empty()) lanIps[ep] = std::move(lan);
+                auto isp = e.value("isp_ip", std::string());
+                if (!isp.empty()) ispIps[ep] = std::move(isp);
                 if (auto lt = e.value("lifetime", std::uint32_t{0}); lt != 0)
                     lifetimes[ep] = lt;
                 if (auto loc = e.value("location", std::string()); !loc.empty())
@@ -223,6 +226,12 @@ bool reconcile_registrations(data_store::Client& ds,
             changed = true;
         auto nit = lanIps.find(ep.ep);
         if (nit != lanIps.end() && reg.update_lan_ip(ep.ep, nit->second))
+            changed = true;
+        // Public/ISP IP from the registration peer — retained across offline
+        // (only updated when the device reports one, never cleared here), so it
+        // survives a VPN drop. See publish_regs in apps/src/main.cpp.
+        auto iit = ispIps.find(ep.ep);
+        if (iit != ispIps.end() && reg.update_wan_ip(ep.ep, iit->second))
             changed = true;
         // Heartbeat interval + /rd location (Endpoints table columns).
         {
@@ -1114,15 +1123,17 @@ int main(int argc, char** argv) {
                         server::openvpn::CertAuthority::sanitize_cn(e.ep));
                     if (it != ips.end()) {
                         ip_changed |= ep_reg.update_dev_tun_ip(e.ep, it->second.vip);
-                        ep_reg.update_wan_ip(e.ep, it->second.wan_ip);
                     } else {
                         // Tunnel down for this endpoint — clear the stale
                         // assigned IP so the cloud UI gates Launch UI off and
                         // the DNAT stops targeting a dead vip (dev_tun_ip is
                         // the per-device "VPN up" signal the UI keys on).
                         ip_changed |= ep_reg.update_dev_tun_ip(e.ep, "");
-                        ep_reg.update_wan_ip(e.ep, "");
                     }
+                    // NOTE: wan_ip (public/ISP IP) is NOT touched here anymore.
+                    // It now comes from the LwM2M registration peer (reconcile_
+                    // registrations), so it is VPN-independent + retained across
+                    // a tunnel drop. The OpenVPN real-addr is the same NAT IP.
                 }
                 if (ip_changed) {
                     sync_endpoints_to_ds(ds, ep_reg);

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -94,7 +94,12 @@ interface EpCred {
           <clr-dg-cell><code>{{ e.lan_ip || '—' }}</code></clr-dg-cell>
           <clr-dg-cell>{{e.proxy_port}}</clr-dg-cell>
           <clr-dg-cell>
-            <code>{{ nextHeartbeat(e) }}</code>
+            <!-- Online: countdown to the next registration Update. Offline:
+                 how long since the device was last seen (the row's retained
+                 LAN/ISP IPs are a snapshot from that time). -->
+            <code *ngIf="e.registered">{{ nextHeartbeat(e) }}</code>
+            <code *ngIf="!e.registered" class="stale"
+                  title="time since the device was last registered">last seen {{ lastSeen(e) }}</code>
             <!-- Debug mode: reveal the raw ds values the countdown derives from
                  (cloud.endpoints[].lifetime + .last_seen_unix), mirroring the
                  *dsDebug hint convention used on the config forms. -->
@@ -173,6 +178,7 @@ interface EpCred {
     .page{padding:24px;} h3{color:#333;margin:0;font-size:16px;font-weight:600;}
     .header-row{display:flex;align-items:center;justify-content:space-between;margin:0 0 16px 0;}
     .hint{font-size:12px;color:#888;}
+    .stale{color:#999;font-style:italic;}
     .cred-list{display:grid;grid-template-columns:auto 1fr;gap:6px 16px;margin:0;}
     .cred-list dt{color:#666;font-weight:600;}
     .cred-list dd{margin:0;word-break:break-all;}
@@ -237,6 +243,18 @@ export class EndpointListComponent implements OnInit, OnDestroy {
   nextHeartbeat(e: EpInfo): string {
     if (!e.lifetime || !e.last_seen_unix) return '—';
     return this.hhmmss(e.last_seen_unix + e.lifetime - this.now);
+  }
+
+  /** Relative time since the device was last seen (shown when offline, so the
+   *  retained LAN/ISP IPs read as a dated snapshot). '—' if never seen. */
+  lastSeen(e: EpInfo): string {
+    if (!e.last_seen_unix) return '—';
+    const ago = this.now - e.last_seen_unix;
+    if (ago < 0)      return 'just now';
+    if (ago < 60)     return ago + 's ago';
+    if (ago < 3600)   return Math.floor(ago / 60) + 'm ago';
+    if (ago < 86400)  return Math.floor(ago / 3600) + 'h ago';
+    return Math.floor(ago / 86400) + 'd ago';
   }
 
   ngOnInit(): void {

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -463,6 +463,14 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                         if (lit != epLanIps->end() && !lit->second.empty())
                             row["lan_ip"] = lit->second;
                     }
+                    // Device public/ISP IP = the DTLS registration peer address
+                    // (the NAT public IP the device's DIRECT Register/Update
+                    // arrives from, :5683). Captured here on the LwM2M plane so
+                    // it is VPN-INDEPENDENT and, carried in the reg record, is
+                    // retained across offline like lan_ip/version — vs the old
+                    // OpenVPN-status source that cleared when the tunnel dropped.
+                    if (!kv.second.peerHost.empty())
+                        row["isp_ip"] = kv.second.peerHost;
                     arr.push_back(std::move(row));
                 }
                 *lastSeen = std::move(kept);


### PR DESCRIPTION
Per operator feedback: ISP IP now derives from the **DTLS registration peer** (the device's NAT public IP on its direct Register/Update to :5683) instead of the OpenVPN status — so it's VPN-independent and **retained across a tunnel drop**, like LAN IP. lwm2m-dm emits isp_ip in the reg record; iot-cloudd merges it (retained) and the VPN poll no longer sets/clears wan_ip. Also: Endpoints shows 'last seen Xm ago' when offline so retained IPs read as a dated snapshot. Both binaries compile in the podman dev-build.