### PR TITLE
feat(cloud): purge transferred-out device's telemetry history from Mongo

### DIFF
--- a/apps/cloud/docker-compose.yml
+++ b/apps/cloud/docker-compose.yml
@@ -49,6 +49,10 @@ services:
       - iot-etc:/etc/iot
       - iot-vpn:/etc/iot/vpn
       - iot-ca-key:/run/secrets/iot-ca-key:ro
+      # On transfer-out, iot-cloudd queues the released serial here for the
+      # mongo-capable iot-telemetry-ingest sidecar to purge from the 60-day
+      # history (iot-cloudd has no mongo driver). Shared with iot-httpd + ingest.
+      - iot-telemetry-spool:/var/lib/iot/telemetry-spool
     cap_add:
       - NET_ADMIN           # openvpn tun + per-device nftables DNAT
     sysctls:

--- a/apps/cloud/scripts/iot-telemetry-ingest.sh
+++ b/apps/cloud/scripts/iot-telemetry-ingest.sh
@@ -13,6 +13,7 @@
 set -u
 
 SPOOL=/var/lib/iot/telemetry-spool/spool.ndjson
+PURGE=/var/lib/iot/telemetry-spool/purge.list
 HISTORY=/var/lib/iot/telemetry-spool/history.json
 HOST="${MONGO_HOST:-mongo}"
 WINDOW="${HISTORY_WINDOW_SEC:-86400}"      # read-back window, default 24h
@@ -26,6 +27,25 @@ while true; do
         if mv "$SPOOL" "$SPOOL.proc" 2>/dev/null; then
             mongoimport --quiet --host "$HOST" --db iot --collection telemetry \
                 --file "$SPOOL.proc" && rm -f "$SPOOL.proc"
+        fi
+    fi
+
+    # 1b) PURGE — a transferred-out device's history is deleted. iot-cloudd has
+    #     no mongo driver, so it appends released serials here (one per line) on
+    #     transfer-out; we deleteMany({endpoint}) per serial. Claim the file so a
+    #     concurrent append starts fresh. Serials are validated to a safe charset
+    #     before reaching mongosh (operator-supplied via the release request).
+    if [ -s "$PURGE" ]; then
+        if mv "$PURGE" "$PURGE.proc" 2>/dev/null; then
+            while IFS= read -r serial; do
+                case "$serial" in
+                    ''|*[!A-Za-z0-9._@-]*) continue ;;   # skip empty / unsafe
+                esac
+                n=$(mongosh --quiet "mongodb://$HOST/iot" --eval \
+                    "db.telemetry.deleteMany({endpoint:\"$serial\"}).deletedCount" 2>/dev/null)
+                echo "iot-telemetry-ingest: purged ${n:-?} history doc(s) for $serial"
+            done < "$PURGE.proc"
+            rm -f "$PURGE.proc"
         fi
     fi
 

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -970,7 +970,18 @@ int main(int argc, char** argv) {
                            {"ts", static_cast<std::int64_t>(ACE_OS::time(nullptr))}});
             ds.set("cloud.transfer.audit", data_store::Value{aud.dump()});
         } catch (const std::exception&) {}
-        // 4. One-shot: clear the trigger.
+        // 4. Queue the serial for cloud telemetry-history purge. iot-cloudd has
+        //    no mongo driver, so it appends to a file in the shared spool volume
+        //    that the mongo-capable iot-telemetry-ingest sidecar consumes
+        //    (db.telemetry.deleteMany({endpoint})). Best-effort + a no-op when the
+        //    telemetry profile (spool volume) isn't deployed. One serial per line.
+        {
+            const std::string dir = "/var/lib/iot/telemetry-spool";
+            ::mkdir(dir.c_str(), 0775);
+            std::ofstream pf(dir + "/purge.list", std::ios::app);
+            if (pf) pf << ep << "\n";
+        }
+        // 5. One-shot: clear the trigger.
         ds.set("cloud.transfer.release.request", data_store::Value{std::string("")});
     };
 

--- a/apps/docs/tdd-device-transfer.md
+++ b/apps/docs/tdd-device-transfer.md
@@ -262,10 +262,18 @@ How B's `bs.uri` + BS PSK reach the device after the wipe:
   request`). "Claim device" reuses the existing provision form (new owner's BS
   PSK), so no new claim UI is needed.
 
-  **Telemetry purge** (device buffer + cloud 60-day Mongo history) remains the
-  one deferred item — the volatile `cloud.vehicle.telemetry` row falls off
-  naturally when the released device deregisters; the Mongo history purge needs
-  a Mongo client in iot-cloudd (out of scope here).
+  **Telemetry-history purge** [CLOUD] — **DONE**. iot-cloudd has no mongo driver,
+  so on release it appends the serial to `purge.list` in the shared
+  `iot-telemetry-spool` volume; the mongo-capable `iot-telemetry-ingest` sidecar
+  consumes it each loop and `db.telemetry.deleteMany({endpoint})` (serials
+  validated to a safe charset first). Spool volume now mounted on iot-cloudd;
+  purges survive (and apply later) even if the telemetry profile is enabled
+  after the fact. The volatile `cloud.vehicle.telemetry` row falls off on its
+  own when the released device deregisters. iot-cloudd recompiles clean in
+  podman; ingest script passes `sh -n`.
+
+  Still deferred (minor): the device-side store-and-forward buffer purge (needs
+  a privileged step on the device — `iot-vehicled`/Mongo); noted in §5a.
 - **G. Release backend** [CLOUD] — `cloud.transfer.release.request` watch →
   deprovision + revoke + purge telemetry (`cloud.vehicle.telemetry` + Mongo) +
   audit. One-shot trigger like provision/deprovision.


### PR DESCRIPTION
The last open item of the device-transfer design: on transfer-out, remove the released device's 60-day vehicle-telemetry history from cloud Mongo.

## Approach (follows the existing no-mongo-driver spool pattern)
iot-cloudd has no mongo driver, so on release it appends the serial (one per line) to `purge.list` in the shared `iot-telemetry-spool` volume. The mongo-capable **`iot-telemetry-ingest`** sidecar (already looping every 30s) claims the file and runs `db.telemetry.deleteMany({endpoint})` per serial — serials validated to `[A-Za-z0-9._@-]` before reaching `mongosh`.

- **compose:** mount `iot-telemetry-spool` on iot-cloudd (shared with iot-httpd + ingest). Unconditional, so a purge queued while the telemetry profile is off is applied once it's enabled.
- **ingest sidecar:** new PURGE step (claim → `deleteMany` per serial → drop).

The volatile `cloud.vehicle.telemetry` row falls off on its own when the released device deregisters.

## Validation
- iot-cloudd **recompiles clean** in podman (iot-devbuild).
- ingest script passes `sh -n`.

## Still deferred (minor)
Device-side store-and-forward buffer purge — needs a privileged on-device step (`iot-vehicled`/Mongo); noted in the TDD §5a.

This completes the device-transfer TDD (Phase 1 + Phase 2 F/G/H + telemetry purge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)