### PR TITLE
feat(cloud-vpn): VPN client-cert revocation (CRL) — Phase 2 F engine

### DIFF
--- a/apps/docs/tdd-device-transfer.md
+++ b/apps/docs/tdd-device-transfer.md
@@ -224,10 +224,28 @@ How B's `bs.uri` + BS PSK reach the device after the wipe:
 
 ### Phase 2 — cloud release/claim + revocation
 
-- **F. CRL in `CertAuthority`** [CLOUD] — generate/maintain `crl.pem`, revoke a
-  serial, persist `cloud.vpn.crl.pem`; add `crl-verify` to `build_server_config`;
-  `OpenVpnServer::reconfigure` already restarts on a rendered-config change so a
-  CRL update propagates. Tests: revoked cert rejected.
+- **F. CRL in `CertAuthority`** [CLOUD] — **engine DONE** (this slice):
+  - `CertAuthority` now mints through `openssl ca` (was `x509 -req`) so issued
+    certs land in a CA database (`index.txt`) and are revocable; `ensure()`
+    stands up the CRL scaffolding (`openssl.cnf`, `index.txt`, `serial`,
+    `crlnumber`, `newcerts/`, initial empty CRL) idempotently — backfilled for a
+    CA created before this feature.
+  - `revoke(client_cert_pem)` → `openssl ca -revoke` + `-gencrl`, returns the
+    fresh CRL PEM; `crl_pem()` reads the current CRL.
+  - `build_server_config` emits `crl-verify <path>` **only when `cfg.crl` is set**
+    (default empty → unchanged; openvpn won't refuse to start on a missing file).
+  - Tests (real openssl, podman): initial CRL stood up; a revoked cert is
+    rejected by `openssl verify -crl_check` while others still pass; a foreign
+    cert can't be revoked; `build_server_config` crl-verify on/off.
+  - **Wiring still TODO** (next slice): set `ovpn_cfg.crl = capaths.crl` after
+    `ensure()`; persist/restore `crl.pem` (+ `index.txt`/`crlnumber`) in ds like
+    the runtime PKI so enforcement + future revokes survive an iot-vpn volume
+    loss; `OpenVpnServer::reconfigure` already restarts on a rendered-config
+    change so a first-time `crl-verify` propagates.
+  - **Caveat:** only `openssl ca`-minted certs are revocable. Devices whose cert
+    was issued by the OLD `x509 -req` path (pre-feature) aren't in the CA db —
+    they become revocable after a re-provision. Fresh deployments: all
+    revocable.
 - **G. Release backend** [CLOUD] — `cloud.transfer.release.request` watch →
   deprovision + revoke + purge telemetry (`cloud.vehicle.telemetry` + Mongo) +
   audit. One-shot trigger like provision/deprovision.

--- a/modules/server/openvpn/inc/cert_authority.hpp
+++ b/modules/server/openvpn/inc/cert_authority.hpp
@@ -32,6 +32,16 @@ struct CaPaths {
     std::string ca_subj   = "/O=IoT Cloud/CN=iot-cloud-ca";
     std::string srv_subj  = "/O=IoT Cloud/CN=cloud-vpn";
     int         days      = 3650;
+    // CRL / CA-database material (Phase 2 of apps/docs/tdd-device-transfer.md).
+    // Minting goes through `openssl ca` (vs `x509 -req`) so issued certs land in
+    // `ca_db` (index.txt) and can later be revoked + rolled into a CRL.
+    std::string crl       = "/etc/iot/vpn/ca/crl.pem";
+    std::string ca_db     = "/etc/iot/vpn/ca/index.txt";
+    std::string ca_serial = "/etc/iot/vpn/ca/serial";
+    std::string ca_crlnum = "/etc/iot/vpn/ca/crlnumber";
+    std::string ca_cnf    = "/etc/iot/vpn/ca/openssl.cnf";
+    std::string ca_newdir = "/etc/iot/vpn/ca/newcerts";
+    int         crl_days  = 3650;
 };
 
 /// A freshly minted client credential family. ca_crt is included so the
@@ -57,9 +67,26 @@ public:
     /// True once a CA private key is present (after a successful ensure()).
     bool have_ca() const;
 
-    /// Mint a client cert + key signed by the CA, CN = sanitized `cn`.
-    /// Returns std::nullopt on failure (no CA, openssl error, IO error).
+    /// Mint a client cert + key signed by the CA, CN = sanitized `cn`. Signed
+    /// via `openssl ca` so the cert is recorded in the CA database and is
+    /// revocable later. Returns std::nullopt on failure (no CA, openssl/IO).
     std::optional<MintedCert> mint_client(const std::string& cn);
+
+    /// Ensure the CRL/CA-database scaffolding exists (openssl.cnf, index.txt,
+    /// serial, crlnumber, newcerts/, and an initial empty CRL). Idempotent and
+    /// safe to call on an already-initialised CA (e.g. a cloud upgraded into
+    /// the CRL feature). Called from ensure() and before mint/revoke. Returns
+    /// false if there is no CA or on openssl/IO failure.
+    bool ensure_crl();
+
+    /// Revoke a previously-minted client cert (passed as its PEM) and roll a
+    /// fresh CRL. Returns the new CRL PEM on success. Fails (nullopt) if the
+    /// cert was not minted by this CA's database (e.g. issued before the CRL
+    /// feature) — only `openssl ca`-minted certs are revocable.
+    std::optional<std::string> revoke(const std::string& client_cert_pem);
+
+    /// Current CRL PEM (empty optional if none yet). Read-only.
+    std::optional<std::string> crl_pem() const;
 
     /// CN sanitiser exposed for tests: keep [A-Za-z0-9._@-], map the rest to
     /// '_', cap at 64 chars, never empty.
@@ -67,6 +94,7 @@ public:
 
 private:
     bool run_openssl(const std::string& args) const;  // args appended to the binary
+    bool write_ca_cnf() const;                         // (re)write openssl.cnf
 
     CaPaths     m_p;
     std::string m_openssl;

--- a/modules/server/openvpn/inc/openvpn_server.hpp
+++ b/modules/server/openvpn/inc/openvpn_server.hpp
@@ -32,6 +32,8 @@ struct OpenVpnServerConfig {
     std::string   cipher     = "AES-256-GCM";
     std::string   dns;                          // empty → no DNS pushed;
                                                 // else `push "dhcp-option DNS …"`
+    std::string   crl;                          // empty → no crl-verify; else
+                                                // `crl-verify <path>` (revocation)
     std::uint16_t mgmt_port  = 7506;            // management 127.0.0.1 <port>
     int           verb       = 3;
 };

--- a/modules/server/openvpn/src/cert_authority.cpp
+++ b/modules/server/openvpn/src/cert_authority.cpp
@@ -34,6 +34,13 @@ bool slurp(const std::string& path, std::string& out) {
     return true;
 }
 
+bool write_file(const std::string& path, const std::string& data) {
+    std::ofstream ofs(path, std::ios::binary | std::ios::trunc);
+    if (!ofs.is_open()) return false;
+    ofs << data;
+    return ofs.good();
+}
+
 } // namespace
 
 CertAuthority::CertAuthority(CaPaths paths, std::string openssl)
@@ -80,6 +87,12 @@ bool CertAuthority::ensure() {
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l CA key present (%C); "
                             "runtime CA already initialised\n"),
                    m_p.ca_key.c_str()));
+        // Backfill the CRL/CA-database scaffolding for a CA that predates the
+        // CRL feature. Best-effort: a CRL failure must not fail CA bring-up.
+        if (!ensure_crl())
+            ACE_ERROR((LM_WARNING,
+                       ACE_TEXT("%D cloudd:thread:%t %M %N:%l CRL scaffolding "
+                                "backfill failed (revocation unavailable)\n")));
         return true;
     }
 
@@ -114,11 +127,105 @@ bool CertAuthority::ensure() {
     ::unlink(csr.c_str());
     (void)srl;
 
+    // Stand up the CRL/CA-database scaffolding so per-device certs minted below
+    // are revocable. Best-effort: a CRL failure must not fail CA bring-up.
+    if (!ensure_crl())
+        ACE_ERROR((LM_WARNING,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l CRL scaffolding init "
+                            "failed (revocation unavailable)\n")));
+
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("%D cloudd:thread:%t %M %N:%l runtime CA + server cert "
                         "generated (ca=%C server=%C)\n"),
                m_p.ca_crt.c_str(), m_p.srv_crt.c_str()));
     return true;
+}
+
+bool CertAuthority::write_ca_cnf() const {
+    std::ostringstream c;
+    c << "[ ca ]\n"
+      << "default_ca = CA_default\n\n"
+      << "[ CA_default ]\n"
+      << "dir              = " << dirname_of(m_p.ca_crt) << "\n"
+      << "database         = " << m_p.ca_db     << "\n"
+      << "new_certs_dir    = " << m_p.ca_newdir << "\n"
+      << "serial           = " << m_p.ca_serial << "\n"
+      << "crlnumber        = " << m_p.ca_crlnum << "\n"
+      << "certificate      = " << m_p.ca_crt    << "\n"
+      << "private_key      = " << m_p.ca_key    << "\n"
+      << "default_md       = sha256\n"
+      << "default_days     = " << m_p.days      << "\n"
+      << "default_crl_days = " << m_p.crl_days  << "\n"
+      << "policy           = policy_any\n"
+      << "email_in_dn      = no\n"
+      << "unique_subject   = no\n"
+      << "copy_extensions  = none\n"
+      << "preserve         = no\n\n"
+      << "[ policy_any ]\n"
+      << "commonName             = supplied\n"
+      << "organizationName       = optional\n"
+      << "organizationalUnitName = optional\n"
+      << "countryName            = optional\n"
+      << "stateOrProvinceName    = optional\n"
+      << "localityName           = optional\n"
+      << "emailAddress           = optional\n";
+    return write_file(m_p.ca_cnf, c.str());
+}
+
+bool CertAuthority::ensure_crl() {
+    if (!have_ca()) return false;
+    ::mkdir(m_p.ca_newdir.c_str(), 0755);
+    if (!file_exists(m_p.ca_db)     && !write_file(m_p.ca_db, ""))         return false;
+    // openssl reads unique_subject from index.txt.attr if present; force "no"
+    // so re-provisioning the same CN (a re-mint) doesn't error on a duplicate.
+    write_file(m_p.ca_db + ".attr", "unique_subject = no\n");
+    if (!file_exists(m_p.ca_serial) && !write_file(m_p.ca_serial, "01\n")) return false;
+    if (!file_exists(m_p.ca_crlnum) && !write_file(m_p.ca_crlnum, "01\n")) return false;
+    if (!write_ca_cnf()) return false;
+    // Emit an initial (empty) CRL so the server always has a crl-verify target.
+    if (!file_exists(m_p.crl)) {
+        if (!run_openssl("ca -batch -config '" + m_p.ca_cnf +
+                         "' -gencrl -out '" + m_p.crl + "'")) return false;
+    }
+    return true;
+}
+
+std::optional<std::string> CertAuthority::crl_pem() const {
+    std::string pem;
+    if (!slurp(m_p.crl, pem)) return std::nullopt;
+    return pem;
+}
+
+std::optional<std::string> CertAuthority::revoke(const std::string& client_cert_pem) {
+    if (!have_ca() || !ensure_crl()) return std::nullopt;
+
+    char tmpl[] = "/tmp/iot-revoke-XXXXXX";
+    char* dir = ::mkdtemp(tmpl);
+    if (!dir) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l revoke: mkdtemp failed "
+                            "errno=%d\n"), errno));
+        return std::nullopt;
+    }
+    const std::string d    = dir;
+    const std::string cert = d + "/cert.pem";
+
+    std::optional<std::string> result;
+    if (write_file(cert, client_cert_pem) &&
+        run_openssl("ca -batch -config '" + m_p.ca_cnf + "' -revoke '" + cert + "'") &&
+        run_openssl("ca -batch -config '" + m_p.ca_cnf +
+                    "' -gencrl -out '" + m_p.crl + "'")) {
+        std::string pem;
+        if (slurp(m_p.crl, pem)) result = std::move(pem);
+    }
+    ::unlink(cert.c_str());
+    ::rmdir(d.c_str());
+
+    if (!result)
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l revoke failed (cert not "
+                            "minted by this CA's database, or openssl error)\n")));
+    return result;
 }
 
 std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn) {
@@ -146,13 +253,17 @@ std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn) {
     const std::string csr = d + "/client.csr";
     const std::string crt = d + "/client.crt";
 
+    // Sign through `openssl ca` (not `x509 -req`) so the cert is recorded in the
+    // CA database (index.txt) and can be revoked later. `-notext` keeps the
+    // output a clean PEM (no human-readable header). ensure_crl() first so the
+    // database + openssl.cnf exist.
     bool ok =
+        ensure_crl() &&
         run_openssl("genrsa -out '" + key + "' 2048") &&
         run_openssl("req -new -key '" + key + "' -out '" + csr +
                     "' -subj '/O=IoT Cloud/CN=" + safe + "'") &&
-        run_openssl("x509 -req -days " + std::to_string(m_p.days) + " -in '" + csr +
-                    "' -CA '" + m_p.ca_crt + "' -CAkey '" + m_p.ca_key +
-                    "' -CAcreateserial -out '" + crt + "'");
+        run_openssl("ca -batch -notext -config '" + m_p.ca_cnf + "' -days " +
+                    std::to_string(m_p.days) + " -in '" + csr + "' -out '" + crt + "'");
 
     MintedCert out;
     if (ok) {

--- a/modules/server/openvpn/src/openvpn_server.cpp
+++ b/modules/server/openvpn/src/openvpn_server.cpp
@@ -72,6 +72,12 @@ std::string build_server_config(const OpenVpnServerConfig& c) {
     ss << "ca   " << c.ca_path   << "\n";
     ss << "cert " << c.cert_path << "\n";
     ss << "key  " << c.key_path  << "\n";
+    // Revocation: when a CRL is configured, openvpn rejects any client cert
+    // listed in it. Conditional — emitted only when set, so a deployment
+    // without a CRL is unchanged (and openvpn won't refuse to start on a
+    // missing crl-verify file). The CA writes the CRL; iot-cloudd points
+    // c.crl at it once it exists. See apps/docs/tdd-device-transfer.md.
+    if (!c.crl.empty()) ss << "crl-verify " << c.crl << "\n";
     ss << "dh none\n";                       // ECDH — no dh.pem needed
     ss << "cipher " << c.cipher  << "\n";
     ss << "keepalive 10 120\n";

--- a/modules/server/openvpn/test/cert_authority_test.cpp
+++ b/modules/server/openvpn/test/cert_authority_test.cpp
@@ -36,7 +36,21 @@ CaPaths paths_under(const std::string& dir) {
     p.ca_crt  = dir + "/ca/ca.crt";
     p.srv_key = dir + "/server.key";
     p.srv_crt = dir + "/server.crt";
+    p.crl       = dir + "/ca/crl.pem";
+    p.ca_db     = dir + "/ca/index.txt";
+    p.ca_serial = dir + "/ca/serial";
+    p.ca_crlnum = dir + "/ca/crlnumber";
+    p.ca_cnf    = dir + "/ca/openssl.cnf";
+    p.ca_newdir = dir + "/ca/newcerts";
     return p;
+}
+
+// True if `openssl verify -crl_check` ACCEPTS the cert against the CA + CRL.
+bool crl_verify_ok(const std::string& ca_crt, const std::string& crl,
+                   const std::string& cert) {
+    return std::system(("/usr/bin/openssl verify -crl_check -CAfile '" + ca_crt +
+                        "' -CRLfile '" + crl + "' '" + cert +
+                        "' >/dev/null 2>&1").c_str()) == 0;
 }
 
 } // namespace
@@ -113,4 +127,68 @@ TEST(CertAuthority, mint_without_ca_fails) {
     CaPaths p = paths_under(dir);
     CertAuthority ca(p);                 // ensure() not called
     EXPECT_FALSE(ca.mint_client("x").has_value());
+}
+
+/* ─────────────────────── CRL / revocation (needs openssl) ─────────────── */
+
+TEST(CertAuthority, ensure_stands_up_crl_database_and_initial_crl) {
+    if (!have_openssl()) GTEST_SKIP() << "openssl CLI not available";
+    const std::string dir = scratch();
+    if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";
+    CaPaths p = paths_under(dir);
+
+    CertAuthority ca(p);
+    ASSERT_TRUE(ca.ensure());
+    EXPECT_TRUE(exists(p.crl));
+    EXPECT_TRUE(exists(p.ca_db));
+    EXPECT_TRUE(exists(p.ca_cnf));
+    auto pem = ca.crl_pem();
+    ASSERT_TRUE(pem.has_value());
+    EXPECT_NE(std::string::npos, pem->find("BEGIN X509 CRL"));
+}
+
+TEST(CertAuthority, revoked_cert_is_rejected_while_others_still_verify) {
+    if (!have_openssl()) GTEST_SKIP() << "openssl CLI not available";
+    const std::string dir = scratch();
+    if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";
+    CaPaths p = paths_under(dir);
+
+    CertAuthority ca(p);
+    ASSERT_TRUE(ca.ensure());
+
+    auto keep = ca.mint_client("rpi-keep@cloud.local");
+    auto gone = ca.mint_client("rpi-gone@cloud.local");
+    ASSERT_TRUE(keep.has_value());
+    ASSERT_TRUE(gone.has_value());
+
+    const std::string keepCrt = dir + "/keep.crt";
+    const std::string goneCrt = dir + "/gone.crt";
+    std::ofstream(keepCrt, std::ios::binary) << keep->client_crt;
+    std::ofstream(goneCrt, std::ios::binary) << gone->client_crt;
+
+    // Before revocation both verify against the (empty) CRL.
+    EXPECT_TRUE(crl_verify_ok(p.ca_crt, p.crl, keepCrt));
+    EXPECT_TRUE(crl_verify_ok(p.ca_crt, p.crl, goneCrt));
+
+    // Revoke one → a fresh CRL is returned + persisted.
+    auto crl = ca.revoke(gone->client_crt);
+    ASSERT_TRUE(crl.has_value());
+    EXPECT_NE(std::string::npos, crl->find("BEGIN X509 CRL"));
+
+    // Now the revoked cert is rejected; the other still passes.
+    EXPECT_FALSE(crl_verify_ok(p.ca_crt, p.crl, goneCrt));
+    EXPECT_TRUE(crl_verify_ok(p.ca_crt, p.crl, keepCrt));
+}
+
+TEST(CertAuthority, revoke_foreign_cert_fails) {
+    if (!have_openssl()) GTEST_SKIP() << "openssl CLI not available";
+    const std::string dir = scratch();
+    if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";
+    CaPaths p = paths_under(dir);
+
+    CertAuthority ca(p);
+    ASSERT_TRUE(ca.ensure());
+    // A cert not minted by this CA's database cannot be revoked.
+    EXPECT_FALSE(ca.revoke("-----BEGIN CERTIFICATE-----\nnotacert\n"
+                           "-----END CERTIFICATE-----\n").has_value());
 }

--- a/modules/server/openvpn/test/openvpn_server_test.cpp
+++ b/modules/server/openvpn/test/openvpn_server_test.cpp
@@ -93,6 +93,21 @@ TEST(BuildServerConfig, noDnsPushWhenEmpty) {
     EXPECT_EQ(conf.find("dhcp-option DNS"), std::string::npos);
 }
 
+TEST(BuildServerConfig, crlVerifyEmittedWhenSet) {
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";
+    c.crl = "/etc/iot/vpn/ca/crl.pem";
+    const std::string conf = build_server_config(c);
+    EXPECT_NE(conf.find("crl-verify /etc/iot/vpn/ca/crl.pem"), std::string::npos);
+}
+
+TEST(BuildServerConfig, noCrlVerifyWhenUnset) {
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/24";   // c.crl left empty
+    const std::string conf = build_server_config(c);
+    EXPECT_EQ(conf.find("crl-verify"), std::string::npos);
+}
+
 TEST(Reconfigure, noopWhenRenderedConfigUnchanged) {
     // A redundant ds write (same effective config) must NOT report a change,
     // so the cloud hot-reload path doesn't bounce a healthy tunnel.


### PR DESCRIPTION
The revocation engine for device transfer, and the fix for the gap found while tracing deprovision: it removes creds/registry but **never revoked the issued VPN cert**, so the CA kept trusting it.

## CertAuthority
- Mints through **`openssl ca`** (was `x509 -req`; `-notext` → clean PEM) so each issued cert is recorded in a CA database (`index.txt`) and is **revocable**.
- `ensure()` stands up the CRL scaffolding idempotently (`openssl.cnf`, `index.txt`, `serial`, `crlnumber`, `newcerts/`, an initial empty CRL) — **backfilled** for a CA created before this feature.
- `revoke(client_cert_pem)` → `openssl ca -revoke` + `-gencrl`, returns the fresh CRL PEM; `crl_pem()` reads the current CRL.

## Server config
`build_server_config` emits `crl-verify <path>` **only when `cfg.crl` is set** (default empty → openvpn config unchanged; won't refuse to start on a missing file). **Inert at runtime** until iot-cloudd points `cfg.crl` at the CRL — so this slice carries no VPN-server behavior change.

## Validation (real openssl 3.0.2, podman `iot-devbuild`)
- `cert-authority-tests` **7/7** — a revoked cert is rejected by `openssl verify -crl_check` while others still verify; a foreign cert can't be revoked; initial CRL stood up.
- `openvpn-server-tests` **14/14** — `crl-verify` on/off + existing config/reconfigure tests.

## Caveat
Only `openssl ca`-minted certs are revocable; devices issued by the old `x509 -req` path become revocable after a re-provision. Fresh deployments: all revocable.

## Next slice (not here)
Set `ovpn_cfg.crl` after `ensure()` + persist/restore `crl.pem` (+`index.txt`/`crlnumber`) in ds like the runtime PKI + the transfer-out revoke trigger (task G). See `apps/docs/tdd-device-transfer.md` §F.

🤖 Generated with [Claude Code](https://claude.com/claude-code)