### PR TITLE
fix(device): enable iot-reboot.path + iot-factory-reset.path in systemd preset

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
@@ -22,3 +22,9 @@ enable iot-ota-stage.path
 enable iot-swupdate.path
 enable iot-vpn-cert.path
 enable iot-ota-confirm.service
+# device-ui Advanced -> Reboot / Factory Reset: these .path units watch the
+# /run/iot triggers iot-httpd drops. Without an explicit preset, preset-all on
+# first boot resets them to the default "disable" policy, so the trigger file is
+# written but nothing acts on it — the reboot/factory-reset silently no-ops.
+enable iot-reboot.path
+enable iot-factory-reset.path


### PR DESCRIPTION
## Problem

device-ui **Advanced → Reboot** (and **Factory Reset**) silently did nothing. iot-httpd armed the trigger file in `/run/iot` and returned `{"ok":true}`, but **no `.path` unit was watching it**, so the root `iot-reboot.service` never fired.

## Root cause

The two `.path` units were **missing from `90-iot.preset`**. `SYSTEMD_SERVICE` creates the `WantedBy` symlinks at image-build time, but the image runs `systemctl preset-all` on first boot, which resets every unit to its preset policy — and with no matching rule the built-in default is **disable**. So the build-time enables were undone and the units came up `disabled`+`inactive`. This is the exact class of bug the preset file's own header warns about; every **working** path unit (`iot-swupdate`, `iot-ota-stage`, `iot-vpn-cert`) is listed — these two weren't.

## Confirmed on hardware (192.168.1.50)

```
iot-reboot.path          enabled=disabled active=inactive
iot-factory-reset.path   enabled=disabled active=inactive
iot-swupdate.path        enabled=enabled  active=active
iot-ota-stage.path       enabled=enabled  active=active
iot-vpn-cert.path        enabled=enabled  active=active
```

The unit files themselves are correct (the #384 `systemctl`-PATH fix is present in `iot-reboot.service`).

## Fix

Add `enable iot-reboot.path` + `enable iot-factory-reset.path` to `90-iot.preset` so the enablement sticks across `preset-all`.

**Already-flashed devices** recover without a reflash:
```
systemctl enable --now iot-reboot.path iot-factory-reset.path
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)