### PR TITLE
fix(vpn): proto/endpoint changes propagate to device + live cloud reconfigure

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -577,23 +577,30 @@ int main(int argc, char** argv) {
         }
     }
     // ── OpenVPN server — spawn + supervise (config from cloud.vpn.*) ──
-    server::openvpn::OpenVpnServerConfig ovpn_cfg;
-    ovpn_cfg.subnet    = ds_str(ds, "cloud.vpn.subnet",     "10.9.0.0/24");
-    // Operator-facing base form ("tcp"/"udp") — build_server_config adds the
-    // "-server" suffix for the TCP listen socket, and the device push uses the
-    // base as-is (client). Default "tcp"; legacy "tcp-server" still normalizes.
-    ovpn_cfg.proto     = ds_str(ds, "cloud.vpn.proto",      "tcp");
-    ovpn_cfg.ca_path   = ds_str(ds, "cloud.vpn.ca.crt",     "/etc/iot/vpn/ca/ca.crt");
-    ovpn_cfg.cert_path = ds_str(ds, "cloud.vpn.server.crt", "/etc/iot/vpn/server.crt");
-    ovpn_cfg.key_path  = ds_str(ds, "cloud.vpn.server.key", "/etc/iot/vpn/server.key");
-    ovpn_cfg.cipher    = ds_str(ds, "cloud.vpn.cipher",     "AES-256-GCM");
-    ovpn_cfg.dev       = ds_str(ds, "cloud.vpn.dev",        "tun");
-    ovpn_cfg.port      = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.listen.port", 1194));
-    ovpn_cfg.mgmt_port = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.mgmt.port", 7506));
-    ovpn_cfg.verb      = ds_int(ds, "cloud.vpn.verb", 3);
-    // DNS resolver pushed to devices (so the device surfaces vpn.assigned.dns).
-    // Empty disables the push; default 1.1.1.1 so the field is populated.
-    ovpn_cfg.dns       = ds_str(ds, "cloud.vpn.dns", "1.1.1.1");
+    // Read the server-config knobs from ds. Factored into a lambda so the live
+    // hot-reload path (the cloud.vpn.* watch in the main loop) rebuilds the
+    // exact same config an operator's UI change should produce.
+    auto load_ovpn_cfg = [&ds]() {
+        server::openvpn::OpenVpnServerConfig c;
+        c.subnet    = ds_str(ds, "cloud.vpn.subnet",     "10.9.0.0/24");
+        // Operator-facing base form ("tcp"/"udp") — build_server_config adds the
+        // "-server" suffix for the TCP listen socket, and the device push uses
+        // the base as-is (client). Default "tcp"; legacy "tcp-server" normalizes.
+        c.proto     = ds_str(ds, "cloud.vpn.proto",      "tcp");
+        c.ca_path   = ds_str(ds, "cloud.vpn.ca.crt",     "/etc/iot/vpn/ca/ca.crt");
+        c.cert_path = ds_str(ds, "cloud.vpn.server.crt", "/etc/iot/vpn/server.crt");
+        c.key_path  = ds_str(ds, "cloud.vpn.server.key", "/etc/iot/vpn/server.key");
+        c.cipher    = ds_str(ds, "cloud.vpn.cipher",     "AES-256-GCM");
+        c.dev       = ds_str(ds, "cloud.vpn.dev",        "tun");
+        c.port      = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.listen.port", 1194));
+        c.mgmt_port = static_cast<std::uint16_t>(ds_int(ds, "cloud.vpn.mgmt.port", 7506));
+        c.verb      = ds_int(ds, "cloud.vpn.verb", 3);
+        // DNS resolver pushed to devices (so the device surfaces vpn.assigned.dns).
+        // Empty disables the push; default 1.1.1.1 so the field is populated.
+        c.dns       = ds_str(ds, "cloud.vpn.dns", "1.1.1.1");
+        return c;
+    };
+    server::openvpn::OpenVpnServerConfig ovpn_cfg = load_ovpn_cfg();
     // Seed the effective config back to ds so every cloud.vpn.* key exists
     // with its default (visible in the cloud UI / ds-cli).
     ds.set({
@@ -608,6 +615,24 @@ int main(int argc, char** argv) {
         {"cloud.vpn.verb",        data_store::Value{static_cast<std::int32_t>(ovpn_cfg.verb)}},
         {"cloud.vpn.dns",         data_store::Value{ovpn_cfg.dns}},
     });
+    // Live hot-reload of the VPN server config: watch the knobs that feed
+    // build_server_config so an operator changing proto/port/cipher/etc. in the
+    // cloud UI reconfigures + restarts openvpn without an iot-cloudd restart.
+    // Pull-style (drained in the main loop) so the restart runs on the SAME
+    // thread that owns the child process — no cross-thread waitpid race.
+    // Registered AFTER the seed above so the seed's own writes don't self-fire.
+    auto ws_vpncfg = ds.watch(std::vector<std::string>{
+        "cloud.vpn.proto", "cloud.vpn.listen.port", "cloud.vpn.cipher",
+        "cloud.vpn.dev", "cloud.vpn.subnet", "cloud.vpn.dns",
+        "cloud.vpn.verb", "cloud.vpn.mgmt.port",
+        "cloud.vpn.ca.crt", "cloud.vpn.server.crt", "cloud.vpn.server.key",
+    }, 1000);
+    if (!ws_vpncfg.ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l watch cloud.vpn.* config "
+                            "failed: %C — live VPN reconfigure disabled\n"),
+                   ws_vpncfg.err.c_str()));
+    }
     // ── Runtime VPN PKI (Phase 2) ─────────────────────────────────
     // The cloud image generates a CA + server cert at build time but PURGES
     // the CA key, so the shipped image can't sign new client certs. Generate
@@ -973,6 +998,24 @@ int main(int argc, char** argv) {
                 // lwm2m-dm published a registration change — fold online/
                 // offline into the endpoint registry before the sync below.
                 reconcile_registrations(ds, ep_reg);
+            } else if (ev.key.rfind("cloud.vpn.", 0) == 0) {
+                // A VPN server config knob changed (proto/port/cipher/…).
+                // Rebuild the config from ds and reconfigure: a no-op (returns
+                // false) when the rendered config is unchanged, so a redundant
+                // write doesn't bounce a healthy tunnel. On a real change it
+                // stops the child; we clear the crash-backoff (this is a
+                // DELIBERATE restart, not a failure) and supervise_ovpn() brings
+                // it back up with the new config — all on this main thread.
+                if (ovpn.reconfigure(load_ovpn_cfg())) {
+                    ACE_DEBUG((LM_INFO,
+                               ACE_TEXT("%D cloudd:thread:%t %M %N:%l cloud.vpn.* "
+                                        "changed ('%C') — restarting openvpn server "
+                                        "with new config\n"), ev.key.c_str()));
+                    ovpn_fails       = 0;
+                    ovpn_last_start  = {};
+                    ovpn_retry_after = {};
+                    supervise_ovpn();
+                }
             } else if (ev.key == "cloud.update.request") {
                 // OTA: validate the request against the firmware manifest +
                 // known endpoints, then emit per-endpoint jobs for lwm2m-dm.

--- a/apps/src/lwm2m_object_cert.cpp
+++ b/apps/src/lwm2m_object_cert.cpp
@@ -206,20 +206,34 @@ ObjectInstance make_instance(std::uint32_t iid,
                     }
                 }
             }
+            // The cloud-pushed VPN endpoint (RID 5/6/7) is folded into the
+            // idempotency fingerprint below. It is NOT a cert PEM, but it IS
+            // part of "what's currently applied" — without it, a proto/host/port
+            // change that keeps the same cert family would hash identically and
+            // be silently skipped, so the device never learns the new endpoint
+            // (e.g. an operator flipping cloud.vpn.proto tcp↔udp). The unit
+            // separator keeps the three fields unambiguous against PEM bytes.
+            const std::string ep_suffix =
+                vpn ? ("\x1f" + vpn->host + "\x1f" + vpn->port + "\x1f" + vpn->proto)
+                    : std::string();
             // Idempotency gate: the cloud re-pushes the cert family every ~30s
             // until the tunnel reports up, which re-triggers this Apply. If the
-            // staged family is byte-identical to what's already applied (RID 4
-            // fingerprint), skip the store + reload entirely — otherwise we
-            // bounce openvpn every 30s and it can never finish a handshake. The
-            // fp is computed over the staged PEMs in the same ca,cert,key order
-            // as the committed one below.
+            // staged family + endpoint is byte-identical to what's already
+            // applied (RID 4 fingerprint), skip the store + reload entirely —
+            // otherwise we bounce openvpn every 30s and it can never finish a
+            // handshake. The fp is computed over the staged PEMs in the same
+            // ca,cert,key order as the committed one below, plus ep_suffix.
             if (applied && !applied->empty()) {
                 std::string cand;
-                for (auto& [type, s] : *staging) { if (s.present) cand += s.pem; }
-                if (!cand.empty() && fnv1a_hex(cand) == *applied) {
+                bool any_pem = false;
+                for (auto& [type, s] : *staging) {
+                    if (s.present) { cand += s.pem; any_pem = true; }
+                }
+                if (any_pem) cand += ep_suffix;
+                if (any_pem && fnv1a_hex(cand) == *applied) {
                     ACE_DEBUG((LM_INFO,
-                        ACE_TEXT("%D [cert-obj] %M %N:%l apply skipped: family "
-                                 "unchanged (fp=%C) — not reloading\n"),
+                        ACE_TEXT("%D [cert-obj] %M %N:%l apply skipped: family + "
+                                 "endpoint unchanged (fp=%C) — not reloading\n"),
                         applied->c_str()));
                     staging->clear();
                     return 0;   // already applied; no store, no reload
@@ -249,6 +263,10 @@ ObjectInstance make_instance(std::uint32_t iid,
             }
             // Clear staging so a later partial push can't re-commit stale bytes.
             staging->clear();
+            // Fold the VPN endpoint into the committed fingerprint, matching the
+            // candidate hashed in the idempotency gate above — so a later
+            // endpoint-only change (same certs) hashes differently and applies.
+            fpInput += ep_suffix;
             if (applied) *applied = fnv1a_hex(fpInput);
             // Materialise the cloud-pushed VPN endpoint (if any) into ds before
             // the reload hook, so openvpn (re)starts against the right server.

--- a/apps/test/objects_test.cpp
+++ b/apps/test/objects_test.cpp
@@ -404,3 +404,47 @@ TEST(CertObject, applied_fingerprint_is_deterministic_for_same_family) {
     EXPECT_EQ(fp_of("A", "B", "C"), fp_of("A", "B", "C"));   // stable
     EXPECT_NE(fp_of("A", "B", "C"), fp_of("A", "B", "X"));   // sensitive to key
 }
+
+TEST(CertObject, endpoint_change_with_same_certs_reapplies_not_skipped) {
+    // Regression: an operator flips cloud.vpn.proto (tcp↔udp). The cloud
+    // re-pushes the SAME cert family with the new proto on RID 7. The
+    // idempotency gate must NOT short-circuit on the unchanged certs —
+    // otherwise set_vpn_endpoint never runs, the device keeps the stale proto,
+    // and the tunnel can never come up (the symptom that motivated this test).
+    int applied = 0;
+    std::string seen_proto;
+    objects::CertHooks h;
+    h.store_artifact = [](const std::string&, const std::string&) { return 0; };
+    h.apply = [&]() { ++applied; return 0; };
+    h.set_vpn_endpoint = [&](const std::string&, const std::string&,
+                             const std::string& proto) { seen_proto = proto; return 0; };
+
+    ObjectStore store;
+    objects::install_cert(store, "/unused", std::move(h));   // require_complete=true
+
+    auto push = [&](const std::string& proto) {
+        cwrite(store, 0, "CA");
+        cwrite(store, 1, "CERT");
+        cwrite(store, 2, "KEY");
+        store.find(2048, 0, 5)->write("vpn.example.com");    // host
+        store.find(2048, 0, 6)->write("1194");               // port
+        store.find(2048, 0, 7)->write(proto);                // proto
+        return store.find(2048, 0, 3)->execute("");
+    };
+
+    // First apply (tcp): reload + endpoint hook both fire.
+    ASSERT_EQ(0, push("tcp"));
+    EXPECT_EQ(1, applied);
+    EXPECT_EQ("tcp", seen_proto);
+    const std::string fp_tcp = store.find(2048, 0, 4)->read();
+
+    // Identical certs + same proto → idempotent skip (no openvpn bounce).
+    ASSERT_EQ(0, push("tcp"));
+    EXPECT_EQ(1, applied);                                    // reload NOT re-run
+
+    // Identical certs but proto flipped → must re-apply so the device learns it.
+    ASSERT_EQ(0, push("udp"));
+    EXPECT_EQ(2, applied);                                    // reload fired again
+    EXPECT_EQ("udp", seen_proto);                             // new proto materialised
+    EXPECT_NE(fp_tcp, store.find(2048, 0, 4)->read());        // fp tracks endpoint
+}

--- a/modules/server/openvpn/inc/openvpn_server.hpp
+++ b/modules/server/openvpn/inc/openvpn_server.hpp
@@ -58,6 +58,14 @@ public:
     /// running. Returns true on successful fork+exec.
     bool start();
 
+    /// Swap in a new config. If the rendered config is byte-identical to the
+    /// current one, this is a no-op and returns false (so a redundant ds write
+    /// can't bounce a healthy tunnel). On a real change it updates the config
+    /// and stops any running child, returning true — the caller restarts it
+    /// (e.g. via its supervisor) so the new config takes effect. Lets an
+    /// operator change cloud.vpn.* (proto/port/cipher/…) live, no daemon restart.
+    bool reconfigure(const OpenVpnServerConfig& cfg);
+
     /// SIGTERM (grace) then SIGKILL; reap. No-op if not running.
     void stop(std::chrono::milliseconds grace = std::chrono::seconds(3));
 

--- a/modules/server/openvpn/src/openvpn_server.cpp
+++ b/modules/server/openvpn/src/openvpn_server.cpp
@@ -115,6 +115,18 @@ OpenVpnServer::~OpenVpnServer() {
     if (!m_config_path.empty()) ::unlink(m_config_path.c_str());
 }
 
+bool OpenVpnServer::reconfigure(const OpenVpnServerConfig& cfg) {
+    // Compare on the RENDERED config, not field-by-field: it's the single
+    // source of truth for what actually reaches openvpn, so a change to any
+    // knob that affects the file (and only those) triggers a restart. A
+    // redundant ds write (same effective config) renders identically → no-op,
+    // so a healthy tunnel isn't bounced.
+    if (build_server_config(cfg) == build_server_config(m_cfg)) return false;
+    m_cfg = cfg;
+    if (running()) stop();                  // caller restarts with the new cfg
+    return true;
+}
+
 bool OpenVpnServer::start() {
     if (running()) return true;             // already up — idempotent
 

--- a/modules/server/openvpn/test/openvpn_server_test.cpp
+++ b/modules/server/openvpn/test/openvpn_server_test.cpp
@@ -4,6 +4,7 @@
 
 #include "openvpn_server.hpp"
 
+using server::openvpn::OpenVpnServer;
 using server::openvpn::OpenVpnServerConfig;
 using server::openvpn::build_server_config;
 using server::openvpn::cidr_to_net_mask;
@@ -90,6 +91,32 @@ TEST(BuildServerConfig, noDnsPushWhenEmpty) {
     c.subnet = "10.9.0.0/24";   // c.dns left empty
     const std::string conf = build_server_config(c);
     EXPECT_EQ(conf.find("dhcp-option DNS"), std::string::npos);
+}
+
+TEST(Reconfigure, noopWhenRenderedConfigUnchanged) {
+    // A redundant ds write (same effective config) must NOT report a change,
+    // so the cloud hot-reload path doesn't bounce a healthy tunnel.
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";
+    c.proto  = "tcp";
+    OpenVpnServer srv(c);              // never started → no child to manage
+    OpenVpnServerConfig same = c;
+    EXPECT_FALSE(srv.reconfigure(same));
+}
+
+TEST(Reconfigure, reportsChangeWhenProtoFlips) {
+    // The motivating case: operator flips cloud.vpn.proto tcp→udp. The rendered
+    // config differs (proto tcp-server → proto udp), so reconfigure() reports a
+    // change and the caller restarts the server on the new socket.
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";
+    c.proto  = "tcp";
+    OpenVpnServer srv(c);
+    OpenVpnServerConfig flipped = c;
+    flipped.proto = "udp";
+    EXPECT_TRUE(srv.reconfigure(flipped));
+    // Idempotent: re-applying the now-current config is a no-op.
+    EXPECT_FALSE(srv.reconfigure(flipped));
 }
 
 }  // namespace


### PR DESCRIPTION
## Problem

Switching `cloud.vpn.proto` (e.g. tcp↔udp) left the VPN client unable to come back up, even after reverting. Two independent gaps:

1. **Device side** — The Object-2048 Apply idempotency gate (PR #385) hashed the **cert PEMs only**. The cloud-pushed VPN endpoint (host/port/proto, RID 5/6/7) rides in the same push, but `set_vpn_endpoint()` only ran on the non-skip path. So once a device's cert family was stable, **proto/host/port changes were silently dropped** — `vpn.remote.proto` froze and the client kept dialing the old transport.

2. **Cloud side** — `cloud.vpn.*` was read only at iot-cloudd startup; the running openvpn server was never rebuilt on a live change. Flipping proto in the UI needed an iot-cloudd restart to take effect.

## Fix

- **`fix(cert)`** — fold the VPN endpoint (`host|port|proto`) into both the idempotency candidate and the committed fingerprint. An endpoint-only change now re-applies (reload + `set_vpn_endpoint`); an unchanged family+endpoint still skips (anti-bounce preserved).
- **`feat(cloud-vpn)`** — `OpenVpnServer::reconfigure(cfg)` (compares on the rendered config, swaps + stops on real change), plus a pull-style `cloud.vpn.*` watch handled in the iot-cloudd main loop (same thread that owns the child → no waitpid race), clearing crash-backoff for the deliberate restart.

## Tests

- `CertObject.endpoint_change_with_same_certs_reapplies_not_skipped`
- `Reconfigure.noopWhenRenderedConfigUnchanged`, `Reconfigure.reportsChangeWhenProtoFlips`

> Note: also worth adding `1194:1194/udp` to the compose `ports:` (currently TCP-only) before UDP can actually traverse — left out of this PR as a deploy-time knob.

🤖 Generated with [Claude Code](https://claude.com/claude-code)