### PR TITLE
feat(containers): shim-based on-device container runtime (iot-containerd)

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -153,6 +153,15 @@ set(VEHICLE_BUILD_DAEMON ON CACHE BOOL "" FORCE)
 add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/vehicle
                  ${CMAKE_BINARY_DIR}/vehicle)
 
+# containers module (single-container runtime shim). Builds iot-containerd, the
+# privileged reactor-driven shim that pulls an OCI image, mounts its layers and
+# drives crun, publishing container.* to ds for the device-ui. Reuses the
+# datastore_client target added above; pure image-ref core is host-testable.
+# See modules/containers/README.md + apps/docs/tdd-device-containers.md.
+set(CONTAINERS_BUILD_DAEMON ON CACHE BOOL "" FORCE)
+add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../modules/containers
+                 ${CMAKE_BINARY_DIR}/containers)
+
 # mqtt module (iot-mqttd MQTT mirror). Daemon OFF by default here — only the
 # device Yocto build enables it (-DMQTT_BUILD_DAEMON=ON in the recipe), since the
 # cloud Docker builder has no libmosquitto. This add_subdirectory just exposes
@@ -279,6 +288,7 @@ if(IOT_PACKAGING_INSTALL)
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-cellular-client.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-vehicled.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-can0-up.service
+                ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-containerd.service
                 ${CMAKE_CURRENT_SOURCE_DIR}/../packaging/systemd/iot-mqttd.service
             DESTINATION lib/systemd/system)
 

--- a/apps/docs/tdd-device-containers.md
+++ b/apps/docs/tdd-device-containers.md
@@ -163,7 +163,7 @@ status long-poll only.
 - **P4 ✅ DONE** OCI bundle gen + crun create/start/state/kill/delete + supervision (poll-loop, TERM→grace→KILL, daemon-shutdown kill) + **cgroup mem/cpu limits** (folded in from P5). gtest: image-config parse, args resolution, mem/cpu/user parse, config.json (host-net/args/limits). `run`→running+pid, `stop`→stopped.
 - **P5 ✅ DONE (merged into P4)** cgroup mem/cpu limits wiring — `container.limit.mem`/`.cpus` → crun `linux.resources`.
 - **P6 ✅ DONE** device-ui **Containers** page (`iot-ui/src/app/containers/`): Admin-gated nav entry; status datagrid (state badge / image / size / pid / pull progress / error); pull form (ref + optional write-only creds); run form (Entrypoint / CMD / mem / cpu) + Run/Stop. Live via a 2s `dbGet` self-poll; commands via `dbSet` + bumped `*.request` tokens. (Did NOT extend the shared `/status` long-poll — avoids a C++ handler change for a page only open while managing a container.)
-- **P7** e2e on RPi3B: pull `busybox`/`nginx`, run, verify, stop. **Cgroup driver risk:** crun uses `--cgroup-manager cgroupfs` as root under the unit's `Delegate=yes` subtree — validate mem/cpu limits actually apply on the RPi cgroup-v2 hierarchy. Also validate `/var/lib-containers` is writable + has SD space on the target image.
+- **P7** e2e on RPi3B: pull `busybox`/`nginx`, run, verify, stop. Full recipe in §12. **Cgroup driver risk:** crun uses `--cgroup-manager cgroupfs` as root under the unit's `Delegate=yes` subtree — validate mem/cpu limits actually apply on the RPi cgroup-v2 hierarchy. Also validate `/var/lib/iot-containers` is writable + has SD space on the target image.
 
 ## 9. Testing
 
@@ -184,3 +184,142 @@ status long-poll only.
 - Multi-container, autostart/restart-policy, bridge networking, volume mounts,
   image GC/pruning, registry mirror/offline tar import — all **post-v1**.
 - Confirm RPi3B kernel already enables USER_NS + cgroup v2 hierarchy crun expects.
+- **Container IP:** with host networking the container shares the device's
+  network namespace — it has **no separate IP** (it uses the device's IP and
+  binds device ports directly). A per-container IP only exists under the
+  deferred bridge+NAT mode; until then the UI deliberately shows none.
+
+## 12. Phase 7 — hardware test recipe (RPi3B)
+
+End-to-end validation on a real device. Assumes an image built from this branch
+(crun + iot-containerd) and shell access. Device access per the project memory:
+`ssh root@<device-ip>` (LAN), device-ui at `http://<device-ip>:8080`
+(admin/admin). Control via `ds-cli` on the device (string values are JSON, so
+double-quote them): `ds-cli set <key> '"<val>"'`, `ds-cli get <key>`,
+`ds-cli watch --count=N <key>...`. The single-container id is `c0`; crun state
+lives under `/run/iot-containers/state`.
+
+### 12.0 Pre-flight — image + kernel + daemon
+
+```sh
+opkg list-installed | grep -E 'iot-containerd|crun'   # both present
+crun --version
+systemctl status iot-containerd                       # active (running)
+journalctl -u iot-containerd -n 5                      # "up: ... (pull/run/stop ready)"
+
+# storage dirs (tmpfiles), writable, on a writable fs with space
+ls -ld /var/lib/iot-containers /run/iot-containers
+df -h /var/lib
+
+# kernel features
+grep -q overlay /proc/filesystems && echo "overlayfs OK"
+ls /sys/fs/cgroup/cgroup.controllers                  # cgroup v2; lists "memory cpu ..."
+ls -l /proc/self/ns                                   # net/pid/mnt/uts/ipc/user present
+zcat /proc/config.gz 2>/dev/null | grep -E \
+  'CONFIG_(OVERLAY_FS|USER_NS|NET_NS|MEMCG|CFS_BANDWIDTH|SECCOMP)='
+
+ds-cli get container.state                            # idle
+```
+
+If the `memory`/`cpu` controllers are missing from a child cgroup, enable them on
+the parent: `echo +memory +cpu > /sys/fs/cgroup/cgroup.subtree_control`.
+
+### 12.1 Pull (busybox)
+
+```sh
+ds-cli set container.image.ref '"docker.io/library/busybox:latest"'
+ds-cli set container.pull.request "$(date +%s)"
+ds-cli watch --count=30 container.state container.pull.progress   # pulling → pulled
+ds-cli get container.state container.image.id container.image.size container.error
+```
+
+Expect `state=pulled`, `image.id=sha256:…`, `error` empty. Verify the store +
+that a blob's contents hash to its filename (the sha256-verify path):
+
+```sh
+ls /var/lib/iot-containers/blobs/sha256/ /var/lib/iot-containers/manifests/
+f=$(ls /var/lib/iot-containers/blobs/sha256/ | head -1)
+sha256sum /var/lib/iot-containers/blobs/sha256/$f      # digest == $f
+```
+
+### 12.2 Run + verify (busybox)
+
+```sh
+ds-cli set container.cmd '"sleep 600"'                 # ws-split → ["sleep","600"]
+ds-cli set container.run.request "$(date +%s)"
+ds-cli watch --count=10 container.state                # mounting → created → running
+ds-cli get container.state container.run.pid
+
+crun --root /run/iot-containers/state list             # c0  running
+mount | grep /run/iot-containers/c0/rootfs             # overlay mounted
+sed -n '1,5p' /run/iot-containers/c0/config.json       # generated bundle
+
+# exec in: confirm rootfs, host networking (shared device IP), DNS
+crun --root /run/iot-containers/state exec c0 /bin/sh -c \
+  'id; ip addr 2>/dev/null | grep "inet "; cat /etc/resolv.conf; \
+   wget -qO- http://example.com 2>/dev/null | head -1'
+```
+
+Host networking means `ip addr` inside the container shows the **device's**
+interfaces/IP — there is no separate container IP (expected for v1).
+
+### 12.3 Resource limits (cgroups)
+
+```sh
+ds-cli set container.stop.request "$(date +%s)" ; sleep 3
+ds-cli set container.limit.mem '"64M"'
+ds-cli set container.limit.cpus '"0.5"'
+ds-cli set container.run.request "$(date +%s)" ; sleep 3
+cat /sys/fs/cgroup/c0/memory.max                       # 67108864
+cat /sys/fs/cgroup/c0/cpu.max                          # "50000 100000"
+```
+
+(If `/sys/fs/cgroup/c0` isn't the path, find it: `grep -r '' \
+/sys/fs/cgroup/*/cgroup.procs 2>/dev/null | grep "$(ds-cli get container.run.pid)"`.)
+
+### 12.4 Stop
+
+```sh
+ds-cli set container.stop.request "$(date +%s)"
+ds-cli watch --count=6 container.state                 # stopping → stopped
+crun --root /run/iot-containers/state list             # empty
+mount | grep /run/iot-containers/c0 || echo "unmounted OK"
+```
+
+### 12.5 nginx (host-net port bind)
+
+```sh
+ds-cli set container.image.ref '"docker.io/library/nginx:stable"'
+ds-cli set container.pull.request "$(date +%s)" ; ds-cli watch --count=40 container.state
+ds-cli set container.entrypoint '""' ; ds-cli set container.cmd '""'   # image defaults
+ds-cli set container.run.request "$(date +%s)" ; ds-cli watch --count=10 container.state
+curl -s http://127.0.0.1:80/ | head -1                 # nginx serves on the device (host net)
+ds-cli set container.stop.request "$(date +%s)"
+```
+
+(nginx binds `:80` on the device via host net — confirm nothing else owns `:80`.)
+
+### 12.6 device-ui path
+
+Browse `http://<device-ip>:8080` → login (admin) → **Containers** (Admin-only).
+Pull form → `busybox:latest` → **Pull** (progress bar → pulled). Run form → CMD
+`sleep 600`, Memory `64M` → **Run** (badge → running, PID shown) → **Stop**.
+
+### 12.7 Troubleshooting
+
+| Symptom | Likely cause / fix |
+|---|---|
+| pull `registry unreachable` / TLS | clock unset (no-RTC) → NTP not synced; `date`, check timesyncd |
+| pull `401` | private image → set registry user/pass |
+| `image has no Entrypoint/Cmd` | set `container.cmd` (busybox has no default CMD in some tags) |
+| `crun create failed` cgroup | enable controllers in parent `cgroup.subtree_control` (see 12.0) |
+| `overlay mount failed` EINVAL | kernel missing `OVERLAY_FS`, or `/var`/`/run` fs quirk → `dmesg` |
+| DNS fails in container | host `/etc/resolv.conf` empty (host-net reuses it) |
+
+### 12.8 Cleanup
+
+```sh
+ds-cli set container.stop.request "$(date +%s)"
+rm -rf /var/lib/iot-containers/blobs /var/lib/iot-containers/layers \
+       /var/lib/iot-containers/manifests   # drop cached images
+```

--- a/apps/docs/tdd-device-containers.md
+++ b/apps/docs/tdd-device-containers.md
@@ -1,0 +1,186 @@
+# TDD: Shim-Based Container Runtime on the Device
+
+Status: PLAN (not yet implemented)
+Author: naushada
+Date: 2026-06-22
+
+## 1. Goal
+
+Let an operator pull an OCI/Docker image onto the device from the device-ui,
+mount its layers, and run / stop a single container with a custom
+CMD/Entrypoint and resource caps — using a **thin shim daemon over `crun`**
+(not Docker/Podman) so the footprint fits a 1 GB RPi3B on Yocto.
+
+## 2. Locked design decisions
+
+| Topic | Decision |
+|-------|----------|
+| Runtime | Ship `crun` (small C OCI runtime); we write `iot-containerd`, a thin shim that pulls, mounts overlay, generates the OCI bundle, and drives `crun`. |
+| Image source | OCI / Docker **registry v2 pull** (`registry/repo:tag` + optional user/pass). |
+| Networking | **Host network** (container shares device netns; no veth/bridge/NAT). |
+| Scope (v1) | **Single** container, manual pull/run/stop. No autostart / reboot persistence. |
+| Storage | Images+layers **persist** in `/var/lib/iot-containers`; runtime overlay+bundle **ephemeral** in `/run/iot-containers`. (Dedicated top-level paths — NOT under `/var/lib/iot`, which is ds-server's DynamicUser `StateDirectory=iot` and would get migrated to `/var/lib/private/iot`.) |
+| crun source | Upstream **meta-virtualization** layer → `IMAGE_INSTALL += crun`. |
+| Control plane | **ds keys** (UI `db/set` command keys, long-polls status keys); `iot-containerd` watches ds. Matches sensord/OTA pattern. |
+| Resource limits | **Yes** — mem + cpu caps in the run form → crun cgroup config. |
+
+## 3. Components
+
+```
+device-ui /containers page (Angular, Admin-only)
+   │  POST /api/v1/db/set   (command keys)
+   │  long-poll /api/v1/db/get (status keys)
+   ▼
+data-store (ds)  ── command/status bus
+   ▲
+   │  watch()/set()
+iot-containerd  (NEW, root daemon, ACE_Reactor)
+   ├─ registry v2 client (libcurl): auth → manifest/index → config + layer blobs (sha256 verify)
+   ├─ layer store + OCI-whiteout-aware extraction → overlayfs mount
+   ├─ OCI bundle gen (config.json: rootfs, env, cmd/entrypoint, host-net, cgroup limits)
+   └─ crun create/start/state/kill/delete  + supervision
+         ▼
+       crun  (meta-virtualization .ipk) — namespaces / cgroups / exec
+```
+
+## 4. Data-store keys
+
+Command keys (UI writes via `/api/v1/db/set`):
+
+| Key | Meaning |
+|-----|---------|
+| `container.image.ref` | e.g. `docker.io/library/nginx:latest` |
+| `container.registry.user` / `container.registry.pass` | optional auth (**write-only / sensitive**, never echoed back — follow PSK-provisioning pattern) |
+| `container.pull.request` | bump to trigger pull (monotonic token) |
+| `container.entrypoint` | override Entrypoint (JSON array or string; empty = image default) |
+| `container.cmd` | override CMD (JSON array or string; empty = image default) |
+| `container.limit.mem` | e.g. `256M` |
+| `container.limit.cpus` | e.g. `0.5` |
+| `container.run.request` | bump to trigger create+start |
+| `container.stop.request` | bump to trigger kill+delete |
+
+Status keys (`iot-containerd` publishes; volatile; UI long-polls):
+
+| Key | Meaning |
+|-----|---------|
+| `container.state` | `idle\|pulling\|pulled\|mounting\|created\|running\|stopped\|error` |
+| `container.pull.progress` | 0..100 (bytes across all layers) |
+| `container.pull.detail` | current layer digest / message |
+| `container.image.id` | resolved config digest |
+| `container.image.size` | total bytes |
+| `container.run.pid` | crun container PID |
+| `container.run.started` | start timestamp |
+| `container.exit.code` | last exit code |
+| `container.status` | human summary mirroring `crun state` |
+| `container.error` | last error message |
+
+(New domain ⇒ new keys justified; still reuse `to_int32`/`Value` helpers and the
+existing `db/set` + long-poll transport — no new REST endpoints.)
+
+## 5. iot-containerd internals
+
+ACE_Reactor daemon, `data_store::Client` connected to the ds socket, `watch()`
+on the command keys. State machine:
+
+1. **Pull** (`container.pull.request` bumped)
+   - Parse ref → registry host/repo/tag. `docker.io` ⇒ `registry-1.docker.io`,
+     token from `auth.docker.io` on `401 WWW-Authenticate: Bearer`.
+   - `GET /v2/<repo>/manifests/<tag>` (Accept: OCI index + docker manifest-list +
+     manifest v2). If index/list ⇒ select platform matching device arch
+     (`aarch64`→`linux/arm64`, else `linux/arm`/`v7`); re-GET platform manifest.
+   - Fetch config blob (image config JSON: Env, Entrypoint, Cmd, WorkingDir, User).
+   - Fetch each layer blob by digest → **sha256 verify** (mind the OTA `\n`-in-sha
+     bug: trim digests) → store `/var/lib/iot-containers/blobs/sha256/<digest>`.
+   - Publish per-byte `container.pull.progress` / `.detail`. End ⇒ `state=pulled`.
+2. **Mount** (begins on run)
+   - Extract each layer tar (gzip) into `/var/lib/iot-containers/layers/<digest>/`,
+     **converting OCI whiteouts** (`.wh.<name>` ⇒ overlay whiteout char dev 0:0;
+     `.wh..wh..opq` ⇒ `trusted.overlay.opaque=y` xattr). Cache per-digest.
+   - `mount -t overlay` with `lowerdir=<topLayer>:...:<baseLayer>`,
+     `upperdir=/run/iot-containers/<id>/upper`,
+     `workdir=/run/iot-containers/<id>/work` ⇒ merged
+     `/run/iot-containers/<id>/rootfs`. (Use ACE/`ACE_OS` mount wrappers; root daemon.)
+3. **Bundle** — generate `/run/iot-containers/<id>/config.json` (OCI runtime spec):
+   - `root.path` = merged rootfs; `process.args` = entrypoint+cmd (override or image
+     default); `process.env`/`cwd`/`user` from image config + overrides.
+   - **Host network** ⇒ omit a `network` namespace (keep mount/pid/uts/ipc; drop
+     privileged caps; default seccomp profile).
+   - `linux.resources.memory.limit` and `cpu.quota/period` from limit keys.
+4. **Run** — `crun create <id> --bundle <dir>` → `state=created` →
+   `crun start <id>` → `state=running`, publish pid/started. Supervise via
+   reactor (SIGCHLD handler / `crun state` poll timer); on exit publish
+   `exit.code`, `state=stopped`.
+5. **Stop** (`container.stop.request`) — `crun kill <id> SIGTERM` (grace) →
+   `SIGKILL` → `crun delete <id>`; unmount overlay; `state=stopped`.
+
+## 6. Yocto / image prerequisites (Phase 0 gating)
+
+- Add **meta-virtualization** (+ its **meta-filesystems** dep) to *both* build
+  paths — they are kept in sync: the kas path (`yocto/kas-iot.yml`) and the
+  primary Containerfile/entrypoint path (`yocto/Containerfile` clone +
+  `yocto/entrypoint.sh` `bitbake-layers add-layer`). `crun` is pulled via
+  `RDEPENDS:iot-containerd` and listed in `packagegroup-iot-full`.
+- **Kernel config fragment** `linux-raspberrypi_%.bbappend` + `files/container.cfg`:
+  `CONFIG_OVERLAY_FS`, `CONFIG_NAMESPACES` + `PID/NET/UTS/IPC/USER_NS`,
+  `CONFIG_MEMCG` + `CONFIG_CGROUP_*`/`CFS_BANDWIDTH` (cpu caps), `CONFIG_SECCOMP`.
+  Most are already in the raspberrypi3-64 defconfig; the fragment is a no-op
+  where already set. (`seccomp` is already in scarthgap poky's default
+  `DISTRO_FEATURES`, so crun builds with seccomp support without a distro change.)
+- `tmpfiles.d` (`iot.conf`) creates `/var/lib/iot-containers` and
+  `/run/iot-containers`, both `0700 root:root`. **Dedicated top-level paths** —
+  NOT under `/var/lib/iot` (ds-server's DynamicUser `StateDirectory=iot`, which
+  systemd migrates to `/var/lib/private/iot`) and NOT `RuntimeDirectory=iot` in
+  the unit (would clobber the ds socket).
+- `iot-containerd.service`: `Type=simple`, root, `After=iot-ds.service
+  network-online.target`, `Restart=on-failure`. Add `enable iot-containerd.service`
+  to `90-iot.preset` (else `preset-all` disables it — known preset gotcha).
+- Recipe `iot_git.bb`: new `-DCONTAINERD_BUILD_DAEMON=ON`, package split
+  `FILES:${PN}-containerd` (binary + unit), `SYSTEMD_SERVICE`, SRC_URI for the unit.
+- Module layout: `modules/containers/{daemon,inc,src,test}/` + `CMakeLists.txt`,
+  linking `datastore_client`, ACE, libcurl.
+
+## 7. device-ui — /containers page
+
+`iot-ui/src/app/containers/containers.component.{ts,html}` (Admin-only; gate behind
+role like the device-shell terminal feature). Talks via `HttpsvcService.dbSet` /
+status long-poll only.
+
+- **Pull form** (`.form-grid`, 4-col, pad short rows): image ref, optional
+  registry user/pass. "Pull" ⇒ `db/set` ref + creds + bump `pull.request`.
+  Progress bar bound to `container.pull.progress`/`.detail`. On `pulled` show
+  `image.id`/`image.size`.
+- **Run form**: Entrypoint, CMD, mem limit, cpu limit. "Run" ⇒ `db/set` overrides
+  + bump `run.request`.
+- **Status panel**: `container.state`, pid, started, status string; **Stop** button
+  ⇒ bump `stop.request`. Any list view uses `clr-datagrid` (never `<table>`).
+
+## 8. Phasing
+
+- **P0 ✅ DONE** Yocto: meta-virtualization+crun (both build paths), kernel fragment, tmpfiles, unit+preset, recipe split, module builds.
+- **P1 ✅ DONE** `iot-containerd` skeleton: ds connect/watch, command→reactor dispatch, `container.state` lifecycle.
+- **P2 ✅ DONE** Registry v2 pull: ref parse, bearer auth, manifest/index arch-select, blob download + sha256-verify (cache), worker thread + progress → `state=pulled`. gtest: ref parse, auth-challenge parse, token parse, index arch select, digest validation.
+- **P3 ✅ DONE** Layer extraction (zlib gzip + in-process tar) + OCI whiteout conversion + path-traversal guard + overlay mount; `run`→extract+mount→`created`, `stop`→unmount. gtest: tar header/octal, whiteout classify, path safety, lowerdir ordering. (crun create/start is P4 — `created` = rootfs assembled, not executing.)
+- **P4 ✅ DONE** OCI bundle gen + crun create/start/state/kill/delete + supervision (poll-loop, TERM→grace→KILL, daemon-shutdown kill) + **cgroup mem/cpu limits** (folded in from P5). gtest: image-config parse, args resolution, mem/cpu/user parse, config.json (host-net/args/limits). `run`→running+pid, `stop`→stopped.
+- **P5 ✅ DONE (merged into P4)** cgroup mem/cpu limits wiring — `container.limit.mem`/`.cpus` → crun `linux.resources`.
+- **P6 ✅ DONE** device-ui **Containers** page (`iot-ui/src/app/containers/`): Admin-gated nav entry; status datagrid (state badge / image / size / pid / pull progress / error); pull form (ref + optional write-only creds); run form (Entrypoint / CMD / mem / cpu) + Run/Stop. Live via a 2s `dbGet` self-poll; commands via `dbSet` + bumped `*.request` tokens. (Did NOT extend the shared `/status` long-poll — avoids a C++ handler change for a page only open while managing a container.)
+- **P7** e2e on RPi3B: pull `busybox`/`nginx`, run, verify, stop. **Cgroup driver risk:** crun uses `--cgroup-manager cgroupfs` as root under the unit's `Delegate=yes` subtree — validate mem/cpu limits actually apply on the RPi cgroup-v2 hierarchy. Also validate `/var/lib-containers` is writable + has SD space on the target image.
+
+## 9. Testing
+
+- Host-buildable gtest (podman runner per project memory) for all parser/codegen
+  units — no hardware needed.
+- e2e on HW for pull→run→stop.
+
+## 10. Security notes
+
+- Registry creds: **write-only sensitive** ds keys, never echoed back to UI.
+- Mandatory **sha256 verification** of every blob (digest-trim — OTA `\n` lesson).
+- Container runs **host-net** ⇒ can reach device services; mitigate with default
+  seccomp profile, dropped capabilities (no `privileged`), and **Admin-only** UI.
+- Resource caps mandatory to prevent OOM on the 1 GB device.
+
+## 11. Open items / deferred
+
+- Multi-container, autostart/restart-policy, bridge networking, volume mounts,
+  image GC/pruning, registry mirror/offline tar import — all **post-v1**.
+- Confirm RPi3B kernel already enables USER_NS + cgroup v2 hierarchy crun expects.

--- a/iot-ui/src/app/app.module.ts
+++ b/iot-ui/src/app/app.module.ts
@@ -42,6 +42,7 @@ import { ToastComponent } from './common/toast/toast.component';
 import { UsersComponent } from './users/users.component';
 import { SoftwareUpdateComponent } from './software-update/software-update.component';
 import { HttpConfigComponent } from './http-config/http-config.component';
+import { ContainersComponent } from './containers/containers.component';
 import { ShellComponent } from './shell/shell.component';
 import { AdvancedComponent } from './advanced/advanced.component';
 
@@ -66,6 +67,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     ServicesSubmenuComponent, ServicesListComponent,
     LogLevelComponent, LogViewerComponent, ToastComponent,
     UsersComponent, SoftwareUpdateComponent, HttpConfigComponent,
+    ContainersComponent,
     ShellComponent,
     AdvancedComponent,
     DsHintComponent, DsDebugDirective,

--- a/iot-ui/src/app/containers/containers.component.ts
+++ b/iot-ui/src/app/containers/containers.component.ts
@@ -1,0 +1,314 @@
+import { Component, OnInit, OnDestroy } from '@angular/core';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+import { ToastService } from '../../common/toast.service';
+
+/// Containers page — drive the on-device single-container runtime shim
+/// (iot-containerd) over the container.* data-store keys. Pull an OCI/Docker
+/// image, run it with an optional CMD/Entrypoint + resource caps, and stop it.
+///
+/// Admin-only (the daemon runs containers as root). Live status comes from a
+/// lightweight 2s self-poll of the container.* keys while the page is open —
+/// this page is only mounted when an operator is actively managing a container,
+/// so it does not warrant a slot on the shared /status long-poll.
+@Component({
+  selector: 'app-containers',
+  template: `
+    <div class="page">
+      <h3>Containers</h3>
+
+      <ng-container *ngIf="isAdmin; else noAccess">
+        <!-- ── Status ─────────────────────────────────────────────── -->
+        <clr-datagrid style="margin-bottom:20px;">
+          <clr-dg-column>Property</clr-dg-column>
+          <clr-dg-column>Value</clr-dg-column>
+          <clr-dg-row>
+            <clr-dg-cell>State
+              <app-ds-hint *dsDebug key="container.state"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell><app-status-badge [label]="state || 'idle'" [state]="badgeState"></app-status-badge></clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="imageId">
+            <clr-dg-cell>Image
+              <app-ds-hint *dsDebug key="container.image.id"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell><code class="digest">{{ imageId }}</code></clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="imageSize > 0">
+            <clr-dg-cell>Size
+              <app-ds-hint *dsDebug key="container.image.size"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell>{{ sizeLabel }}</clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="state === 'running' && runPid">
+            <clr-dg-cell>PID
+              <app-ds-hint *dsDebug key="container.run.pid"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell>{{ runPid }}<span class="hint" *ngIf="startedLabel"> · started {{ startedLabel }}</span></clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="state === 'pulling'">
+            <clr-dg-cell>Pull
+              <app-ds-hint *dsDebug key="container.pull.progress"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell>
+              <ng-container *ngIf="pullProgress > 0; else indet">
+                <div class="pbar"><span [style.width.%]="pullProgress"></span></div>
+                <span class="pbar-pct">{{ pullProgress }}%</span>
+              </ng-container>
+              <ng-template #indet>
+                <div class="pbar indet"><span></span></div>
+                <span class="pbar-pct">pulling…</span>
+              </ng-template>
+              <span class="hint" *ngIf="pullDetail"> {{ pullDetail }}</span>
+            </clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="statusMsg">
+            <clr-dg-cell>Status
+              <app-ds-hint *dsDebug key="container.status"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell>{{ statusMsg }}</clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="error">
+            <clr-dg-cell>Error
+              <app-ds-hint *dsDebug key="container.error"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell><span class="err">{{ error }}</span></clr-dg-cell>
+          </clr-dg-row>
+        </clr-datagrid>
+
+        <!-- ── Pull an image ──────────────────────────────────────── -->
+        <h4>Pull an image</h4>
+        <div class="form-grid" style="align-items:end;">
+          <clr-input-container style="grid-column: span 3;">
+            <label>Image reference</label>
+            <input clrInput [(ngModel)]="imageRef" style="width:100%;"
+                   placeholder="docker.io/library/nginx:latest" />
+            <clr-control-helper *dsDebug><app-ds-hint key="container.image.ref"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <div class="btn-cell">
+            <button class="btn btn-primary" (click)="pull()"
+                    [disabled]="state === 'pulling' || !imageRef">
+              {{ state === 'pulling' ? 'Pulling…' : 'Pull' }}
+            </button>
+          </div>
+          <clr-input-container>
+            <label>Registry user <span class="hint">(optional)</span></label>
+            <input clrInput [(ngModel)]="regUser" autocomplete="off" />
+          </clr-input-container>
+          <clr-password-container>
+            <label>Registry password <span class="hint">(optional)</span></label>
+            <input clrPassword [(ngModel)]="regPass" autocomplete="new-password" />
+          </clr-password-container>
+          <div></div>
+          <div></div>
+        </div>
+        <p class="hint">Pulls from an OCI/Docker registry for this device's
+          architecture (linux/arm64). Credentials are write-only — sent once and
+          never read back.</p>
+
+        <!-- ── Run ────────────────────────────────────────────────── -->
+        <h4>Run</h4>
+        <div class="form-grid" style="align-items:end;">
+          <clr-input-container>
+            <label>Entrypoint <span class="hint">(override)</span></label>
+            <input clrInput [(ngModel)]="entrypoint" placeholder='["/entry.sh"] or blank' />
+            <clr-control-helper *dsDebug><app-ds-hint key="container.entrypoint"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>CMD <span class="hint">(override)</span></label>
+            <input clrInput [(ngModel)]="cmd" placeholder='["-g","daemon off;"] or blank' />
+            <clr-control-helper *dsDebug><app-ds-hint key="container.cmd"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>Memory limit</label>
+            <input clrInput [(ngModel)]="limitMem" placeholder="256M" />
+            <clr-control-helper *dsDebug><app-ds-hint key="container.limit.mem"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>CPUs</label>
+            <input clrInput [(ngModel)]="limitCpus" placeholder="0.5" />
+            <clr-control-helper *dsDebug><app-ds-hint key="container.limit.cpus"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <div class="btn-cell">
+            <button class="btn btn-success-outline" (click)="run()"
+                    [disabled]="!canRun">
+              {{ runVerb }}
+            </button>
+          </div>
+          <div class="btn-cell">
+            <button class="btn btn-danger-outline" (click)="stop()"
+                    [disabled]="!canStop">Stop</button>
+          </div>
+          <div></div>
+          <div></div>
+        </div>
+        <p class="hint">Entrypoint/CMD accept a JSON array
+          (<code>["/bin/sh","-c","echo hi"]</code>) or a plain space-separated
+          string; leave blank to use the image defaults. Networking is shared
+          with the host. Memory/CPU are optional caps.</p>
+      </ng-container>
+
+      <ng-template #noAccess><p class="hint">You need Admin access to manage containers.</p></ng-template>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; }
+    h3 { color: #333; margin: 0 0 16px 0; font-size: 16px; font-weight: 600; }
+    h4 { color: #555; margin: 18px 0 10px 0; font-size: 13px; font-weight: 600; }
+    .hint { color: #888; font-size: 12px; margin-top: 8px; font-weight: 400; }
+    .err { color: #c92100; font-size: 13px; }
+    .digest { font-size: 12px; word-break: break-all; }
+    .btn-cell { display: flex; align-items: flex-end; }
+    .btn-cell .btn { white-space: nowrap; }
+    .pbar { display: inline-block; width: 140px; height: 8px; background: #e0e6e9;
+      border-radius: 4px; overflow: hidden; vertical-align: middle; }
+    .pbar > span { display: block; height: 100%; background: #0072a3;
+      transition: width 0.3s ease; border-radius: 4px; }
+    .pbar.indet > span { width: 35%; animation: pbar-slide 1.1s ease-in-out infinite; }
+    .pbar-pct { margin-left: 8px; font-size: 12px; color: #607d8b; vertical-align: middle; }
+    @keyframes pbar-slide { 0% { margin-left: -35%; } 100% { margin-left: 100%; } }
+  `]
+})
+export class ContainersComponent implements OnInit, OnDestroy {
+  // Live status (polled).
+  state = 'idle';
+  statusMsg = '';
+  error = '';
+  pullProgress = 0;
+  pullDetail = '';
+  imageId = '';
+  imageSize = 0;
+  runPid = '';
+  runStarted = '';
+
+  // Form (loaded once; not overwritten by the poll so typing isn't clobbered).
+  imageRef = '';
+  regUser = '';
+  regPass = '';
+  entrypoint = '';
+  cmd = '';
+  limitMem = '';
+  limitCpus = '';
+
+  private timer: ReturnType<typeof setInterval> | null = null;
+
+  private readonly STATUS_KEYS = [
+    'container.state', 'container.status', 'container.error',
+    'container.pull.progress', 'container.pull.detail',
+    'container.image.id', 'container.image.size',
+    'container.run.pid', 'container.run.started',
+  ];
+  private readonly CONFIG_KEYS = [
+    'container.image.ref', 'container.entrypoint', 'container.cmd',
+    'container.limit.mem', 'container.limit.cpus',
+  ];
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  get badgeState(): string {
+    switch (this.state) {
+      case 'running':  return 'connected';
+      case 'error':    return 'exited';
+      case 'stopped':
+      case 'idle':     return 'idle';
+      default:         return 'starting';   // pulling/pulled/mounting/created
+    }
+  }
+
+  // A pulled image (image.id set) can be run when nothing is in flight.
+  get canRun(): boolean {
+    return !!this.imageId &&
+           this.state !== 'pulling' && this.state !== 'mounting' &&
+           this.state !== 'running' && this.state !== 'created';
+  }
+  get canStop(): boolean {
+    return this.state === 'running' || this.state === 'mounting' || this.state === 'created';
+  }
+  get runVerb(): string {
+    if (this.state === 'mounting') return 'Mounting…';
+    if (this.state === 'running')  return 'Running';
+    return 'Run';
+  }
+
+  get sizeLabel(): string {
+    let v = this.imageSize, i = 0;
+    const u = ['B', 'KB', 'MB', 'GB'];
+    while (v >= 1024 && i < u.length - 1) { v /= 1024; i++; }
+    return (i === 0 ? v.toFixed(0) : v.toFixed(v < 10 ? 1 : 0)) + ' ' + u[i];
+  }
+  get startedLabel(): string {
+    const t = Number(this.runStarted);
+    return t > 0 ? new Date(t * 1000).toLocaleString() : '';
+  }
+
+  constructor(private http: HttpsvcService, private session: SessionService,
+              private toast: ToastService) {}
+
+  ngOnInit(): void {
+    if (!this.isAdmin) return;
+    // Prefill the form once from the saved config keys.
+    this.http.dbGet(this.CONFIG_KEYS).subscribe(r => {
+      if (r.ok && r.data) {
+        const d = r.data;
+        this.imageRef   = String(d['container.image.ref'] ?? '');
+        this.entrypoint = String(d['container.entrypoint'] ?? '');
+        this.cmd        = String(d['container.cmd'] ?? '');
+        this.limitMem   = String(d['container.limit.mem'] ?? '');
+        this.limitCpus  = String(d['container.limit.cpus'] ?? '');
+      }
+    });
+    this.poll();
+    this.timer = setInterval(() => this.poll(), 2000);
+  }
+
+  ngOnDestroy(): void {
+    if (this.timer) { clearInterval(this.timer); this.timer = null; }
+  }
+
+  private poll(): void {
+    this.http.dbGet(this.STATUS_KEYS).subscribe(r => {
+      if (!r.ok || !r.data) return;
+      const d = r.data;
+      this.state        = String(d['container.state'] ?? 'idle');
+      this.statusMsg    = String(d['container.status'] ?? '');
+      this.error        = String(d['container.error'] ?? '');
+      this.pullProgress = Math.max(0, Math.min(100, Number(d['container.pull.progress']) || 0));
+      this.pullDetail   = String(d['container.pull.detail'] ?? '');
+      this.imageId      = String(d['container.image.id'] ?? '');
+      this.imageSize    = Number(d['container.image.size']) || 0;
+      this.runPid       = String(d['container.run.pid'] ?? '');
+      this.runStarted   = String(d['container.run.started'] ?? '');
+    });
+  }
+
+  pull(): void {
+    if (!this.imageRef) { this.toast.error('Image reference required'); return; }
+    const pairs: { key: string; value: unknown }[] = [
+      { key: 'container.image.ref', value: this.imageRef },
+      { key: 'container.registry.user', value: this.regUser },
+    ];
+    if (this.regPass) pairs.push({ key: 'container.registry.pass', value: this.regPass });
+    pairs.push({ key: 'container.pull.request', value: String(Date.now()) });
+    this.http.dbSet(pairs).subscribe({
+      next: (r) => {
+        if (r.ok) { this.toast.success('Pulling ' + this.imageRef + '…'); this.regPass = ''; }
+        else this.toast.error(r.err || 'Pull failed');
+      },
+      error: () => this.toast.error('Pull failed'),
+    });
+  }
+
+  run(): void {
+    if (!this.imageId) { this.toast.error('Pull an image first'); return; }
+    this.http.dbSet([
+      { key: 'container.entrypoint', value: this.entrypoint },
+      { key: 'container.cmd', value: this.cmd },
+      { key: 'container.limit.mem', value: this.limitMem },
+      { key: 'container.limit.cpus', value: this.limitCpus },
+      { key: 'container.run.request', value: String(Date.now()) },
+    ]).subscribe({
+      next: (r) => { if (r.ok) this.toast.success('Starting container…'); else this.toast.error(r.err || 'Run failed'); },
+      error: () => this.toast.error('Run failed'),
+    });
+  }
+
+  stop(): void {
+    this.http.dbSet([{ key: 'container.stop.request', value: String(Date.now()) }]).subscribe({
+      next: (r) => { if (r.ok) this.toast.success('Stopping container…'); else this.toast.error(r.err || 'Stop failed'); },
+      error: () => this.toast.error('Stop failed'),
+    });
+  }
+}

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -143,6 +143,9 @@
       <!-- Software Update -->
       <app-software-update *ngIf="selectedMenu==='software'"></app-software-update>
 
+      <!-- Containers (single-container runtime; Admin-only) -->
+      <app-containers *ngIf="selectedMenu==='containers' && isAdmin"></app-containers>
+
       <!-- Terminal (remote shell) -->
       <app-shell *ngIf="selectedMenu==='shell' && shellEnabled && isAdmin"></app-shell>
 

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -44,6 +44,7 @@ export class MainComponent {
     { id: 'logs',      label: 'Logs',      svg: 'assets/icons/logs.svg', children: [] as {id:string,label:string}[] },
     { id: 'users',     label: 'Users',     svg: 'assets/icons/users.svg', children: [] as {id:string,label:string}[] },
     { id: 'software',  label: 'Software',  svg: 'assets/icons/software.svg', children: [] as {id:string,label:string}[] },
+    { id: 'containers',label: 'Containers',svg: 'assets/icons/containers.svg', children: [] as {id:string,label:string}[] },
     { id: 'shell',     label: 'Terminal',  svg: 'assets/icons/terminal.svg', children: [] as {id:string,label:string}[] },
     { id: 'advanced',  label: 'Advanced',  svg: 'assets/icons/advanced.svg',
       children: [{id:'reboot',label:'Reboot'},{id:'factory',label:'Factory Reset'},{id:'transfer',label:'Transfer'}] },
@@ -57,11 +58,12 @@ export class MainComponent {
 
   // Terminal is a remote shell (runs as the iot-httpd service user, not root):
   // only surface it to Admins when the operator has switched on
-  // http.shell.enabled. Everything else is always shown (each page enforces its
-  // own access).
+  // http.shell.enabled. Containers run as root, so that page is Admin-only too.
+  // Everything else is always shown (each page enforces its own access).
   get navMenus() {
     return this.menus.filter(m =>
-      m.id !== 'shell' || (this.shellEnabled && this.isAdmin));
+      (m.id !== 'shell' || (this.shellEnabled && this.isAdmin)) &&
+      (m.id !== 'containers' || this.isAdmin));
   }
 
   constructor(

--- a/iot-ui/src/assets/icons/containers.svg
+++ b/iot-ui/src/assets/icons/containers.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"/>
+  <polyline points="3.27 6.96 12 12.01 20.73 6.96"/>
+  <line x1="12" y1="22.08" x2="12" y2="12"/>
+</svg>

--- a/modules/containers/CMakeLists.txt
+++ b/modules/containers/CMakeLists.txt
@@ -1,0 +1,98 @@
+cmake_minimum_required(VERSION 3.16.3)
+project(containers CXX)
+
+# Top-level (own build) vs. pulled in via add_subdirectory() from the iot tree.
+if(CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR)
+    set(CONTAINERS_TOP_LEVEL ON)
+else()
+    set(CONTAINERS_TOP_LEVEL OFF)
+endif()
+
+option(CONTAINERS_BUILD_TESTS  "Build the containers gtest suite"            ${CONTAINERS_TOP_LEVEL})
+option(CONTAINERS_BUILD_DAEMON "Build the iot-containerd runtime-shim daemon" OFF)
+
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
+# nlohmann::json — vendored under apps/3rdparty/json/ (also a Yocto DEPENDS).
+# Used by the pure registry manifest/index parser.
+set(NLOHMANN_JSON_INCLUDE
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../apps/3rdparty/json/single_include)
+
+# Pure OCI image-reference + registry-v2 protocol core: no ACE, no network, no
+# data-store (JSON via header-only nlohmann) — fully host-unit-testable. The
+# HTTP transport (curl), overlay mount and crun lifecycle live in the
+# iot-containerd daemon, gated by CONTAINERS_BUILD_DAEMON (forced ON in the iot
+# image build). See apps/docs/tdd-device-containers.md.
+add_library(containers_core STATIC
+    src/image_ref.cpp
+    src/registry.cpp
+    src/oci_layer.cpp
+    src/oci_bundle.cpp)
+target_include_directories(containers_core PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/inc
+    ${NLOHMANN_JSON_INCLUDE})
+target_compile_options(containers_core PRIVATE -Wall -Wextra)
+add_library(containers::core ALIAS containers_core)
+
+# ── Install the container.* schema (operator + daemon contract) ──
+include(GNUInstallDirs)
+if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+    install(FILES schemas/container.lua
+            DESTINATION ${CMAKE_INSTALL_FULL_SYSCONFDIR}/iot/ds-schemas)
+endif()
+
+# ── iot-containerd daemon (privileged shim; reactor-driven, ACE-only) ──
+# Built when CONTAINERS_BUILD_DAEMON=ON (forced on in the iot image build). Off
+# by default for a plain `cmake modules/containers` core/test build.
+if(CONTAINERS_BUILD_DAEMON)
+    if(NOT DEFINED ACE_ROOT)
+        set(ACE_ROOT /usr/local/ACE_TAO-7.0.0)
+    endif()
+    if(NOT TARGET datastore_client)
+        add_subdirectory(${CMAKE_CURRENT_SOURCE_DIR}/../data-store
+                         ${CMAKE_BINARY_DIR}/data-store)
+    endif()
+
+    # OpenSSL::Crypto — streaming SHA-256 of downloaded blobs (http_client).
+    find_package(OpenSSL REQUIRED)
+
+    add_executable(iot-containerd
+        daemon/main.cpp
+        daemon/containerd.cpp
+        daemon/http_client.cpp
+        daemon/registry_puller.cpp
+        daemon/layer_store.cpp
+        daemon/crun_runtime.cpp)
+    target_include_directories(iot-containerd PRIVATE
+        ${CMAKE_CURRENT_SOURCE_DIR}/daemon
+        ${CMAKE_CURRENT_SOURCE_DIR}/inc
+        ${CMAKE_CURRENT_SOURCE_DIR}/../data-store/inc
+        ${NLOHMANN_JSON_INCLUDE}
+        ${ACE_ROOT}/include)
+    target_link_directories(iot-containerd PRIVATE ${ACE_ROOT}/lib)
+    # z: gzip layer decompression (zlib, already a base image dep, as in apps).
+    target_link_libraries(iot-containerd PRIVATE
+        containers_core datastore_client ACE pthread OpenSSL::Crypto z)
+
+    if(NOT DEFINED IOT_PACKAGING_INSTALL OR IOT_PACKAGING_INSTALL)
+        install(TARGETS iot-containerd RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+    endif()
+endif()
+
+if(CONTAINERS_BUILD_TESTS)
+    enable_testing()
+    find_package(GTest REQUIRED)
+    add_executable(containers-tests
+        test/image_ref_test.cpp
+        test/registry_test.cpp
+        test/oci_layer_test.cpp
+        test/oci_bundle_test.cpp)
+    target_link_libraries(containers-tests containers_core GTest::gtest GTest::gtest_main pthread)
+    include(GoogleTest)
+    if(CONTAINERS_TOP_LEVEL)
+        gtest_discover_tests(containers-tests)
+    else()
+        add_test(NAME containers-tests COMMAND containers-tests)
+    endif()
+endif()

--- a/modules/containers/README.md
+++ b/modules/containers/README.md
@@ -43,7 +43,7 @@ This module lands incrementally (see the TDD doc):
   manifest is persisted under `/var/lib/iot-containers/manifests/` for the mount
   phase. Registry credentials are consumed write-only (cleared from ds).
 - **Phase 3 (done): layer extraction + overlay mount.** A `run` extracts each
-  layer (zlib gzip + in-process tar) into `/var/lib-containers/layers/<hex>/fs`
+  layer (zlib gzip + in-process tar) into `/var/lib/iot-containers/layers/<hex>/fs`
   — converting OCI whiteouts (`.wh.*` → char dev 0:0; `.wh..wh..opq` →
   `trusted.overlay.opaque`), guarding traversal, preserving mode/uid/gid — then
   `mount(2)`s an overlay (lowers base→top reversed, ephemeral upper/work under

--- a/modules/containers/README.md
+++ b/modules/containers/README.md
@@ -1,0 +1,87 @@
+# containers — on-device single-container runtime (iot-containerd)
+
+A thin, **crun-backed** shim that lets an operator pull an OCI/Docker image
+onto the device from the device-ui, mount its layers, and run / stop a single
+container with a custom CMD/Entrypoint and resource caps. Designed for a 1 GB
+RPi3B on Yocto — no Docker/Podman daemon. Full design:
+[`apps/docs/tdd-device-containers.md`](../../apps/docs/tdd-device-containers.md).
+
+## Layout
+
+| Path | What |
+|------|------|
+| `inc/image_ref.hpp`, `src/image_ref.cpp` | Pure OCI/Docker image-reference parsing — host-unit-testable `containers_core`. |
+| `inc/registry.hpp`, `src/registry.cpp` | Pure registry-v2 protocol logic: Bearer-challenge + token + manifest/index parse (nlohmann), platform select, digest validation. Part of `containers_core`. |
+| `inc/oci_layer.hpp`, `src/oci_layer.cpp` | Pure tar-header parse, OCI-whiteout classification, path-traversal guard, overlay lowerdir ordering. Part of `containers_core`. |
+| `inc/oci_bundle.hpp`, `src/oci_bundle.cpp` | Pure image-config parse, CMD/Entrypoint resolution, mem/cpu/user parsing, and OCI runtime `config.json` generation (host-net, default caps, cgroup limits). Part of `containers_core`. |
+| `daemon/http_client.{hpp,cpp}` | HTTP(S) transport — `curl` via `ACE_Process` + OpenSSL streaming SHA-256 + `mkdir_p`. |
+| `daemon/registry_puller.{hpp,cpp}` | Pull orchestration: auth → arch-select → download + sha256-verify blobs to the store. |
+| `daemon/layer_store.{hpp,cpp}` | gzip+tar layer extraction (zlib) with whiteout → overlay conversion + cache, and the overlayfs `mount(2)` that assembles the rootfs. |
+| `daemon/crun_runtime.{hpp,cpp}` | `crun` CLI wrapper (create/start/state/kill/delete) via `ACE_Process`. |
+| `daemon/containerd.{hpp,cpp}`, `daemon/main.cpp` | `iot-containerd` — privileged, reactor-driven (ACE-only) shim. Watches `container.*` commands, runs pull + (mount→bundle→crun→supervise) on worker threads, publishes status. |
+| `schemas/container.lua` | The `container.*` data-store schema (operator + daemon contract). |
+| `test/*_test.cpp` | gtest for the pure core (image-ref, registry, oci-layer, oci-bundle). |
+
+## Control plane (data-store keys)
+
+The device-ui writes command keys via `/api/v1/db/set` and long-polls the
+status keys; `iot-containerd` watches the `*.request` tokens and publishes
+`container.state` / progress. See `schemas/container.lua` for the full list.
+
+## Status: phased
+
+This module lands incrementally (see the TDD doc):
+
+- **Phase 1 (done): control-plane skeleton.** ds connect, `container.state`
+  lifecycle, command watch + reactor dispatch.
+- **Phase 2 (done): registry-v2 pull.** `pull` request → Bearer auth →
+  manifest/index fetch + arch-select for this device → download config + layer
+  blobs to `/var/lib/iot-containers/blobs/sha256/`, each **sha256-verified**
+  (cached blobs reused), with `container.pull.progress`/`.detail` updates,
+  ending at `container.state=pulled` (`container.image.id` / `.size` set). Runs
+  on a worker thread so the reactor stays responsive. The platform image
+  manifest is persisted under `/var/lib/iot-containers/manifests/` for the mount
+  phase. Registry credentials are consumed write-only (cleared from ds).
+- **Phase 3 (done): layer extraction + overlay mount.** A `run` extracts each
+  layer (zlib gzip + in-process tar) into `/var/lib-containers/layers/<hex>/fs`
+  — converting OCI whiteouts (`.wh.*` → char dev 0:0; `.wh..wh..opq` →
+  `trusted.overlay.opaque`), guarding traversal, preserving mode/uid/gid — then
+  `mount(2)`s an overlay (lowers base→top reversed, ephemeral upper/work under
+  `/run/iot-containers/c0`) to assemble the rootfs.
+- **Phase 4 (done): crun lifecycle + supervision.** After mount, the run worker
+  reads the image config, resolves args (image Entrypoint/Cmd + UI overrides,
+  Docker semantics), generates the OCI `config.json` (host networking, default
+  caps, NoNewPrivileges, mem/cpu cgroup limits, `/etc/resolv.conf` bind), and
+  drives `crun create`→`start`→`state` → `container.state=running` with
+  `run.pid`. It then supervises (polls `crun state`) until the container exits;
+  `stop` requests SIGTERM→grace→SIGKILL, then `crun delete` + unmount →
+  `stopped`. Daemon shutdown kills + cleans up.
+- **Phase 6 (done): device-ui Containers page.** `iot-ui/src/app/containers/` —
+  Admin-only nav entry with a status datagrid (state badge / image / size / pid /
+  pull progress / error), a pull form (image ref + optional write-only registry
+  creds), and a run form (Entrypoint / CMD / mem / cpu) with Run/Stop. Drives the
+  `container.*` keys: a 2s `dbGet` self-poll for live status, `dbSet` + bumped
+  `*.request` tokens for commands.
+- **Phase 7 (next)**: e2e on RPi3B hardware (pull → run → stop), validating
+  overlayfs + crun + cgroups on the real kernel.
+
+## Build
+
+Daemon is built in the integrated iot image (`-DCONTAINERS_BUILD_DAEMON=ON`).
+For a host core/test build:
+
+```sh
+cmake -S modules/containers -B build/containers
+cmake --build build/containers
+ctest --test-dir build/containers
+```
+
+## Runtime
+
+`iot-containerd` runs as **root** (it will mount overlayfs and drive crun's
+namespaces/cgroups). Storage uses dedicated top-level paths (created by
+tmpfiles.d): persistent images/layers under `/var/lib/iot-containers`,
+ephemeral overlay/bundle under `/run/iot-containers`. These are deliberately
+NOT under `/var/lib/iot` — that path is ds-server's DynamicUser
+`StateDirectory=iot` and systemd migrates pre-created children into
+`/var/lib/private/iot`. `crun` ships from the meta-virtualization layer.

--- a/modules/containers/daemon/containerd.cpp
+++ b/modules/containers/daemon/containerd.cpp
@@ -1,0 +1,442 @@
+#include "containerd.hpp"
+
+#include <ctime>
+#include <fstream>
+#include <sstream>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
+#include <ace/Reactor.h>
+#include <ace/Time_Value.h>
+
+#include "data_store/log_buffer.hpp"
+#include "data_store/stats_publisher.hpp"
+#include "data_store/value.hpp"
+
+#include "crun_runtime.hpp"
+#include "http_client.hpp"     // mkdir_p
+#include "image_ref.hpp"
+#include "layer_store.hpp"
+#include "oci_bundle.hpp"
+#include "registry.hpp"
+#include "registry_puller.hpp"
+
+namespace containers {
+
+namespace {
+// v1 is single-container; a fixed id keeps the run/overlay paths stable.
+constexpr const char* kContainerId = "c0";
+
+std::string slurp(const std::string& path) {
+    std::ifstream f(path, std::ios::binary);
+    std::ostringstream ss;
+    ss << f.rdbuf();
+    return ss.str();
+}
+
+bool spit(const std::string& path, const std::string& body) {
+    std::ofstream f(path, std::ios::binary | std::ios::trunc);
+    f << body;
+    return f.good();
+}
+} // namespace
+
+Containerd::~Containerd() {
+    m_pull_cancel.store(true);
+    m_shutdown.store(true);        // break the supervise loop fast (kills the container)
+    m_stop_requested.store(true);
+    if (m_pull_thread.joinable()) m_pull_thread.join();
+    if (m_run_thread.joinable())  m_run_thread.join();
+}
+
+// Captures this daemon's ACE log output to log.containerd.text and applies the
+// per-daemon level from log.level.container (falls back to log.level).
+static data_store::LogBuffer g_log("containerd", "log.containerd.text", "log.level.container");
+
+std::string Containerd::get_str(const std::string& key) {
+    std::vector<data_store::Client::GetResult> got;
+    if (m_ds.get({key}, got).ok && !got.empty() && got[0].has_value)
+        if (auto s = data_store::to_string(got[0].value)) return *s;
+    return {};
+}
+
+void Containerd::set_state(const char* state) {
+    m_ds.set_volatile(std::string("container.state"), data_store::Value{std::string(state)});
+}
+
+void Containerd::set_error(const std::string& msg) {
+    m_ds.set_volatile(std::string("container.error"), data_store::Value{msg});
+}
+
+void Containerd::publish_initial_status() {
+    std::vector<data_store::KV> kv;
+    kv.emplace_back("container.state",         data_store::Value{std::string("idle")});
+    kv.emplace_back("container.pull.progress", data_store::Value{std::string("0")});
+    kv.emplace_back("container.pull.detail",   data_store::Value{std::string("")});
+    kv.emplace_back("container.status",        data_store::Value{std::string("idle")});
+    kv.emplace_back("container.error",         data_store::Value{std::string("")});
+    m_ds.set_volatile(kv);
+}
+
+void Containerd::on_command_event(const data_store::Client::Event& ev) {
+    const std::string val = data_store::to_string(ev.value).value_or(std::string());
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        if (ev.key == "container.pull.request") {
+            if (val == m_pull_token) return;     // unchanged → ignore re-notify
+            m_pull_token = val; m_pull_pending = true;
+        } else if (ev.key == "container.run.request") {
+            if (val == m_run_token) return;
+            m_run_token = val; m_run_pending = true;
+        } else if (ev.key == "container.stop.request") {
+            if (val == m_stop_token) return;
+            m_stop_token = val; m_stop_pending = true;
+        } else {
+            return;
+        }
+    }
+    // Hand off to the reactor thread; handle_exception() does the work.
+    ACE_Reactor::instance()->notify(this);
+}
+
+int Containerd::handle_exception(ACE_HANDLE) {
+    bool pull, run, stop;
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        pull = m_pull_pending; m_pull_pending = false;
+        run  = m_run_pending;  m_run_pending  = false;
+        stop = m_stop_pending; m_stop_pending = false;
+    }
+    if (stop) handle_stop();    // stop first so a stop+run pair restarts cleanly
+    if (pull) handle_pull();
+    if (run)  handle_run();
+    return 0;
+}
+
+void Containerd::handle_pull() {
+    if (m_pull_active.load()) {
+        set_error("a pull is already in progress");
+        return;
+    }
+    const std::string ref_s = get_str("container.image.ref");
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] pull requested: ref=%C\n"),
+               ref_s.empty() ? "(unset)" : ref_s.c_str()));
+    if (ref_s.empty()) {
+        set_error("container.image.ref is empty — set an image to pull");
+        set_state("error");
+        return;
+    }
+    ImageRef ref;
+    if (!parse_image_ref(ref_s, ref)) {
+        set_error("could not parse image ref: " + ref_s);
+        set_state("error");
+        return;
+    }
+    ACE_DEBUG((LM_INFO,
+        ACE_TEXT("%D [ctr]   -> registry=%C repo=%C tag=%C digest=%C\n"),
+        ref.registry.c_str(), ref.repository.c_str(),
+        ref.tag.c_str(), ref.digest.c_str()));
+
+    const std::string user = get_str("container.registry.user");
+    const std::string pass = get_str("container.registry.pass");
+    // Consume the secret: do not leave the registry password persisted in ds
+    // (it would otherwise sit on the SD card + in any ds snapshot). Cleared
+    // persistently; the operator re-enters it per pull (write-only by design).
+    if (!pass.empty())
+        m_ds.set(std::string("container.registry.pass"), data_store::Value{std::string()});
+
+    // Reap a previously-finished worker before launching a new one.
+    if (m_pull_thread.joinable()) m_pull_thread.join();
+    m_pull_cancel.store(false);
+    m_pull_active.store(true);
+
+    set_error("");
+    set_state("pulling");
+    m_ds.set_volatile(std::string("container.pull.progress"),
+                      data_store::Value{std::string("0")});
+
+    const std::string root = m_cfg.root;
+    m_pull_thread = std::thread([this, ref, user, pass, root]() {
+        auto progress = [this](int pct, const std::string& detail) {
+            std::vector<data_store::KV> kv;
+            kv.emplace_back("container.pull.progress", data_store::Value{std::to_string(pct)});
+            kv.emplace_back("container.pull.detail",   data_store::Value{detail});
+            m_ds.set_volatile(kv);
+        };
+        PullResult r = pull_image(ref, user, pass, root, progress, m_pull_cancel);
+        if (r.ok) {
+            std::vector<data_store::KV> kv;
+            kv.emplace_back("container.image.id",      data_store::Value{r.image_id});
+            kv.emplace_back("container.image.size",    data_store::Value{std::to_string(r.total_size)});
+            kv.emplace_back("container.pull.progress", data_store::Value{std::string("100")});
+            kv.emplace_back("container.pull.detail",   data_store::Value{std::string("pull complete")});
+            kv.emplace_back("container.error",         data_store::Value{std::string()});
+            kv.emplace_back("container.state",         data_store::Value{std::string("pulled")});
+            m_ds.set_volatile(kv);
+            ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] pull ok: %C (%lld bytes)\n"),
+                       r.image_id.c_str(), static_cast<long long>(r.total_size)));
+        } else {
+            set_error(r.error);
+            set_state("error");
+            ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] pull failed: %C\n"), r.error.c_str()));
+        }
+        m_pull_active.store(false);
+    });
+}
+
+void Containerd::handle_run() {
+    if (m_run_active.load()) { set_error("a run/stop is already in progress"); return; }
+
+    const std::string image_id = get_str("container.image.id");
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] run requested (image=%C)\n"),
+               image_id.empty() ? "(none)" : image_id.c_str()));
+    if (image_id.empty() || !is_valid_digest(image_id)) {
+        set_error("no image pulled yet — pull an image first");
+        set_state("error");
+        return;
+    }
+
+    // Process overrides + resource limits (read on the reactor thread).
+    const std::string ov_entrypoint = get_str("container.entrypoint");
+    const std::string ov_cmd        = get_str("container.cmd");
+    const std::string lim_mem       = get_str("container.limit.mem");
+    const std::string lim_cpus      = get_str("container.limit.cpus");
+
+    if (m_run_thread.joinable()) m_run_thread.join();
+    m_stop_requested.store(false);
+    m_run_active.store(true);
+    set_error("");
+    set_state("mounting");
+    m_ds.set_volatile(std::string("container.pull.detail"),
+                      data_store::Value{std::string("extracting layers")});
+
+    const std::string root     = m_cfg.root;
+    const std::string run_root = m_cfg.run;
+    m_run_thread = std::thread([this, image_id, root, run_root,
+                                ov_entrypoint, ov_cmd, lim_mem, lim_cpus]() {
+        const std::string hex  = image_id.substr(7);
+        const std::string body = slurp(root + "/manifests/" + hex + ".json");
+        ImageManifest im = parse_image_manifest(body);
+        if (!im.ok) {
+            set_error("image manifest missing/corrupt — re-pull the image");
+            set_state("error");
+            m_run_active.store(false);
+            return;
+        }
+
+        std::vector<std::string> digests;
+        for (const auto& l : im.layers) digests.push_back(l.digest);
+
+        std::string err;
+        std::vector<std::string> layer_dirs;
+        if (!ensure_layers_extracted(root, digests, layer_dirs, err)) {
+            set_error("layer extraction failed: " + err);
+            set_state("error");
+            m_run_active.store(false);
+            return;
+        }
+
+        MountResult mr = mount_overlay(layer_dirs, run_root, kContainerId);
+        if (!mr.ok) {
+            set_error("overlay mount failed: " + mr.error);
+            set_state("error");
+            m_run_active.store(false);
+            return;
+        }
+
+        {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            m_merged = mr.merged;
+        }
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] overlay mounted: %C (%u layers)\n"),
+                   mr.merged.c_str(), static_cast<unsigned>(layer_dirs.size())));
+
+        // ── Build the OCI bundle (config.json next to the rootfs) ──────────
+        const std::string bundle = run_root + "/" + kContainerId;   // mr.merged == bundle/rootfs
+        ImageConfig ic = parse_image_config(slurp(blob_path(root, im.config.digest)));
+
+        std::vector<std::string> args = resolve_process_args(
+            ic.entrypoint, ic.cmd,
+            parse_args_field(ov_entrypoint), !ov_entrypoint.empty(),
+            parse_args_field(ov_cmd),        !ov_cmd.empty());
+        if (args.empty()) {
+            set_error("image has no Entrypoint/Cmd — set a CMD/Entrypoint to run");
+            set_state("error");
+            unmount_overlay(run_root, kContainerId, err);
+            m_run_active.store(false);
+            return;
+        }
+
+        OciSpec spec;
+        spec.args = args;
+        spec.env  = ic.env;
+        spec.cwd  = ic.working_dir.empty() ? "/" : ic.working_dir;
+        resolve_user(ic.user, spec.uid, spec.gid);
+        spec.mem_limit_bytes = parse_mem_limit(lim_mem);
+        spec.cpu_quota       = parse_cpu_quota(lim_cpus, spec.cpu_period);
+
+        if (!spit(bundle + "/config.json", generate_oci_config(spec))) {
+            set_error("could not write OCI bundle config.json");
+            set_state("error");
+            unmount_overlay(run_root, kContainerId, err);
+            m_run_active.store(false);
+            return;
+        }
+
+        // ── crun create + start ────────────────────────────────────────────
+        const std::string state_root = run_root + "/state";
+        mkdir_p(state_root);
+        CrunRuntime crun(state_root);
+        crun.remove(kContainerId, true, err);   // clear any stale container
+
+        set_state("created");
+        if (!crun.create(kContainerId, bundle, err)) {
+            set_error("crun create failed: " + err);
+            set_state("error");
+            unmount_overlay(run_root, kContainerId, err);
+            m_run_active.store(false);
+            return;
+        }
+        if (!crun.start(kContainerId, err)) {
+            set_error("crun start failed: " + err);
+            set_state("error");
+            crun.remove(kContainerId, true, err);
+            unmount_overlay(run_root, kContainerId, err);
+            m_run_active.store(false);
+            return;
+        }
+
+        // Grab the pid + announce running.
+        long pid = crun.state(kContainerId).pid;
+        std::vector<data_store::KV> kv;
+        kv.emplace_back("container.run.pid",     data_store::Value{std::to_string(pid)});
+        kv.emplace_back("container.run.started", data_store::Value{std::to_string(
+                                                     static_cast<long long>(std::time(nullptr)))});
+        kv.emplace_back("container.exit.code",   data_store::Value{std::string()});
+        kv.emplace_back("container.status",      data_store::Value{std::string("running")});
+        kv.emplace_back("container.error",       data_store::Value{std::string()});
+        kv.emplace_back("container.state",       data_store::Value{std::string("running")});
+        m_ds.set_volatile(kv);
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] container started: pid=%d\n"),
+                   static_cast<int>(pid)));
+
+        // ── Supervise: poll until the container exits, honoring stop ───────
+        bool term_sent = false;
+        int  grace_ticks = 0;
+        while (true) {
+            // ~2s poll, but wake every 250ms so daemon shutdown is responsive.
+            bool shutting = false;
+            for (int i = 0; i < 8; ++i) {
+                ACE_OS::sleep(ACE_Time_Value(0, 250000));
+                if (m_shutdown.load()) { shutting = true; break; }
+            }
+            if (shutting) { crun.kill(kContainerId, "KILL", err); break; }
+
+            CrunStatus st = crun.state(kContainerId);
+            if (!st.exists || st.status == "stopped") break;   // exited
+            if (m_stop_requested.load()) {
+                if (!term_sent) {
+                    crun.kill(kContainerId, "TERM", err);
+                    term_sent = true;
+                    grace_ticks = 0;
+                    m_ds.set_volatile(std::string("container.status"),
+                                      data_store::Value{std::string("stopping")});
+                } else if (++grace_ticks >= 5) {               // ~10s grace → SIGKILL
+                    crun.kill(kContainerId, "KILL", err);
+                }
+            }
+        }
+
+        // ── Exited: clean up + report ──────────────────────────────────────
+        crun.remove(kContainerId, true, err);
+        unmount_overlay(run_root, kContainerId, err);
+        {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            m_merged.clear();
+        }
+        std::vector<data_store::KV> done;
+        done.emplace_back("container.run.pid", data_store::Value{std::string()});
+        done.emplace_back("container.status",  data_store::Value{std::string("stopped")});
+        done.emplace_back("container.state",   data_store::Value{std::string("stopped")});
+        m_ds.set_volatile(done);
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] container stopped%C\n"),
+                   m_stop_requested.load() ? " (by request)" : " (exited)"));
+        m_run_active.store(false);
+    });
+}
+
+void Containerd::handle_stop() {
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] stop requested\n")));
+    if (m_run_active.load()) {
+        // The run worker owns the container + overlay; ask it to tear down
+        // (SIGTERM → grace → SIGKILL → delete + unmount). All crun calls stay
+        // on the worker thread to avoid racing on the crun state dir.
+        m_stop_requested.store(true);
+        m_ds.set_volatile(std::string("container.status"),
+                          data_store::Value{std::string("stopping")});
+        return;
+    }
+    // Nothing running: clear any stale crun state + overlay mount.
+    std::string err;
+    CrunRuntime crun(m_cfg.run + "/state");
+    crun.remove(kContainerId, true, err);
+    unmount_overlay(m_cfg.run, kContainerId, err);
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_merged.clear();
+    }
+    m_ds.set_volatile(std::string("container.status"), data_store::Value{std::string("stopped")});
+    set_error("");
+    set_state("stopped");
+}
+
+int Containerd::run() {
+    if (!m_ds.connect(m_cfg.ds_sock).ok)
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%D [ctr] ds connect failed\n")), 1);
+
+    // Baseline the request tokens BEFORE watching so a stale value (e.g. a
+    // previous session's request) does not fire a spurious command on boot.
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_pull_token = get_str("container.pull.request");
+        m_run_token  = get_str("container.run.request");
+        m_stop_token = get_str("container.stop.request");
+    }
+
+    publish_initial_status();
+
+    data_store::Client::WatchHandle h = data_store::Client::kInvalidHandle;
+    if (!m_ds.watch(
+            std::vector<std::string>{"container.pull.request",
+                                     "container.run.request",
+                                     "container.stop.request"},
+            [this](const data_store::Client::Event& ev) { on_command_event(ev); },
+            &h).ok) {
+        ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%D [ctr] command watch failed\n")), 2);
+    }
+
+    // ACE is initialised now (reactor used above): capture logs to
+    // log.containerd.text, apply log.level.container, drive the flush timer.
+    g_log.start();
+    g_log.apply_level(m_ds);
+    g_log.open(m_ds, 5, 1);
+    // Self-report for the Services page.
+    m_ds.set(std::string("services.container.state"), data_store::Value{std::string("running")});
+
+    // L22 resource telemetry → services.container.{cpu,mem,fd,threads}. We pump
+    // the singleton reactor in-thread, so schedule on it (no extra thread).
+    data_store::StatsPublisher stats("services.container",
+        [this](const std::vector<data_store::KV>& kv) { m_ds.set(kv); });
+    stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC, false);
+
+    ACE_DEBUG((LM_INFO,
+        ACE_TEXT("%D [ctr] up: root=%C run=%C (phase-1 skeleton: commands "
+                 "acknowledged; pull/run/stop not yet implemented)\n"),
+        m_cfg.root.c_str(), m_cfg.run.c_str()));
+
+    ACE_Reactor::instance()->run_reactor_event_loop();
+    return 0;
+}
+
+} // namespace containers

--- a/modules/containers/daemon/containerd.cpp
+++ b/modules/containers/daemon/containerd.cpp
@@ -431,8 +431,7 @@ int Containerd::run() {
     stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC, false);
 
     ACE_DEBUG((LM_INFO,
-        ACE_TEXT("%D [ctr] up: root=%C run=%C (phase-1 skeleton: commands "
-                 "acknowledged; pull/run/stop not yet implemented)\n"),
+        ACE_TEXT("%D [ctr] up: root=%C run=%C (pull/run/stop ready)\n"),
         m_cfg.root.c_str(), m_cfg.run.c_str()));
 
     ACE_Reactor::instance()->run_reactor_event_loop();

--- a/modules/containers/daemon/containerd.hpp
+++ b/modules/containers/daemon/containerd.hpp
@@ -1,0 +1,98 @@
+#ifndef __iot_containerd_hpp__
+#define __iot_containerd_hpp__
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <string>
+#include <thread>
+
+#include <ace/Event_Handler.h>
+
+#include "data_store/client.hpp"
+
+/// iot-containerd — privileged single-container runtime shim (crun-backed).
+///
+/// Phase 1 (this build) is the control-plane skeleton. It connects to the
+/// data-store, publishes the container.* status keys (state=idle on boot) and
+/// watches the container.{pull,run,stop}.request command keys the device-ui
+/// bumps. Each command is acknowledged on the reactor thread; until the pull /
+/// overlay-mount / crun phases land, the action is reported back as
+/// not-yet-implemented via container.error. A `pull` does run the pure
+/// containers::parse_image_ref() so the parsed registry/repo/tag already shows
+/// up in the log. See apps/docs/tdd-device-containers.md.
+///
+/// Reactor-driven and ACE-only by project convention. The ds watch callback
+/// fires on the client's listener thread; it only records the new request token
+/// and notify()s the reactor, so all command handling runs single-threaded on
+/// the reactor thread (handle_exception) — the home the future crun/mount work
+/// needs.
+
+namespace containers {
+
+class Containerd : public ACE_Event_Handler {
+public:
+    struct Config {
+        std::string ds_sock;                          ///< "" → ds default socket
+        // Dedicated top-level paths — deliberately NOT under /var/lib/iot
+        // (that is ds-server's DynamicUser StateDirectory=iot; pre-creating
+        // children there makes systemd migrate it to /var/lib/private/iot).
+        std::string root = "/var/lib/iot-containers";  ///< persistent image/layer store
+        std::string run  = "/run/iot-containers";      ///< ephemeral overlay/bundle dir
+    };
+
+    explicit Containerd(Config cfg) : m_cfg(std::move(cfg)) {}
+    ~Containerd() override;
+
+    /// Connect ds, publish initial status, register the command watch, run the
+    /// reactor. Returns a process exit code (non-zero on ds-connect/watch
+    /// failure so systemd restarts us).
+    int run();
+
+    /// Reactor-thread command pump — woken by the ds watch via notify().
+    int handle_exception(ACE_HANDLE = ACE_INVALID_HANDLE) override;
+
+private:
+    std::string get_str(const std::string& key);
+    void publish_initial_status();
+    void on_command_event(const data_store::Client::Event& ev);
+    void handle_pull();
+    void handle_run();
+    void handle_stop();
+    void set_state(const char* state);
+    void set_error(const std::string& msg);
+
+    Config             m_cfg;
+    data_store::Client m_ds;
+
+    // Request tokens last seen + a per-command pending flag. The tokens are
+    // baselined at startup so a stale value (a previous session's request) does
+    // not fire on boot. Written on the listener thread (on_command_event),
+    // drained on the reactor thread (handle_exception) — guarded by m_mtx.
+    std::mutex  m_mtx;
+    std::string m_pull_token;
+    std::string m_run_token;
+    std::string m_stop_token;
+    bool        m_pull_pending = false;
+    bool        m_run_pending  = false;
+    bool        m_stop_pending = false;
+
+    // Pull runs on a worker thread (a registry pull can take minutes) so the
+    // reactor stays responsive; the ds Client is thread-safe, so the worker
+    // publishes container.* progress/state directly.
+    std::thread       m_pull_thread;
+    std::atomic<bool> m_pull_active{false};
+    std::atomic<bool> m_pull_cancel{false};
+
+    // Run (layer extract + overlay mount + crun create/start + supervision)
+    // runs on a worker thread that lives for the container's lifetime.
+    std::thread       m_run_thread;
+    std::atomic<bool> m_run_active{false};
+    std::atomic<bool> m_stop_requested{false};   ///< set by handle_stop, honored by the run worker
+    std::atomic<bool> m_shutdown{false};         ///< daemon teardown — supervise loop exits fast (SIGKILL)
+    std::string       m_merged;   ///< mounted rootfs path (guarded by m_mtx)
+};
+
+} // namespace containers
+
+#endif /* __iot_containerd_hpp__ */

--- a/modules/containers/daemon/crun_runtime.cpp
+++ b/modules/containers/daemon/crun_runtime.cpp
@@ -1,0 +1,152 @@
+#include "crun_runtime.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
+#include <ace/Process.h>
+
+#include <nlohmann/json.hpp>
+
+namespace containers {
+
+namespace {
+
+std::string resolve_crun() {
+    for (const char* p : {"/usr/bin/crun", "/bin/crun", "/usr/local/bin/crun"}) {
+        if (ACE_OS::access(p, X_OK) == 0) return p;
+    }
+    return "crun";
+}
+
+std::string make_temp(const char* tag) {
+    std::string tmpl = std::string("/tmp/iot-crun-") + tag + "-XXXXXX";
+    std::vector<char> buf(tmpl.begin(), tmpl.end());
+    buf.push_back('\0');
+    int fd = ::mkstemp(buf.data());
+    if (fd < 0) return {};
+    ::close(fd);
+    return std::string(buf.data());
+}
+
+std::string read_file(const std::string& path) {
+    std::string out;
+    FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) return out;
+    char b[4096];
+    size_t n;
+    while ((n = std::fread(b, 1, sizeof b, f)) > 0) out.append(b, n);
+    std::fclose(f);
+    return out;
+}
+
+std::string trim(const std::string& s) {
+    std::size_t a = 0, b = s.size();
+    while (a < b && (s[a] == ' ' || s[a] == '\n' || s[a] == '\r' || s[a] == '\t')) ++a;
+    while (b > a && (s[b-1] == ' ' || s[b-1] == '\n' || s[b-1] == '\r' || s[b-1] == '\t')) --b;
+    return s.substr(a, b - a);
+}
+
+} // namespace
+
+CrunRuntime::CrunRuntime(std::string state_root)
+    : m_state_root(std::move(state_root)), m_crun(resolve_crun()) {}
+
+int CrunRuntime::run(const std::vector<std::string>& args, std::string* out,
+                     std::string& err) {
+    const std::string out_path = make_temp("out");
+    const std::string err_path = make_temp("err");
+    if (out_path.empty() || err_path.empty()) {
+        err = "could not create temp files";
+        if (!out_path.empty()) ::unlink(out_path.c_str());
+        if (!err_path.empty()) ::unlink(err_path.c_str());
+        return -1;
+    }
+
+    // cgroupfs manager: we run as root, so crun manages the container cgroup
+    // directly (no dbus / transient-scope dependency the systemd manager needs).
+    std::vector<std::string> full = {m_crun, "--root", m_state_root,
+                                     "--cgroup-manager", "cgroupfs"};
+    full.insert(full.end(), args.begin(), args.end());
+
+    std::vector<char*> argv;
+    argv.reserve(full.size() + 1);
+    for (auto& s : full) argv.push_back(s.data());
+    argv.push_back(nullptr);
+
+    ACE_Process_Options opts;
+    opts.command_line(argv.data());
+
+    int devnull = ::open("/dev/null", O_RDONLY);
+    int outfd   = ::open(out_path.c_str(), O_WRONLY | O_TRUNC);
+    int errfd   = ::open(err_path.c_str(), O_WRONLY | O_TRUNC);
+    if (devnull >= 0 && outfd >= 0 && errfd >= 0)
+        opts.set_handles(devnull, outfd, errfd);
+
+    ACE_Process proc;
+    pid_t pid = proc.spawn(opts);
+    if (devnull >= 0) ::close(devnull);
+    if (outfd   >= 0) ::close(outfd);
+    if (errfd   >= 0) ::close(errfd);
+
+    if (pid == ACE_INVALID_PID) {
+        err = "failed to spawn crun";
+        ::unlink(out_path.c_str());
+        ::unlink(err_path.c_str());
+        return -1;
+    }
+
+    ACE_exitcode status = 0;
+    proc.wait(&status);
+    const int code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+
+    if (out) *out = read_file(out_path);
+    if (code != 0) err = trim(read_file(err_path));
+    ::unlink(out_path.c_str());
+    ::unlink(err_path.c_str());
+    return code;
+}
+
+bool CrunRuntime::create(const std::string& id, const std::string& bundle_dir,
+                         std::string& err) {
+    return run({"create", "--bundle", bundle_dir, id}, nullptr, err) == 0;
+}
+
+bool CrunRuntime::start(const std::string& id, std::string& err) {
+    return run({"start", id}, nullptr, err) == 0;
+}
+
+CrunStatus CrunRuntime::state(const std::string& id) {
+    CrunStatus st;
+    std::string out, err;
+    if (run({"state", id}, &out, err) != 0) return st;   // exists=false
+    try {
+        auto j = nlohmann::json::parse(out);
+        st.exists = true;
+        if (j.contains("status") && j["status"].is_string())
+            st.status = j["status"].get<std::string>();
+        if (j.contains("pid") && j["pid"].is_number_integer())
+            st.pid = j["pid"].get<long>();
+    } catch (...) {
+        st.exists = false;
+    }
+    return st;
+}
+
+bool CrunRuntime::kill(const std::string& id, const std::string& signal,
+                       std::string& err) {
+    return run({"kill", id, signal}, nullptr, err) == 0;
+}
+
+bool CrunRuntime::remove(const std::string& id, bool force, std::string& err) {
+    std::vector<std::string> a = {"delete"};
+    if (force) a.push_back("--force");
+    a.push_back(id);
+    return run(a, nullptr, err) == 0;
+}
+
+} // namespace containers

--- a/modules/containers/daemon/crun_runtime.hpp
+++ b/modules/containers/daemon/crun_runtime.hpp
@@ -1,0 +1,51 @@
+#ifndef __iot_container_crun_runtime_hpp__
+#define __iot_container_crun_runtime_hpp__
+
+#include <string>
+#include <vector>
+
+/// Thin wrapper around the `crun` OCI runtime CLI (via ACE_Process), mirroring
+/// the http_client/curl pattern. The daemon drives a single container through
+/// create → start → (supervise via state) → kill → delete. Container state
+/// lives under a dedicated `--root` dir. See apps/docs/tdd-device-containers.md.
+
+namespace containers {
+
+struct CrunStatus {
+    bool        exists = false;   ///< `crun state` found the container
+    std::string status;          ///< "creating"|"created"|"running"|"stopped"
+    long        pid = 0;         ///< container PID (host view), 0 when none
+};
+
+class CrunRuntime {
+public:
+    /// `state_root` is passed as `crun --root <dir>` — where crun keeps its
+    /// per-container state (must be on a writable, preferably tmpfs, path).
+    explicit CrunRuntime(std::string state_root);
+
+    /// `crun create --bundle <bundle_dir> <id>` — set up namespaces/cgroups
+    /// from <bundle_dir>/config.json, paused before the user process.
+    bool create(const std::string& id, const std::string& bundle_dir, std::string& err);
+
+    /// `crun start <id>` — exec the container's process.
+    bool start(const std::string& id, std::string& err);
+
+    /// `crun state <id>` — current status + pid (exists=false when gone).
+    CrunStatus state(const std::string& id);
+
+    /// `crun kill <id> <signal>` — signal is "TERM" / "KILL" / etc.
+    bool kill(const std::string& id, const std::string& signal, std::string& err);
+
+    /// `crun delete [--force] <id>` — drop the container's state.
+    bool remove(const std::string& id, bool force, std::string& err);
+
+private:
+    int run(const std::vector<std::string>& args, std::string* out, std::string& err);
+
+    std::string m_state_root;
+    std::string m_crun;   ///< resolved crun binary path
+};
+
+} // namespace containers
+
+#endif /* __iot_container_crun_runtime_hpp__ */

--- a/modules/containers/daemon/http_client.cpp
+++ b/modules/containers/daemon/http_client.cpp
@@ -1,0 +1,210 @@
+#include "http_client.hpp"
+
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <sstream>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_sys_stat.h>
+#include <ace/OS_NS_unistd.h>
+#include <ace/Process.h>
+
+#include <openssl/evp.h>
+
+namespace containers {
+
+namespace {
+
+// Resolve the curl binary once. Try the usual locations, then fall back to a
+// bare name (ACE_Process → execvp searches PATH). Empty only if nothing found.
+std::string curl_path() {
+    for (const char* p : {"/usr/bin/curl", "/bin/curl", "/usr/local/bin/curl"}) {
+        if (ACE_OS::access(p, X_OK) == 0) return p;
+    }
+    return "curl";
+}
+
+// Create a temp file; returns its path ("" on failure). The file is created
+// empty and closed — curl (re)writes it.
+std::string make_temp(const char* tag) {
+    std::string tmpl = std::string("/tmp/iot-ctr-") + tag + "-XXXXXX";
+    std::vector<char> buf(tmpl.begin(), tmpl.end());
+    buf.push_back('\0');
+    int fd = ::mkstemp(buf.data());
+    if (fd < 0) return {};
+    ::close(fd);
+    return std::string(buf.data());
+}
+
+std::string read_file(const std::string& path) {
+    std::string out;
+    FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) return out;
+    char buf[4096];
+    size_t n;
+    while ((n = std::fread(buf, 1, sizeof buf, f)) > 0) out.append(buf, n);
+    std::fclose(f);
+    return out;
+}
+
+// The final HTTP status across all redirect hops (-D dumps a status line per
+// hop; the last one is authoritative).
+long status_from_headers(const std::string& headers) {
+    long last = 0;
+    std::istringstream iss(headers);
+    std::string line;
+    while (std::getline(iss, line)) {
+        if (line.rfind("HTTP/", 0) == 0) {
+            auto sp = line.find(' ');
+            if (sp != std::string::npos) {
+                try { last = std::stol(line.substr(sp + 1)); } catch (...) {}
+            }
+        }
+    }
+    return last;
+}
+
+} // namespace
+
+bool http_get(const std::string&              url,
+              const std::vector<std::string>& accept,
+              const std::string&              bearer,
+              const std::string&              basic,
+              const std::string&              body_path,
+              bool                            follow_redirects,
+              int                             timeout_sec,
+              HttpResponse&                   resp,
+              std::string&                    err) {
+    resp = HttpResponse{};
+
+    const std::string hdr_path = make_temp("hdr");
+    const std::string err_path = make_temp("err");
+    if (hdr_path.empty() || err_path.empty()) {
+        err = "could not create temp files";
+        if (!hdr_path.empty()) ::unlink(hdr_path.c_str());
+        if (!err_path.empty()) ::unlink(err_path.c_str());
+        return false;
+    }
+
+    // Build argv. No -f: a 401/404 must still return so the caller can react
+    // (bearer auth / not-found) rather than curl exiting with an error.
+    std::vector<std::string> args = {
+        curl_path(), "-sS", "--connect-timeout", "20",
+        "-m", std::to_string(timeout_sec),
+        "-D", hdr_path,
+        "-o", body_path.empty() ? std::string("/dev/null") : body_path,
+    };
+    if (follow_redirects) args.push_back("-L");
+    for (const auto& a : accept) { args.push_back("-H"); args.push_back("Accept: " + a); }
+    if (!bearer.empty()) { args.push_back("-H"); args.push_back("Authorization: Bearer " + bearer); }
+    if (!basic.empty())  { args.push_back("-u"); args.push_back(basic); }
+    args.push_back(url);
+
+    // Mutable char* vector for the argv-array command_line() overload (avoids
+    // the const-qualification mismatch with const char**). std::string::data()
+    // is non-const since C++17.
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (auto& s : args) argv.push_back(s.data());
+    argv.push_back(nullptr);
+
+    ACE_Process_Options opts;
+    // argv-array form: no shell tokenization, so header values with spaces stay
+    // intact (vs the format-string command_line()).
+    opts.command_line(argv.data());
+
+    // Redirect the child's std handles: stdin/stdout → /dev/null (curl writes
+    // body to -o and headers to -D), stderr → err_path for diagnostics.
+    int devnull = ::open("/dev/null", O_RDWR);
+    int errfd   = ::open(err_path.c_str(), O_WRONLY | O_TRUNC);
+    if (devnull >= 0 && errfd >= 0)
+        opts.set_handles(devnull, devnull, errfd);
+
+    ACE_Process proc;
+    pid_t pid = proc.spawn(opts);
+    if (devnull >= 0) ::close(devnull);
+    if (errfd   >= 0) ::close(errfd);
+
+    if (pid == ACE_INVALID_PID) {
+        err = "failed to spawn curl";
+        ::unlink(hdr_path.c_str());
+        ::unlink(err_path.c_str());
+        return false;
+    }
+
+    ACE_exitcode status = 0;
+    proc.wait(&status);
+    const int exit_code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+
+    resp.headers = read_file(hdr_path);
+    resp.status  = status_from_headers(resp.headers);
+    const std::string curl_err = read_file(err_path);
+    ::unlink(hdr_path.c_str());
+    ::unlink(err_path.c_str());
+
+    // Transport failure: curl exited non-zero AND we never saw an HTTP status.
+    if (exit_code != 0 && resp.status == 0) {
+        err = "curl exit " + std::to_string(exit_code);
+        if (!curl_err.empty()) err += ": " + curl_err;
+        return false;
+    }
+    resp.transport_ok = true;
+    return true;
+}
+
+bool sha256_file(const std::string& path, std::string& hex_out) {
+    FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) return false;
+    EVP_MD_CTX* ctx = EVP_MD_CTX_new();
+    if (!ctx) { std::fclose(f); return false; }
+
+    bool ok = EVP_DigestInit_ex(ctx, EVP_sha256(), nullptr) == 1;
+    unsigned char buf[65536];
+    size_t n;
+    while (ok && (n = std::fread(buf, 1, sizeof buf, f)) > 0)
+        ok = EVP_DigestUpdate(ctx, buf, n) == 1;
+    if (std::ferror(f)) ok = false;
+
+    unsigned char md[EVP_MAX_MD_SIZE];
+    unsigned int  mdlen = 0;
+    if (ok) ok = EVP_DigestFinal_ex(ctx, md, &mdlen) == 1;
+    EVP_MD_CTX_free(ctx);
+    std::fclose(f);
+    if (!ok) return false;
+
+    static const char* hex = "0123456789abcdef";
+    hex_out.clear();
+    hex_out.reserve(mdlen * 2);
+    for (unsigned i = 0; i < mdlen; ++i) {
+        hex_out.push_back(hex[md[i] >> 4]);
+        hex_out.push_back(hex[md[i] & 0x0F]);
+    }
+    return true;
+}
+
+bool mkdir_p(const std::string& path) {
+    std::string acc;
+    std::size_t start = 0;
+    while (start < path.size()) {
+        std::size_t slash = path.find('/', start);
+        std::string comp = (slash == std::string::npos)
+                               ? path.substr(start)
+                               : path.substr(start, slash - start);
+        if (!comp.empty()) {
+            acc += "/" + comp;       // paths are absolute (leading '/')
+            if (ACE_OS::mkdir(acc.c_str(), 0700) != 0 && errno != EEXIST)
+                return false;
+        }
+        if (slash == std::string::npos) break;
+        start = slash + 1;
+    }
+    return true;
+}
+
+} // namespace containers

--- a/modules/containers/daemon/http_client.hpp
+++ b/modules/containers/daemon/http_client.hpp
@@ -1,0 +1,46 @@
+#ifndef __iot_container_http_client_hpp__
+#define __iot_container_http_client_hpp__
+
+#include <string>
+#include <vector>
+
+/// Thin HTTP(S) transport for the registry puller. Shells out to the `curl`
+/// CLI via ACE_Process (matching the OTA download path — no libcurl link dep),
+/// plus an OpenSSL streaming SHA-256 for blob verification. Kept out of the
+/// pure containers_core so that core stays network/ACE-free + host-testable.
+
+namespace containers {
+
+struct HttpResponse {
+    bool        transport_ok = false;  ///< curl produced an HTTP response
+    long        status = 0;            ///< final HTTP status code
+    std::string headers;               ///< raw response headers (curl -D, all hops)
+};
+
+/// HTTP GET via curl. Body is written to `body_path` ("" → discard). Optional
+/// auth: `bearer` → `Authorization: Bearer …`; `basic` ("user:pass") → HTTP
+/// Basic (`curl -u`). Each `accept` entry becomes an `Accept:` header.
+/// `follow_redirects` adds `-L` (blob GETs 307 to a CDN).
+///
+/// Returns true when curl produced an HTTP response — even 4xx/5xx, so the
+/// caller inspects `resp.status` (401 → auth, 404 → not found). Returns false
+/// only on transport failure (curl missing, DNS, connect, TLS); `err` is set.
+bool http_get(const std::string&              url,
+              const std::vector<std::string>& accept,
+              const std::string&              bearer,
+              const std::string&              basic,
+              const std::string&              body_path,
+              bool                            follow_redirects,
+              int                             timeout_sec,
+              HttpResponse&                   resp,
+              std::string&                    err);
+
+/// Streaming SHA-256 of a file → lowercase hex. False on open/read error.
+bool sha256_file(const std::string& path, std::string& hex_out);
+
+/// `mkdir -p` for an absolute path (each component, mode 0700, EEXIST ok).
+bool mkdir_p(const std::string& path);
+
+} // namespace containers
+
+#endif /* __iot_container_http_client_hpp__ */

--- a/modules/containers/daemon/layer_store.cpp
+++ b/modules/containers/daemon/layer_store.cpp
@@ -1,0 +1,336 @@
+#include "layer_store.hpp"
+
+#include <cctype>
+#include <cerrno>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fcntl.h>
+#include <ftw.h>
+#include <sys/mount.h>
+#include <sys/stat.h>
+#include <sys/sysmacros.h>
+#include <sys/types.h>
+#include <sys/xattr.h>
+#include <unistd.h>
+
+#include <zlib.h>
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
+
+#include "http_client.hpp"   // mkdir_p
+#include "oci_layer.hpp"
+#include "registry.hpp"      // is_valid_digest / blob_path
+
+namespace containers {
+
+namespace {
+
+std::string dirname_of(const std::string& p) {
+    auto s = p.rfind('/');
+    return s == std::string::npos ? std::string() : p.substr(0, s);
+}
+
+bool ensure_parent(const std::string& full) {
+    const std::string d = dirname_of(full);
+    return d.empty() ? true : mkdir_p(d);
+}
+
+// Read exactly `n` decompressed bytes. Returns bytes read (n on success, 0 on
+// clean EOF, <n on truncation).
+int gz_read_full(gzFile gz, char* buf, int n) {
+    int total = 0;
+    while (total < n) {
+        int r = gzread(gz, buf + total, n - total);
+        if (r <= 0) break;
+        total += r;
+    }
+    return total;
+}
+
+// Skip the 512-byte zero padding after `size` bytes of entry data.
+bool gz_skip(gzFile gz, long long count) {
+    char buf[8192];
+    while (count > 0) {
+        int want = static_cast<int>(count > (long long)sizeof buf ? sizeof buf : count);
+        int r = gzread(gz, buf, want);
+        if (r <= 0) return false;
+        count -= r;
+    }
+    return true;
+}
+
+bool gz_skip_data(gzFile gz, long long size) {
+    long long pad = (512 - (size % 512)) % 512;
+    return gz_skip(gz, size + pad);
+}
+
+bool gz_read_data_str(gzFile gz, long long size, std::string& out) {
+    out.clear();
+    out.resize(static_cast<std::size_t>(size));
+    if (size > 0 && gz_read_full(gz, &out[0], static_cast<int>(size)) != size) return false;
+    long long pad = (512 - (size % 512)) % 512;
+    return gz_skip(gz, pad);
+}
+
+// Stream `size` data bytes from gz into fd, then consume the padding.
+bool gz_stream_to_fd(gzFile gz, int fd, long long size) {
+    char buf[65536];
+    long long remaining = size;
+    while (remaining > 0) {
+        int want = static_cast<int>(remaining > (long long)sizeof buf ? sizeof buf : remaining);
+        int r = gzread(gz, buf, want);
+        if (r <= 0) return false;
+        ssize_t off = 0;
+        while (off < r) {
+            ssize_t w = ::write(fd, buf + off, r - off);
+            if (w < 0) { if (errno == EINTR) continue; return false; }
+            off += w;
+        }
+        remaining -= r;
+    }
+    long long pad = (512 - (size % 512)) % 512;
+    return gz_skip(gz, pad);
+}
+
+// Parse PAX extended-header records ("<len> key=value\n"...) for path/linkpath.
+void parse_pax(const std::string& s, std::string& path, std::string& linkpath) {
+    std::size_t i = 0;
+    while (i < s.size()) {
+        std::size_t j = i;
+        while (j < s.size() && std::isdigit(static_cast<unsigned char>(s[j]))) ++j;
+        if (j == i) break;
+        long len = std::strtol(s.substr(i, j - i).c_str(), nullptr, 10);
+        if (len <= 0 || i + static_cast<std::size_t>(len) > s.size()) break;
+        std::string rec = s.substr(j + 1, i + len - (j + 1));   // "key=value\n"
+        if (!rec.empty() && rec.back() == '\n') rec.pop_back();
+        auto eq = rec.find('=');
+        if (eq != std::string::npos) {
+            const std::string k = rec.substr(0, eq), v = rec.substr(eq + 1);
+            if (k == "path") path = v;
+            else if (k == "linkpath") linkpath = v;
+        }
+        i += static_cast<std::size_t>(len);
+    }
+}
+
+int nftw_rm(const char* p, const struct stat*, int, struct FTW*) { return ::remove(p); }
+
+void rm_rf(const std::string& path) {
+    if (ACE_OS::access(path.c_str(), F_OK) != 0) return;
+    ::nftw(path.c_str(), nftw_rm, 16, FTW_DEPTH | FTW_PHYS);
+}
+
+// Apply a single (non long-name/PAX) tar entry under dest_dir. Sets
+// `streamed` when it consumed the entry's data (a regular file) so the caller
+// does not skip it again.
+void apply_entry(const std::string& dest_dir, const std::string& rel,
+                 const TarEntry& e, const std::string& link, gzFile gz,
+                 bool& streamed) {
+    streamed = false;
+
+    std::string target;
+    const WhiteoutKind wk = classify_whiteout(rel, target);
+    if (wk == WhiteoutKind::Remove) {
+        const std::string tp = dest_dir + "/" + target;
+        ensure_parent(tp);
+        ::unlink(tp.c_str());
+        if (::mknod(tp.c_str(), S_IFCHR | 0, makedev(0, 0)) != 0)
+            ACE_DEBUG((LM_WARNING, ACE_TEXT("%D [ctr] whiteout mknod %C: %C\n"),
+                       tp.c_str(), std::strerror(errno)));
+        return;
+    }
+    if (wk == WhiteoutKind::Opaque) {
+        const std::string tp = target.empty() ? dest_dir : dest_dir + "/" + target;
+        mkdir_p(tp);
+        if (::setxattr(tp.c_str(), "trusted.overlay.opaque", "y", 1, 0) != 0)
+            ACE_DEBUG((LM_WARNING, ACE_TEXT("%D [ctr] opaque xattr %C: %C\n"),
+                       tp.c_str(), std::strerror(errno)));
+        return;
+    }
+
+    const std::string full = dest_dir + "/" + rel;
+    switch (e.type) {
+        case tar::kDirectory:
+            mkdir_p(full);
+            ::chmod(full.c_str(), e.mode ? e.mode : 0755);
+            ::chown(full.c_str(), e.uid, e.gid);
+            break;
+        case tar::kRegular:
+        case tar::kRegularA: {
+            ensure_parent(full);
+            ::unlink(full.c_str());
+            int fd = ::open(full.c_str(), O_WRONLY | O_CREAT | O_TRUNC,
+                            e.mode ? e.mode : 0644);
+            if (fd < 0) {
+                ACE_DEBUG((LM_WARNING, ACE_TEXT("%D [ctr] open %C: %C\n"),
+                           full.c_str(), std::strerror(errno)));
+                break;   // streamed stays false → caller skips the data
+            }
+            if (!gz_stream_to_fd(gz, fd, e.size))
+                ACE_DEBUG((LM_WARNING, ACE_TEXT("%D [ctr] short write %C\n"), full.c_str()));
+            ::fchmod(fd, e.mode ? e.mode : 0644);
+            ::fchown(fd, e.uid, e.gid);
+            ::close(fd);
+            streamed = true;
+            break;
+        }
+        case tar::kSymlink:
+            ensure_parent(full);
+            ::unlink(full.c_str());
+            if (::symlink(link.c_str(), full.c_str()) == 0)
+                ::lchown(full.c_str(), e.uid, e.gid);
+            break;
+        case tar::kHardLink: {
+            ensure_parent(full);
+            const std::string lrel = safe_rel_path(link);
+            if (!lrel.empty()) {
+                ::unlink(full.c_str());
+                ::link((dest_dir + "/" + lrel).c_str(), full.c_str());
+            }
+            break;
+        }
+        default:
+            // char/block/fifo device nodes in a layer are skipped: the runtime
+            // populates /dev. (Whiteouts above already handled the 0/0 case.)
+            break;
+    }
+}
+
+} // namespace
+
+bool extract_layer(const std::string& blob_file, const std::string& dest_dir,
+                   std::string& err) {
+    if (!mkdir_p(dest_dir)) { err = "could not create " + dest_dir; return false; }
+    gzFile gz = gzopen(blob_file.c_str(), "rb");
+    if (!gz) { err = "gzopen failed: " + blob_file; return false; }
+
+    std::string pending_name, pending_link;
+    char block[tar::kBlockSize];
+    bool ok = true;
+
+    while (true) {
+        int n = gz_read_full(gz, block, tar::kBlockSize);
+        if (n == 0) break;                                 // clean EOF
+        if (n != tar::kBlockSize) { err = "truncated tar"; ok = false; break; }
+
+        TarEntry e;
+        bool zero = false;
+        if (!parse_tar_header(block, e, zero)) {
+            if (zero) break;                               // end-of-archive marker
+            err = "malformed tar header"; ok = false; break;
+        }
+
+        if (e.type == tar::kGnuLongName || e.type == tar::kGnuLongLink) {
+            std::string data;
+            if (!gz_read_data_str(gz, e.size, data)) { err = "truncated long name"; ok = false; break; }
+            if (!data.empty() && data.back() == '\0') data.pop_back();
+            (e.type == tar::kGnuLongName ? pending_name : pending_link) = data;
+            continue;
+        }
+        if (e.type == tar::kPaxExtended) {
+            std::string data;
+            if (!gz_read_data_str(gz, e.size, data)) { err = "truncated pax"; ok = false; break; }
+            parse_pax(data, pending_name, pending_link);
+            continue;
+        }
+        if (e.type == tar::kPaxGlobal) {
+            if (!gz_skip_data(gz, e.size)) { err = "truncated pax-global"; ok = false; break; }
+            continue;
+        }
+
+        const std::string name = pending_name.empty() ? e.name : pending_name;
+        const std::string link = pending_link.empty() ? e.linkname : pending_link;
+        pending_name.clear();
+        pending_link.clear();
+
+        const std::string rel = safe_rel_path(name);
+        bool streamed = false;
+        if (!rel.empty()) apply_entry(dest_dir, rel, e, link, gz, streamed);
+        if (!streamed) {
+            if (!gz_skip_data(gz, e.size)) { err = "truncated entry data"; ok = false; break; }
+        }
+    }
+
+    gzclose(gz);
+    return ok;
+}
+
+bool ensure_layers_extracted(const std::string&              root,
+                             const std::vector<std::string>& layer_digests,
+                             std::vector<std::string>&       out_dirs,
+                             std::string&                    err) {
+    out_dirs.clear();
+    for (const auto& digest : layer_digests) {
+        if (!is_valid_digest(digest)) { err = "layer has a malformed digest"; return false; }
+        const std::string hex   = digest.substr(7);
+        const std::string base  = root + "/layers/" + hex;
+        const std::string fsdir = base + "/fs";
+        const std::string done  = base + "/.done";
+
+        if (ACE_OS::access(done.c_str(), F_OK) == 0) {     // cache hit
+            out_dirs.push_back(fsdir);
+            continue;
+        }
+
+        const std::string blob = blob_path(root, digest);
+        if (blob.empty() || ACE_OS::access(blob.c_str(), F_OK) != 0) {
+            err = "missing blob for layer " + digest; return false;
+        }
+        // Fresh extraction: clear any partial dir first.
+        rm_rf(fsdir);
+        if (!extract_layer(blob, fsdir, err)) return false;
+
+        FILE* mk = std::fopen(done.c_str(), "w");
+        if (mk) std::fclose(mk);
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] extracted layer %C\n"), hex.c_str()));
+        out_dirs.push_back(fsdir);
+    }
+    return true;
+}
+
+MountResult mount_overlay(const std::vector<std::string>& layer_dirs,
+                          const std::string&              run_root,
+                          const std::string&              id) {
+    MountResult res;
+    if (layer_dirs.empty()) { res.error = "image has no layers"; return res; }
+
+    const std::string idd    = run_root + "/" + id;
+    const std::string upper  = idd + "/upper";
+    const std::string work   = idd + "/work";
+    const std::string merged = idd + "/rootfs";
+
+    std::string e;
+    unmount_overlay(run_root, id, e);                      // clear any stale mount
+
+    if (!mkdir_p(upper) || !mkdir_p(work) || !mkdir_p(merged)) {
+        res.error = "could not create overlay dirs under " + idd;
+        return res;
+    }
+
+    const std::string opts = "lowerdir=" + overlay_lowerdir(layer_dirs) +
+                             ",upperdir=" + upper + ",workdir=" + work;
+    if (::mount("overlay", merged.c_str(), "overlay", 0, opts.c_str()) != 0) {
+        res.error = std::string("overlay mount failed: ") + std::strerror(errno);
+        return res;
+    }
+    res.merged = merged;
+    res.ok = true;
+    return res;
+}
+
+bool unmount_overlay(const std::string& run_root, const std::string& id,
+                     std::string& err) {
+    (void) err;
+    const std::string idd    = run_root + "/" + id;
+    const std::string merged = idd + "/rootfs";
+    if (ACE_OS::access(merged.c_str(), F_OK) == 0) {
+        if (::umount2(merged.c_str(), 0) != 0 && errno != EINVAL && errno != ENOENT)
+            ::umount2(merged.c_str(), MNT_DETACH);          // lazy fallback
+    }
+    rm_rf(idd);
+    return true;
+}
+
+} // namespace containers

--- a/modules/containers/daemon/layer_store.hpp
+++ b/modules/containers/daemon/layer_store.hpp
@@ -1,0 +1,51 @@
+#ifndef __iot_container_layer_store_hpp__
+#define __iot_container_layer_store_hpp__
+
+#include <string>
+#include <vector>
+
+/// Layer store: gzip+tar layer extraction (with OCI-whiteout conversion) into a
+/// content-addressed cache, and the overlayfs mount that assembles them into a
+/// container rootfs. Uses zlib + filesystem syscalls + mount(2), so it lives in
+/// the daemon (the pure tar/whiteout/overlay-order logic is in oci_layer).
+/// See apps/docs/tdd-device-containers.md.
+
+namespace containers {
+
+struct MountResult {
+    bool        ok = false;
+    std::string merged;     ///< merged rootfs path (run_root/<id>/rootfs)
+    std::string error;
+};
+
+/// Extract a single gzip-compressed tar layer `blob_file` into `dest_dir`
+/// (created if needed), converting OCI whiteouts to overlayfs whiteouts
+/// (`.wh.<n>` → char dev 0:0; `.wh..wh..opq` → trusted.overlay.opaque xattr).
+/// Must run as root (mknod, chown, trusted xattr). False with `err` on failure.
+bool extract_layer(const std::string& blob_file, const std::string& dest_dir,
+                   std::string& err);
+
+/// Ensure every layer digest in `layer_digests` (OCI order: base→top) is
+/// extracted under `<root>/layers/<hex>/fs` (cached via a `.done` marker so a
+/// re-run is instant). Reads blobs from `<root>/blobs/sha256/<hex>`. Returns
+/// the ordered extracted `fs` dirs in `out_dirs`. False with `err` on failure.
+bool ensure_layers_extracted(const std::string&              root,
+                             const std::vector<std::string>& layer_digests,
+                             std::vector<std::string>&       out_dirs,
+                             std::string&                    err);
+
+/// Mount the overlay for container `id`: lowerdir from `layer_dirs` (base→top),
+/// with upper/work/merged created under `<run_root>/<id>/`. Any stale mount for
+/// `id` is torn down first. Must run as root (mount).
+MountResult mount_overlay(const std::vector<std::string>& layer_dirs,
+                          const std::string&              run_root,
+                          const std::string&              id);
+
+/// Unmount the overlay for container `id` and remove its run dir. Idempotent
+/// (no-op when not mounted). False with `err` only on a hard failure.
+bool unmount_overlay(const std::string& run_root, const std::string& id,
+                     std::string& err);
+
+} // namespace containers
+
+#endif /* __iot_container_layer_store_hpp__ */

--- a/modules/containers/daemon/main.cpp
+++ b/modules/containers/daemon/main.cpp
@@ -1,0 +1,55 @@
+/// iot-containerd — single-container runtime shim (crun-backed) entry.
+///
+/// Reactor-driven (ACE): connects to the data-store, publishes container.*
+/// status, and watches the container.{pull,run,stop}.request command keys the
+/// device-ui bumps. Phase 1 is the control-plane skeleton — it acknowledges
+/// commands but the registry pull, overlay mount and crun lifecycle land in
+/// later phases. See apps/docs/tdd-device-containers.md.
+
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+#include "containerd.hpp"
+
+namespace {
+
+void usage() {
+    std::cout <<
+        "iot-containerd — single-container runtime shim (crun-backed)\n"
+        "\n"
+        "Usage: iot-containerd [--ds-sock=PATH] [--root=DIR] [--run=DIR] [--help]\n"
+        "\n"
+        "  --ds-sock=PATH   ds-server unix socket (default: ds built-in).\n"
+        "  --root=DIR       persistent image/layer store (default\n"
+        "                   /var/lib/iot-containers).\n"
+        "  --run=DIR        ephemeral overlay/bundle dir (default\n"
+        "                   /run/iot-containers).\n"
+        "  --help           show this and exit.\n";
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    containers::Containerd::Config cfg;
+    try {
+        for (int i = 1; i < argc; ++i) {
+            std::string a = argv[i];
+            if      (a.rfind("--ds-sock=", 0) == 0) cfg.ds_sock = a.substr(10);
+            else if (a.rfind("--root=", 0)    == 0) cfg.root = a.substr(7);
+            else if (a.rfind("--run=", 0)     == 0) cfg.run = a.substr(6);
+            else if (a == "--help" || a == "-h")    { usage(); return 0; }
+            else {
+                std::cerr << "iot-containerd: unknown argument '" << a << "'\n";
+                usage();
+                return 2;
+            }
+        }
+    } catch (const std::exception& e) {
+        std::cerr << "iot-containerd: bad argument: " << e.what() << "\n";
+        return 2;
+    }
+
+    containers::Containerd daemon(std::move(cfg));
+    return daemon.run();
+}

--- a/modules/containers/daemon/registry_puller.cpp
+++ b/modules/containers/daemon/registry_puller.cpp
@@ -1,0 +1,235 @@
+#include "registry_puller.hpp"
+
+#include <cstdio>
+#include <unistd.h>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_stdio.h>
+#include <ace/OS_NS_unistd.h>
+
+#include "http_client.hpp"
+#include "registry.hpp"
+
+namespace containers {
+
+namespace {
+
+const int kManifestTimeout = 60;     // seconds
+const int kBlobTimeout     = 600;    // seconds — layers can be large on slow links
+
+std::string read_file(const std::string& path) {
+    std::string out;
+    FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) return out;
+    char buf[4096];
+    size_t n;
+    while ((n = std::fread(buf, 1, sizeof buf, f)) > 0) out.append(buf, n);
+    std::fclose(f);
+    return out;
+}
+
+bool write_file(const std::string& path, const std::string& body) {
+    FILE* f = std::fopen(path.c_str(), "wb");
+    if (!f) return false;
+    bool ok = std::fwrite(body.data(), 1, body.size(), f) == body.size();
+    std::fclose(f);
+    return ok;
+}
+
+bool file_exists(const std::string& path) {
+    return ACE_OS::access(path.c_str(), F_OK) == 0;
+}
+
+std::vector<std::string> manifest_accepts() {
+    return {kMediaOciIndex, kMediaDockerList, kMediaOciManifest, kMediaDockerManifest};
+}
+
+} // namespace
+
+PullResult pull_image(const ImageRef&     ref,
+                      const std::string&  user,
+                      const std::string&  pass,
+                      const std::string&  root,
+                      const PullProgress& progress,
+                      std::atomic<bool>&  cancel) {
+    PullResult res;
+
+    const std::string base    = "https://" + ref.registry;
+    const std::string repo    = ref.repository;
+    const std::string workdir = root + "/tmp";
+    if (!mkdir_p(workdir) || !mkdir_p(root + "/blobs/sha256") ||
+        !mkdir_p(root + "/manifests")) {
+        res.error = "cannot create store under " + root;
+        return res;
+    }
+    const std::string token_path = workdir + "/token.json";
+
+    // Bearer token, cached + reused across manifest/blob GETs (same pull scope).
+    std::string token;
+
+    // GET with lazy bearer auth: on 401, parse the challenge, fetch a token
+    // (HTTP Basic with creds when given), then retry once. Returns the final
+    // HTTP status (0 on transport failure, with `err` set).
+    auto authorized_get = [&](const std::string& url,
+                              const std::vector<std::string>& accept,
+                              const std::string& body_path,
+                              bool follow, int timeout,
+                              std::string& err) -> long {
+        HttpResponse r;
+        if (!http_get(url, accept, token, "", body_path, follow, timeout, r, err))
+            return 0;
+        if (r.status != 401) return r.status;
+
+        auto ch = parse_bearer_challenge(r.headers);
+        if (!ch.ok) { err = "401 without a Bearer challenge"; return r.status; }
+        const std::string turl = build_token_url(ch);
+        const std::string basic = user.empty() ? std::string() : (user + ":" + pass);
+        HttpResponse tr;
+        if (!http_get(turl, {}, "", basic, token_path, false, 30, tr, err)) {
+            err = "token fetch failed: " + err;
+            return 0;
+        }
+        if (tr.status / 100 != 2) {
+            err = "token endpoint returned " + std::to_string(tr.status) +
+                  (user.empty() ? " (try setting registry credentials)" : "");
+            return tr.status;
+        }
+        token = parse_token_response(read_file(token_path));
+        if (token.empty()) { err = "empty token from " + ch.realm; return tr.status; }
+
+        HttpResponse r2;
+        if (!http_get(url, accept, token, "", body_path, follow, timeout, r2, err))
+            return 0;
+        return r2.status;
+    };
+
+    // ── 1. Top manifest (tag or digest) ────────────────────────────────────
+    const std::string ref_str = ref.digest.empty() ? ref.tag : ref.digest;
+    const std::string manifest_path = workdir + "/manifest.json";
+    std::string err;
+    long st = authorized_get(base + "/v2/" + repo + "/manifests/" + ref_str,
+                             manifest_accepts(), manifest_path, false,
+                             kManifestTimeout, err);
+    if (st == 0)        { res.error = "registry unreachable: " + err; return res; }
+    if (st == 401 || st == 403) { res.error = "registry auth failed (" + std::to_string(st) +
+                                              "): " + err; return res; }
+    if (st == 404)      { res.error = "image/tag not found: " + repo + ":" + ref_str; return res; }
+    if (st / 100 != 2)  { res.error = "manifest GET returned " + std::to_string(st); return res; }
+
+    std::string body = read_file(manifest_path);
+    res.manifest_digest = ref.digest;   // refined below for an index
+
+    // ── 2. Resolve a manifest-list/index to this device's platform ─────────
+    if (manifest_is_index(body)) {
+        auto entries = parse_manifest_index(body);
+        int idx = select_platform(entries, default_os(), default_arch(), default_variant());
+        if (idx < 0) {
+            res.error = std::string("no image for platform ") + default_os() + "/" +
+                        default_arch();
+            return res;
+        }
+        const std::string md = entries[idx].digest;
+        if (!is_valid_digest(md)) { res.error = "index has a malformed digest"; return res; }
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] index → %C/%C manifest %C\n"),
+                   default_os(), default_arch(), md.c_str()));
+        st = authorized_get(base + "/v2/" + repo + "/manifests/" + md,
+                            manifest_accepts(), manifest_path, false,
+                            kManifestTimeout, err);
+        if (st / 100 != 2) {
+            res.error = "platform manifest GET returned " + std::to_string(st) + " " + err;
+            return res;
+        }
+        body = read_file(manifest_path);
+        res.manifest_digest = md;
+    }
+
+    // ── 3. Parse + validate the image manifest ─────────────────────────────
+    ImageManifest im = parse_image_manifest(body);
+    if (!im.ok) { res.error = "could not parse image manifest"; return res; }
+    if (!is_valid_digest(im.config.digest)) {
+        res.error = "image config has a malformed digest";
+        return res;
+    }
+    for (const auto& l : im.layers) {
+        if (!is_valid_digest(l.digest)) { res.error = "layer has a malformed digest"; return res; }
+    }
+    res.image_id = im.config.digest;
+
+    // ── 4. Download + verify blobs (config first, then layers) ─────────────
+    std::vector<Descriptor> blobs;
+    blobs.push_back(im.config);
+    for (const auto& l : im.layers) blobs.push_back(l);
+
+    long long total = 0;
+    for (const auto& b : blobs) total += (b.size > 0 ? b.size : 0);
+    res.total_size = total;
+
+    long long done = 0;
+    for (std::size_t i = 0; i < blobs.size(); ++i) {
+        if (cancel.load()) { res.error = "cancelled"; return res; }
+
+        const Descriptor& b = blobs[i];
+        const std::string dest = blob_path(root, b.digest);
+        const std::string hex  = b.digest.substr(7);   // after "sha256:"
+        const std::string what = (i == 0 ? "config" : "layer " + std::to_string(i) +
+                                                       "/" + std::to_string(blobs.size() - 1));
+        auto pct = [&]() -> int {
+            if (total > 0) return static_cast<int>(done * 100 / total);
+            return static_cast<int>(i * 100 / blobs.size());
+        };
+
+        // Cache hit: present + digest still verifies.
+        if (file_exists(dest)) {
+            std::string have;
+            if (sha256_file(dest, have) && have == hex) {
+                done += (b.size > 0 ? b.size : 0);
+                progress(pct(), "cached " + what);
+                continue;
+            }
+        }
+
+        progress(pct(), "pulling " + what);
+        const std::string part = dest + ".part";
+        st = authorized_get(base + "/v2/" + repo + "/blobs/" + b.digest,
+                            {}, part, /*follow=*/true, kBlobTimeout, err);
+        if (st / 100 != 2) {
+            ::unlink(part.c_str());
+            res.error = "blob " + b.digest + " GET returned " + std::to_string(st) +
+                        (err.empty() ? "" : " " + err);
+            return res;
+        }
+
+        std::string have;
+        if (!sha256_file(part, have)) {
+            ::unlink(part.c_str());
+            res.error = "could not hash downloaded blob " + b.digest;
+            return res;
+        }
+        if (have != hex) {
+            ::unlink(part.c_str());
+            res.error = "blob digest mismatch: expected sha256:" + hex +
+                        " got sha256:" + have;
+            return res;
+        }
+        if (ACE_OS::rename(part.c_str(), dest.c_str()) != 0) {
+            ::unlink(part.c_str());
+            res.error = "could not store blob " + b.digest;
+            return res;
+        }
+        done += (b.size > 0 ? b.size : 0);
+        progress(pct(), "verified " + what);
+    }
+
+    // ── 5. Persist the platform image manifest for the mount phase ─────────
+    if (!write_file(root + "/manifests/" + im.config.digest.substr(7) + ".json", body)) {
+        res.error = "could not persist manifest sidecar";
+        return res;
+    }
+
+    progress(100, "pull complete");
+    res.ok = true;
+    return res;
+}
+
+} // namespace containers

--- a/modules/containers/daemon/registry_puller.hpp
+++ b/modules/containers/daemon/registry_puller.hpp
@@ -1,0 +1,43 @@
+#ifndef __iot_container_registry_puller_hpp__
+#define __iot_container_registry_puller_hpp__
+
+#include <atomic>
+#include <functional>
+#include <string>
+
+#include "image_ref.hpp"
+
+/// Registry-v2 pull orchestration: stitches the pure containers_core protocol
+/// helpers to the curl/OpenSSL http_client. Blocking — the daemon runs it on a
+/// worker thread. See apps/docs/tdd-device-containers.md.
+
+namespace containers {
+
+struct PullResult {
+    bool        ok = false;
+    std::string image_id;          ///< image config digest ("sha256:…")
+    std::string manifest_digest;   ///< platform image-manifest digest (for mount)
+    long long   total_size = 0;    ///< config + layers, bytes
+    std::string error;             ///< human message on failure
+};
+
+/// Progress callback: percent 0..100 + a short human detail string. Invoked on
+/// the worker thread; the implementation must be thread-safe (the daemon writes
+/// it straight to ds, which is).
+using PullProgress = std::function<void(int pct, const std::string& detail)>;
+
+/// Pull `ref` into the content-addressed store under `root`
+/// (`<root>/blobs/sha256/<hex>` + `<root>/manifests/<image-id>.json`).
+/// Handles bearer auth, manifest-index arch selection for this device, and
+/// sha256-verifies every blob (cached blobs are reused). `user`/`pass` are
+/// optional registry credentials. `cancel` is polled between blobs.
+PullResult pull_image(const ImageRef&     ref,
+                      const std::string&  user,
+                      const std::string&  pass,
+                      const std::string&  root,
+                      const PullProgress& progress,
+                      std::atomic<bool>&  cancel);
+
+} // namespace containers
+
+#endif /* __iot_container_registry_puller_hpp__ */

--- a/modules/containers/inc/image_ref.hpp
+++ b/modules/containers/inc/image_ref.hpp
@@ -1,0 +1,43 @@
+#ifndef __iot_container_image_ref_hpp__
+#define __iot_container_image_ref_hpp__
+
+#include <string>
+
+/// Pure OCI/Docker image-reference parsing — no ACE, no data-store, no libcurl,
+/// so it is fully host-unit-testable. The registry v2 client (Phase 2) builds
+/// its request URLs directly from the parsed fields. See
+/// apps/docs/tdd-device-containers.md.
+
+namespace containers {
+
+/// Parsed image reference, normalized with Docker's rules.
+///
+///   registry   - registry host[:port] to contact. "docker.io" (and the bare /
+///                single-segment form) is rewritten to the registry-1.docker.io
+///                API endpoint.
+///   repository - full repository path INCLUDING the implicit `library/`
+///                namespace for single-segment Docker Hub images
+///                (`nginx` -> `library/nginx`).
+///   tag        - image tag; defaults to "latest" when neither a tag nor a
+///                digest is given, and is empty when a digest pins the ref.
+///   digest     - "sha256:..." when the ref is digest-pinned
+///                (`repo@sha256:...`), otherwise empty.
+struct ImageRef {
+    std::string registry;
+    std::string repository;
+    std::string tag;
+    std::string digest;
+};
+
+/// Canonical Docker Hub registry-v2 API host (what "docker.io" resolves to).
+inline constexpr const char* kDockerRegistryHost = "registry-1.docker.io";
+
+/// Normalize `ref` (e.g. "nginx", "nginx:1.25", "ghcr.io/owner/app:dev",
+/// "localhost:5000/team/app@sha256:...") into `out`. Returns false when `ref`
+/// is empty or malformed (empty repository, trailing ':' / '@'); `out` is left
+/// unspecified on false.
+bool parse_image_ref(const std::string& ref, ImageRef& out);
+
+} // namespace containers
+
+#endif /* __iot_container_image_ref_hpp__ */

--- a/modules/containers/inc/oci_bundle.hpp
+++ b/modules/containers/inc/oci_bundle.hpp
@@ -1,0 +1,80 @@
+#ifndef __iot_container_oci_bundle_hpp__
+#define __iot_container_oci_bundle_hpp__
+
+#include <string>
+#include <vector>
+
+/// Pure OCI bundle generation — image-config parsing, CMD/Entrypoint
+/// resolution, resource-limit parsing, and the runtime `config.json` (the OCI
+/// runtime spec crun consumes). JSON via header-only nlohmann; no filesystem,
+/// no crun, no ACE — host-unit-testable. The crun process lifecycle lives in
+/// the daemon's crun_runtime. See apps/docs/tdd-device-containers.md.
+
+namespace containers {
+
+/// The parts of an OCI image config (the config blob's `config` object) the
+/// runtime needs.
+struct ImageConfig {
+    bool                     ok = false;
+    std::vector<std::string> env;          ///< "KEY=value" entries
+    std::vector<std::string> entrypoint;
+    std::vector<std::string> cmd;
+    std::string              working_dir;  ///< "" → "/"
+    std::string              user;         ///< "uid[:gid]" or a name
+};
+
+/// Parse an image config blob (JSON). Reads the nested `config` object's Env /
+/// Entrypoint / Cmd / WorkingDir / User. ok=false on parse failure.
+ImageConfig parse_image_config(const std::string& json);
+
+/// Parse a UI override field into an argv vector. A value starting with '['
+/// is parsed as a JSON string array; otherwise it is split on whitespace.
+/// Empty → empty vector.
+std::vector<std::string> parse_args_field(const std::string& field);
+
+/// Docker arg resolution: effective entrypoint + effective cmd, where each is
+/// the override when provided (its *_set flag true) else the image value.
+std::vector<std::string> resolve_process_args(
+    const std::vector<std::string>& img_entrypoint,
+    const std::vector<std::string>& img_cmd,
+    const std::vector<std::string>& ov_entrypoint, bool ov_entrypoint_set,
+    const std::vector<std::string>& ov_cmd, bool ov_cmd_set);
+
+/// Parse a memory limit like "256M" / "1g" / "536870912" into bytes. Suffixes
+/// k/m/g (and ki/mi/gi) are honored, case-insensitively. Returns 0 for an
+/// empty/invalid value (→ unbounded).
+long long parse_mem_limit(const std::string& s);
+
+/// Parse a CPU quota like "0.5" / "2" into a cgroup quota for `period`
+/// microseconds (e.g. 0.5 @ 100000 → 50000). Returns 0 for empty/invalid
+/// (→ unbounded).
+long long parse_cpu_quota(const std::string& cpus, long long period);
+
+/// Resolve an image `User` ("1000", "1000:1000", "root", "") into numeric
+/// uid/gid. Non-numeric names fall back to 0:0 (named-user /etc/passwd lookup
+/// is out of scope for v1).
+void resolve_user(const std::string& user, unsigned& uid, unsigned& gid);
+
+/// Inputs for the runtime config.json.
+struct OciSpec {
+    std::vector<std::string> args;            ///< process.args (non-empty)
+    std::vector<std::string> env;
+    std::string              cwd = "/";
+    unsigned                 uid = 0;
+    unsigned                 gid = 0;
+    long long                mem_limit_bytes = 0;   ///< 0 → unbounded
+    long long                cpu_quota = 0;         ///< 0 → unbounded
+    long long                cpu_period = 100000;
+    bool                     bind_resolv_conf = true; ///< host /etc/resolv.conf (ro)
+    std::string              hostname = "iot-container";
+};
+
+/// Generate the OCI runtime config.json string. Host networking (no network
+/// namespace), a Docker-like default capability set, NoNewPrivileges, the
+/// standard mounts, and the cgroup resource limits from `spec`. `root.path` is
+/// "rootfs" (relative to the bundle dir).
+std::string generate_oci_config(const OciSpec& spec);
+
+} // namespace containers
+
+#endif /* __iot_container_oci_bundle_hpp__ */

--- a/modules/containers/inc/oci_layer.hpp
+++ b/modules/containers/inc/oci_layer.hpp
@@ -1,0 +1,80 @@
+#ifndef __iot_container_oci_layer_hpp__
+#define __iot_container_oci_layer_hpp__
+
+#include <string>
+#include <vector>
+
+/// Pure OCI image-layer helpers — tar-header parsing, OCI-whiteout
+/// classification, path-traversal safety, and overlayfs lowerdir ordering. No
+/// zlib, no filesystem, no ACE, so it is fully host-unit-testable. The actual
+/// gzip/tar extraction + mknod/symlink/xattr application + the overlay mount
+/// live in the daemon's layer_store. See apps/docs/tdd-device-containers.md.
+
+namespace containers {
+
+// ── tar (ustar / GNU) ──────────────────────────────────────────────────────
+namespace tar {
+constexpr int kRegular   = '0';
+constexpr int kRegularA  = '\0';   // legacy regular-file typeflag
+constexpr int kHardLink  = '1';
+constexpr int kSymlink   = '2';
+constexpr int kCharDev   = '3';
+constexpr int kBlockDev  = '4';
+constexpr int kDirectory = '5';
+constexpr int kFifo      = '6';
+constexpr int kGnuLongName = 'L';  // entry data = name of the FOLLOWING entry
+constexpr int kGnuLongLink = 'K';  // entry data = linkname of the following entry
+constexpr int kPaxExtended = 'x';  // PAX per-file extended header (key=value)
+constexpr int kPaxGlobal   = 'g';  // PAX global header (ignored)
+constexpr int kBlockSize  = 512;
+}
+
+struct TarEntry {
+    std::string name;        ///< full path (prefix + name), as stored
+    std::string linkname;    ///< link target for sym/hard links
+    long long   size = 0;    ///< file data size in bytes
+    unsigned    mode = 0;    ///< permission bits (octal-decoded)
+    unsigned    uid  = 0;    ///< owner uid (for chown of the extracted file)
+    unsigned    gid  = 0;    ///< owner gid
+    int         type = tar::kRegularA;
+};
+
+/// Parse a 512-byte tar header block. Sets `is_zero_block` when the block is
+/// all-zero (archive end marker) — in that case the return value is false and
+/// `out` is untouched. Returns false (with is_zero_block=false) on a malformed
+/// header. ustar `prefix` is joined to `name` with '/'.
+bool parse_tar_header(const char block[tar::kBlockSize], TarEntry& out,
+                      bool& is_zero_block);
+
+/// Decode a tar octal numeric field (`len` bytes, space/NUL terminated).
+/// Returns false on a non-octal byte. Leading spaces are skipped; an empty
+/// field decodes to 0.
+bool parse_tar_octal(const char* field, std::size_t len, long long& out);
+
+// ── OCI whiteouts ──────────────────────────────────────────────────────────
+enum class WhiteoutKind {
+    None,      ///< a normal entry
+    Remove,    ///< `<dir>/.wh.<name>` — `<dir>/<name>` is deleted from lowers
+    Opaque,    ///< `<dir>/.wh..wh..opq` — `<dir>` hides all lower contents
+};
+
+/// Classify an entry path as an OCI whiteout. For Remove/Opaque, `target_rel`
+/// is set to the affected path (the file to whiteout, or the dir to mark
+/// opaque) relative to the layer root.
+WhiteoutKind classify_whiteout(const std::string& path, std::string& target_rel);
+
+// ── Path safety + overlay ──────────────────────────────────────────────────
+/// Normalize a tar member name into a safe relative path: strips a leading
+/// "./" and "/", collapses "." components, and REJECTS any ".." component or
+/// otherwise-escaping path (returns "" — caller must skip the entry). Prevents
+/// a malicious layer from writing outside its extraction dir.
+std::string safe_rel_path(const std::string& name);
+
+/// Build the overlayfs `lowerdir=` value from image layer dirs ordered
+/// base→top (OCI order). overlayfs wants highest-priority (top) first, so the
+/// list is reversed and ':'-joined.
+std::string overlay_lowerdir(const std::vector<std::string>& layer_dirs_base_to_top);
+
+} // namespace containers
+
+#endif /* __iot_container_oci_layer_hpp__ */

--- a/modules/containers/inc/registry.hpp
+++ b/modules/containers/inc/registry.hpp
@@ -1,0 +1,114 @@
+#ifndef __iot_container_registry_hpp__
+#define __iot_container_registry_hpp__
+
+#include <string>
+#include <vector>
+
+/// Pure OCI/Docker registry-v2 protocol helpers — the string/JSON logic with
+/// NO network and NO ACE, so it is fully host-unit-testable. The actual HTTP
+/// transfers (curl) live in the daemon's http_client; registry_puller stitches
+/// these helpers to it. See apps/docs/tdd-device-containers.md.
+
+namespace containers {
+
+// ── Manifest media types (Accept negotiation) ──────────────────────────────
+inline constexpr const char* kMediaOciIndex   = "application/vnd.oci.image.index.v1+json";
+inline constexpr const char* kMediaOciManifest = "application/vnd.oci.image.manifest.v1+json";
+inline constexpr const char* kMediaDockerList  = "application/vnd.docker.distribution.manifest.list.v2+json";
+inline constexpr const char* kMediaDockerManifest = "application/vnd.docker.distribution.manifest.v2+json";
+
+// ── Bearer auth challenge (RFC 6750 / Docker token flow) ───────────────────
+struct BearerChallenge {
+    bool        ok = false;     ///< a Bearer challenge was parsed
+    std::string realm;          ///< token endpoint URL
+    std::string service;        ///< service= param
+    std::string scope;          ///< scope= param (may be empty)
+};
+
+/// Parse a `WWW-Authenticate:` header value. Handles the full response-header
+/// blob (finds the Bearer line) or a bare challenge. Returns ok=false when no
+/// `Bearer` scheme is present (e.g. a plain 401 or Basic-only).
+BearerChallenge parse_bearer_challenge(const std::string& www_authenticate);
+
+/// Build the token request URL: `<realm>?service=<service>&scope=<scope>`
+/// (params URL-encoded; scope omitted when empty).
+std::string build_token_url(const BearerChallenge& c);
+
+/// Extract the bearer token from a token-endpoint JSON response. Registries
+/// return it as either `token` or `access_token`. Returns "" on parse failure.
+std::string parse_token_response(const std::string& json);
+
+// ── Image descriptors ──────────────────────────────────────────────────────
+struct Descriptor {
+    std::string media_type;
+    std::string digest;         ///< "sha256:<64 hex>"
+    long long   size = 0;       ///< bytes
+};
+
+struct PlatformDescriptor : Descriptor {
+    std::string os;             ///< e.g. "linux"
+    std::string arch;           ///< e.g. "arm64"
+    std::string variant;        ///< e.g. "v8" (often empty)
+};
+
+struct ImageManifest {
+    bool                    ok = false;
+    Descriptor              config;     ///< image config blob
+    std::vector<Descriptor> layers;     ///< ordered base → top
+};
+
+/// True when the manifest JSON is a manifest-list / image-index (has a
+/// top-level `manifests` array) rather than a single image manifest.
+bool manifest_is_index(const std::string& json);
+
+/// Parse a manifest-list / image-index into its per-platform entries. Returns
+/// an empty vector on parse failure.
+std::vector<PlatformDescriptor> parse_manifest_index(const std::string& json);
+
+/// Choose the entry matching (os, arch, variant). Exact os+arch is required; a
+/// requested variant prefers an exact variant match but falls back to an
+/// entry with no/empty variant. Returns -1 when nothing matches.
+int select_platform(const std::vector<PlatformDescriptor>& entries,
+                    const std::string& os, const std::string& arch,
+                    const std::string& variant);
+
+/// Parse a single image manifest (config + ordered layers). ok=false on
+/// failure.
+ImageManifest parse_image_manifest(const std::string& json);
+
+// ── Digest + storage helpers ───────────────────────────────────────────────
+/// Strictly validate a content digest: exactly "sha256:" followed by 64
+/// lowercase hex chars, no surrounding whitespace. (Guards the OTA `\n`-in-sha
+/// class of bug — a digest read from anywhere is rejected unless it is clean.)
+bool is_valid_digest(const std::string& digest);
+
+/// Local content-addressed path for a blob: `<root>/blobs/sha256/<hex>`.
+/// Returns "" when `digest` is not a valid sha256 digest.
+std::string blob_path(const std::string& root, const std::string& digest);
+
+// ── Host platform (what to pull for this device) ───────────────────────────
+inline const char* default_os() { return "linux"; }
+
+inline const char* default_arch() {
+#if defined(__aarch64__)
+    return "arm64";
+#elif defined(__arm__)
+    return "arm";
+#elif defined(__x86_64__)
+    return "amd64";
+#else
+    return "";
+#endif
+}
+
+inline const char* default_variant() {
+#if defined(__arm__) && !defined(__aarch64__)
+    return "v7";
+#else
+    return "";
+#endif
+}
+
+} // namespace containers
+
+#endif /* __iot_container_registry_hpp__ */

--- a/modules/containers/schemas/container.lua
+++ b/modules/containers/schemas/container.lua
@@ -1,0 +1,53 @@
+-- container.* schema for the iot-containerd single-container runtime shim.
+-- See apps/docs/tdd-device-containers.md.
+--
+-- Control plane (device-ui -> daemon). The UI writes these via /api/v1/db/set.
+-- The *.request keys are monotonic tokens: bump (write a new value) to trigger
+-- the action. iot-containerd records the value present at startup as a baseline
+-- so a stale value does NOT fire a command on boot.
+--   container.image.ref       - OCI/Docker ref to pull, e.g. docker.io/library/nginx:latest
+--   container.registry.user   - optional registry username (write-only by convention)
+--   container.registry.pass   - optional registry password/token (write-only by convention)
+--   container.entrypoint      - override Entrypoint (JSON array or string; "" = image default)
+--   container.cmd             - override CMD (JSON array or string; "" = image default)
+--   container.limit.mem       - memory cap, e.g. "256M" ("" = unbounded)
+--   container.limit.cpus      - CPU quota, e.g. "0.5" ("" = unbounded)
+--   container.pull.request    - bump to pull container.image.ref
+--   container.run.request     - bump to create + start the container
+--   container.stop.request    - bump to stop + delete the container
+--
+-- Status plane (daemon -> device-ui). Written VOLATILE (live, no SD-card fsync;
+-- resets on reboot — v1 has no autostart / persistence).
+--   container.state           - idle|pulling|pulled|mounting|created|running|stopped|error
+--   container.pull.progress   - 0..100 (percent of total layer bytes)
+--   container.pull.detail     - current layer digest / status message
+--   container.image.id        - resolved image config digest
+--   container.image.size      - total image size in bytes (decimal string)
+--   container.run.pid         - running container PID (decimal string)
+--   container.run.started     - start timestamp
+--   container.exit.code       - last container exit code (decimal string)
+--   container.status          - human-readable status summary
+--   container.error           - last error message ("" = none)
+return {
+    ["container.image.ref"]     = { access = "Admin",  type = "string", default = "" },
+    ["container.registry.user"] = { access = "Admin",  type = "string", default = "" },
+    ["container.registry.pass"] = { access = "Admin",  type = "string", default = "" },
+    ["container.entrypoint"]    = { access = "Admin",  type = "string", default = "" },
+    ["container.cmd"]           = { access = "Admin",  type = "string", default = "" },
+    ["container.limit.mem"]     = { access = "Admin",  type = "string", default = "" },
+    ["container.limit.cpus"]    = { access = "Admin",  type = "string", default = "" },
+    ["container.pull.request"]  = { access = "Admin",  type = "string", default = "" },
+    ["container.run.request"]   = { access = "Admin",  type = "string", default = "" },
+    ["container.stop.request"]  = { access = "Admin",  type = "string", default = "" },
+
+    ["container.state"]         = { access = "Viewer", type = "string", default = "idle" },
+    ["container.pull.progress"] = { access = "Viewer", type = "string", default = "0" },
+    ["container.pull.detail"]   = { access = "Viewer", type = "string", default = "" },
+    ["container.image.id"]      = { access = "Viewer", type = "string", default = "" },
+    ["container.image.size"]    = { access = "Viewer", type = "string", default = "" },
+    ["container.run.pid"]       = { access = "Viewer", type = "string", default = "" },
+    ["container.run.started"]   = { access = "Viewer", type = "string", default = "" },
+    ["container.exit.code"]     = { access = "Viewer", type = "string", default = "" },
+    ["container.status"]        = { access = "Viewer", type = "string", default = "" },
+    ["container.error"]         = { access = "Viewer", type = "string", default = "" },
+}

--- a/modules/containers/src/image_ref.cpp
+++ b/modules/containers/src/image_ref.cpp
@@ -1,0 +1,75 @@
+#include "image_ref.hpp"
+
+namespace containers {
+
+namespace {
+
+constexpr const char* kDefaultTag = "latest";
+
+// Docker rule: the first path component is a registry host (rather than a
+// Docker Hub user/org) only if it contains a '.' (domain), a ':' (port), or is
+// exactly "localhost".
+bool looks_like_registry(const std::string& s) {
+    return s == "localhost" ||
+           s.find('.') != std::string::npos ||
+           s.find(':') != std::string::npos;
+}
+
+} // namespace
+
+bool parse_image_ref(const std::string& ref, ImageRef& out) {
+    if (ref.empty()) return false;
+
+    out = ImageRef{};
+
+    // 1. Peel an optional registry off the front (component before the first
+    //    '/', if it looks like a host). This must run before the tag split so a
+    //    registry port (host:5000/...) is not mistaken for a tag.
+    std::string registry;
+    std::string name = ref;             // repository[:tag][@digest]
+    auto slash = name.find('/');
+    if (slash != std::string::npos && looks_like_registry(name.substr(0, slash))) {
+        registry = name.substr(0, slash);
+        name = name.substr(slash + 1);
+    }
+
+    // 2. Peel an optional @digest.
+    auto at = name.find('@');
+    if (at != std::string::npos) {
+        out.digest = name.substr(at + 1);
+        name = name.substr(0, at);
+        if (out.digest.empty()) return false;
+    }
+
+    // 3. Peel an optional :tag — only a ':' that falls after the last '/'
+    //    (any registry port was already removed in step 1).
+    auto last_slash = name.rfind('/');
+    auto colon = name.rfind(':');
+    if (colon != std::string::npos &&
+        (last_slash == std::string::npos || colon > last_slash)) {
+        out.tag = name.substr(colon + 1);
+        name = name.substr(0, colon);
+        if (out.tag.empty()) return false;
+    }
+
+    if (name.empty()) return false;
+    out.repository = name;
+
+    // 4. Docker Hub normalization: rewrite the host and add the implicit
+    //    library/ namespace for single-segment names.
+    if (registry.empty() || registry == "docker.io" || registry == "index.docker.io") {
+        out.registry = kDockerRegistryHost;
+        if (out.repository.find('/') == std::string::npos)
+            out.repository = "library/" + out.repository;
+    } else {
+        out.registry = registry;
+    }
+
+    // 5. Default the tag only when the ref is not digest-pinned.
+    if (out.tag.empty() && out.digest.empty())
+        out.tag = kDefaultTag;
+
+    return true;
+}
+
+} // namespace containers

--- a/modules/containers/src/oci_bundle.cpp
+++ b/modules/containers/src/oci_bundle.cpp
@@ -1,0 +1,192 @@
+#include "oci_bundle.hpp"
+
+#include <algorithm>
+#include <cctype>
+#include <cstdlib>
+#include <sstream>
+
+#include <nlohmann/json.hpp>
+
+namespace containers {
+
+namespace {
+
+using json = nlohmann::json;
+
+std::string trim(const std::string& s) {
+    std::size_t a = 0, b = s.size();
+    while (a < b && std::isspace(static_cast<unsigned char>(s[a]))) ++a;
+    while (b > a && std::isspace(static_cast<unsigned char>(s[b - 1]))) --b;
+    return s.substr(a, b - a);
+}
+
+bool all_digits(const std::string& x) {
+    return !x.empty() &&
+           std::all_of(x.begin(), x.end(),
+                       [](unsigned char c) { return std::isdigit(c) != 0; });
+}
+
+} // namespace
+
+ImageConfig parse_image_config(const std::string& body) {
+    ImageConfig c;
+    try {
+        auto j = json::parse(body);
+        const json& cfg = (j.contains("config") && j["config"].is_object()) ? j["config"] : j;
+        auto arr = [&](const char* k, std::vector<std::string>& out) {
+            if (cfg.contains(k) && cfg[k].is_array())
+                for (const auto& e : cfg[k])
+                    if (e.is_string()) out.push_back(e.get<std::string>());
+        };
+        arr("Env", c.env);
+        arr("Entrypoint", c.entrypoint);
+        arr("Cmd", c.cmd);
+        if (cfg.contains("WorkingDir") && cfg["WorkingDir"].is_string())
+            c.working_dir = cfg["WorkingDir"].get<std::string>();
+        if (cfg.contains("User") && cfg["User"].is_string())
+            c.user = cfg["User"].get<std::string>();
+        c.ok = true;
+    } catch (...) {
+        c = ImageConfig{};
+    }
+    return c;
+}
+
+std::vector<std::string> parse_args_field(const std::string& field) {
+    std::vector<std::string> out;
+    const std::string s = trim(field);
+    if (s.empty()) return out;
+    if (s.front() == '[') {
+        try {
+            auto j = json::parse(s);
+            if (j.is_array()) {
+                for (const auto& e : j)
+                    if (e.is_string()) out.push_back(e.get<std::string>());
+                return out;
+            }
+        } catch (...) {
+            out.clear();   // fall through to whitespace split
+        }
+    }
+    std::istringstream iss(s);
+    std::string tok;
+    while (iss >> tok) out.push_back(tok);
+    return out;
+}
+
+std::vector<std::string> resolve_process_args(
+    const std::vector<std::string>& img_entrypoint,
+    const std::vector<std::string>& img_cmd,
+    const std::vector<std::string>& ov_entrypoint, bool ov_entrypoint_set,
+    const std::vector<std::string>& ov_cmd, bool ov_cmd_set) {
+    const std::vector<std::string>& ep  = ov_entrypoint_set ? ov_entrypoint : img_entrypoint;
+    const std::vector<std::string>& cmd = ov_cmd_set ? ov_cmd : img_cmd;
+    std::vector<std::string> args = ep;
+    args.insert(args.end(), cmd.begin(), cmd.end());
+    return args;
+}
+
+long long parse_mem_limit(const std::string& s_) {
+    const std::string s = trim(s_);
+    if (s.empty()) return 0;
+    char* end = nullptr;
+    const double v = std::strtod(s.c_str(), &end);
+    if (end == s.c_str() || v < 0) return 0;
+    std::string suf;
+    while (*end) suf.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(*end++))));
+    long long mult = 1;
+    if (suf.empty() || suf == "b")                                    mult = 1;
+    else if (suf == "k" || suf == "kb" || suf == "ki" || suf == "kib") mult = 1024LL;
+    else if (suf == "m" || suf == "mb" || suf == "mi" || suf == "mib") mult = 1024LL * 1024;
+    else if (suf == "g" || suf == "gb" || suf == "gi" || suf == "gib") mult = 1024LL * 1024 * 1024;
+    else return 0;
+    return static_cast<long long>(v * static_cast<double>(mult));
+}
+
+long long parse_cpu_quota(const std::string& cpus_, long long period) {
+    const std::string s = trim(cpus_);
+    if (s.empty()) return 0;
+    char* end = nullptr;
+    const double v = std::strtod(s.c_str(), &end);
+    if (end == s.c_str() || v <= 0) return 0;
+    return static_cast<long long>(v * static_cast<double>(period));
+}
+
+void resolve_user(const std::string& user, unsigned& uid, unsigned& gid) {
+    uid = 0;
+    gid = 0;
+    const std::string s = trim(user);
+    if (s.empty()) return;
+    const auto colon = s.find(':');
+    const std::string us = (colon == std::string::npos) ? s : s.substr(0, colon);
+    const std::string gs = (colon == std::string::npos) ? std::string() : s.substr(colon + 1);
+    if (all_digits(us)) uid = static_cast<unsigned>(std::strtoul(us.c_str(), nullptr, 10));
+    if (all_digits(gs)) gid = static_cast<unsigned>(std::strtoul(gs.c_str(), nullptr, 10));
+}
+
+std::string generate_oci_config(const OciSpec& spec) {
+    json j;
+    j["ociVersion"] = "1.0.0";
+
+    json proc;
+    proc["terminal"] = false;
+    proc["user"] = {{"uid", spec.uid}, {"gid", spec.gid}};
+    proc["args"] = spec.args;
+
+    std::vector<std::string> env = spec.env;
+    if (env.empty())
+        env.push_back("PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin");
+    proc["env"] = env;
+    proc["cwd"] = spec.cwd.empty() ? "/" : spec.cwd;
+
+    // Docker-like default capability set (non-privileged container).
+    const json caps = json::array({
+        "CAP_CHOWN", "CAP_DAC_OVERRIDE", "CAP_FSETID", "CAP_FOWNER", "CAP_MKNOD",
+        "CAP_NET_RAW", "CAP_SETGID", "CAP_SETUID", "CAP_SETFCAP", "CAP_SETPCAP",
+        "CAP_NET_BIND_SERVICE", "CAP_SYS_CHROOT", "CAP_KILL", "CAP_AUDIT_WRITE"});
+    proc["capabilities"] = {{"bounding", caps}, {"effective", caps}, {"permitted", caps}};
+    proc["noNewPrivileges"] = true;
+    proc["rlimits"] = json::array({{{"type", "RLIMIT_NOFILE"}, {"hard", 1024}, {"soft", 1024}}});
+    j["process"] = proc;
+
+    j["root"] = {{"path", "rootfs"}, {"readonly", false}};
+    j["hostname"] = spec.hostname;
+
+    json mounts = json::array();
+    mounts.push_back({{"destination", "/proc"}, {"type", "proc"}, {"source", "proc"}});
+    mounts.push_back({{"destination", "/dev"}, {"type", "tmpfs"}, {"source", "tmpfs"},
+                      {"options", json::array({"nosuid", "strictatime", "mode=755", "size=65536k"})}});
+    mounts.push_back({{"destination", "/dev/pts"}, {"type", "devpts"}, {"source", "devpts"},
+                      {"options", json::array({"nosuid", "noexec", "newinstance", "ptmxmode=0666", "mode=0620"})}});
+    mounts.push_back({{"destination", "/dev/shm"}, {"type", "tmpfs"}, {"source", "shm"},
+                      {"options", json::array({"nosuid", "noexec", "nodev", "mode=1777", "size=65536k"})}});
+    mounts.push_back({{"destination", "/dev/mqueue"}, {"type", "mqueue"}, {"source", "mqueue"},
+                      {"options", json::array({"nosuid", "noexec", "nodev"})}});
+    mounts.push_back({{"destination", "/sys"}, {"type", "sysfs"}, {"source", "sysfs"},
+                      {"options", json::array({"nosuid", "noexec", "nodev", "ro"})}});
+    if (spec.bind_resolv_conf)
+        mounts.push_back({{"destination", "/etc/resolv.conf"}, {"type", "bind"},
+                          {"source", "/etc/resolv.conf"},
+                          {"options", json::array({"rbind", "ro"})}});
+    j["mounts"] = mounts;
+
+    json lin;
+    // No "network" namespace → the container shares the host net namespace.
+    lin["namespaces"] = json::array({{{"type", "pid"}}, {{"type", "ipc"}},
+                                     {{"type", "uts"}}, {{"type", "mount"}}});
+    lin["maskedPaths"] = json::array({
+        "/proc/acpi", "/proc/asound", "/proc/kcore", "/proc/keys", "/proc/latency_stats",
+        "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug", "/proc/scsi", "/sys/firmware"});
+    lin["readonlyPaths"] = json::array({
+        "/proc/bus", "/proc/fs", "/proc/irq", "/proc/sys", "/proc/sysrq-trigger"});
+
+    json resources;
+    if (spec.mem_limit_bytes > 0) resources["memory"] = {{"limit", spec.mem_limit_bytes}};
+    if (spec.cpu_quota > 0)       resources["cpu"] = {{"quota", spec.cpu_quota}, {"period", spec.cpu_period}};
+    if (!resources.empty())       lin["resources"] = resources;
+    j["linux"] = lin;
+
+    return j.dump(2);
+}
+
+} // namespace containers

--- a/modules/containers/src/oci_layer.cpp
+++ b/modules/containers/src/oci_layer.cpp
@@ -1,0 +1,125 @@
+#include "oci_layer.hpp"
+
+#include <sstream>
+
+namespace containers {
+
+namespace {
+
+// Read a fixed-width tar field up to the first NUL (or the full width).
+std::string field_str(const char* p, std::size_t maxlen) {
+    std::size_t n = 0;
+    while (n < maxlen && p[n] != '\0') ++n;
+    return std::string(p, n);
+}
+
+std::string dirname_of(const std::string& path) {
+    auto slash = path.rfind('/');
+    return slash == std::string::npos ? std::string() : path.substr(0, slash);
+}
+
+std::string basename_of(const std::string& path) {
+    auto slash = path.rfind('/');
+    return slash == std::string::npos ? path : path.substr(slash + 1);
+}
+
+} // namespace
+
+bool parse_tar_octal(const char* field, std::size_t len, long long& out) {
+    std::size_t i = 0;
+    while (i < len && (field[i] == ' ' || field[i] == '\0')) ++i;   // leading pad
+    long long v = 0;
+    bool any = false;
+    for (; i < len; ++i) {
+        char c = field[i];
+        if (c == ' ' || c == '\0') break;                            // trailing pad
+        if (c < '0' || c > '7') return false;
+        v = (v << 3) + (c - '0');
+        any = true;
+    }
+    out = any ? v : 0;
+    return true;
+}
+
+bool parse_tar_header(const char block[tar::kBlockSize], TarEntry& out,
+                      bool& is_zero_block) {
+    is_zero_block = false;
+    bool all_zero = true;
+    for (int i = 0; i < tar::kBlockSize; ++i) {
+        if (block[i] != 0) { all_zero = false; break; }
+    }
+    if (all_zero) { is_zero_block = true; return false; }
+
+    long long mode = 0, size = 0, uid = 0, gid = 0;
+    if (!parse_tar_octal(block + 100, 8, mode)) return false;
+    if (!parse_tar_octal(block + 124, 12, size)) return false;
+    // uid/gid are best-effort: a bad field shouldn't reject the whole header.
+    parse_tar_octal(block + 108, 8, uid);
+    parse_tar_octal(block + 116, 8, gid);
+
+    out = TarEntry{};
+    std::string name = field_str(block, 100);
+    // ustar: a non-empty `prefix` is joined to `name` with '/'.
+    const std::string magic = field_str(block + 257, 6);
+    if (magic.rfind("ustar", 0) == 0) {
+        const std::string prefix = field_str(block + 345, 155);
+        if (!prefix.empty()) name = prefix + "/" + name;
+    }
+    out.name     = name;
+    out.linkname = field_str(block + 157, 100);
+    out.size     = size;
+    out.mode     = static_cast<unsigned>(mode) & 07777;
+    out.uid      = static_cast<unsigned>(uid);
+    out.gid      = static_cast<unsigned>(gid);
+    const char tf = block[156];
+    out.type = (tf == '\0') ? tar::kRegularA : tf;
+    return true;
+}
+
+WhiteoutKind classify_whiteout(const std::string& path, std::string& target_rel) {
+    const std::string base = basename_of(path);
+    const std::string dir  = dirname_of(path);
+    static const std::string opq = ".wh..wh..opq";
+    static const std::string pre = ".wh.";
+
+    if (base == opq) {
+        target_rel = dir;                 // may be "" → the layer root itself
+        return WhiteoutKind::Opaque;
+    }
+    if (base.size() > pre.size() && base.compare(0, pre.size(), pre) == 0) {
+        const std::string real = base.substr(pre.size());
+        target_rel = dir.empty() ? real : dir + "/" + real;
+        return WhiteoutKind::Remove;
+    }
+    target_rel.clear();
+    return WhiteoutKind::None;
+}
+
+std::string safe_rel_path(const std::string& name) {
+    std::vector<std::string> out;
+    std::string comp;
+    std::stringstream ss(name);
+    while (std::getline(ss, comp, '/')) {
+        if (comp.empty() || comp == ".") continue;
+        if (comp == "..") return {};      // traversal — reject the whole path
+        out.push_back(comp);
+    }
+    std::string joined;
+    for (std::size_t i = 0; i < out.size(); ++i) {
+        if (i) joined += '/';
+        joined += out[i];
+    }
+    return joined;                        // "" when the name was "."/"./"/empty
+}
+
+std::string overlay_lowerdir(const std::vector<std::string>& layer_dirs_base_to_top) {
+    std::string out;
+    // overlayfs wants the highest-priority (topmost) layer first.
+    for (auto it = layer_dirs_base_to_top.rbegin(); it != layer_dirs_base_to_top.rend(); ++it) {
+        if (!out.empty()) out += ':';
+        out += *it;
+    }
+    return out;
+}
+
+} // namespace containers

--- a/modules/containers/src/registry.cpp
+++ b/modules/containers/src/registry.cpp
@@ -1,0 +1,198 @@
+#include "registry.hpp"
+
+#include <algorithm>
+#include <cctype>
+
+#include <nlohmann/json.hpp>
+
+namespace containers {
+
+namespace {
+
+using json = nlohmann::json;
+
+std::string to_lower(std::string s) {
+    std::transform(s.begin(), s.end(), s.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return s;
+}
+
+// Extract `key=value` from a challenge fragment. Value may be double-quoted
+// ("realm=\"https://...\"") or a bare token up to the next comma/space.
+std::string extract_param(const std::string& s, const std::string& key) {
+    const std::string needle = key + "=";
+    auto pos = s.find(needle);
+    if (pos == std::string::npos) return {};
+    pos += needle.size();
+    if (pos < s.size() && s[pos] == '"') {
+        ++pos;
+        auto end = s.find('"', pos);
+        if (end == std::string::npos) return {};
+        return s.substr(pos, end - pos);
+    }
+    auto end = s.find_first_of(", \t", pos);
+    return s.substr(pos, end == std::string::npos ? std::string::npos : end - pos);
+}
+
+// Conservative URL-encoding: percent-encode anything outside a safe set. The
+// safe set keeps the characters Docker scope/service strings rely on
+// (':' '/' etc.) intact while escaping spaces and other unsafe bytes.
+std::string url_encode(const std::string& s) {
+    static const std::string safe =
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        "-._~:/?&=,+@";
+    std::string out;
+    out.reserve(s.size());
+    for (unsigned char c : s) {
+        if (safe.find(static_cast<char>(c)) != std::string::npos) {
+            out.push_back(static_cast<char>(c));
+        } else {
+            static const char* hex = "0123456789ABCDEF";
+            out.push_back('%');
+            out.push_back(hex[c >> 4]);
+            out.push_back(hex[c & 0x0F]);
+        }
+    }
+    return out;
+}
+
+Descriptor parse_descriptor(const json& d) {
+    Descriptor out;
+    if (d.contains("mediaType") && d["mediaType"].is_string())
+        out.media_type = d["mediaType"].get<std::string>();
+    if (d.contains("digest") && d["digest"].is_string())
+        out.digest = d["digest"].get<std::string>();
+    if (d.contains("size") && d["size"].is_number_integer())
+        out.size = d["size"].get<long long>();
+    return out;
+}
+
+} // namespace
+
+BearerChallenge parse_bearer_challenge(const std::string& www_authenticate) {
+    BearerChallenge c;
+    const std::string lower = to_lower(www_authenticate);
+    auto bpos = lower.find("bearer");
+    if (bpos == std::string::npos) return c;       // no Bearer scheme
+    // Params are case-insensitive keys with original-case values; extract from
+    // the original string starting at the Bearer position.
+    const std::string frag = www_authenticate.substr(bpos);
+    c.realm   = extract_param(frag, "realm");
+    c.service = extract_param(frag, "service");
+    c.scope   = extract_param(frag, "scope");
+    c.ok = !c.realm.empty();
+    return c;
+}
+
+std::string build_token_url(const BearerChallenge& c) {
+    if (c.realm.empty()) return {};
+    std::string url = c.realm;
+    char sep = (url.find('?') == std::string::npos) ? '?' : '&';
+    if (!c.service.empty()) {
+        url += sep;
+        url += "service=" + url_encode(c.service);
+        sep = '&';
+    }
+    if (!c.scope.empty()) {
+        url += sep;
+        url += "scope=" + url_encode(c.scope);
+    }
+    return url;
+}
+
+std::string parse_token_response(const std::string& body) {
+    try {
+        auto j = json::parse(body);
+        if (j.contains("token") && j["token"].is_string())
+            return j["token"].get<std::string>();
+        if (j.contains("access_token") && j["access_token"].is_string())
+            return j["access_token"].get<std::string>();
+    } catch (...) {
+    }
+    return {};
+}
+
+bool manifest_is_index(const std::string& body) {
+    try {
+        auto j = json::parse(body);
+        return j.contains("manifests") && j["manifests"].is_array();
+    } catch (...) {
+        return false;
+    }
+}
+
+std::vector<PlatformDescriptor> parse_manifest_index(const std::string& body) {
+    std::vector<PlatformDescriptor> out;
+    try {
+        auto j = json::parse(body);
+        if (!j.contains("manifests") || !j["manifests"].is_array()) return out;
+        for (const auto& m : j["manifests"]) {
+            PlatformDescriptor p;
+            static_cast<Descriptor&>(p) = parse_descriptor(m);
+            if (m.contains("platform") && m["platform"].is_object()) {
+                const auto& pl = m["platform"];
+                if (pl.contains("os") && pl["os"].is_string())
+                    p.os = pl["os"].get<std::string>();
+                if (pl.contains("architecture") && pl["architecture"].is_string())
+                    p.arch = pl["architecture"].get<std::string>();
+                if (pl.contains("variant") && pl["variant"].is_string())
+                    p.variant = pl["variant"].get<std::string>();
+            }
+            // Skip attestation / "unknown" placeholder manifests.
+            if (p.os == "unknown" || p.arch == "unknown") continue;
+            out.push_back(std::move(p));
+        }
+    } catch (...) {
+        out.clear();
+    }
+    return out;
+}
+
+int select_platform(const std::vector<PlatformDescriptor>& entries,
+                    const std::string& os, const std::string& arch,
+                    const std::string& variant) {
+    int fallback = -1;
+    for (std::size_t i = 0; i < entries.size(); ++i) {
+        const auto& e = entries[i];
+        if (e.os != os || e.arch != arch) continue;
+        if (e.variant == variant) return static_cast<int>(i);  // exact
+        // os+arch match with a differing variant — remember the first as a
+        // fallback (covers want-variant="" vs an entry tagged e.g. "v8").
+        if (fallback < 0) fallback = static_cast<int>(i);
+    }
+    return fallback;
+}
+
+ImageManifest parse_image_manifest(const std::string& body) {
+    ImageManifest out;
+    try {
+        auto j = json::parse(body);
+        if (!j.contains("config") || !j.contains("layers")) return out;
+        out.config = parse_descriptor(j["config"]);
+        for (const auto& l : j["layers"])
+            out.layers.push_back(parse_descriptor(l));
+        out.ok = !out.config.digest.empty();
+    } catch (...) {
+        out = ImageManifest{};
+    }
+    return out;
+}
+
+bool is_valid_digest(const std::string& digest) {
+    static const std::string prefix = "sha256:";
+    if (digest.size() != prefix.size() + 64) return false;
+    if (digest.compare(0, prefix.size(), prefix) != 0) return false;
+    for (std::size_t i = prefix.size(); i < digest.size(); ++i) {
+        char c = digest[i];
+        bool hex = (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f');
+        if (!hex) return false;
+    }
+    return true;
+}
+
+std::string blob_path(const std::string& root, const std::string& digest) {
+    if (!is_valid_digest(digest)) return {};
+    return root + "/blobs/sha256/" + digest.substr(7);
+}
+
+} // namespace containers

--- a/modules/containers/test/image_ref_test.cpp
+++ b/modules/containers/test/image_ref_test.cpp
@@ -1,0 +1,98 @@
+#include <gtest/gtest.h>
+
+#include "image_ref.hpp"
+
+using containers::ImageRef;
+using containers::parse_image_ref;
+
+TEST(ImageRef, BareNameDefaultsToDockerHubLibraryLatest) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("nginx", r));
+    EXPECT_EQ(r.registry, "registry-1.docker.io");
+    EXPECT_EQ(r.repository, "library/nginx");
+    EXPECT_EQ(r.tag, "latest");
+    EXPECT_TRUE(r.digest.empty());
+}
+
+TEST(ImageRef, NameWithTag) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("nginx:1.25", r));
+    EXPECT_EQ(r.registry, "registry-1.docker.io");
+    EXPECT_EQ(r.repository, "library/nginx");
+    EXPECT_EQ(r.tag, "1.25");
+}
+
+TEST(ImageRef, DockerHubOrgRepoKeepsBothSegments) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("grafana/grafana:10.0.0", r));
+    EXPECT_EQ(r.registry, "registry-1.docker.io");
+    EXPECT_EQ(r.repository, "grafana/grafana");   // no implicit library/
+    EXPECT_EQ(r.tag, "10.0.0");
+}
+
+TEST(ImageRef, ExplicitDockerIoIsRewritten) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("docker.io/library/nginx:latest", r));
+    EXPECT_EQ(r.registry, "registry-1.docker.io");
+    EXPECT_EQ(r.repository, "library/nginx");
+    EXPECT_EQ(r.tag, "latest");
+}
+
+TEST(ImageRef, ThirdPartyRegistry) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("ghcr.io/owner/app:dev", r));
+    EXPECT_EQ(r.registry, "ghcr.io");
+    EXPECT_EQ(r.repository, "owner/app");
+    EXPECT_EQ(r.tag, "dev");
+}
+
+TEST(ImageRef, RegistryWithPortIsNotMistakenForTag) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("localhost:5000/team/app:1", r));
+    EXPECT_EQ(r.registry, "localhost:5000");
+    EXPECT_EQ(r.repository, "team/app");
+    EXPECT_EQ(r.tag, "1");
+}
+
+TEST(ImageRef, RegistryWithPortAndNoTagDefaultsLatest) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("localhost:5000/app", r));
+    EXPECT_EQ(r.registry, "localhost:5000");
+    EXPECT_EQ(r.repository, "app");
+    EXPECT_EQ(r.tag, "latest");
+}
+
+TEST(ImageRef, DigestPinHasNoDefaultTag) {
+    const std::string ref =
+        "nginx@sha256:0000000000000000000000000000000000000000000000000000000000000000";
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref(ref, r));
+    EXPECT_EQ(r.repository, "library/nginx");
+    EXPECT_TRUE(r.tag.empty());
+    EXPECT_EQ(r.digest,
+              "sha256:0000000000000000000000000000000000000000000000000000000000000000");
+}
+
+TEST(ImageRef, RegistryRepoDigestPin) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("ghcr.io/owner/app@sha256:abc", r));
+    EXPECT_EQ(r.registry, "ghcr.io");
+    EXPECT_EQ(r.repository, "owner/app");
+    EXPECT_TRUE(r.tag.empty());
+    EXPECT_EQ(r.digest, "sha256:abc");
+}
+
+TEST(ImageRef, EmptyIsRejected) {
+    ImageRef r;
+    EXPECT_FALSE(parse_image_ref("", r));
+}
+
+TEST(ImageRef, TrailingColonIsRejected) {
+    ImageRef r;
+    EXPECT_FALSE(parse_image_ref("nginx:", r));
+}
+
+TEST(ImageRef, TrailingAtIsRejected) {
+    ImageRef r;
+    EXPECT_FALSE(parse_image_ref("nginx@", r));
+}

--- a/modules/containers/test/oci_bundle_test.cpp
+++ b/modules/containers/test/oci_bundle_test.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <nlohmann/json.hpp>
+
+#include "oci_bundle.hpp"
+
+using namespace containers;
+using json = nlohmann::json;
+
+// ── image config parse ─────────────────────────────────────────────────────
+TEST(ImageConfig, ParsesNestedConfig) {
+    const char* body = R"({
+      "architecture":"arm64","os":"linux",
+      "config":{
+        "Env":["PATH=/usr/bin","FOO=bar"],
+        "Entrypoint":["/entry.sh"],
+        "Cmd":["-g","daemon off;"],
+        "WorkingDir":"/app",
+        "User":"1000:2000"
+      }
+    })";
+    auto c = parse_image_config(body);
+    ASSERT_TRUE(c.ok);
+    EXPECT_EQ(c.env.size(), 2u);
+    EXPECT_EQ(c.entrypoint, (std::vector<std::string>{"/entry.sh"}));
+    EXPECT_EQ(c.cmd, (std::vector<std::string>{"-g", "daemon off;"}));
+    EXPECT_EQ(c.working_dir, "/app");
+    EXPECT_EQ(c.user, "1000:2000");
+}
+
+TEST(ImageConfig, GarbageNotOk) {
+    EXPECT_FALSE(parse_image_config("nope").ok);
+}
+
+// ── args field parse ───────────────────────────────────────────────────────
+TEST(ArgsField, JsonArray) {
+    EXPECT_EQ(parse_args_field(R"(["nginx","-g","daemon off;"])"),
+              (std::vector<std::string>{"nginx", "-g", "daemon off;"}));
+}
+TEST(ArgsField, WhitespaceSplit) {
+    EXPECT_EQ(parse_args_field("echo hello world"),
+              (std::vector<std::string>{"echo", "hello", "world"}));
+}
+TEST(ArgsField, EmptyIsEmpty) {
+    EXPECT_TRUE(parse_args_field("   ").empty());
+}
+
+// ── arg resolution ─────────────────────────────────────────────────────────
+TEST(ResolveArgs, ImageDefaults) {
+    auto a = resolve_process_args({"/entry"}, {"--default"}, {}, false, {}, false);
+    EXPECT_EQ(a, (std::vector<std::string>{"/entry", "--default"}));
+}
+TEST(ResolveArgs, CmdOverrideOnly) {
+    // `docker run img CMD...` — image entrypoint + override cmd.
+    auto a = resolve_process_args({"/entry"}, {"--default"}, {}, false, {"run", "now"}, true);
+    EXPECT_EQ(a, (std::vector<std::string>{"/entry", "run", "now"}));
+}
+TEST(ResolveArgs, EntrypointOverride) {
+    auto a = resolve_process_args({"/entry"}, {"--default"}, {"/sh"}, true, {}, false);
+    EXPECT_EQ(a, (std::vector<std::string>{"/sh", "--default"}));
+}
+
+// ── limits ─────────────────────────────────────────────────────────────────
+TEST(Limits, Memory) {
+    EXPECT_EQ(parse_mem_limit("256M"), 256LL * 1024 * 1024);
+    EXPECT_EQ(parse_mem_limit("1g"), 1024LL * 1024 * 1024);
+    EXPECT_EQ(parse_mem_limit("536870912"), 536870912LL);
+    EXPECT_EQ(parse_mem_limit(""), 0);
+    EXPECT_EQ(parse_mem_limit("lots"), 0);
+}
+TEST(Limits, CpuQuota) {
+    EXPECT_EQ(parse_cpu_quota("0.5", 100000), 50000);
+    EXPECT_EQ(parse_cpu_quota("2", 100000), 200000);
+    EXPECT_EQ(parse_cpu_quota("", 100000), 0);
+    EXPECT_EQ(parse_cpu_quota("0", 100000), 0);
+}
+TEST(Limits, User) {
+    unsigned uid = 9, gid = 9;
+    resolve_user("1000:2000", uid, gid);
+    EXPECT_EQ(uid, 1000u);
+    EXPECT_EQ(gid, 2000u);
+    resolve_user("1000", uid, gid);
+    EXPECT_EQ(uid, 1000u);
+    EXPECT_EQ(gid, 0u);
+    resolve_user("root", uid, gid);   // named → 0:0 (v1)
+    EXPECT_EQ(uid, 0u);
+    EXPECT_EQ(gid, 0u);
+}
+
+// ── config.json generation ─────────────────────────────────────────────────
+TEST(OciConfig, HostNetAndArgsAndLimits) {
+    OciSpec s;
+    s.args = {"/bin/sh", "-c", "echo hi"};
+    s.env = {"FOO=bar"};
+    s.cwd = "/app";
+    s.uid = 1000;
+    s.gid = 1000;
+    s.mem_limit_bytes = 256LL * 1024 * 1024;
+    s.cpu_quota = 50000;
+    auto out = generate_oci_config(s);
+    auto j = json::parse(out);
+
+    EXPECT_EQ(j["process"]["args"], json::array({"/bin/sh", "-c", "echo hi"}));
+    EXPECT_EQ(j["process"]["cwd"], "/app");
+    EXPECT_EQ(j["process"]["user"]["uid"], 1000);
+    EXPECT_EQ(j["root"]["path"], "rootfs");
+    EXPECT_EQ(j["process"]["noNewPrivileges"], true);
+
+    // host networking: there must be NO network namespace.
+    bool has_net = false;
+    for (const auto& n : j["linux"]["namespaces"])
+        if (n["type"] == "network") has_net = true;
+    EXPECT_FALSE(has_net);
+
+    EXPECT_EQ(j["linux"]["resources"]["memory"]["limit"], 256LL * 1024 * 1024);
+    EXPECT_EQ(j["linux"]["resources"]["cpu"]["quota"], 50000);
+    EXPECT_EQ(j["linux"]["resources"]["cpu"]["period"], 100000);
+}
+
+TEST(OciConfig, NoLimitsOmitsResources) {
+    OciSpec s;
+    s.args = {"/bin/true"};
+    auto j = json::parse(generate_oci_config(s));
+    // resources object absent (or without memory/cpu) when unbounded.
+    if (j["linux"].contains("resources")) {
+        EXPECT_FALSE(j["linux"]["resources"].contains("memory"));
+        EXPECT_FALSE(j["linux"]["resources"].contains("cpu"));
+    }
+    // empty env → a default PATH is injected.
+    bool has_path = false;
+    for (const auto& e : j["process"]["env"])
+        if (e.get<std::string>().rfind("PATH=", 0) == 0) has_path = true;
+    EXPECT_TRUE(has_path);
+}

--- a/modules/containers/test/oci_layer_test.cpp
+++ b/modules/containers/test/oci_layer_test.cpp
@@ -1,0 +1,134 @@
+#include <gtest/gtest.h>
+
+#include <cstring>
+#include <string>
+
+#include "oci_layer.hpp"
+
+using namespace containers;
+
+namespace {
+
+// Build a minimal ustar header block for tests.
+std::string make_header(const std::string& name, long long size, char type,
+                        const std::string& linkname = "",
+                        const std::string& prefix = "",
+                        unsigned mode = 0644) {
+    std::string b(tar::kBlockSize, '\0');
+    auto put = [&](std::size_t off, const std::string& s, std::size_t max) {
+        std::memcpy(&b[off], s.data(), std::min(s.size(), max));
+    };
+    auto put_octal = [&](std::size_t off, long long v, std::size_t width) {
+        // width-1 octal digits, NUL-terminated (classic tar field).
+        char buf[32];
+        std::snprintf(buf, sizeof buf, "%0*llo", static_cast<int>(width - 1), v);
+        put(off, buf, width - 1);
+    };
+    put(0, name, 100);
+    put_octal(100, mode, 8);
+    put_octal(124, size, 12);
+    b[156] = type;
+    put(157, linkname, 100);
+    put(257, "ustar", 6);
+    put(263, "00", 2);
+    if (!prefix.empty()) put(345, prefix, 155);
+    return b;
+}
+
+} // namespace
+
+// ── octal ──────────────────────────────────────────────────────────────────
+TEST(TarOctal, Basic) {
+    long long v = -1;
+    ASSERT_TRUE(parse_tar_octal("000644 \0", 8, v));
+    EXPECT_EQ(v, 0644);
+}
+TEST(TarOctal, EmptyIsZero) {
+    long long v = -1;
+    ASSERT_TRUE(parse_tar_octal("        ", 8, v));
+    EXPECT_EQ(v, 0);
+}
+TEST(TarOctal, RejectsNonOctal) {
+    long long v = 0;
+    EXPECT_FALSE(parse_tar_octal("12389\0\0\0", 8, v));
+}
+
+// ── header ───────────────────────────────────────────────────────────────
+TEST(TarHeader, RegularFile) {
+    auto h = make_header("etc/hostname", 5, tar::kRegular);
+    TarEntry e; bool zero = false;
+    ASSERT_TRUE(parse_tar_header(h.data(), e, zero));
+    EXPECT_FALSE(zero);
+    EXPECT_EQ(e.name, "etc/hostname");
+    EXPECT_EQ(e.size, 5);
+    EXPECT_EQ(e.type, tar::kRegular);
+    EXPECT_EQ(e.mode, 0644u);
+}
+TEST(TarHeader, UstarPrefixJoined) {
+    auto h = make_header("hostname", 0, tar::kRegular, "", "very/long/etc");
+    TarEntry e; bool zero = false;
+    ASSERT_TRUE(parse_tar_header(h.data(), e, zero));
+    EXPECT_EQ(e.name, "very/long/etc/hostname");
+}
+TEST(TarHeader, Symlink) {
+    auto h = make_header("bin/sh", 0, tar::kSymlink, "busybox");
+    TarEntry e; bool zero = false;
+    ASSERT_TRUE(parse_tar_header(h.data(), e, zero));
+    EXPECT_EQ(e.type, tar::kSymlink);
+    EXPECT_EQ(e.linkname, "busybox");
+}
+TEST(TarHeader, ZeroBlockIsEnd) {
+    std::string b(tar::kBlockSize, '\0');
+    TarEntry e; bool zero = false;
+    EXPECT_FALSE(parse_tar_header(b.data(), e, zero));
+    EXPECT_TRUE(zero);
+}
+
+// ── whiteouts ──────────────────────────────────────────────────────────────
+TEST(Whiteout, RemoveFile) {
+    std::string target;
+    EXPECT_EQ(classify_whiteout("usr/bin/.wh.oldtool", target), WhiteoutKind::Remove);
+    EXPECT_EQ(target, "usr/bin/oldtool");
+}
+TEST(Whiteout, RemoveAtRoot) {
+    std::string target;
+    EXPECT_EQ(classify_whiteout(".wh.toplevel", target), WhiteoutKind::Remove);
+    EXPECT_EQ(target, "toplevel");
+}
+TEST(Whiteout, OpaqueDir) {
+    std::string target;
+    EXPECT_EQ(classify_whiteout("var/cache/.wh..wh..opq", target), WhiteoutKind::Opaque);
+    EXPECT_EQ(target, "var/cache");
+}
+TEST(Whiteout, NormalIsNone) {
+    std::string target;
+    EXPECT_EQ(classify_whiteout("etc/passwd", target), WhiteoutKind::None);
+    // ".whatever" is NOT a whiteout — the prefix is exactly ".wh." (the 4th
+    // char must be a dot), so this is a normal dotfile.
+    EXPECT_EQ(classify_whiteout("etc/.whatever", target), WhiteoutKind::None);
+}
+
+// ── path safety ────────────────────────────────────────────────────────────
+TEST(SafePath, StripsLeadingDotSlash) {
+    EXPECT_EQ(safe_rel_path("./etc/hostname"), "etc/hostname");
+    EXPECT_EQ(safe_rel_path("/etc/hostname"), "etc/hostname");
+}
+TEST(SafePath, RejectsTraversal) {
+    EXPECT_EQ(safe_rel_path("../etc/shadow"), "");
+    EXPECT_EQ(safe_rel_path("a/../../b"), "");
+    EXPECT_EQ(safe_rel_path("a/b/../c"), "");   // any ".." rejected (conservative)
+}
+TEST(SafePath, RootIsEmpty) {
+    EXPECT_EQ(safe_rel_path("."), "");
+    EXPECT_EQ(safe_rel_path("./"), "");
+}
+
+// ── overlay lowerdir ordering ──────────────────────────────────────────────
+TEST(Overlay, TopLayerFirst) {
+    // OCI order is base → top; overlay wants top first.
+    std::vector<std::string> dirs = {"/l/base", "/l/mid", "/l/top"};
+    EXPECT_EQ(overlay_lowerdir(dirs), "/l/top:/l/mid:/l/base");
+}
+TEST(Overlay, SingleLayer) {
+    EXPECT_EQ(overlay_lowerdir({"/l/only"}), "/l/only");
+}

--- a/modules/containers/test/registry_test.cpp
+++ b/modules/containers/test/registry_test.cpp
@@ -1,0 +1,158 @@
+#include <gtest/gtest.h>
+
+#include "registry.hpp"
+
+using namespace containers;
+
+// ── Bearer challenge ───────────────────────────────────────────────────────
+TEST(Bearer, DockerHubChallenge) {
+    const std::string hdr =
+        "Www-Authenticate: Bearer realm=\"https://auth.docker.io/token\","
+        "service=\"registry.docker.io\","
+        "scope=\"repository:library/nginx:pull\"";
+    auto c = parse_bearer_challenge(hdr);
+    ASSERT_TRUE(c.ok);
+    EXPECT_EQ(c.realm, "https://auth.docker.io/token");
+    EXPECT_EQ(c.service, "registry.docker.io");
+    EXPECT_EQ(c.scope, "repository:library/nginx:pull");
+}
+
+TEST(Bearer, NoScopeIsOk) {
+    auto c = parse_bearer_challenge(
+        "Bearer realm=\"https://ghcr.io/token\",service=\"ghcr.io\"");
+    ASSERT_TRUE(c.ok);
+    EXPECT_EQ(c.realm, "https://ghcr.io/token");
+    EXPECT_TRUE(c.scope.empty());
+}
+
+TEST(Bearer, BasicSchemeIsNotBearer) {
+    auto c = parse_bearer_challenge("Www-Authenticate: Basic realm=\"x\"");
+    EXPECT_FALSE(c.ok);
+}
+
+TEST(Bearer, TokenUrlBuild) {
+    BearerChallenge c;
+    c.realm = "https://auth.docker.io/token";
+    c.service = "registry.docker.io";
+    c.scope = "repository:library/nginx:pull";
+    EXPECT_EQ(build_token_url(c),
+              "https://auth.docker.io/token?service=registry.docker.io"
+              "&scope=repository:library/nginx:pull");
+}
+
+TEST(Bearer, TokenUrlNoScope) {
+    BearerChallenge c;
+    c.realm = "https://ghcr.io/token";
+    c.service = "ghcr.io";
+    EXPECT_EQ(build_token_url(c), "https://ghcr.io/token?service=ghcr.io");
+}
+
+// ── Token response ─────────────────────────────────────────────────────────
+TEST(Token, TokenField) {
+    EXPECT_EQ(parse_token_response(R"({"token":"abc.def"})"), "abc.def");
+}
+TEST(Token, AccessTokenField) {
+    EXPECT_EQ(parse_token_response(R"({"access_token":"xyz"})"), "xyz");
+}
+TEST(Token, GarbageIsEmpty) {
+    EXPECT_EQ(parse_token_response("not json"), "");
+}
+
+// ── Manifest index / platform select ───────────────────────────────────────
+static const char* kIndex = R"({
+  "mediaType":"application/vnd.oci.image.index.v1+json",
+  "manifests":[
+    {"mediaType":"application/vnd.oci.image.manifest.v1+json",
+     "digest":"sha256:1111111111111111111111111111111111111111111111111111111111111111",
+     "size":111,"platform":{"os":"linux","architecture":"amd64"}},
+    {"mediaType":"application/vnd.oci.image.manifest.v1+json",
+     "digest":"sha256:2222222222222222222222222222222222222222222222222222222222222222",
+     "size":222,"platform":{"os":"linux","architecture":"arm64","variant":"v8"}},
+    {"mediaType":"application/vnd.oci.image.manifest.v1+json",
+     "digest":"sha256:3333333333333333333333333333333333333333333333333333333333333333",
+     "size":333,"platform":{"os":"unknown","architecture":"unknown"}}
+  ]
+})";
+
+TEST(Index, IsIndex) {
+    EXPECT_TRUE(manifest_is_index(kIndex));
+    EXPECT_FALSE(manifest_is_index(R"({"config":{},"layers":[]})"));
+}
+
+TEST(Index, ParseDropsUnknown) {
+    auto v = parse_manifest_index(kIndex);
+    ASSERT_EQ(v.size(), 2u);          // unknown/unknown attestation dropped
+    EXPECT_EQ(v[0].arch, "amd64");
+    EXPECT_EQ(v[1].arch, "arm64");
+    EXPECT_EQ(v[1].variant, "v8");
+}
+
+TEST(Index, SelectArm64FallsBackOverVariant) {
+    auto v = parse_manifest_index(kIndex);
+    // Want arm64 with empty variant; the entry is tagged v8 → fallback match.
+    int i = select_platform(v, "linux", "arm64", "");
+    ASSERT_GE(i, 0);
+    EXPECT_EQ(v[i].digest,
+        "sha256:2222222222222222222222222222222222222222222222222222222222222222");
+}
+
+TEST(Index, SelectExactAmd64) {
+    auto v = parse_manifest_index(kIndex);
+    int i = select_platform(v, "linux", "amd64", "");
+    ASSERT_GE(i, 0);
+    EXPECT_EQ(v[i].arch, "amd64");
+}
+
+TEST(Index, SelectMissingArchIsMinusOne) {
+    auto v = parse_manifest_index(kIndex);
+    EXPECT_EQ(select_platform(v, "linux", "riscv64", ""), -1);
+}
+
+// ── Image manifest ─────────────────────────────────────────────────────────
+TEST(Manifest, ParseConfigAndLayers) {
+    const char* m = R"({
+      "config":{"mediaType":"application/vnd.oci.image.config.v1+json",
+                "digest":"sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "size":7000},
+      "layers":[
+        {"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest":"sha256:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+         "size":100},
+        {"mediaType":"application/vnd.oci.image.layer.v1.tar+gzip",
+         "digest":"sha256:cccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc",
+         "size":200}
+      ]
+    })";
+    auto im = parse_image_manifest(m);
+    ASSERT_TRUE(im.ok);
+    EXPECT_EQ(im.config.size, 7000);
+    ASSERT_EQ(im.layers.size(), 2u);
+    EXPECT_EQ(im.layers[1].size, 200);
+}
+
+TEST(Manifest, IndexIsNotImageManifest) {
+    EXPECT_FALSE(parse_image_manifest(kIndex).ok);
+}
+
+// ── Digest validation + blob path (OTA \n-in-sha guard) ────────────────────
+TEST(Digest, ValidLowercase64) {
+    EXPECT_TRUE(is_valid_digest(
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"));
+}
+TEST(Digest, RejectsTrailingNewline) {
+    EXPECT_FALSE(is_valid_digest(
+        "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef\n"));
+}
+TEST(Digest, RejectsUppercaseAndShort) {
+    EXPECT_FALSE(is_valid_digest("sha256:ABCD"));
+    EXPECT_FALSE(is_valid_digest("sha256:zz"));
+    EXPECT_FALSE(is_valid_digest("md5:0123456789abcdef0123456789abcdef"));
+}
+TEST(Digest, BlobPath) {
+    EXPECT_EQ(
+        blob_path("/var/lib/iot-containers",
+            "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"),
+        "/var/lib/iot-containers/blobs/sha256/"
+        "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef");
+    EXPECT_EQ(blob_path("/x", "bogus"), "");
+}

--- a/packaging/systemd/iot-containerd.service
+++ b/packaging/systemd/iot-containerd.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=IoT single-container runtime shim (crun-backed; container.* in ds)
+Documentation=file:///usr/local/share/doc/iot/tdd-device-containers.md
+# Needs ds-server up (publishes container.* on connect; the daemon watches the
+# container.{pull,run,stop}.request command keys the device-ui bumps).
+After=network-online.target iot-ds.service
+Wants=iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+ExecStart=/usr/local/bin/iot-containerd
+
+# Runs as root: it mounts overlayfs for the container rootfs and drives crun,
+# which creates the namespaces + cgroups and execs the container. Delegate a
+# cgroup subtree so crun can manage the container's resource limits under this
+# unit's slice. The heavy ProtectControlGroups= / PrivateMounts= sandboxing the
+# producer daemons use is deliberately NOT applied here — it would block crun's
+# cgroup + mount operations.
+Delegate=yes
+
+# Storage lives in dedicated top-level paths created by tmpfiles.d (iot.conf):
+# the ephemeral overlay/bundle under /run/iot-containers and the persistent
+# image store under /var/lib/iot-containers. These are deliberately NOT under
+# /run/iot or /var/lib/iot — the latter is ds-server's DynamicUser
+# StateDirectory=iot, and RuntimeDirectory=iot would clobber the ds socket.
+
+Restart=on-failure
+RestartSec=10s
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/packaging/systemd/iot.conf
+++ b/packaging/systemd/iot.conf
@@ -9,3 +9,8 @@
 # Type Path                Mode UID  GID   Age Argument
 d      /run/iot            0755 root root  -   -
 d      /var/lib/iot        0750 root root  -   -
+# Container runtime store for iot-containerd (root). See the yocto files/ copy
+# for the full rationale (kept off /var/lib/iot to avoid the ds-server
+# StateDirectory=iot migration).
+d      /var/lib/iot-containers 0700 root root - -
+d      /run/iot-containers     0700 root root - -

--- a/yocto/Containerfile
+++ b/yocto/Containerfile
@@ -62,6 +62,8 @@ ARG RPI_BRANCH=scarthgap
 # to bblayers for IOT_AB=1 builds (entrypoint.sh), so the default single-rootfs
 # image is unaffected.
 ARG RAUC_BRANCH=scarthgap
+# meta-virtualization provides crun, the OCI runtime iot-containerd drives.
+ARG VIRT_BRANCH=scarthgap
 
 RUN git clone --depth=1 -b ${POKY_BRANCH} \
         https://git.yoctoproject.org/poky && \
@@ -69,6 +71,8 @@ RUN git clone --depth=1 -b ${POKY_BRANCH} \
         https://git.openembedded.org/meta-openembedded && \
     git clone --depth=1 -b ${RPI_BRANCH} \
         https://git.yoctoproject.org/meta-raspberrypi && \
+    git clone --depth=1 -b ${VIRT_BRANCH} \
+        https://git.yoctoproject.org/meta-virtualization && \
     git clone --depth=1 -b ${RAUC_BRANCH} \
         https://github.com/rauc/meta-rauc && \
     git clone --depth=1 -b ${RAUC_BRANCH} \

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -37,6 +37,11 @@ echo "→ Adding layers ..."
 bitbake-layers add-layer ../meta-openembedded/meta-oe
 bitbake-layers add-layer ../meta-openembedded/meta-python
 bitbake-layers add-layer ../meta-openembedded/meta-networking
+# meta-filesystems + meta-virtualization: provide crun, the OCI runtime
+# iot-containerd drives. meta-virtualization LAYERDEPENDS on meta-oe, meta-python,
+# meta-networking (added above) and meta-filesystems, so add that first.
+bitbake-layers add-layer ../meta-openembedded/meta-filesystems
+bitbake-layers add-layer ../meta-virtualization
 # meta-raspberrypi provides the raspberrypi3-64 MACHINE, bootfiles,
 # pi-bluetooth, and the rpidistro Wi-Fi firmware. Harmless for the qemu
 # machines (only its recipes for the selected MACHINE are pulled in).

--- a/yocto/kas-iot.yml
+++ b/yocto/kas-iot.yml
@@ -35,6 +35,7 @@ repos:
 
   # meta-openembedded — lua, nlohmann-json, gtest, openvpn (networking).
   # meta-networking depends on meta-python, so both are enabled.
+  # meta-filesystems is a meta-virtualization dependency (filesystems-layer).
   meta-openembedded:
     url: https://git.openembedded.org/meta-openembedded
     refspec: scarthgap
@@ -42,6 +43,16 @@ repos:
       meta-oe:
       meta-python:
       meta-networking:
+      meta-filesystems:
+
+  # meta-virtualization — provides crun, the small OCI runtime iot-containerd
+  # drives. LAYERDEPENDS: core, meta-oe, meta-python, meta-networking,
+  # meta-filesystems (all enabled above).
+  meta-virtualization:
+    url: https://git.yoctoproject.org/meta-virtualization
+    refspec: scarthgap
+    layers:
+      meta-virtualization:
 
   # meta-raspberrypi — raspberrypi3-64 MACHINE, bootfiles, pi-bluetooth,
   # and the rpidistro onboard Wi-Fi/Bluetooth firmware.

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
@@ -29,3 +29,6 @@ enable iot-ota-confirm.service
 enable iot-reboot.path
 enable iot-factory-reset.path
 enable iot-transfer.path
+# iot-containerd: single-container runtime shim. Enabled so the device-ui
+# container feature works out of the box; idle until an Admin issues a pull/run.
+enable iot-containerd.service

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-containerd.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-containerd.service
@@ -1,0 +1,36 @@
+[Unit]
+Description=IoT single-container runtime shim (crun-backed; container.* in ds)
+Documentation=file:///usr/local/share/doc/iot/tdd-device-containers.md
+# Needs ds-server up (publishes container.* on connect; the daemon watches the
+# container.{pull,run,stop}.request command keys the device-ui bumps).
+After=network-online.target iot-ds.service
+Wants=iot-ds.service
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+ExecStart=/usr/bin/iot-containerd
+
+# Runs as root: it mounts overlayfs for the container rootfs and drives crun,
+# which creates the namespaces + cgroups and execs the container. Delegate a
+# cgroup subtree so crun can manage the container's resource limits under this
+# unit's slice. The heavy ProtectControlGroups= / PrivateMounts= sandboxing the
+# producer daemons use is deliberately NOT applied here — it would block crun's
+# cgroup + mount operations.
+Delegate=yes
+
+# Storage lives in dedicated top-level paths created by tmpfiles.d (iot.conf):
+# the ephemeral overlay/bundle under /run/iot-containers and the persistent
+# image store under /var/lib/iot-containers. These are deliberately NOT under
+# /run/iot or /var/lib/iot — the latter is ds-server's DynamicUser
+# StateDirectory=iot, and RuntimeDirectory=iot would clobber the ds socket.
+
+Restart=on-failure
+RestartSec=10s
+
+StandardOutput=journal
+StandardError=journal
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot.conf
@@ -33,3 +33,11 @@ d      /run/wpa_supplicant 2775 root iot  -   -
 # engineer:iot — engineer owns + writes, setgid so files inherit group iot, and
 # group r-x lets openvpn traverse + read (the key is written group-readable).
 d      /etc/iot/vpn        2750 engineer iot - -
+# Container runtime store for iot-containerd (runs as root). Dedicated top-level
+# dirs — deliberately NOT under /var/lib/iot (ds-server's DynamicUser
+# StateDirectory=iot, which systemd would migrate to /var/lib/private/iot) nor
+# under the group-iot /run/iot. 0700 root:root: only the root daemon needs them.
+# /var/lib/iot-containers persists pulled images/layers; /run/iot-containers
+# holds the ephemeral overlay merged-rootfs + OCI bundle (lost on reboot).
+d      /var/lib/iot-containers 0700 root root - -
+d      /run/iot-containers     0700 root root - -

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -38,6 +38,7 @@ SRC_URI = "\
     file://iot-cellular-client.service \
     file://iot-vehicled.service \
     file://iot-can0-up.service \
+    file://iot-containerd.service \
     file://iot-mqttd.service \
     file://10-iot-wired.network \
     file://iot-wifi-client.service \
@@ -341,6 +342,10 @@ do_install() {
         # vehicle/CAN-equipped units. iot-vehicled Wants= iot-can0-up (brings up can0).
         install -m 0644 ${WORKDIR}/iot-vehicled.service        ${D}${systemd_system_unitdir}/
         install -m 0644 ${WORKDIR}/iot-can0-up.service         ${D}${systemd_system_unitdir}/
+        # iot-containerd: single-container runtime shim (crun-backed). Runs as
+        # root (mounts overlayfs + drives crun). Enabled by default — idle until
+        # the device-ui issues a pull/run command; needs crun (RDEPENDS).
+        install -m 0644 ${WORKDIR}/iot-containerd.service      ${D}${systemd_system_unitdir}/
         # iot-mqttd: MQTT telemetry mirror. Enabled by default but parks until a
         # broker is configured (mqtt.broker.host), so it is harmless when unused.
         install -m 0644 ${WORKDIR}/iot-mqttd.service           ${D}${systemd_system_unitdir}/
@@ -424,6 +429,7 @@ PACKAGE_BEFORE_PN = "\
     ${PN}-sensord \
     ${PN}-cellular \
     ${PN}-vehicle \
+    ${PN}-containerd \
     ${PN}-mqtt \
     ${PN}-config \
     ${PN}-bcm2837-selftest \
@@ -613,6 +619,23 @@ RRECOMMENDS:${PN}-vehicle = "\
     ${PN}-config \
 "
 
+# containerd — iot-containerd single-container runtime shim. Pulls an OCI image,
+# mounts its layers (overlayfs) and drives crun, publishing container.* to ds for
+# the device-ui. Runs as root. container.lua schema ships in ${PN}-config.
+# RDEPENDS crun (from meta-virtualization). See apps/docs/tdd-device-containers.md.
+FILES:${PN}-containerd = "\
+    ${bindir}/iot-containerd \
+    ${systemd_system_unitdir}/iot-containerd.service \
+"
+# curl: the registry-v2 HTTP transport (puller shells out to it, like the OTA
+# path). openssl: libcrypto for blob sha256. zlib: gzip layer decompression.
+# (openssl/zlib are also auto-added by the shlib scan; listed for clarity.)
+RDEPENDS:${PN}-containerd = "ace-tao crun curl openssl zlib"
+RRECOMMENDS:${PN}-containerd = "\
+    ${PN}-ds-server \
+    ${PN}-config \
+"
+
 # mqtt — iot-mqttd telemetry mirror to an operator MQTT broker (libmosquitto).
 # Enabled by default; parks until mqtt.broker.host is configured. mqtt.lua
 # schema ships in ${PN}-config.
@@ -690,6 +713,13 @@ SYSTEMD_AUTO_ENABLE:${PN}-cellular = "disable"
 # enables it on vehicle/CAN-equipped hardware (Wants= pulls in iot-can0-up).
 SYSTEMD_SERVICE:${PN}-vehicle = "iot-vehicled.service iot-can0-up.service"
 SYSTEMD_AUTO_ENABLE:${PN}-vehicle = "disable"
+# containerd enabled by default so the device-ui container feature works out of
+# the box. It is idle (just watches ds) until an Admin issues a pull/run, so it
+# is a no-op on devices that never use it. Listed in 90-iot.preset so preset-all
+# keeps it enabled. Needs the kernel features (overlayfs, namespaces, cgroups)
+# the linux-raspberrypi container.cfg fragment turns on, plus crun (RDEPENDS).
+SYSTEMD_SERVICE:${PN}-containerd = "iot-containerd.service"
+SYSTEMD_AUTO_ENABLE:${PN}-containerd = "enable"
 # mqtt mirror enabled by default — it parks (no broker connection) until
 # mqtt.broker.host is configured, so it is a no-op until the operator sets it up.
 SYSTEMD_SERVICE:${PN}-mqtt = "iot-mqttd.service"

--- a/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
+++ b/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
@@ -41,11 +41,15 @@ RDEPENDS:${PN}-full = "\
     iot-bcm2837-selftest \
     iot-sensord \
     iot-cellular \
+    iot-containerd \
     openvpn \
     nftables \
     iproute2 \
     wpa-supplicant \
+    crun \
 "
+# crun: the OCI runtime iot-containerd shells out to (from meta-virtualization).
+# Also pulled transitively via RDEPENDS:iot-containerd, listed here explicitly.
 # Note: no wireless-tools (iwconfig/iwlist) — it was dropped from modern
 # Yocto and the wifi-client daemon never used it; scanning goes through
 # wpa_cli. The DHCP client comes from the recipe's

--- a/yocto/meta-iot/recipes-kernel/linux/files/container.cfg
+++ b/yocto/meta-iot/recipes-kernel/linux/files/container.cfg
@@ -1,0 +1,29 @@
+# Container runtime kernel requirements (crun + iot-containerd).
+# See apps/docs/tdd-device-containers.md.
+
+# Overlay filesystem — the container's merged rootfs (lower image layers +
+# ephemeral upper) is an overlayfs mount.
+CONFIG_OVERLAY_FS=y
+
+# Namespaces — isolation for the container process (crun unshares these; the
+# network namespace is intentionally NOT used in v1: host networking).
+CONFIG_NAMESPACES=y
+CONFIG_UTS_NS=y
+CONFIG_IPC_NS=y
+CONFIG_PID_NS=y
+CONFIG_NET_NS=y
+CONFIG_USER_NS=y
+
+# Control groups — resource accounting + the memory/CPU caps the run form sets
+# (crun writes the container's cgroup under the unit's delegated subtree).
+CONFIG_CGROUPS=y
+CONFIG_MEMCG=y
+CONFIG_CPUSETS=y
+CONFIG_CGROUP_CPUACCT=y
+CONFIG_CGROUP_SCHED=y
+CONFIG_FAIR_GROUP_SCHED=y
+CONFIG_CFS_BANDWIDTH=y
+
+# Seccomp — crun applies a default syscall filter to the container.
+CONFIG_SECCOMP=y
+CONFIG_SECCOMP_FILTER=y

--- a/yocto/meta-iot/recipes-kernel/linux/linux-raspberrypi_%.bbappend
+++ b/yocto/meta-iot/recipes-kernel/linux/linux-raspberrypi_%.bbappend
@@ -1,0 +1,10 @@
+# Kernel config fragment for the on-device container runtime (crun +
+# iot-containerd): overlayfs for the container rootfs, the namespaces + cgroup
+# controllers for isolation and the memory/CPU caps the run form sets, and
+# seccomp for crun's default syscall filter. Most of these are already enabled
+# in the raspberrypi3-64 defconfig — the fragment makes the requirement explicit
+# and is a no-op where the symbol is already set.
+# See apps/docs/tdd-device-containers.md.
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"
+
+SRC_URI += "file://container.cfg"


### PR DESCRIPTION
Adds a thin, **crun-backed** single-container runtime so an operator can pull an OCI/Docker image onto the device from the device-ui, mount its layers, and run/stop it with a custom CMD/Entrypoint and resource caps. Built for a 1 GB RPi3B on Yocto — **no Docker/Podman daemon**. Full design: `apps/docs/tdd-device-containers.md`.

## Architecture
```
device-ui /containers (Admin)
   │ db/set command keys · 2s db/get status poll
   ▼
data-store (container.*)  ◄── iot-containerd (root, ACE reactor)
                               ├ registry-v2 pull (curl, sha256-verified, cached)
                               ├ zlib gzip+tar extract → OCI-whiteout → overlayfs mount
                               ├ OCI bundle gen (host-net, default caps, cgroup limits)
                               └ crun create/start/state/kill/delete + supervision
                                     ▼ crun (meta-virtualization)
```

## What's here (phases 0–6)
- **`modules/containers/` core** (`containers_core`, **60 gtests**, host-testable, no ACE/network): image-ref parse · registry-v2 protocol (bearer challenge/token, manifest+index parse, arch select, digest validation) · OCI tar/whiteout/path-safety/overlay-order · OCI bundle gen (image-config parse, Docker arg resolution, mem/cpu/user, `config.json`).
- **`iot-containerd` daemon** (root, reactor-driven, ACE-only): `container.*` command/status plane · registry pull over `curl` on a worker thread · zlib gzip+tar layer extraction with OCI-whiteout→overlayfs conversion + `mount(2)` overlay · `crun` create/start/state/kill/delete + supervision (TERM→grace→KILL, shutdown-safe) · host networking · cgroup mem/cpu limits. Registry creds are **write-only** (cleared from ds after use).
- **device-ui**: Admin-gated **Containers** page (status datagrid, pull form, run form with CMD/Entrypoint + mem/cpu, Run/Stop) — Clarity, follows Project Rules 4 & 5.
- **Yocto/build**: `crun` via **meta-virtualization** (+ meta-filesystems) added to **both** the kas and Containerfile/entrypoint paths · `iot-containerd` packaged + enabled (preset) · kernel config fragment (overlayfs/namespaces/cgroups/seccomp) · dedicated tmpfiles dirs `/var/lib-containers` + `/run/iot-containers` (kept off the ds-server `StateDirectory`).

## Locked design decisions
crun + thin shim · OCI/Docker **registry pull** · **host networking** · **single container** (no reboot persistence) · persistent image store at `/var/lib-containers` · ds-key control plane · **mem+cpu caps** in the run form.

## Review notes / caveats
- **Not yet built or run** — there's no local C++ compiler or Node here, so this compile-checks only at **CI-on-main** (image workflows trigger on push to `main`, not PRs). The meta-virtualization layer add + kernel fragment surface only at the full image build.
- **Phase 7 (RPi hardware e2e)** is the remaining validation pass: pull→run→stop on the real kernel. Main unknowns: overlayfs + crun + **cgroups** (crun uses `--cgroup-manager cgroupfs` under the unit's `Delegate=yes`), and `/var/lib-containers` writability + SD space.
- Per-blob pull progress (not per-byte) and container exit code not captured (`crun state` doesn't expose it) — documented v1 limitations.
- Containerd is **enabled by default** (idle until commanded, Admin-gated UI). Flip `SYSTEMD_AUTO_ENABLE` + the preset line to make it opt-in if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)