### PR TITLE
feat(cloud): wire VPN CRL + transfer-out (release) flow — Phase 2 F-wiring/G/H

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -25,6 +25,7 @@
 #include "data_store/value.hpp"
 
 #include <ace/Log_Msg.h>
+#include <ace/OS_NS_time.h>
 #include <ace/INET_Addr.h>
 #include <ace/SOCK_Connector.h>
 #include <ace/SOCK_Stream.h>
@@ -533,6 +534,14 @@ int main(int argc, char** argv) {
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l watch deprovision.request failed: %C\n"),
                    ws_depr.err.c_str()));
     }
+    // Transfer-out (release a device to a new owner): revoke its VPN cert +
+    // deprovision. cloud-ui writes the endpoint name here.
+    auto ws_rel = ds.watch("cloud.transfer.release.request", 1000);
+    if (!ws_rel.ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l watch transfer.release.request failed: %C\n"),
+                   ws_rel.err.c_str()));
+    }
     // Watch log.level so operator changes via cloud UI take effect
     // immediately (no need to wait for the periodic timeout tick).
     auto ws_loglevel = ds.watch("log.level", 5000);
@@ -664,9 +673,19 @@ int main(int argc, char** argv) {
             write_file(capaths.ca_crt, caCrt, 0644);
             if (!srvKey.empty()) write_file(capaths.srv_key, srvKey, 0600);
             if (!srvCrt.empty()) write_file(capaths.srv_crt, srvCrt, 0644);
+            // Also restore the CRL + CA database so revocation state (and the
+            // ability to revoke certs minted before the loss) survives a wiped
+            // iot-vpn volume. ensure_crl() keeps these (creates only if missing).
+            ::mkdir(capaths.ca_newdir.c_str(), 0755);
+            if (const auto crl = ds_str(ds, "cloud.vpn.crl.pem",      ""); !crl.empty())
+                write_file(capaths.crl,       crl, 0644);
+            if (const auto idx = ds_str(ds, "cloud.vpn.ca.index",     ""); !idx.empty())
+                write_file(capaths.ca_db,     idx, 0644);
+            if (const auto crn = ds_str(ds, "cloud.vpn.ca.crlnumber", ""); !crn.empty())
+                write_file(capaths.ca_crlnum, crn, 0644);
             ACE_DEBUG((LM_INFO,
                        ACE_TEXT("%D cloudd:thread:%t %M %N:%l restored runtime PKI "
-                                "from ds (iot-vpn volume not required)\n")));
+                                "+ CRL from ds (iot-vpn volume not required)\n")));
         }
     }
 
@@ -686,6 +705,24 @@ int main(int argc, char** argv) {
             {"cloud.vpn.server.key.pem", data_store::Value{read_file(capaths.srv_key)}},
             {"cloud.vpn.server.crt.pem", data_store::Value{read_file(capaths.srv_crt)}},
         });
+    }
+
+    // Persist the CRL + CA database to ds (durable across an iot-vpn volume
+    // loss). Called at startup and after every mint/revoke so a later revoke
+    // can still find a cert's serial and enforcement survives a volume wipe.
+    auto persist_ca_db = [&ds, &capaths]() {
+        ds.set({
+            {"cloud.vpn.crl.pem",      data_store::Value{read_file(capaths.crl)}},
+            {"cloud.vpn.ca.index",     data_store::Value{read_file(capaths.ca_db)}},
+            {"cloud.vpn.ca.crlnumber", data_store::Value{read_file(capaths.ca_crlnum)}},
+        });
+    };
+    // Enforce revocation: point openvpn at the CA's CRL (ensure() created an
+    // initial empty one). Conditional on the file existing so a CRL-init failure
+    // can't make openvpn refuse to start on a missing crl-verify target.
+    if (cert_ca.have_ca() && !read_file(capaths.crl).empty()) {
+        ovpn_cfg.crl = capaths.crl;
+        persist_ca_db();
     }
 
     server::openvpn::OpenVpnServer ovpn(ovpn_cfg);
@@ -869,6 +906,74 @@ int main(int argc, char** argv) {
         ds.set("cloud.provision.request",   data_store::Value{std::string("")});
     };
 
+    // Transfer-out (release): revoke the device's VPN cert (roll a fresh CRL +
+    // make openvpn enforce it), then deprovision (remove creds + registry +
+    // free the VPN IP), and audit. The device-side wipe (Phase 1) drops its own
+    // cert; revocation here stops a LEAKED key from reconnecting to this cloud.
+    auto handle_release = [&](const std::string& ep) {
+        ACE_DEBUG((LM_WARNING,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l TRANSFER-OUT release '%C'\n"),
+                   ep.c_str()));
+        bool revoked = false;
+        // 1. Find the device's stored VPN client cert and revoke it.
+        try {
+            std::string clientCert;
+            auto arr = nlohmann::json::parse(
+                ds_str(ds, "cloud.endpoint.credentials", "[]"));
+            if (arr.is_array()) for (const auto& e : arr) {
+                if (e.is_object() && e.value("serial", "") == ep) {
+                    clientCert = e.value("vpn.client.cert", "");
+                    break;
+                }
+            }
+            if (clientCert.empty()) {
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D cloudd:thread:%t %M %N:%l release %C: no VPN "
+                                    "cert on record — nothing to revoke\n"), ep.c_str()));
+            } else if (auto crl = cert_ca.revoke(clientCert)) {
+                ds.set("cloud.vpn.crl.pem", data_store::Value{*crl});
+                persist_ca_db();
+                revoked = true;
+                // Make openvpn enforce the new CRL. If crl-verify wasn't on the
+                // running config yet (first ever revoke), reconfigure() restarts
+                // it; otherwise only the CRL FILE changed (same config text), so
+                // force a restart to reload it deterministically across openvpn
+                // versions. Brief reconnect of other tunnels — acceptable for a
+                // rare ownership transfer + the revocation guarantee.
+                ovpn_cfg.crl = capaths.crl;
+                if (!ovpn.reconfigure(ovpn_cfg)) ovpn.stop();
+                ovpn_fails = 0; ovpn_last_start = {}; ovpn_retry_after = {};
+                supervise_ovpn();
+                ACE_DEBUG((LM_WARNING,
+                           ACE_TEXT("%D cloudd:thread:%t %M %N:%l release %C: VPN cert "
+                                    "revoked + CRL reloaded\n"), ep.c_str()));
+            } else {
+                ACE_ERROR((LM_ERROR,
+                           ACE_TEXT("%D cloudd:thread:%t %M %N:%l release %C: cert "
+                                    "revoke failed (minted before CRL feature?)\n"),
+                           ep.c_str()));
+            }
+        } catch (const std::exception& e) {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D cloudd:thread:%t %M %N:%l release %C revoke: %C\n"),
+                       ep.c_str(), e.what()));
+        }
+        // 2. Deprovision (clears creds + registry + VPN IP; clears the
+        //    provision/deprovision triggers as its one-shot tail).
+        handle_deprovision(ep);
+        // 3. Audit (append-only).
+        try {
+            auto aud = nlohmann::json::parse(ds_str(ds, "cloud.transfer.audit", "[]"));
+            if (!aud.is_array()) aud = nlohmann::json::array();
+            aud.push_back({{"serial", ep}, {"action", "release"},
+                           {"revoked", revoked},
+                           {"ts", static_cast<std::int64_t>(ACE_OS::time(nullptr))}});
+            ds.set("cloud.transfer.audit", data_store::Value{aud.dump()});
+        } catch (const std::exception&) {}
+        // 4. One-shot: clear the trigger.
+        ds.set("cloud.transfer.release.request", data_store::Value{std::string("")});
+    };
+
     // Startup self-heal: honor a deprovision request left pending in ds (the
     // edge-triggered watch won't replay it), then sync so cloud.endpoints
     // reflects the removal immediately instead of after the first periodic tick.
@@ -877,6 +982,14 @@ int main(int argc, char** argv) {
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l honoring pending deprovision "
                             "request '%C' from ds at startup\n"), pending.c_str()));
         handle_deprovision(pending);
+        sync_endpoints_to_ds(ds, ep_reg);
+    }
+    // Same for a transfer-out release left pending across a restart.
+    if (auto pending = ds_str(ds, "cloud.transfer.release.request", ""); !pending.empty()) {
+        ACE_DEBUG((LM_INFO,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l honoring pending transfer "
+                            "release '%C' from ds at startup\n"), pending.c_str()));
+        handle_release(pending);
         sync_endpoints_to_ds(ds, ep_reg);
     }
 
@@ -955,6 +1068,10 @@ int main(int argc, char** argv) {
                                         mc->client_crt, mc->client_key);
                                 ds.set("cloud.endpoint.credentials",
                                        data_store::Value{next});
+                                // The mint recorded the cert in the CA database;
+                                // persist it so the cert stays revocable across a
+                                // restart / iot-vpn volume loss.
+                                persist_ca_db();
                                 ACE_DEBUG((LM_INFO,
                                            ACE_TEXT("%D cloudd:thread:%t %M %N:%l "
                                                     "minted+stored VPN client cert "
@@ -990,6 +1107,9 @@ int main(int argc, char** argv) {
             } else if (ev.key == "cloud.deprovision.request") {
                 if (auto ep = data_store::to_string(ev.value); ep && !ep->empty())
                     handle_deprovision(*ep);
+            } else if (ev.key == "cloud.transfer.release.request") {
+                if (auto ep = data_store::to_string(ev.value); ep && !ep->empty())
+                    handle_release(*ep);
             } else if (ev.key == "log.level") {
                 g_log.apply_level(ds);
                 ACE_DEBUG((LM_INFO,

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -130,6 +130,7 @@ interface EpCred {
           </clr-dg-cell>
           <clr-dg-cell *ngIf="isAdmin">
             <button class="btn btn-sm btn-outline" (click)="editPsk(e.endpoint)">Edit</button>
+            <button class="btn btn-sm btn-warning" (click)="transferOut(e.endpoint)">Transfer out</button>
             <button class="btn btn-sm btn-danger" (click)="deprovision(e.endpoint)">Remove</button>
           </clr-dg-cell>
         </clr-dg-row>
@@ -356,6 +357,24 @@ export class EndpointListComponent implements OnInit, OnDestroy {
         else { this.toast.error(r.err || 'Failed'); }
       },
       error: () => this.toast.error('Deprovision failed')
+    });
+  }
+
+  /** Transfer-out: release the device to a new owner. iot-cloudd revokes its
+   *  VPN cert (CRL) + deprovisions. db/set-driven, like provision. */
+  transferOut(ep: string): void {
+    if (!window.confirm(
+          `Transfer out "${ep}"?\n\nThis REVOKES the device's VPN certificate and ` +
+          `removes it from this cloud. The new owner must re-commission the device. ` +
+          `This cannot be undone.`)) return;
+    this.http.dbSet([{ key: 'cloud.transfer.release.request', value: ep }]).subscribe({
+      next: (r) => {
+        if (r.ok) {
+          this.toast.success('Transfer-out requested for ' + ep);
+          this.endpoints = this.endpoints.filter(e => e.endpoint !== ep);
+        } else this.toast.error(r.err || 'Failed');
+      },
+      error: () => this.toast.error('Transfer-out failed')
     });
   }
 

--- a/apps/docs/tdd-device-transfer.md
+++ b/apps/docs/tdd-device-transfer.md
@@ -237,15 +237,35 @@ How B's `bs.uri` + BS PSK reach the device after the wipe:
   - Tests (real openssl, podman): initial CRL stood up; a revoked cert is
     rejected by `openssl verify -crl_check` while others still pass; a foreign
     cert can't be revoked; `build_server_config` crl-verify on/off.
-  - **Wiring still TODO** (next slice): set `ovpn_cfg.crl = capaths.crl` after
-    `ensure()`; persist/restore `crl.pem` (+ `index.txt`/`crlnumber`) in ds like
-    the runtime PKI so enforcement + future revokes survive an iot-vpn volume
-    loss; `OpenVpnServer::reconfigure` already restarts on a rendered-config
-    change so a first-time `crl-verify` propagates.
+  - **Wiring DONE:** iot-cloudd sets `ovpn_cfg.crl = capaths.crl` after `ensure()`
+    (so the server enforces it); persists/restores `crl.pem` + `index.txt` +
+    `crlnumber` in ds (`cloud.vpn.crl.pem` / `cloud.vpn.ca.index` /
+    `cloud.vpn.ca.crlnumber`) like the runtime PKI, re-persisting after each
+    mint + revoke so enforcement and future revokes survive an iot-vpn volume
+    loss. iot-cloudd compiles clean in podman (iot-devbuild).
   - **Caveat:** only `openssl ca`-minted certs are revocable. Devices whose cert
     was issued by the OLD `x509 -req` path (pre-feature) aren't in the CA db —
     they become revocable after a re-provision. Fresh deployments: all
     revocable.
+
+- **G. Transfer-out (release) backend** [CLOUD] — **DONE**. `cloud.transfer.
+  release.request` (one-shot, like provision/deprovision) → `handle_release`:
+  looks up the device's `vpn.client.cert` in `cloud.endpoint.credentials`,
+  `cert_ca.revoke()` → rolls + persists a fresh CRL, forces an openvpn restart
+  so the CRL is reloaded (brief reconnect of other tunnels — acceptable for a
+  rare ownership change), then `handle_deprovision()` (creds + registry + VPN
+  IP) and an append-only `cloud.transfer.audit` record. Startup self-heal for a
+  pending release. The device-side wipe (Phase 1) drops its own cert; revocation
+  here stops a LEAKED key from reconnecting.
+- **H. cloud-ui "Transfer out"** [CLOUD/UI] — **DONE**. Endpoints page gains a
+  Transfer-out action (Admin, `window.confirm` → `db/set cloud.transfer.release.
+  request`). "Claim device" reuses the existing provision form (new owner's BS
+  PSK), so no new claim UI is needed.
+
+  **Telemetry purge** (device buffer + cloud 60-day Mongo history) remains the
+  one deferred item — the volatile `cloud.vehicle.telemetry` row falls off
+  naturally when the released device deregisters; the Mongo history purge needs
+  a Mongo client in iot-cloudd (out of scope here).
 - **G. Release backend** [CLOUD] — `cloud.transfer.release.request` watch →
   deprovision + revoke + purge telemetry (`cloud.vehicle.telemetry` + Mongo) +
   audit. One-shot trigger like provision/deprovision.

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -368,6 +368,38 @@ return {
         write_acl = {"gid:cloud-svc"},
     },
 
+    -- Runtime VPN CRL + CA database, persisted in ds like the PKI above so
+    -- revocation (device transfer) survives an iot-vpn volume loss. crl.pem is
+    -- what openvpn enforces (crl-verify); index.txt/crlnumber let iot-cloudd
+    -- revoke a cert minted before a volume loss. See apps/docs/tdd-device-transfer.md.
+    ["cloud.vpn.crl.pem"] = {
+        access = "Admin", type = "string", default = "",
+        write_acl = {"gid:cloud-svc"},
+    },
+    ["cloud.vpn.ca.index"] = {
+        access = "Admin", type = "string", default = "",
+        write_acl = {"gid:cloud-svc"},
+    },
+    ["cloud.vpn.ca.crlnumber"] = {
+        access = "Admin", type = "string", default = "",
+        write_acl = {"gid:cloud-svc"},
+    },
+
+    -- Transfer-out (release a device from this cloud to a new owner): the
+    -- cloud-ui writes the endpoint name here; iot-cloudd watches it, revokes the
+    -- device's VPN cert (CRL), deprovisions, and audits. One-shot like
+    -- cloud.provision.request. See apps/docs/tdd-device-transfer.md §G.
+    ["cloud.transfer.release.request"] = {
+        access  = "Admin",
+        type    = "string",
+        default = "",
+    },
+    -- Append-only audit of releases/claims (JSON array).
+    ["cloud.transfer.audit"] = {
+        access = "Admin", type = "string", default = "[]",
+        write_acl = {"gid:cloud-svc"},
+    },
+
     -- Next available proxy port (bump-counter).
     ["cloud.vpn.port.next"] = {
       type    = "integer",


### PR DESCRIPTION
Completes the device-transfer cloud side: enforces the CRL engine from #397 and adds the operator transfer-out flow.

## F-wiring — iot-cloudd enforces + persists the CRL
- Points the openvpn server at the CA's CRL (`ovpn_cfg.crl`) after `ensure()` so a revoked client cert is rejected. **Conditional** on the file existing → no behavior change when there's no CRL.
- Persists `crl.pem` + `index.txt` + `crlnumber` to ds (`cloud.vpn.crl.pem` / `cloud.vpn.ca.index` / `cloud.vpn.ca.crlnumber`), restores them on an iot-vpn volume loss, and **re-persists after every mint + revoke** so enforcement *and* the ability to revoke a previously-issued cert survive a volume wipe.

## G — transfer-out (release)
`cloud.transfer.release.request` (one-shot, like provision/deprovision) → `handle_release`:
1. find the device's `vpn.client.cert` in `cloud.endpoint.credentials`
2. `cert_ca.revoke()` → roll + persist a fresh CRL
3. force an openvpn restart so the CRL reloads (brief reconnect of other tunnels — acceptable for a rare ownership change)
4. `handle_deprovision()` (creds + registry + VPN IP)
5. append-only `cloud.transfer.audit`

Startup self-heal for a pending release. The device-side Phase-1 wipe drops its own cert; revocation here stops a **leaked key** from reconnecting.

## H — cloud-ui
Endpoints page gains a **Transfer out** action (Admin, `window.confirm` → `db/set` the release trigger). "Claim device" reuses the existing provision form.

## Validation
- **iot-cloudd compiles clean** in podman (iot-devbuild) — built the ds client lib + iot-cloudd with all wiring.
- CRL engine's own tests (PR #397) pass against real openssl.

## Deferred
Telemetry-history purge (cloud 60-day Mongo) — needs a Mongo client in iot-cloudd; the volatile `cloud.vehicle.telemetry` row falls off naturally when the released device deregisters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)