### PR TITLE
fix(bcm2837): zero overlay storage so the self-test passes under -O2/-O3

### DIFF
--- a/modules/bcm2837/test/clock_test.hpp
+++ b/modules/bcm2837/test/clock_test.hpp
@@ -6,6 +6,7 @@
 #include <vector>
 #include <algorithm>
 #include <unordered_map>
+#include <cstring>
 
 #include "clock.hpp"
 
@@ -16,13 +17,17 @@ class CLOCKTest : public ::testing::Test
          * @brief Memory region for CLOCK instance will be taken from m_memory_region,
          *        the CLOCK instance layout will be done from m_memory_region.
         */
-        CLOCKTest() : m_memory_region(BCM2837::ClockRegistersAddress::Register::CM_GPn_MAX), 
+        CLOCKTest() : m_memory_region(BCM2837::ClockRegistersAddress::Register::CM_GPn_MAX),
                       m_clock(CLOCK(m_memory_region.data())) {
-            /*
-            ::printf("start memory_region: 0x%X ", m_memory_region.data());
-            ::printf("end memory_region: 0x%X ", m_memory_region.data() + GPIORegistersAddress::Register::BCM2837_MAX+1);
-            ::printf("GPIO: 0x%X ", &m_gpio.memory().m_register[0]);
-            */
+            // Reset the overlaid registers to a known 0 state. The driver
+            // placement-new's a register block whose constructor is trivial (so
+            // it does not clobber live MMIO), which ends the vector elements'
+            // lifetimes; at -O2/-O3 the compiler then drops the vector's value
+            // initialisation as a dead store, leaving the registers as heap
+            // garbage. Zeroing *after* the overlay is observed by the driver's
+            // volatile reads, so it is not elided.
+            std::memset(m_memory_region.data(), 0,
+                        m_memory_region.size() * sizeof(std::uint32_t));
         }
         virtual ~CLOCKTest() override = default;
         

--- a/modules/bcm2837/test/gpio_test.hpp
+++ b/modules/bcm2837/test/gpio_test.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <algorithm>
 #include <unordered_map>
+#include <cstring>
 
 #include "gpio.hpp"
 
@@ -18,11 +19,12 @@ class GPIOTest : public ::testing::Test
          *        the GPIO instance layout will be done from m_memory_region.
         */
         GPIOTest() : m_memory_region(BCM2837::GPIORegistersAddress::Register::BCM2837_MAX), m_gpio(GPIO(m_memory_region.data())) {
-            /*
-            ::printf("start memory_region: 0x%X ", m_memory_region.data());
-            ::printf("end memory_region: 0x%X ", m_memory_region.data() + GPIORegistersAddress::Register::BCM2837_MAX+1);
-            ::printf("GPIO: 0x%X ", &m_gpio.memory().m_register[0]);
-            */
+            // Zero the overlaid registers. The register block has a trivial ctor
+            // (so it doesn't clobber live MMIO), which lets -O2/-O3 drop the
+            // vector's value-init as a dead store; zeroing after the overlay is
+            // observed by the driver's volatile reads and is not elided.
+            std::memset(m_memory_region.data(), 0,
+                        m_memory_region.size() * sizeof(std::uint32_t));
         }
         virtual ~GPIOTest() override = default;
         

--- a/modules/bcm2837/test/i2c_test.hpp
+++ b/modules/bcm2837/test/i2c_test.hpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 #include <vector>
+#include <cstring>
 
 #include "i2c.hpp"
 
@@ -14,7 +15,14 @@ class I2CTest : public ::testing::Test
          *        m_memory_region so register access hits the buffer, not MMIO.
         */
         I2CTest() : m_memory_region(BCM2837::BSCRegistersAddress::Register::BSC_MAX),
-                    m_i2c(I2C(m_memory_region.data())) {}
+                    m_i2c(I2C(m_memory_region.data())) {
+            // Zero the overlaid registers. The register block has a trivial ctor
+            // (so it doesn't clobber live MMIO), which lets -O2/-O3 drop the
+            // vector's value-init as a dead store; zeroing after the overlay is
+            // observed by the driver's volatile reads and is not elided.
+            std::memset(m_memory_region.data(), 0,
+                        m_memory_region.size() * sizeof(std::uint32_t));
+        }
         virtual ~I2CTest() override = default;
 
         virtual void SetUp() override;

--- a/modules/bcm2837/test/interrupt_test.hpp
+++ b/modules/bcm2837/test/interrupt_test.hpp
@@ -7,6 +7,7 @@
 #include <vector>
 #include <algorithm>
 #include <unordered_map>
+#include <cstring>
 
 #include "interrupt.hpp"
 
@@ -17,9 +18,18 @@ class IRQTest : public ::testing::Test
          * @brief Memory region for IRQ instance will be taken from m_memory_region,
          *        the IRQ instance layout will be done from m_memory_region.
         */
-        IRQTest() : m_memory_region(BCM2837::InterruptRegisterAddress::Register::IRQs_ALL_MAX), 
+        IRQTest() : m_memory_region(BCM2837::InterruptRegisterAddress::Register::IRQs_ALL_MAX
+                                    + (sizeof(IVT) + sizeof(std::uint32_t) - 1) / sizeof(std::uint32_t)),
                     m_irq(IRQ(m_memory_region.data())) {
-            
+            // The IRQ driver overlays the register block AND places an IVT right
+            // past it (at region + IRQs_ALL_MAX), so the buffer must cover both —
+            // otherwise install_*Handler writes past the end (the bus error).
+            // Zero after the overlay: the register/IVT structs have trivial ctors
+            // (so they don't clobber live MMIO), which lets -O2/-O3 drop the
+            // vector's value-init as a dead store; zeroing here is observed by
+            // the driver's volatile reads and is not elided.
+            std::memset(m_memory_region.data(), 0,
+                        m_memory_region.size() * sizeof(std::uint32_t));
         }
 
         virtual ~IRQTest() override = default;

--- a/modules/bcm2837/test/spi_test.hpp
+++ b/modules/bcm2837/test/spi_test.hpp
@@ -3,6 +3,7 @@
 
 #include <gtest/gtest.h>
 #include <vector>
+#include <cstring>
 
 #include "spi.hpp"
 
@@ -14,7 +15,14 @@ class SPITest : public ::testing::Test
          *        m_memory_region so register access hits the buffer, not MMIO.
         */
         SPITest() : m_memory_region(BCM2837::SPIRegistersAddress::Register::SPI_MAX),
-                    m_spi(SPI(m_memory_region.data())) {}
+                    m_spi(SPI(m_memory_region.data())) {
+            // Zero the overlaid registers. The register block has a trivial ctor
+            // (so it doesn't clobber live MMIO), which lets -O2/-O3 drop the
+            // vector's value-init as a dead store; zeroing after the overlay is
+            // observed by the driver's volatile reads and is not elided.
+            std::memset(m_memory_region.data(), 0,
+                        m_memory_region.size() * sizeof(std::uint32_t));
+        }
         virtual ~SPITest() override = default;
 
         virtual void SetUp() override;


### PR DESCRIPTION
## Summary

Syncs the test-harness fix from [`naushada/rpi3B@05b95bd`](https://github.com/naushada/rpi3B/pull/6) into the vendored `modules/bcm2837` tree. The `bcm2837` gtest suite ships here as the **`iot-bcm2837-selftest`** boot oneshot, and 17/94 of its cases failed in **Release only** (passed at `-O0`).

## Root cause

Each fixture value-initialised a `std::vector<uint32_t>` and placement-new'd the register block over it. `mmio_reg` is trivially default-constructible *by design* (so the overlay never clobbers live MMIO), so placement-new ends the vector elements' lifetimes without rewriting them; at `-O2`/`-O3` the optimiser drops the now-unobserved zero-init as a **dead store** and registers start as heap garbage. Tests reading a register they didn't themselves write then saw garbage.

## Fix

- All fixtures (clock/gpio/i2c/irq/spi) now `std::memset` the region to 0 **after** constructing the driver; those stores are observed by the drivers' `volatile` reads and aren't elided.
- The IRQ fixture also undersized its buffer — `IRQ` overlays the register block *and* an IVT at `region + IRQs_ALL_MAX`, so `install_*Handler` wrote past a 10-word vector (a **bus error**). Sized to `IRQs_ALL_MAX + ceil(sizeof(IVT)/4)` words.

Only the 5 test fixture headers change; no driver logic, and iot-specific additions (`system_timer`, the local `i2c_irq` variant) are untouched.

## Verification

`100% tests passed, 0 failed out of 103` under `-DCMAKE_BUILD_TYPE=Release` in `modules/bcm2837` (94 bcm2837 + 9 system_timer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)