### PR TITLE
feat(bcm2837): support Pi 1/Zero/Zero W (BCM2835) and Pi 4/400/CM4 (BCM2711)

### DIFF
--- a/modules/bcm2837/inc/memory_map.hpp
+++ b/modules/bcm2837/inc/memory_map.hpp
@@ -4,6 +4,23 @@
 #include <cstdint>
 #include <cstdio>
 
+/**
+ * @brief Peripheral physical base for the *bare-metal* default placement
+ *        addresses below (the `operator new` fallbacks used when no region
+ *        pointer is supplied). Defaults to BCM2836/7 (Pi 2/3/Zero 2 W); override
+ *        at compile time to retarget a freestanding build:
+ *
+ *          -DBCM_PERIPH_BASE=0x20000000   // BCM2835: Pi 1, Pi Zero, Pi Zero W
+ *          -DBCM_PERIPH_BASE=0x3F000000   // BCM2836/7: Pi 2, Pi 3, Pi Zero 2 W
+ *          -DBCM_PERIPH_BASE=0xFE000000   // BCM2711: Pi 4, Pi 400, CM4
+ *
+ * The booted-Linux path (inc/mmio.hpp) ignores this and auto-detects the base
+ * at runtime, so a single Linux binary already targets every supported board.
+*/
+#ifndef BCM_PERIPH_BASE
+#define BCM_PERIPH_BASE 0x3F000000U
+#endif
+
 namespace BCM2837 {
 
     /**
@@ -133,7 +150,7 @@ namespace BCM2837 {
                         starting at 0x7E000000. Thus a peripheral advertised here at bus address 0x7Ennnnnn is
                         available at physical address 0x3Fnnnnnn.
                 */
-                return reinterpret_cast<void *>((0x3F000000) + (0x00200000));
+                return reinterpret_cast<void *>((BCM_PERIPH_BASE) + (0x00200000U));
             }
             return(region);
         }
@@ -242,7 +259,7 @@ namespace BCM2837 {
         void *operator new(std::size_t nBytes, void *region=nullptr) {
             (void)nBytes;
             if(nullptr == region) {
-                return reinterpret_cast<void *>((0x3F000000) + (0x00100000));
+                return reinterpret_cast<void *>((BCM_PERIPH_BASE) + (0x00100000U));
             }
             return(region);
         }
@@ -288,7 +305,7 @@ namespace BCM2837 {
         void *operator new(std::size_t nBytes, void *region=nullptr) {
             (void)nBytes;
             if(nullptr == region) {
-                return reinterpret_cast<void *>(0x3F00B200);
+                return reinterpret_cast<void *>((BCM_PERIPH_BASE) + (0x0000B200U));
             }
             return(region);
         }
@@ -414,8 +431,8 @@ namespace BCM2837 {
         void *operator new(std::size_t nBytes, void *region=nullptr) {
             (void)nBytes;
             if(nullptr == region) {
-                /* System Timer physical base (bus 0x7E003000 -> phys 0x3F003000). */
-                return reinterpret_cast<void *>(0x3F003000U);
+                /* System Timer physical base (bus 0x7E003000 -> phys base + 0x3000). */
+                return reinterpret_cast<void *>((BCM_PERIPH_BASE) + (0x00003000U));
             }
             return(region);
         }
@@ -478,8 +495,8 @@ namespace BCM2837 {
         void *operator new(std::size_t nBytes, void *region=nullptr) {
             (void)nBytes;
             if(nullptr == region) {
-                /* SPI0 physical base (bus 0x7E204000 -> phys 0x3F204000). */
-                return reinterpret_cast<void *>(0x3F204000U);
+                /* SPI0 physical base (bus 0x7E204000 -> phys base + 0x204000). */
+                return reinterpret_cast<void *>((BCM_PERIPH_BASE) + (0x00204000U));
             }
             return(region);
         }

--- a/modules/bcm2837/inc/mmio.hpp
+++ b/modules/bcm2837/inc/mmio.hpp
@@ -45,14 +45,61 @@
 
 namespace BCM2837 {
 
-    /// @brief BCM2837 (Pi 2/3) peripheral physical bases. Datasheet bus
-    ///        addresses 0x7Ennnnnn map to physical 0x3Fnnnnnn.
-    inline constexpr std::uintptr_t PERIPH_BASE = 0x3F000000U;
-    inline constexpr std::uintptr_t GPIO_PHYS   = PERIPH_BASE + 0x200000U; ///< 0x3F200000
-    inline constexpr std::uintptr_t CLOCK_PHYS  = PERIPH_BASE + 0x101070U; ///< 0x3F101070 (CM_GP0CTL)
-    inline constexpr std::uintptr_t I2C1_PHYS   = PERIPH_BASE + 0x804000U; ///< 0x3F804000 (BSC1)
-    inline constexpr std::uintptr_t SPI0_PHYS   = PERIPH_BASE + 0x204000U; ///< 0x3F204000
-    inline constexpr std::uintptr_t SYSTIMER_PHYS = PERIPH_BASE + 0x3000U; ///< 0x3F003000 (System Timer)
+    /// @brief Peripheral *offsets* from the SoC peripheral base. These are the
+    ///        datasheet bus addresses 0x7Ennnnnn with the 0x7E000000 prefix
+    ///        stripped, and are identical across BCM2835, BCM2836/7 and BCM2711.
+    inline constexpr std::uintptr_t GPIO_OFFSET     = 0x200000U; ///< GPIO
+    inline constexpr std::uintptr_t CLOCK_OFFSET    = 0x101070U; ///< CM_GP0CTL
+    inline constexpr std::uintptr_t I2C1_OFFSET     = 0x804000U; ///< BSC1
+    inline constexpr std::uintptr_t SPI0_OFFSET     = 0x204000U; ///< SPI0
+    inline constexpr std::uintptr_t SYSTIMER_OFFSET = 0x3000U;   ///< System Timer
+
+    /// @brief Known Raspberry Pi SoC peripheral physical bases. Only the base
+    ///        differs between models; the per-peripheral offsets above do not.
+    enum class SocPeriphBase : std::uintptr_t {
+        BCM2835   = 0x20000000U, ///< Pi 1, Pi Zero, Pi Zero W
+        BCM2836_7 = 0x3F000000U, ///< Pi 2, Pi 3, Pi Zero 2 W
+        BCM2711   = 0xFE000000U, ///< Pi 4, Pi 400, CM4
+    };
+
+    /**
+     * @brief Detect the peripheral base of the running board from the device
+     *        tree (/proc/device-tree/soc/ranges), so one binary targets every
+     *        supported Pi. Returns BCM2836_7 (0x3F000000) if detection fails.
+     *
+     * The ranges blob stores the CPU-physical base big-endian. The second u32
+     * holds it on BCM2835/6/7; on BCM2711 that slot is 0, so fall through to the
+     * next u32. This matches the well-known bcm2835/pigpio detection.
+    */
+    inline std::uintptr_t detect_periph_base() {
+        unsigned char buf[16] = {0};
+        std::size_t n = 0;
+        if(std::FILE* fp = std::fopen("/proc/device-tree/soc/ranges", "rb")) {
+            n = std::fread(buf, 1U, sizeof(buf), fp);
+            std::fclose(fp);
+        }
+        if(n >= 8U) {
+            std::uintptr_t base = (std::uintptr_t(buf[4]) << 24) | (std::uintptr_t(buf[5]) << 16)
+                                | (std::uintptr_t(buf[6]) <<  8) |  std::uintptr_t(buf[7]);
+            if(base == 0U && n >= 12U) { // BCM2711 device-tree layout
+                base = (std::uintptr_t(buf[8])  << 24) | (std::uintptr_t(buf[9])  << 16)
+                     | (std::uintptr_t(buf[10]) <<  8) |  std::uintptr_t(buf[11]);
+            }
+            if(base != 0U) return base;
+        }
+        return static_cast<std::uintptr_t>(SocPeriphBase::BCM2836_7);
+    }
+
+    /**
+     * @brief Cached peripheral base used by the map_* factories. Auto-detected
+     *        on first use; pass a nonzero @p force_base to override the detected
+     *        base (e.g. a SocPeriphBase value) for testing or unusual boards.
+    */
+    inline std::uintptr_t periph_base(std::uintptr_t force_base = 0U) {
+        static std::uintptr_t base = detect_periph_base();
+        if(force_base != 0U) base = force_base;
+        return base;
+    }
 
     /**
      * @brief RAII mapping of one peripheral register block.
@@ -138,11 +185,11 @@ namespace BCM2837 {
             Driver m_drv;
     };
 
-    inline Mapped<GPIO>  map_gpio()  { return Mapped<GPIO>(GPIO_PHYS,  sizeof(GPIORegistersAddress)); }
-    inline Mapped<CLOCK> map_clock() { return Mapped<CLOCK>(CLOCK_PHYS, sizeof(ClockRegistersAddress)); }
-    inline Mapped<I2C>   map_i2c()   { return Mapped<I2C>(I2C1_PHYS,   sizeof(BSCRegistersAddress)); }
-    inline Mapped<SPI>   map_spi()   { return Mapped<SPI>(SPI0_PHYS,   sizeof(SPIRegistersAddress)); }
-    inline Mapped<SystemTimer> map_systimer() { return Mapped<SystemTimer>(SYSTIMER_PHYS, sizeof(SystemTimerRegistersAddress)); }
+    inline Mapped<GPIO>  map_gpio()  { return Mapped<GPIO>(periph_base() + GPIO_OFFSET,  sizeof(GPIORegistersAddress)); }
+    inline Mapped<CLOCK> map_clock() { return Mapped<CLOCK>(periph_base() + CLOCK_OFFSET, sizeof(ClockRegistersAddress)); }
+    inline Mapped<I2C>   map_i2c()   { return Mapped<I2C>(periph_base() + I2C1_OFFSET,   sizeof(BSCRegistersAddress)); }
+    inline Mapped<SPI>   map_spi()   { return Mapped<SPI>(periph_base() + SPI0_OFFSET,   sizeof(SPIRegistersAddress)); }
+    inline Mapped<SystemTimer> map_systimer() { return Mapped<SystemTimer>(periph_base() + SYSTIMER_OFFSET, sizeof(SystemTimerRegistersAddress)); }
 
     // No map_irq(): the IRQ driver pairs the interrupt-enable registers with an
     // IVT (ARM exception vector table) that its region ctor places *past* the


### PR DESCRIPTION
## Summary

Syncs the multi-SoC support from [`naushada/rpi3B`](https://github.com/naushada/rpi3B/pull/6) into the vendored `modules/bcm2837` tree, so the drivers target Pi 1 / Zero / Zero W (BCM2835) and Pi 4 / 400 / CM4 (BCM2711) in addition to Pi 2/3/Zero 2 W (BCM2836/7).

The peripheral register *offsets* are identical across these SoCs; only the peripheral base differs, so the base is parameterised while the offsets stay fixed.

| SoC | Base | Boards |
|-----|------|--------|
| BCM2835 | `0x20000000` | Pi 1, Pi Zero, Pi Zero W |
| BCM2836/7 | `0x3F000000` | Pi 2, Pi 3, Pi Zero 2 W |
| BCM2711 | `0xFE000000` | Pi 4, Pi 400, CM4 |

## Changes

- **`inc/mmio.hpp`** (booted Linux): auto-detects the base at runtime from `/proc/device-tree/soc/ranges`, so one binary targets every board. Adds `SocPeriphBase`, `detect_periph_base()`, and an overridable `periph_base()`; every `map_*` factory — **including `map_systimer`** — now composes `base + offset`.
- **`inc/memory_map.hpp`** (bare-metal): the `operator new` fallback addresses (GPIO, clock, interrupt, system timer, SPI) derive from a compile-time `BCM_PERIPH_BASE` (default `0x3F000000`); retarget freestanding builds with `-DBCM_PERIPH_BASE=...`.

The iot-specific **`system_timer`** block is preserved and extended to the new base scheme (`SYSTIMER_OFFSET`, `map_systimer`, and its bare-metal fallback). No driver logic or test changes.

## Verification

- `100% tests passed, 0 failed out of 103` under `-DCMAKE_BUILD_TYPE=Release` in `modules/bcm2837`.
- The drivers compile (`-fsyntax-only`) under `-DBCM_PERIPH_BASE` for all three SoC bases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)