### PR TITLE
fix(reboot): run iot-reboot.service via shell so systemctl resolves via PATH

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-reboot.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-reboot.service
@@ -5,6 +5,9 @@ Documentation=https://github.com/naushada/iot
 
 [Service]
 Type=oneshot
-# Remove the trigger first so the .path unit re-arms, then reboot.
-ExecStartPre=/bin/rm -f /run/iot/reboot.request
-ExecStart=/bin/systemctl reboot
+# Run via a shell so `systemctl`/`rm` resolve via PATH (matching the proven
+# iot-swupdate convention) — a unit ExecStart needs an absolute path, and
+# /bin/systemctl does not exist on every image (systemctl may be /usr/bin only),
+# which silently no-op'd the reboot. Remove the trigger first so the .path
+# unit re-arms, then reboot.
+ExecStart=/bin/sh -c 'rm -f /run/iot/reboot.request; exec systemctl reboot'


### PR DESCRIPTION
Advanced -> Reboot did nothing because iot-reboot.service used ExecStart=/bin/systemctl reboot — and /bin/systemctl isn't on every image (may be /usr/bin only), so the unit silently failed. Switch to /bin/sh -c 'rm -f trigger; exec systemctl reboot' (PATH-resolved, matching the working iot-swupdate convention).