### PR TITLE
fix(lwm2m): reuse /rd location per endpoint + refresh ISP IP on re-register/update

### DIFF
--- a/apps/inc/lwm2m_registration.hpp
+++ b/apps/inc/lwm2m_registration.hpp
@@ -51,21 +51,31 @@ class ClientRegistry {
 public:
     ClientRegistry() = default;
 
-    /// Insert a fresh registration. The `location` field is **populated by
-    /// this call** with a freshly-generated identifier; callers must read it
-    /// back from `out` to build the Location-Path response. The current
-    /// system clock and `lifetime` together define `expiresAt`.
-    /// Returns the generated location.
+    /// Insert a registration. If a registration for the **same endpoint**
+    /// already exists (e.g. the device rebooted / came back online and
+    /// re-registered before its prior lifetime expired), its existing
+    /// `location` is **reused** and the record replaced in place — so
+    /// `/rd/{location}` stays stable per endpoint and the registry never
+    /// accumulates duplicate entries for one device. Otherwise a fresh
+    /// identifier is generated. Either way `location` is populated on the
+    /// stored record; callers read the returned value to build the
+    /// Location-Path response. The current clock + `lifetime` define
+    /// `expiresAt`. Returns the (reused or generated) location.
     std::string add(ServerRegistration in,
                     std::chrono::steady_clock::time_point now =
                         std::chrono::steady_clock::now());
 
-    /// Refresh lifetime / advertised set / binding on an existing entry.
-    /// Returns true on success, false if the location is unknown.
+    /// Refresh lifetime / advertised set / binding on an existing entry, and
+    /// (when `peerHost` is non-empty) the public/ISP peer address+port — so a
+    /// device that keeps the same location but reconnects from a new NAT
+    /// address (the Update doubles as the keepalive) updates its recorded
+    /// peer. Returns true on success, false if the location is unknown.
     bool update(const std::string& location,
                 std::uint32_t newLifetime,
                 const std::string& newBinding,
                 const std::vector<linkformat::LinkEntry>* newAdvertised,
+                const std::string& peerHost = std::string(),
+                std::uint16_t peerPort = 0,
                 std::chrono::steady_clock::time_point now =
                     std::chrono::steady_clock::now());
 

--- a/apps/src/lwm2m_registration.cpp
+++ b/apps/src/lwm2m_registration.cpp
@@ -10,6 +10,26 @@ std::string default_id(std::uint64_t counter) {
 
 std::string ClientRegistry::add(ServerRegistration in,
                                 std::chrono::steady_clock::time_point now) {
+    // Re-registration of a known endpoint (device rebooted / came back online
+    // and re-registered while the prior registration still lingers): reuse its
+    // existing location and replace the record in place, rather than minting a
+    // new /rd/{id} and leaving a stale duplicate behind until it expires.
+    // Keeps the location stable per endpoint and prevents duplicate registry
+    // entries — which otherwise surface as duplicate cloud.lwm2m.registrations
+    // rows whose lexicographic location order makes a STALE row win the
+    // last-writer reconcile (e.g. the device's recorded ISP IP stops tracking).
+    if (!in.endpoint.empty()) {
+        for (auto& [loc, reg] : m_byLocation) {
+            if (reg.endpoint == in.endpoint) {
+                in.location     = loc;
+                in.registeredAt = now;
+                in.expiresAt    = now + std::chrono::seconds(in.lifetime);
+                reg = std::move(in);
+                return loc;
+            }
+        }
+    }
+
     auto gen = m_idGen ? m_idGen : default_id;
     std::string loc;
     do {
@@ -27,6 +47,8 @@ bool ClientRegistry::update(const std::string& location,
                             std::uint32_t newLifetime,
                             const std::string& newBinding,
                             const std::vector<linkformat::LinkEntry>* newAdvertised,
+                            const std::string& peerHost,
+                            std::uint16_t peerPort,
                             std::chrono::steady_clock::time_point now) {
     auto it = m_byLocation.find(location);
     if (it == m_byLocation.end()) return false;
@@ -40,6 +62,14 @@ bool ClientRegistry::update(const std::string& location,
     }
     if (newAdvertised) {
         reg.advertisedSet = *newAdvertised;
+    }
+    // Refresh the public/ISP peer on every Update (the registration Update
+    // doubles as the NAT keepalive, so it arrives from the device's current
+    // public address). Only when known — the plain-UDP dispatch path passes an
+    // empty peer and must not clobber a good address captured at Register.
+    if (!peerHost.empty()) {
+        reg.peerHost = peerHost;
+        reg.peerPort = peerPort;
     }
     reg.expiresAt = now + std::chrono::seconds(reg.lifetime);
     return true;

--- a/apps/src/lwm2m_registration_server.cpp
+++ b/apps/src/lwm2m_registration_server.cpp
@@ -134,7 +134,7 @@ RegistrationOutcome RegistrationServer::handle(const CoAPAdapter::CoAPMessage& m
             advPtr = &newAdvertised;
         }
 
-        if (!m_registry->update(uri, newLt, newBinding, advPtr)) {
+        if (!m_registry->update(uri, newLt, newBinding, advPtr, peerHost, peerPort)) {
             out.kind     = RegistrationOutcome::NotFound;
             out.response = build_simple_ack(msg, /*4.04 Not Found*/ 0x84);
             return out;

--- a/apps/test/registration_server_test.cpp
+++ b/apps/test/registration_server_test.cpp
@@ -160,6 +160,47 @@ TEST(RegistrationServer, REQ_REG_003_POST_rd_loc_updates_lifetime) {
     EXPECT_EQ(600u, registry->find(created.location)->lifetime);
 }
 
+TEST(RegistrationServer, reregister_reuses_location_and_refreshes_peer) {
+    auto registry = std::make_shared<ClientRegistry>();
+    RegistrationServer srv(registry);
+    CoAPAdapter coap;
+
+    auto reg1 = make_msg(2, {"rd"}, {"ep=urn:dev:1", "lt=100"});
+    auto first = srv.handle(reg1, coap, "1.2.3.4", 5555);
+    ASSERT_EQ(RegistrationOutcome::Created, first.kind);
+
+    // Device went offline and re-registered from a new public/ISP address
+    // before its lifetime expired: same location, single entry, fresh peer.
+    auto reg2 = make_msg(2, {"rd"}, {"ep=urn:dev:1", "lt=100"});
+    auto second = srv.handle(reg2, coap, "203.0.113.9", 41000);
+    ASSERT_EQ(RegistrationOutcome::Created, second.kind);
+
+    EXPECT_EQ(first.location, second.location);   // /rd/{location} reused
+    EXPECT_EQ(1u, registry->size());              // no duplicate registration
+    const auto* r = registry->find(second.location);
+    ASSERT_NE(nullptr, r);
+    EXPECT_EQ("203.0.113.9", r->peerHost);        // ISP IP tracks the latest
+}
+
+TEST(RegistrationServer, update_refreshes_peer_address) {
+    auto registry = std::make_shared<ClientRegistry>();
+    RegistrationServer srv(registry);
+    CoAPAdapter coap;
+
+    auto reg = make_msg(2, {"rd"}, {"ep=urn:dev:1", "lt=100"});
+    auto created = srv.handle(reg, coap, "1.2.3.4", 5555);
+    ASSERT_EQ(RegistrationOutcome::Created, created.kind);
+    std::string id = created.location.substr(4);
+
+    // The keepalive Update arrives from a new NAT address → recorded ISP IP
+    // follows it (previously frozen at the Register-time address).
+    auto upd = make_msg(2, {"rd", id}, {"lt=0"});
+    auto out = srv.handle(upd, coap, "198.51.100.7", 33333);
+    EXPECT_EQ(RegistrationOutcome::Updated, out.kind);
+    EXPECT_EQ("198.51.100.7", registry->find(created.location)->peerHost);
+    EXPECT_EQ(33333u, registry->find(created.location)->peerPort);
+}
+
 TEST(RegistrationServer, REQ_REG_003_update_unknown_location_4_04) {
     auto registry = std::make_shared<ClientRegistry>();
     RegistrationServer srv(registry);

--- a/apps/test/registry_test.cpp
+++ b/apps/test/registry_test.cpp
@@ -61,13 +61,50 @@ TEST(Registry, REQ_REG_009_locations_are_unique_within_session) {
     EXPECT_EQ(3u, reg.size());
 }
 
+TEST(Registry, reregister_same_endpoint_reuses_location_no_duplicate) {
+    ClientRegistry reg;
+    auto first = reg.add(make_reg("urn:dev:1", /*lt*/ 100));
+    EXPECT_EQ(1u, reg.size());
+
+    // Same endpoint re-registers (device went offline and came back) from a
+    // NEW public/ISP address before the old registration expired.
+    auto again = make_reg("urn:dev:1", /*lt*/ 100);
+    again.peerHost = "203.0.113.9";
+    again.peerPort = 41000;
+    auto second = reg.add(again);
+
+    EXPECT_EQ(first, second);                 // location reused, not churned
+    EXPECT_EQ(1u, reg.size());                // replaced in place, no duplicate
+    auto* rec = reg.find(first);
+    ASSERT_NE(nullptr, rec);
+    EXPECT_EQ("203.0.113.9", rec->peerHost);  // record reflects the new peer
+    EXPECT_EQ(41000u, rec->peerPort);
+}
+
+TEST(Registry, update_refreshes_peer_address_but_empty_does_not_clobber) {
+    ClientRegistry reg;
+    auto loc = reg.add(make_reg("urn:dev:1", /*lt*/ 100));
+
+    // Keepalive Update from a new NAT address → recorded peer (ISP IP) follows.
+    ASSERT_TRUE(reg.update(loc, 0, "", nullptr, "198.51.100.7", 33333));
+    auto* r = reg.find(loc);
+    ASSERT_NE(nullptr, r);
+    EXPECT_EQ("198.51.100.7", r->peerHost);
+    EXPECT_EQ(33333u, r->peerPort);
+
+    // Plain-UDP dispatch path passes an empty peer — must NOT wipe the address.
+    ASSERT_TRUE(reg.update(loc, 0, "", nullptr, "", 0));
+    EXPECT_EQ("198.51.100.7", reg.find(loc)->peerHost);
+}
+
 TEST(Registry, REQ_REG_003_update_refreshes_lifetime) {
     ClientRegistry reg;
     auto t0 = std::chrono::steady_clock::now();
     auto loc = reg.add(make_reg("urn:dev:1", /*lt*/ 100), t0);
 
     auto t1 = t0 + std::chrono::seconds(50);
-    ASSERT_TRUE(reg.update(loc, /*lt*/ 200, /*binding*/ "", nullptr, t1));
+    ASSERT_TRUE(reg.update(loc, /*lt*/ 200, /*binding*/ "", nullptr,
+                           /*peerHost*/ "", /*peerPort*/ 0, t1));
 
     auto* r = reg.find(loc);
     ASSERT_NE(nullptr, r);
@@ -81,7 +118,8 @@ TEST(Registry, REQ_REG_003_update_can_keep_lifetime_with_lt_zero) {
     auto loc = reg.add(make_reg("urn:dev:1", 100), t0);
 
     auto t1 = t0 + std::chrono::seconds(60);
-    ASSERT_TRUE(reg.update(loc, /*lt*/ 0, "", nullptr, t1));
+    ASSERT_TRUE(reg.update(loc, /*lt*/ 0, "", nullptr,
+                           /*peerHost*/ "", /*peerPort*/ 0, t1));
     auto* r = reg.find(loc);
     ASSERT_NE(nullptr, r);
     EXPECT_EQ(100u, r->lifetime);                                // unchanged


### PR DESCRIPTION
## Problems (two reports, one root cause)

`ClientRegistry` was keyed **only by location**, so it never recognised a re-registering endpoint.

1. **Location URI not reused** — a device that went offline and came back (re-Register while the prior registration still lingered — common, since a reboot is faster than the ~90s lifetime) got a brand-new `/rd/{id}` each time, leaving a **stale duplicate** entry until the old one expired.

2. **ISP IP stops updating after DM registration** — those duplicates became duplicate `cloud.lwm2m.registrations` rows for one endpoint. iot-cloudd's `reconcile_registrations` is last-writer-wins over a `std::map<string>` ordered **lexicographically** (`"/rd/10"` < `"/rd/9"`), so a **stale** older row can sort last and win → the endpoint's recorded public/ISP IP (sourced from the registration peer since #379) freezes at an old value. Compounded by `Update` never refreshing the peer.

## Fixes

- **`add()` dedups by endpoint**: an existing endpoint's `location` is reused and the record replaced in place — stable `/rd` per device, no duplicates, so reconcile always sees exactly one current row. (A Register is still answered `2.01 Created` with the Location-Path, per spec.)
- **`update()` refreshes `peerHost`/`peerPort`** when known — a device that keeps its location but reconnects from a new NAT address updates its ISP IP (the Update doubles as the keepalive). An empty peer (plain-UDP dispatch path) is ignored so it can't clobber the Register-time address.

## Tests

- Registry: reuse location + no duplicate; update refreshes peer; empty peer doesn't clobber.
- Server via `handle()`: re-Register reuses location + refreshes peer; Update refreshes peer.

> Note: if the ISP IP still shows a private `172.x`/`127.0.0.1` after this, that's a separate infra concern — the cloud lwm2m-dm runs on a docker bridge, and source-IP preservation for the published `:5683/udp` depends on `userland-proxy`/DNAT config, not this code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)