### PR TITLE
fix(sensord): use bcm2837 map_i2c/map_gpio factories (post-#388 build break)

### DIFF
--- a/modules/sensors/daemon/sensord.cpp
+++ b/modules/sensors/daemon/sensord.cpp
@@ -85,12 +85,12 @@ int run(const Options& opt) {
     }
 
     try {
-        // BSC1 + GPIO live registers. Throws if /dev/mem is unreadable (missing
-        // CAP_SYS_RAWIO / not a Pi), caught below so we exit non-zero.
-        BCM2837::Mapped<I2C>  i2cMap(BCM2837::I2C1_PHYS,
-                                     sizeof(BCM2837::BSCRegistersAddress));
-        BCM2837::Mapped<GPIO> gpioMap(BCM2837::GPIO_PHYS,
-                                      sizeof(BCM2837::GPIORegistersAddress));
+        // BSC1 + GPIO live registers. The map_* factories auto-detect the SoC
+        // peripheral base from the device tree (BCM2835/2836-7/2711), so one
+        // binary targets every supported Pi. Throws if /dev/mem is unreadable
+        // (missing CAP_SYS_RAWIO / not a Pi), caught below so we exit non-zero.
+        auto i2cMap  = BCM2837::map_i2c();
+        auto gpioMap = BCM2837::map_gpio();
         Bcm2837I2cTransport bus(*i2cMap, *gpioMap);
         bus.bus_init();
         ACE_DEBUG((LM_INFO,


### PR DESCRIPTION
## Problem

`iot_git.bb` `do_compile` fails in the Yocto build:

```
sensord.cpp:90: error: 'I2C1_PHYS' is not a member of 'BCM2837'
sensord.cpp:92: error: 'GPIO_PHYS' is not a member of 'BCM2837'
```

PR #388 (multi-board BCM2835/2836-7/2711 support) replaced the fixed `BCM2837::I2C1_PHYS` / `GPIO_PHYS` constants with auto-detecting `map_*()` factories (`periph_base()` from `/proc/device-tree/soc/ranges` + per-peripheral offsets), but `sensord.cpp` still referenced the removed constants. Not caught pre-merge because CI builds on `main` only and there's no local C++ compiler.

## Fix

Switch the BSC `/dev/mem` fallback to `BCM2837::map_i2c()` / `map_gpio()` — the intended API (`sensord.cpp` already includes `mmio.hpp` for it). Deref into `Bcm2837I2cTransport` is unchanged. Bonus: sensord now targets every supported Pi instead of hard-coding the BCM2837 base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)