### PR TITLE
feat(device): Phase 1 device transfer — re-home to a new owner (Advanced→Transfer)

### DIFF
--- a/apps/docs/tdd-device-transfer.md
+++ b/apps/docs/tdd-device-transfer.md
@@ -1,13 +1,35 @@
 # TDD Plan — Device Ownership Transfer (Advanced → Transfer)
 
-Status: **PROPOSAL / DRAFT** — not yet implemented. Replaces the `panel='transfer'`
-placeholder in `iot-ui/src/app/advanced/advanced.component.ts` ("Coming soon —
-device configuration / credential transfer"). Build/test via **podman** (no
+Status: **PHASE 1 IMPLEMENTED** (device-local transfer / field swap); Phase 2
+(cloud release/claim + CRL + token) still to do. Build/test via **podman** (no
 local C++/node toolchain on the dev Mac; image CI builds on `main` only).
 
 This plan is deliberately phased: **Phase 1** ships a self-contained device-local
 transfer (field swap), **Phase 2** adds the two-sided cloud release/claim
 protocol + VPN cert revocation + data purge. Decide §7 before coding Phase 2.
+
+### Phase 1 implementation progress
+
+| Task | State | Notes |
+| --- | --- | --- |
+| A — units + wipe script + recipe | ✅ DONE | `files/iot-transfer` (script), `iot-transfer.{path,service}`; wired into `iot_git.bb` SRC_URI/install/FILES, `SYSTEMD_SERVICE:${PN}-httpd`, **and `90-iot.preset`** (the PR #394 enable lesson). |
+| B — selective wipe mechanism (D4) | ✅ DONE (simplified) | **No new ds-server op.** The script runs as `User=engineer` (matches `iot-lwm2m-client.service`) and clears the customer-scoped keys with `ds-cli set <k> ""` — engineer's primary gid satisfies the `gid:engineer` write_acl (ds-server has no root bypass), and engineer owns `/etc/iot/vpn`. Network keys + `iot.serial` are never touched. |
+| C — `POST /api/v1/system/transfer` | ✅ DONE | `modules/http-server/src/handler.cpp`. **Fail-closed** auth (valid Admin session required when auth enabled; open only when auth disabled) — deliberately unlike the reboot/factory-reset handlers, which default to Admin on an absent cookie. |
+| D — device-ui Advanced → Transfer | ✅ DONE | Replaced the placeholder: warning + "Type TRANSFER to confirm" Clarity input + Admin-gated button; `httpsvc.systemTransfer()`. Error reported honestly (no reboot → connection stays up). |
+| schema | ✅ DONE | `iot.transfer.state` added to `modules/data-store/schemas/iot.lua` (`idle`/`wiping`/`awaiting-commission`, `write_acl gid:engineer`, readable). |
+| E — re-home verification | ⏳ PENDING HW | Needs a device + a 2nd bootstrap server: confirm wipe → park → `should_rebootstrap` re-homes with no client code change. |
+
+**Phase 1 re-commission flow:** Transfer wipes A's creds + VPN trust and parks
+the device; the **new owner enters B's bootstrap URI + BS PSK on the device-ui
+Configuration page** (the same flow a fresh device uses) — no transfer token in
+Phase 1. The device keeps network, so this needs no console visit.
+
+**Deferred from Phase 1 (follow-up):** purging the device-side telemetry
+store-and-forward buffer (§5a) — it needs a privileged step (stop `iot-vehicled`
++ drop the Mongo collection) that the engineer-run wipe can't perform. Until
+then the buffer survives a transfer; flag if A's buffered telemetry must not
+reach B. Operator config keys (`vpn.remote.*` etc.) are likewise left as-is —
+B's cloud re-pushes them over Object 2048 at provision, overwriting A's.
 
 ## 1. Goal
 

--- a/iot-ui/src/app/advanced/advanced.component.ts
+++ b/iot-ui/src/app/advanced/advanced.component.ts
@@ -43,10 +43,23 @@ import { SessionService } from '../../common/session.service';
         </div>
       </ng-container>
 
-      <!-- ── Transfer (placeholder) ───────────────────────────── -->
+      <!-- ── Transfer (re-home to a new owner) ─────────────────── -->
       <ng-container *ngIf="panel==='transfer'">
         <h3>Transfer</h3>
-        <p class="hint">Coming soon — device configuration / credential transfer.</p>
+        <p class="warn">⚠ This <b>re-homes the device to a new owner</b>: it wipes
+          the current customer's credentials and VPN trust and forgets the cloud
+          binding, then parks for re-commissioning. <b>Network settings (WiFi /
+          cellular) are kept</b> so the new owner can re-commission from this UI —
+          this is not a factory reset. The device leaves your fleet.</p>
+        <clr-input-container>
+          <label>Type <code>TRANSFER</code> to confirm:</label>
+          <input clrInput type="text" #tw (input)="transferWord = tw.value"
+                 placeholder="TRANSFER" autocomplete="off" />
+        </clr-input-container>
+        <div class="act">
+          <button class="btn btn-danger" [disabled]="transferWord!=='TRANSFER' || busy || !isAdmin"
+                  (click)="doTransfer()">{{ busy ? '…' : 'Transfer Device' }}</button>
+        </div>
       </ng-container>
 
       <p *ngIf="!isAdmin" class="warn">Admin access is required for these actions.</p>
@@ -71,6 +84,7 @@ export class AdvancedComponent {
   @Input() panel: 'reboot' | 'factory' | 'transfer' = 'reboot';
   rebootOk = false;
   resetWord = '';
+  transferWord = '';
   busy = false;
   msg = '';
 
@@ -99,6 +113,22 @@ export class AdvancedComponent {
                         : ('Error: ' + (r.err || 'failed'));
       },
       error: () => { this.busy = false; this.msg = 'Request sent; the device may already be resetting.'; }
+    });
+  }
+
+  doTransfer(): void {
+    this.busy = true; this.msg = '';
+    // Transfer keeps the network up (no reboot), so the HTTP connection stays
+    // alive — a transport error here is a real failure, reported honestly
+    // (unlike reboot/factory-reset where the drop is expected).
+    this.http.systemTransfer().subscribe({
+      next: (r) => {
+        this.busy = false;
+        this.msg = r.ok
+          ? 'Transfer requested — wiping owner credentials; the device will park for re-commissioning.'
+          : ('Error: ' + (r.err || 'failed'));
+      },
+      error: () => { this.busy = false; this.msg = 'Error: transfer request failed.'; }
     });
   }
 }

--- a/iot-ui/src/common/httpsvc.service.ts
+++ b/iot-ui/src/common/httpsvc.service.ts
@@ -59,6 +59,14 @@ export class HttpsvcService {
       { headers: this.jsonHeaders(), withCredentials: true });
   }
 
+  // Re-home the device to a new owner: wipes customer credentials + VPN trust,
+  // keeps the network, then parks for re-commission. See tdd-device-transfer.md.
+  systemTransfer(): Observable<{ ok: boolean; err?: string }> {
+    return this.http.post<{ ok: boolean; err?: string }>(
+      `${this.api}/api/v1/system/transfer`, {},
+      { headers: this.jsonHeaders(), withCredentials: true });
+  }
+
   // ── Status ────────────────────────────────────────────────────────
 
   getStatus(): Observable<StatusSnapshot> {

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -155,6 +155,18 @@ return {
         default = "idle",
     },
 
+    -- Device-transfer (customer re-home) lifecycle, surfaced in the device-ui
+    -- Advanced -> Transfer panel: "idle" / "wiping" / "awaiting-commission".
+    -- Written by iot-transfer (runs as engineer); readable so the UI reflects
+    -- when the device has been wiped and is parked for the new owner to
+    -- commission. See apps/docs/tdd-device-transfer.md.
+    ["iot.transfer.state"] = {
+        access    = "Viewer",
+        type      = "string",
+        default   = "idle",
+        write_acl = {"gid:engineer"},
+    },
+
     -- ── mangOH Yellow sensor telemetry (iot-sensord → ds → IPSO/UI) ──
     -- The privileged iot-sensord daemon owns the I2C bus, reads the onboard
     -- BME680 / BMI160 / light sensors and publishes their latest values here.

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -561,6 +561,49 @@ void install_handlers(Router& router,
             return r;
         });
 
+    // ── POST /api/v1/system/transfer ──────────────────────────────
+    // Admin-only + ownership-changing. Re-homes the device to a new owner:
+    // arms the trigger that the `engineer` iot-transfer.service acts on, which
+    // wipes the customer-scoped credentials + VPN trust + LwM2M bootstrap
+    // binding but KEEPS the network, then parks for re-commission (Phase 1 of
+    // apps/docs/tdd-device-transfer.md). Yocto/systemd only.
+    //
+    // FAIL-CLOSED auth (deliberately unlike reboot/factory-reset above, which
+    // default to Admin on an absent cookie): a destructive ownership change must
+    // require a valid Admin session whenever auth is enabled. With auth disabled
+    // the whole API is open by operator choice, so it is allowed.
+    router.add("POST", "/api/v1/system/transfer",
+        [auth](const HttpParser::Request& req) -> HttpResponse {
+            HttpResponse r;
+            bool allowed = false;
+            if (auth && auth->enabled()) {
+                std::string token = extract_session_cookie(req.headers, auth->cookie_name());
+                if (!token.empty()) {
+                    const auto* session = auth->validate(token);
+                    if (session && session->access == "Admin") allowed = true;
+                }
+            } else {
+                allowed = true;   // auth disabled → API open by operator choice
+            }
+            if (!allowed) {
+                r.status = 403;
+                r.body = R"({"ok":false,"err":"admin required"})";
+                return r;
+            }
+            std::ofstream trig("/run/iot/transfer.request", std::ios::trunc);
+            if (!trig) {
+                r.status = 500;
+                r.body = R"({"ok":false,"err":"cannot arm transfer - perms or non-Yocto host"})";
+                return r;
+            }
+            trig << "transfer\n";
+            ACE_DEBUG((LM_WARNING,
+                       ACE_TEXT("%D httpd:thread:%t %M %N:%l DEVICE TRANSFER requested "
+                                "via device-ui (armed iot-transfer.path)\n")));
+            r.body = R"({"ok":true})";
+            return r;
+        });
+
     // ── POST /api/v1/firmware/upload?name=<f>&version=&arch=&pkg= ──
     // Cloud-side: browse / drag-drop a .ipk or .tar.gz bundle in the cloud-ui
     // straight into the firmware FEED (firmware_dir, served at /firmware/) and

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
@@ -28,3 +28,4 @@ enable iot-ota-confirm.service
 # written but nothing acts on it — the reboot/factory-reset silently no-ops.
 enable iot-reboot.path
 enable iot-factory-reset.path
+enable iot-transfer.path

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-transfer
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-transfer
@@ -1,0 +1,45 @@
+#!/bin/sh
+# iot-transfer — re-home this device to a new owner (customer A -> B).
+#
+# Armed by the device-ui: POST /api/v1/system/transfer writes
+# /run/iot/transfer.request; iot-transfer.path fires this. Unlike Factory Reset
+# (which wipes EVERYTHING and drops the device off the network), Transfer wipes
+# only the customer-scoped credentials + VPN trust + the LwM2M bootstrap binding
+# and KEEPS the network (WiFi/cellular/net.*) and the hardware serial — so the
+# new owner can re-commission from the device-ui without a console visit.
+#
+# Runs as `engineer` (NOT root): the credential ds keys are write_acl=gid:engineer
+# (ds-server has no root bypass) and /etc/iot/vpn is engineer-owned. engineer is
+# in group `iot` (SupplementaryGroups) to reach the ds socket. See
+# apps/docs/tdd-device-transfer.md.
+set -u
+
+DS=/usr/bin/ds-cli
+log() { logger -t iot-transfer "$*"; }
+
+log "DEVICE TRANSFER: wiping customer credentials + VPN trust, keeping network"
+rm -f /run/iot/transfer.request
+$DS set iot.transfer.state wiping 2>/dev/null || true
+
+# 1. Sever LwM2M: clear the BS + DM PSKs, the DM URI and the BS URI so the
+#    client parks for re-commission, and reset the 3rd-party-BS override + the
+#    connection-state display. Clearing the BS PSK key makes the lwm2m client
+#    self-restart (Restart=always) and re-read the now-empty creds -> park.
+for k in iot.bs.uri iot.bs.psk.identity iot.bs.psk.key \
+         iot.dm.psk.identity iot.dm.psk.key iot.dm.uri iot.conn.state; do
+    $DS set "$k" "" 2>/dev/null || log "warn: could not clear $k"
+done
+$DS set iot.bs.psk.override false 2>/dev/null || log "warn: could not reset iot.bs.psk.override"
+
+# 2. Sever VPN trust: drop the old owner's CA + client cert/key. The dir
+#    (/etc/iot/vpn, 2750 engineer:iot) is kept; only its contents go. The
+#    openvpn-client parks without a cert; the new owner's cloud re-pushes a
+#    fresh family over LwM2M Object 2048 at provision time.
+rm -rf /etc/iot/vpn/* 2>/dev/null || log "warn: could not clear /etc/iot/vpn"
+
+# 3. Parked for re-commission. The new owner enters their bootstrap URI + BS PSK
+#    on the device-ui Configuration page (the same commissioning flow a fresh
+#    device uses); the device then bootstraps into the new owner's cloud.
+$DS set iot.transfer.state awaiting-commission 2>/dev/null || true
+sync
+log "transfer wipe done; device parked for re-commission (network preserved)"

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-transfer.path
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-transfer.path
@@ -1,0 +1,14 @@
+[Unit]
+Description=Watch the device-transfer trigger (device-ui Advanced -> Transfer)
+Documentation=https://github.com/naushada/iot
+
+[Path]
+# iot-httpd (unprivileged) arms this by creating the file; iot-transfer.service
+# (runs as engineer) then wipes the customer credentials + VPN trust, keeping
+# the network. The service removes the trigger to re-arm (a .path unit won't
+# re-fire until the path is gone again).
+PathExists=/run/iot/transfer.request
+Unit=iot-transfer.service
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-transfer.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-transfer.service
@@ -1,0 +1,18 @@
+[Unit]
+Description=Device transfer — wipe customer credentials + VPN trust, keep network
+Documentation=https://github.com/naushada/iot
+# No [Install]: activated by iot-transfer.path, never enabled directly.
+After=iot-ds.service
+Wants=iot-ds.service
+
+[Service]
+Type=oneshot
+# Runs as `engineer`, not root: the credential ds keys are write_acl=gid:engineer
+# (ds-server has NO root bypass) and /etc/iot/vpn is engineer-owned. Group `iot`
+# (supplementary) is needed to reach the ds socket (/run/iot/data_store.sock,
+# 0660 iot-ds:iot). Mirrors iot-lwm2m-client.service's account.
+User=engineer
+Group=engineer
+SupplementaryGroups=iot
+ExecStart=/usr/bin/iot-transfer
+TimeoutStartSec=60

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -63,6 +63,9 @@ SRC_URI = "\
     file://iot-factory-reset \
     file://iot-factory-reset.path \
     file://iot-factory-reset.service \
+    file://iot-transfer \
+    file://iot-transfer.path \
+    file://iot-transfer.service \
     file://iot-bank-switch \
     file://migrations/README.md \
     file://migrations/0000-template.sh.example \
@@ -270,6 +273,9 @@ do_install() {
     # iot-factory-reset.path fires when the unprivileged iot-httpd drops
     # /run/iot/factory-reset.request). Reboot needs no script (systemctl reboot).
     install -m 0755 ${WORKDIR}/iot-factory-reset ${D}${bindir}/iot-factory-reset
+    # Device-transfer wipe script (run as engineer by iot-transfer.service, which
+    # iot-transfer.path fires when iot-httpd drops /run/iot/transfer.request).
+    install -m 0755 ${WORKDIR}/iot-transfer      ${D}${bindir}/iot-transfer
     install -m 0755 ${WORKDIR}/iot-bank-switch  ${D}${bindir}/iot-bank-switch
 
     # iot-dump: operator/debug tool — dumps all data-store keys + values for
@@ -316,6 +322,11 @@ do_install() {
         install -m 0644 ${WORKDIR}/iot-reboot.service         ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-factory-reset.path     ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-factory-reset.service  ${D}${systemd_system_unitdir}/
+        # device-ui Advanced -> Transfer: engineer .path/.service wipe customer
+        # creds + VPN trust, keep network (re-home to a new owner). Phase 1 of
+        # apps/docs/tdd-device-transfer.md.
+        install -m 0644 ${WORKDIR}/iot-transfer.path          ${D}${systemd_system_unitdir}/
+        install -m 0644 ${WORKDIR}/iot-transfer.service       ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-net-router.service     ${D}${systemd_system_unitdir}/
         # iot-sensord: mangOH Yellow sensor producer (maps I2C, publishes
         # iot.sensor.*). NOT auto-enabled — it needs the mangOH board attached
@@ -539,6 +550,7 @@ FILES:${PN}-httpd = "\
     ${bindir}/iot-set-hostname \
     ${bindir}/iot-ds-seed \
     ${bindir}/iot-factory-reset \
+    ${bindir}/iot-transfer \
     ${systemd_system_unitdir}/iot-httpd.service \
     ${systemd_system_unitdir}/iot-hostname.service \
     ${systemd_system_unitdir}/iot-ds-seed.service \
@@ -546,6 +558,8 @@ FILES:${PN}-httpd = "\
     ${systemd_system_unitdir}/iot-reboot.service \
     ${systemd_system_unitdir}/iot-factory-reset.path \
     ${systemd_system_unitdir}/iot-factory-reset.service \
+    ${systemd_system_unitdir}/iot-transfer.path \
+    ${systemd_system_unitdir}/iot-transfer.service \
     ${sysconfdir}/avahi/services/iot-http.service \
     ${datadir}/iot/www \
 "
@@ -660,7 +674,7 @@ SYSTEMD_SERVICE:${PN}-wifi-client = "iot-wifi-client.service"
 # iot-reboot.path + iot-factory-reset.path are enabled (they watch the triggers
 # iot-httpd drops in /run/iot for device-ui Advanced -> Reboot/Factory Reset);
 # their .service units are path-activated, not enabled directly (no [Install]).
-SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service iot-ds-seed.service iot-reboot.path iot-factory-reset.path"
+SYSTEMD_SERVICE:${PN}-httpd = "iot-httpd.service iot-hostname.service iot-ds-seed.service iot-reboot.path iot-factory-reset.path iot-transfer.path"
 # iot-sensord registered but NOT auto-enabled: it needs the mangOH Yellow board
 # + CAP_SYS_RAWIO, so on a board without it the daemon would Restart-loop. The
 # operator `systemctl enable --now iot-sensord` on sensor-equipped hardware.


### PR DESCRIPTION
Phase 1 of `apps/docs/tdd-device-transfer.md` — a device-local **field swap** that re-homes a device from customer A to B.

## What it does
Wipes the current customer's **credentials + VPN trust** and parks the device for re-commissioning, **keeping the network** (WiFi/cellular) and the hardware serial — so the new owner re-commissions from the device-ui with no console visit. Distinct from Factory Reset (wipes everything, drops off-net).

## Pieces
- **device-ui Advanced → Transfer:** real panel (warning + "Type `TRANSFER` to confirm" Clarity input + Admin-gated button) replacing the placeholder; `httpsvc.systemTransfer()`. Errors reported honestly (no reboot → connection stays up).
- **`POST /api/v1/system/transfer`** (`handler.cpp`): arms `/run/iot/transfer.request`. **FAIL-CLOSED** auth — requires a valid Admin session when auth is enabled (deliberately unlike reboot/factory-reset, which default to Admin on an absent cookie; this is ownership-changing).
- **`iot-transfer{,.path,.service}`:** the `.path` watches the trigger and fires the wipe script as **`User=engineer`** (not root) — the credential ds keys are `write_acl=gid:engineer` and ds-server has **no root bypass**, and `/etc/iot/vpn` is engineer-owned. Script clears BS/DM PSKs + DM/BS URI + override via `ds-cli set ""` and `rm`s `/etc/iot/vpn`; the lwm2m client self-restarts on the BS-PSK change and parks. **No new ds-server op** (D4 simplified).
- Wired into `iot_git.bb` **and `90-iot.preset`** (the PR #394 lesson: a `.path` unit absent from the preset gets disabled by first-boot `preset-all`). `ds-cli` already an RDEPENDS of `-httpd`.
- **schema:** `iot.transfer.state` in `iot.lua`.

## Re-commission flow
Device parks → new owner enters B's bootstrap URI + BS PSK on the device-ui Configuration page (same flow a fresh device uses) → device bootstraps into B's cloud. No transfer token in Phase 1.

## Deferred
- Device telemetry-buffer purge (needs a privileged step — `iot-vehicled`/Mongo).
- **E — HW re-home verification** (needs a device + 2nd bootstrap server).
- Phase 2: cloud release/claim + VPN **CRL** revocation + signed transfer token.

🤖 Generated with [Claude Code](https://claude.com/claude-code)