### PR TITLE
feat(containers): bridge networking — give a container its own IP

### DIFF
--- a/apps/docs/tdd-device-containers.md
+++ b/apps/docs/tdd-device-containers.md
@@ -181,13 +181,49 @@ status long-poll only.
 
 ## 11. Open items / deferred
 
-- Multi-container, autostart/restart-policy, bridge networking, volume mounts,
-  image GC/pruning, registry mirror/offline tar import — all **post-v1**.
+- Multi-container, autostart/restart-policy, volume mounts, image GC/pruning,
+  registry mirror/offline tar import, container **port mapping** (DNAT) — all
+  **post-v1**.
 - Confirm RPi3B kernel already enables USER_NS + cgroup v2 hierarchy crun expects.
-- **Container IP:** with host networking the container shares the device's
-  network namespace — it has **no separate IP** (it uses the device's IP and
-  binds device ports directly). A per-container IP only exists under the
-  deferred bridge+NAT mode; until then the UI deliberately shows none.
+
+## 11a. Bridge networking (own container IP) — IMPLEMENTED
+
+Opt-in alternative to host networking, selected per-run via `container.net.mode`
+(`host` default | `bridge`). In bridge mode the container gets its **own IP**:
+- `generate_oci_config` adds a `network` namespace (own netns) instead of
+  omitting it.
+- `net_bridge` (daemon, root, via `ip`/`nft`): ensures a host bridge `iot-cni0`
+  (gateway `10.88.0.1`), enables IPv4 forwarding, installs a **scoped**
+  `inet iot_containers` nft table (postrouting masquerade for the subnet — never
+  touches net-router's `iot_router`), then creates a veth pair, attaches the
+  host end to the bridge and moves the peer into the container netns as `eth0`
+  with `10.88.0.2/24` + default route via the gateway. `crun create` → read pid
+  → `bridge_up(pid)` → publish `container.net.ip`/`.gateway` → `crun start`; teardown
+  on exit (`bridge_down` deletes the veth; the bridge + table persist).
+- Subnet overridable via `container.net.subnet` (a single /24; default
+  `10.88.0.0/24`). Single container ⇒ static `.2` (no IPAM).
+- UI: a **Network** select in the run form + a **Network**/**IP** row in the
+  status datagrid (shows `10.88.0.2` when bridge + running).
+- Kernel: `container.cfg` adds `BRIDGE`/`VETH`/`BRIDGE_NETFILTER`/`NF_NAT`.
+  `RDEPENDS` adds `iproute2`/`nftables`.
+- **Deferred within this:** container port mapping (host:port → container IP via
+  DNAT) and multi-container IPAM.
+
+### Bridge mode HW e2e (extends §12)
+
+```sh
+ds-cli set container.net.mode '"bridge"'
+ds-cli set container.image.ref '"docker.io/library/busybox:latest"'
+ds-cli set container.pull.request "$(date +%s)" ; ds-cli watch --count=30 container.state
+ds-cli set container.cmd '"sleep 600"'
+ds-cli set container.run.request "$(date +%s)" ; ds-cli watch --count=10 container.state
+ds-cli get container.net.ip container.net.gateway          # 10.88.0.2 / 10.88.0.1
+ip addr show iot-cni0                                       # bridge up, 10.88.0.1/24
+nft list table inet iot_containers                         # masquerade rule present
+crun --root /run/iot-containers/state exec c0 /bin/sh -c \
+  'ip addr show eth0; ping -c1 10.88.0.1; wget -qO- http://example.com | head -1'
+ds-cli set container.stop.request "$(date +%s)"            # veth torn down, net.ip cleared
+```
 
 ## 12. Phase 7 — hardware test recipe (RPi3B)
 

--- a/iot-ui/src/app/containers/containers.component.ts
+++ b/iot-ui/src/app/containers/containers.component.ts
@@ -37,6 +37,16 @@ import { ToastService } from '../../common/toast.service';
               <app-ds-hint *dsDebug key="container.image.size"></app-ds-hint></clr-dg-cell>
             <clr-dg-cell>{{ sizeLabel }}</clr-dg-cell>
           </clr-dg-row>
+          <clr-dg-row>
+            <clr-dg-cell>Network
+              <app-ds-hint *dsDebug key="container.net.mode"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell>{{ netMode === 'bridge' ? 'Bridge (own IP)' : 'Host (shared device IP)' }}</clr-dg-cell>
+          </clr-dg-row>
+          <clr-dg-row *ngIf="netIp">
+            <clr-dg-cell>IP
+              <app-ds-hint *dsDebug key="container.net.ip"></app-ds-hint></clr-dg-cell>
+            <clr-dg-cell><code>{{ netIp }}</code><span class="hint" *ngIf="netGateway"> · gw {{ netGateway }}</span></clr-dg-cell>
+          </clr-dg-row>
           <clr-dg-row *ngIf="state === 'running' && runPid">
             <clr-dg-cell>PID
               <app-ds-hint *dsDebug key="container.run.pid"></app-ds-hint></clr-dg-cell>
@@ -122,6 +132,17 @@ import { ToastService } from '../../common/toast.service';
             <input clrInput [(ngModel)]="limitCpus" placeholder="0.5" />
             <clr-control-helper *dsDebug><app-ds-hint key="container.limit.cpus"></app-ds-hint></clr-control-helper>
           </clr-input-container>
+          <clr-select-container>
+            <label>Network</label>
+            <select clrSelect [(ngModel)]="netMode">
+              <option value="host">Host (shared device IP)</option>
+              <option value="bridge">Bridge (own IP)</option>
+            </select>
+            <clr-control-helper *dsDebug><app-ds-hint key="container.net.mode"></app-ds-hint></clr-control-helper>
+          </clr-select-container>
+          <div></div>
+          <div></div>
+          <div></div>
           <div class="btn-cell">
             <button class="btn btn-success-outline" (click)="run()"
                     [disabled]="!canRun">
@@ -137,8 +158,10 @@ import { ToastService } from '../../common/toast.service';
         </div>
         <p class="hint">Entrypoint/CMD accept a JSON array
           (<code>["/bin/sh","-c","echo hi"]</code>) or a plain space-separated
-          string; leave blank to use the image defaults. Networking is shared
-          with the host. Memory/CPU are optional caps.</p>
+          string; leave blank to use the image defaults. Memory/CPU are optional
+          caps. <strong>Host</strong> networking shares the device's IP;
+          <strong>Bridge</strong> gives the container its own IP
+          (<code>10.88.0.2</code>) with masqueraded egress.</p>
       </ng-container>
 
       <ng-template #noAccess><p class="hint">You need Admin access to manage containers.</p></ng-template>
@@ -173,6 +196,8 @@ export class ContainersComponent implements OnInit, OnDestroy {
   imageSize = 0;
   runPid = '';
   runStarted = '';
+  netIp = '';
+  netGateway = '';
 
   // Form (loaded once; not overwritten by the poll so typing isn't clobbered).
   imageRef = '';
@@ -182,6 +207,7 @@ export class ContainersComponent implements OnInit, OnDestroy {
   cmd = '';
   limitMem = '';
   limitCpus = '';
+  netMode = 'host';
 
   private timer: ReturnType<typeof setInterval> | null = null;
 
@@ -190,10 +216,11 @@ export class ContainersComponent implements OnInit, OnDestroy {
     'container.pull.progress', 'container.pull.detail',
     'container.image.id', 'container.image.size',
     'container.run.pid', 'container.run.started',
+    'container.net.ip', 'container.net.gateway',
   ];
   private readonly CONFIG_KEYS = [
     'container.image.ref', 'container.entrypoint', 'container.cmd',
-    'container.limit.mem', 'container.limit.cpus',
+    'container.limit.mem', 'container.limit.cpus', 'container.net.mode',
   ];
 
   get isAdmin(): boolean { return this.session.isAdmin; }
@@ -248,6 +275,7 @@ export class ContainersComponent implements OnInit, OnDestroy {
         this.cmd        = String(d['container.cmd'] ?? '');
         this.limitMem   = String(d['container.limit.mem'] ?? '');
         this.limitCpus  = String(d['container.limit.cpus'] ?? '');
+        this.netMode    = String(d['container.net.mode'] ?? 'host') === 'bridge' ? 'bridge' : 'host';
       }
     });
     this.poll();
@@ -271,6 +299,8 @@ export class ContainersComponent implements OnInit, OnDestroy {
       this.imageSize    = Number(d['container.image.size']) || 0;
       this.runPid       = String(d['container.run.pid'] ?? '');
       this.runStarted   = String(d['container.run.started'] ?? '');
+      this.netIp        = String(d['container.net.ip'] ?? '');
+      this.netGateway   = String(d['container.net.gateway'] ?? '');
     });
   }
 
@@ -298,6 +328,7 @@ export class ContainersComponent implements OnInit, OnDestroy {
       { key: 'container.cmd', value: this.cmd },
       { key: 'container.limit.mem', value: this.limitMem },
       { key: 'container.limit.cpus', value: this.limitCpus },
+      { key: 'container.net.mode', value: this.netMode },
       { key: 'container.run.request', value: String(Date.now()) },
     ]).subscribe({
       next: (r) => { if (r.ok) this.toast.success('Starting container…'); else this.toast.error(r.err || 'Run failed'); },

--- a/modules/containers/CMakeLists.txt
+++ b/modules/containers/CMakeLists.txt
@@ -28,7 +28,8 @@ add_library(containers_core STATIC
     src/image_ref.cpp
     src/registry.cpp
     src/oci_layer.cpp
-    src/oci_bundle.cpp)
+    src/oci_bundle.cpp
+    src/container_net.cpp)
 target_include_directories(containers_core PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/inc
     ${NLOHMANN_JSON_INCLUDE})
@@ -63,7 +64,8 @@ if(CONTAINERS_BUILD_DAEMON)
         daemon/http_client.cpp
         daemon/registry_puller.cpp
         daemon/layer_store.cpp
-        daemon/crun_runtime.cpp)
+        daemon/crun_runtime.cpp
+        daemon/net_bridge.cpp)
     target_include_directories(iot-containerd PRIVATE
         ${CMAKE_CURRENT_SOURCE_DIR}/daemon
         ${CMAKE_CURRENT_SOURCE_DIR}/inc
@@ -87,7 +89,8 @@ if(CONTAINERS_BUILD_TESTS)
         test/image_ref_test.cpp
         test/registry_test.cpp
         test/oci_layer_test.cpp
-        test/oci_bundle_test.cpp)
+        test/oci_bundle_test.cpp
+        test/container_net_test.cpp)
     target_link_libraries(containers-tests containers_core GTest::gtest GTest::gtest_main pthread)
     include(GoogleTest)
     if(CONTAINERS_TOP_LEVEL)

--- a/modules/containers/README.md
+++ b/modules/containers/README.md
@@ -62,8 +62,14 @@ This module lands incrementally (see the TDD doc):
   creds), and a run form (Entrypoint / CMD / mem / cpu) with Run/Stop. Drives the
   `container.*` keys: a 2s `dbGet` self-poll for live status, `dbSet` + bumped
   `*.request` tokens for commands.
-- **Phase 7 (next)**: e2e on RPi3B hardware (pull → run → stop), validating
-  overlayfs + crun + cgroups on the real kernel.
+- **Bridge networking (own IP):** opt-in `container.net.mode=bridge` gives the
+  container its own IP via a veth into a host bridge (`iot-cni0`,
+  `10.88.0.0/24`) with masqueraded egress (scoped `inet iot_containers` nft
+  table). `container_net` (core) plans the subnet + nft ruleset;
+  `net_bridge` (daemon) does the `ip`/`nft` plumbing; the UI adds a Network
+  select + IP row. Host networking stays the default. See TDD §11a.
+- **Phase 7 (next)**: e2e on RPi3B hardware (pull → run → stop, host + bridge),
+  validating overlayfs + crun + cgroups + veth/masquerade on the real kernel.
 
 ## Build
 

--- a/modules/containers/daemon/containerd.cpp
+++ b/modules/containers/daemon/containerd.cpp
@@ -14,10 +14,12 @@
 #include "data_store/stats_publisher.hpp"
 #include "data_store/value.hpp"
 
+#include "container_net.hpp"   // kDefaultSubnet
 #include "crun_runtime.hpp"
 #include "http_client.hpp"     // mkdir_p
 #include "image_ref.hpp"
 #include "layer_store.hpp"
+#include "net_bridge.hpp"
 #include "oci_bundle.hpp"
 #include "registry.hpp"
 #include "registry_puller.hpp"
@@ -197,11 +199,14 @@ void Containerd::handle_run() {
         return;
     }
 
-    // Process overrides + resource limits (read on the reactor thread).
+    // Process overrides + resource limits + network mode (reactor thread).
     const std::string ov_entrypoint = get_str("container.entrypoint");
     const std::string ov_cmd        = get_str("container.cmd");
     const std::string lim_mem       = get_str("container.limit.mem");
     const std::string lim_cpus      = get_str("container.limit.cpus");
+    const std::string net_mode      = get_str("container.net.mode");      // "host" (default) | "bridge"
+    std::string       net_subnet    = get_str("container.net.subnet");
+    if (net_subnet.empty()) net_subnet = kDefaultSubnet;
 
     if (m_run_thread.joinable()) m_run_thread.join();
     m_stop_requested.store(false);
@@ -214,7 +219,9 @@ void Containerd::handle_run() {
     const std::string root     = m_cfg.root;
     const std::string run_root = m_cfg.run;
     m_run_thread = std::thread([this, image_id, root, run_root,
-                                ov_entrypoint, ov_cmd, lim_mem, lim_cpus]() {
+                                ov_entrypoint, ov_cmd, lim_mem, lim_cpus,
+                                net_mode, net_subnet]() {
+        const bool bridge = (net_mode == "bridge");
         const std::string hex  = image_id.substr(7);
         const std::string body = slurp(root + "/manifests/" + hex + ".json");
         ImageManifest im = parse_image_manifest(body);
@@ -275,6 +282,7 @@ void Containerd::handle_run() {
         resolve_user(ic.user, spec.uid, spec.gid);
         spec.mem_limit_bytes = parse_mem_limit(lim_mem);
         spec.cpu_quota       = parse_cpu_quota(lim_cpus, spec.cpu_period);
+        spec.host_network    = !bridge;   // bridge → own netns (IP wired below)
 
         if (!spit(bundle + "/config.json", generate_oci_config(spec))) {
             set_error("could not write OCI bundle config.json");
@@ -298,17 +306,40 @@ void Containerd::handle_run() {
             m_run_active.store(false);
             return;
         }
+
+        // crun create has set up the namespaces (incl. an empty netns in bridge
+        // mode); the init pid is available now, before start.
+        const long pid = crun.state(kContainerId).pid;
+
+        // Bridge mode: wire a veth + IP into the container netns before start.
+        if (bridge) {
+            BridgeNet bn = bridge_up(pid, net_subnet, kContainerId);
+            if (!bn.ok) {
+                set_error("bridge networking failed: " + bn.error);
+                set_state("error");
+                crun.remove(kContainerId, true, err);
+                bridge_down(kContainerId);
+                unmount_overlay(run_root, kContainerId, err);
+                m_run_active.store(false);
+                return;
+            }
+            std::vector<data_store::KV> net;
+            net.emplace_back("container.net.ip",      data_store::Value{bn.ip});
+            net.emplace_back("container.net.gateway", data_store::Value{bn.gateway});
+            m_ds.set_volatile(net);
+        }
+
         if (!crun.start(kContainerId, err)) {
             set_error("crun start failed: " + err);
             set_state("error");
             crun.remove(kContainerId, true, err);
+            if (bridge) bridge_down(kContainerId);
             unmount_overlay(run_root, kContainerId, err);
             m_run_active.store(false);
             return;
         }
 
-        // Grab the pid + announce running.
-        long pid = crun.state(kContainerId).pid;
+        // Announce running (pid already known from above).
         std::vector<data_store::KV> kv;
         kv.emplace_back("container.run.pid",     data_store::Value{std::to_string(pid)});
         kv.emplace_back("container.run.started", data_store::Value{std::to_string(
@@ -350,6 +381,7 @@ void Containerd::handle_run() {
 
         // ── Exited: clean up + report ──────────────────────────────────────
         crun.remove(kContainerId, true, err);
+        if (bridge) bridge_down(kContainerId);
         unmount_overlay(run_root, kContainerId, err);
         {
             std::lock_guard<std::mutex> lk(m_mtx);
@@ -357,6 +389,7 @@ void Containerd::handle_run() {
         }
         std::vector<data_store::KV> done;
         done.emplace_back("container.run.pid", data_store::Value{std::string()});
+        done.emplace_back("container.net.ip",  data_store::Value{std::string()});
         done.emplace_back("container.status",  data_store::Value{std::string("stopped")});
         done.emplace_back("container.state",   data_store::Value{std::string("stopped")});
         m_ds.set_volatile(done);
@@ -377,16 +410,19 @@ void Containerd::handle_stop() {
                           data_store::Value{std::string("stopping")});
         return;
     }
-    // Nothing running: clear any stale crun state + overlay mount.
+    // Nothing running: clear any stale crun state + overlay mount + veth.
     std::string err;
     CrunRuntime crun(m_cfg.run + "/state");
     crun.remove(kContainerId, true, err);
+    bridge_down(kContainerId);
     unmount_overlay(m_cfg.run, kContainerId, err);
     {
         std::lock_guard<std::mutex> lk(m_mtx);
         m_merged.clear();
     }
-    m_ds.set_volatile(std::string("container.status"), data_store::Value{std::string("stopped")});
+    m_ds.set_volatile(std::vector<data_store::KV>{
+        {"container.net.ip", data_store::Value{std::string()}},
+        {"container.status", data_store::Value{std::string("stopped")}}});
     set_error("");
     set_state("stopped");
 }

--- a/modules/containers/daemon/net_bridge.cpp
+++ b/modules/containers/daemon/net_bridge.cpp
@@ -1,0 +1,177 @@
+#include "net_bridge.hpp"
+
+#include <cstdio>
+#include <cstdlib>
+#include <fcntl.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
+
+#include <ace/Log_Msg.h>
+#include <ace/OS_NS_unistd.h>
+#include <ace/Process.h>
+
+#include "container_net.hpp"
+
+namespace containers {
+
+namespace {
+
+std::string resolve(const char* name, std::initializer_list<const char*> paths) {
+    for (const char* p : paths)
+        if (ACE_OS::access(p, X_OK) == 0) return p;
+    return name;   // fall back to PATH (execvp)
+}
+
+const std::string& ip_tool() {
+    static const std::string p = resolve("ip", {"/sbin/ip", "/usr/sbin/ip", "/bin/ip", "/usr/bin/ip"});
+    return p;
+}
+const std::string& nft_tool() {
+    static const std::string p = resolve("nft", {"/usr/sbin/nft", "/sbin/nft", "/usr/bin/nft", "/bin/nft"});
+    return p;
+}
+
+std::string make_temp(const char* tag) {
+    std::string tmpl = std::string("/tmp/iot-net-") + tag + "-XXXXXX";
+    std::vector<char> buf(tmpl.begin(), tmpl.end());
+    buf.push_back('\0');
+    int fd = ::mkstemp(buf.data());
+    if (fd < 0) return {};
+    ::close(fd);
+    return std::string(buf.data());
+}
+
+std::string read_file(const std::string& path) {
+    std::string out;
+    FILE* f = std::fopen(path.c_str(), "rb");
+    if (!f) return out;
+    char b[1024];
+    size_t n;
+    while ((n = std::fread(b, 1, sizeof b, f)) > 0) out.append(b, n);
+    std::fclose(f);
+    return out;
+}
+
+std::string trim(const std::string& s) {
+    std::size_t a = 0, b = s.size();
+    while (a < b && (s[a] == ' ' || s[a] == '\n' || s[a] == '\r' || s[a] == '\t')) ++a;
+    while (b > a && (s[b-1] == ' ' || s[b-1] == '\n' || s[b-1] == '\r' || s[b-1] == '\t')) --b;
+    return s.substr(a, b - a);
+}
+
+// Run a command, capturing stderr into `err` on failure. Returns exit code.
+int run(const std::vector<std::string>& args, std::string& err) {
+    const std::string err_path = make_temp("err");
+    std::vector<char*> argv;
+    for (auto& s : const_cast<std::vector<std::string>&>(args)) argv.push_back(const_cast<char*>(s.c_str()));
+    argv.push_back(nullptr);
+
+    ACE_Process_Options opts;
+    opts.command_line(argv.data());
+    int devnull = ::open("/dev/null", O_RDWR);
+    int errfd   = err_path.empty() ? -1 : ::open(err_path.c_str(), O_WRONLY | O_TRUNC);
+    if (devnull >= 0 && errfd >= 0) opts.set_handles(devnull, devnull, errfd);
+
+    ACE_Process proc;
+    pid_t pid = proc.spawn(opts);
+    if (devnull >= 0) ::close(devnull);
+    if (errfd   >= 0) ::close(errfd);
+    if (pid == ACE_INVALID_PID) {
+        if (!err_path.empty()) ::unlink(err_path.c_str());
+        err = "spawn failed";
+        return -1;
+    }
+    ACE_exitcode status = 0;
+    proc.wait(&status);
+    const int code = WIFEXITED(status) ? WEXITSTATUS(status) : -1;
+    if (code != 0 && !err_path.empty()) err = trim(read_file(err_path));
+    if (!err_path.empty()) ::unlink(err_path.c_str());
+    return code;
+}
+
+// Run, ignoring the result (idempotent setup / best-effort cleanup).
+void run_ok(const std::vector<std::string>& args) {
+    std::string ignore;
+    run(args, ignore);
+}
+
+void write_proc(const char* path, const char* val) {
+    FILE* f = std::fopen(path, "w");
+    if (f) { std::fputs(val, f); std::fclose(f); }
+}
+
+} // namespace
+
+BridgeNet bridge_up(long container_pid, const std::string& subnet_cidr,
+                    const std::string& id) {
+    BridgeNet res;
+    const NetPlan plan = plan_bridge_net(subnet_cidr, kBridgeName);
+    if (!plan.ok) { res.error = "invalid bridge subnet: " + subnet_cidr; return res; }
+
+    const std::string& ip = ip_tool();
+    const std::string host_veth = "vh-" + id;   // host end (≤15 chars)
+    const std::string peer_veth = "vp-" + id;   // container end
+    const std::string netns     = "ctr-" + id;  // ip-netns name for the bind mount
+    const std::string pfx       = std::to_string(plan.prefix);
+    std::string err;
+
+    // 1. Host bridge (create if absent) + gateway IP + up.
+    if (run({ip, "link", "show", kBridgeName}, err) != 0)
+        run_ok({ip, "link", "add", kBridgeName, "type", "bridge"});
+    run_ok({ip, "addr", "add", plan.gateway + "/" + pfx, "dev", kBridgeName});  // EEXIST ok
+    run_ok({ip, "link", "set", kBridgeName, "up"});
+
+    // 2. IPv4 forwarding.
+    write_proc("/proc/sys/net/ipv4/ip_forward", "1\n");
+
+    // 3. Scoped masquerade nft table (separate from net-router's iot_router).
+    const std::string ruleset = nft_container_ruleset(plan.cidr, kBridgeName);
+    const std::string nftfile = make_temp("nft");
+    if (!nftfile.empty()) { write_proc(nftfile.c_str(), ruleset.c_str()); }
+    if (nftfile.empty() || run({nft_tool(), "-f", nftfile}, err) != 0) {
+        if (!nftfile.empty()) ::unlink(nftfile.c_str());
+        res.error = "nft masquerade failed: " + err;
+        return res;
+    }
+    ::unlink(nftfile.c_str());
+
+    // 4. veth pair → bridge, peer into the container netns as eth0.
+    run_ok({ip, "link", "del", host_veth});   // clear any stale veth
+    run_ok({ip, "netns", "del", netns});
+    if (run({ip, "link", "add", host_veth, "type", "veth", "peer", "name", peer_veth}, err) != 0) {
+        res.error = "veth create failed: " + err; return res;
+    }
+    run_ok({ip, "link", "set", host_veth, "master", kBridgeName});
+    run_ok({ip, "link", "set", host_veth, "up"});
+
+    if (run({ip, "netns", "attach", netns, std::to_string(container_pid)}, err) != 0) {
+        run_ok({ip, "link", "del", host_veth});
+        res.error = "netns attach failed: " + err; return res;
+    }
+    if (run({ip, "link", "set", peer_veth, "netns", netns}, err) != 0) {
+        run_ok({ip, "netns", "del", netns});
+        run_ok({ip, "link", "del", host_veth});
+        res.error = "veth move failed: " + err; return res;
+    }
+    run_ok({ip, "-n", netns, "link", "set", peer_veth, "name", "eth0"});
+    run_ok({ip, "-n", netns, "addr", "add", plan.container_ip + "/" + pfx, "dev", "eth0"});
+    run_ok({ip, "-n", netns, "link", "set", "eth0", "up"});
+    run_ok({ip, "-n", netns, "link", "set", "lo", "up"});
+    run_ok({ip, "-n", netns, "route", "add", "default", "via", plan.gateway});
+    run_ok({ip, "netns", "del", netns});   // drop the bind mount (netns lives via the pid)
+
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] bridge: %C → %C (gw %C)\n"),
+               id.c_str(), plan.container_ip.c_str(), plan.gateway.c_str()));
+    res.ok = true;
+    res.ip = plan.container_ip;
+    res.gateway = plan.gateway;
+    return res;
+}
+
+void bridge_down(const std::string& id) {
+    run_ok({ip_tool(), "link", "del", "vh-" + id});
+    run_ok({ip_tool(), "netns", "del", "ctr-" + id});
+}
+
+} // namespace containers

--- a/modules/containers/daemon/net_bridge.hpp
+++ b/modules/containers/daemon/net_bridge.hpp
@@ -1,0 +1,37 @@
+#ifndef __iot_container_net_bridge_hpp__
+#define __iot_container_net_bridge_hpp__
+
+#include <string>
+
+/// Bridge-mode container networking: the imperative `ip`/`nft` plumbing that
+/// gives a container its own IP. The pure subnet/nft-ruleset logic is in
+/// container_net (containers_core); this drives it via ACE_Process as root.
+/// See apps/docs/tdd-device-containers.md (§ bridge mode).
+
+namespace containers {
+
+struct BridgeNet {
+    bool        ok = false;
+    std::string ip;        ///< IP assigned to the container (e.g. 10.88.0.2)
+    std::string gateway;   ///< bridge gateway / container default route (.1)
+    std::string error;
+};
+
+/// Bring up bridge networking for container `id` whose init is `container_pid`:
+///   1. ensure the host bridge (iot-cni0) exists with the gateway IP + up,
+///   2. enable IPv4 forwarding,
+///   3. install the scoped `inet iot_containers` masquerade nft table,
+///   4. create a veth pair, attach the host end to the bridge, move the peer
+///      into the container netns as eth0 with the container IP + default route.
+/// `subnet_cidr` is a /24 (default 10.88.0.0/24). Must run as root. On failure
+/// the partial setup is best-effort torn down and `.error` is set.
+BridgeNet bridge_up(long container_pid, const std::string& subnet_cidr,
+                    const std::string& id);
+
+/// Tear down container `id`'s veth (its peer auto-removes when the container
+/// netns dies). Idempotent; the bridge + nft table persist for reuse.
+void bridge_down(const std::string& id);
+
+} // namespace containers
+
+#endif /* __iot_container_net_bridge_hpp__ */

--- a/modules/containers/inc/container_net.hpp
+++ b/modules/containers/inc/container_net.hpp
@@ -1,0 +1,39 @@
+#ifndef __iot_container_net_hpp__
+#define __iot_container_net_hpp__
+
+#include <string>
+
+/// Pure container-networking helpers for the opt-in bridge mode: subnet
+/// planning + the scoped nftables masquerade ruleset. No `ip`/`nft`/netlink, no
+/// ACE — host-unit-testable. The actual veth/bridge/netns plumbing lives in the
+/// daemon's net_bridge. See apps/docs/tdd-device-containers.md (§ bridge mode).
+
+namespace containers {
+
+/// Default bridge name + subnet for the single-container bridge network.
+inline constexpr const char* kBridgeName    = "iot-cni0";
+inline constexpr const char* kDefaultSubnet = "10.88.0.0/24";
+
+struct NetPlan {
+    bool        ok = false;
+    std::string bridge;        ///< host bridge device
+    std::string cidr;          ///< the subnet, e.g. "10.88.0.0/24"
+    int         prefix = 0;    ///< prefix length (24)
+    std::string gateway;       ///< bridge IP, the container's default route (.1)
+    std::string container_ip;  ///< the container's address (.2)
+};
+
+/// Plan the single-container bridge network from `subnet_cidr` (a /24, e.g.
+/// "10.88.0.0/24") + `bridge`. gateway is host .1, the container gets .2.
+/// ok=false on a malformed or non-/24 CIDR (v1 supports a single /24).
+NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridge);
+
+/// The nftables ruleset (an `nft -f` script) for container egress: a SCOPED
+/// `inet iot_containers` table (separate from net-router's `iot_router`, so the
+/// two never flush each other) with a postrouting masquerade for `cidr` leaving
+/// any non-bridge interface, plus forward-accept for the bridge.
+std::string nft_container_ruleset(const std::string& cidr, const std::string& bridge);
+
+} // namespace containers
+
+#endif /* __iot_container_net_hpp__ */

--- a/modules/containers/inc/oci_bundle.hpp
+++ b/modules/containers/inc/oci_bundle.hpp
@@ -66,6 +66,8 @@ struct OciSpec {
     long long                cpu_quota = 0;         ///< 0 → unbounded
     long long                cpu_period = 100000;
     bool                     bind_resolv_conf = true; ///< host /etc/resolv.conf (ro)
+    bool                     host_network = true;     ///< true → share host netns (no IP);
+                                                      ///< false → own netns (bridge mode)
     std::string              hostname = "iot-container";
 };
 

--- a/modules/containers/schemas/container.lua
+++ b/modules/containers/schemas/container.lua
@@ -12,6 +12,8 @@
 --   container.cmd             - override CMD (JSON array or string; "" = image default)
 --   container.limit.mem       - memory cap, e.g. "256M" ("" = unbounded)
 --   container.limit.cpus      - CPU quota, e.g. "0.5" ("" = unbounded)
+--   container.net.mode        - "host" (default; shares device netns/IP) | "bridge" (own IP)
+--   container.net.subnet      - bridge /24, default "10.88.0.0/24" (bridge mode only)
 --   container.pull.request    - bump to pull container.image.ref
 --   container.run.request     - bump to create + start the container
 --   container.stop.request    - bump to stop + delete the container
@@ -23,6 +25,8 @@
 --   container.pull.detail     - current layer digest / status message
 --   container.image.id        - resolved image config digest
 --   container.image.size      - total image size in bytes (decimal string)
+--   container.net.ip          - container IP in bridge mode ("" in host mode / stopped)
+--   container.net.gateway     - bridge gateway (container default route)
 --   container.run.pid         - running container PID (decimal string)
 --   container.run.started     - start timestamp
 --   container.exit.code       - last container exit code (decimal string)
@@ -36,6 +40,8 @@ return {
     ["container.cmd"]           = { access = "Admin",  type = "string", default = "" },
     ["container.limit.mem"]     = { access = "Admin",  type = "string", default = "" },
     ["container.limit.cpus"]    = { access = "Admin",  type = "string", default = "" },
+    ["container.net.mode"]      = { access = "Admin",  type = "string", default = "host" },
+    ["container.net.subnet"]    = { access = "Admin",  type = "string", default = "10.88.0.0/24" },
     ["container.pull.request"]  = { access = "Admin",  type = "string", default = "" },
     ["container.run.request"]   = { access = "Admin",  type = "string", default = "" },
     ["container.stop.request"]  = { access = "Admin",  type = "string", default = "" },
@@ -45,6 +51,8 @@ return {
     ["container.pull.detail"]   = { access = "Viewer", type = "string", default = "" },
     ["container.image.id"]      = { access = "Viewer", type = "string", default = "" },
     ["container.image.size"]    = { access = "Viewer", type = "string", default = "" },
+    ["container.net.ip"]        = { access = "Viewer", type = "string", default = "" },
+    ["container.net.gateway"]   = { access = "Viewer", type = "string", default = "" },
     ["container.run.pid"]       = { access = "Viewer", type = "string", default = "" },
     ["container.run.started"]   = { access = "Viewer", type = "string", default = "" },
     ["container.exit.code"]     = { access = "Viewer", type = "string", default = "" },

--- a/modules/containers/src/container_net.cpp
+++ b/modules/containers/src/container_net.cpp
@@ -1,0 +1,69 @@
+#include "container_net.hpp"
+
+#include <cstdlib>
+#include <sstream>
+#include <vector>
+
+namespace containers {
+
+namespace {
+
+// Parse "a.b.c.d" into 4 octets; false on malformed / out-of-range.
+bool parse_ipv4(const std::string& s, int oct[4]) {
+    std::stringstream ss(s);
+    std::string part;
+    int i = 0;
+    while (std::getline(ss, part, '.')) {
+        if (i >= 4 || part.empty()) return false;
+        for (char c : part) if (c < '0' || c > '9') return false;
+        long v = std::strtol(part.c_str(), nullptr, 10);
+        if (v < 0 || v > 255) return false;
+        oct[i++] = static_cast<int>(v);
+    }
+    return i == 4;
+}
+
+} // namespace
+
+NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridge) {
+    NetPlan p;
+    const auto slash = subnet_cidr.find('/');
+    if (slash == std::string::npos) return p;
+    const std::string net = subnet_cidr.substr(0, slash);
+    const std::string pfx = subnet_cidr.substr(slash + 1);
+    for (char c : pfx) if (c < '0' || c > '9') return p;
+    const int prefix = pfx.empty() ? -1 : static_cast<int>(std::strtol(pfx.c_str(), nullptr, 10));
+    int oct[4];
+    if (prefix != 24 || !parse_ipv4(net, oct)) return p;   // v1: a single /24
+
+    const std::string base = std::to_string(oct[0]) + "." + std::to_string(oct[1]) +
+                             "." + std::to_string(oct[2]) + ".";
+    p.ok           = true;
+    p.bridge       = bridge;
+    p.cidr         = subnet_cidr;
+    p.prefix       = prefix;
+    p.gateway      = base + "1";
+    p.container_ip = base + "2";
+    return p;
+}
+
+std::string nft_container_ruleset(const std::string& cidr, const std::string& bridge) {
+    std::ostringstream ss;
+    // Flush our scoped table first so re-apply is idempotent — mirrors
+    // net-router's `flush table inet iot_router`. We never touch other tables.
+    ss << "flush table inet iot_containers\n";
+    ss << "table inet iot_containers {\n";
+    ss << "    chain postrouting {\n";
+    ss << "        type nat hook postrouting priority 100; policy accept;\n";
+    ss << "        ip saddr " << cidr << " oifname != \"" << bridge << "\" masquerade\n";
+    ss << "    }\n";
+    ss << "    chain forward {\n";
+    ss << "        type filter hook forward priority 0; policy accept;\n";
+    ss << "        iifname \"" << bridge << "\" accept\n";
+    ss << "        oifname \"" << bridge << "\" accept\n";
+    ss << "    }\n";
+    ss << "}\n";
+    return ss.str();
+}
+
+} // namespace containers

--- a/modules/containers/src/oci_bundle.cpp
+++ b/modules/containers/src/oci_bundle.cpp
@@ -171,9 +171,13 @@ std::string generate_oci_config(const OciSpec& spec) {
     j["mounts"] = mounts;
 
     json lin;
-    // No "network" namespace → the container shares the host net namespace.
-    lin["namespaces"] = json::array({{{"type", "pid"}}, {{"type", "ipc"}},
-                                     {{"type", "uts"}}, {{"type", "mount"}}});
+    // Host networking (default) omits the network namespace → the container
+    // shares the host netns (no IP of its own). Bridge mode adds its own
+    // network namespace; net_bridge then wires a veth + IP into it.
+    json ns = json::array({{{"type", "pid"}}, {{"type", "ipc"}},
+                           {{"type", "uts"}}, {{"type", "mount"}}});
+    if (!spec.host_network) ns.push_back({{"type", "network"}});
+    lin["namespaces"] = ns;
     lin["maskedPaths"] = json::array({
         "/proc/acpi", "/proc/asound", "/proc/kcore", "/proc/keys", "/proc/latency_stats",
         "/proc/timer_list", "/proc/timer_stats", "/proc/sched_debug", "/proc/scsi", "/sys/firmware"});

--- a/modules/containers/test/container_net_test.cpp
+++ b/modules/containers/test/container_net_test.cpp
@@ -1,0 +1,45 @@
+#include <gtest/gtest.h>
+
+#include "container_net.hpp"
+
+using namespace containers;
+
+TEST(NetPlan, DefaultSlash24) {
+    auto p = plan_bridge_net("10.88.0.0/24", "iot-cni0");
+    ASSERT_TRUE(p.ok);
+    EXPECT_EQ(p.bridge, "iot-cni0");
+    EXPECT_EQ(p.prefix, 24);
+    EXPECT_EQ(p.gateway, "10.88.0.1");
+    EXPECT_EQ(p.container_ip, "10.88.0.2");
+}
+
+TEST(NetPlan, OtherSubnet) {
+    auto p = plan_bridge_net("192.168.50.0/24", "br0");
+    ASSERT_TRUE(p.ok);
+    EXPECT_EQ(p.gateway, "192.168.50.1");
+    EXPECT_EQ(p.container_ip, "192.168.50.2");
+}
+
+TEST(NetPlan, RejectsNonSlash24) {
+    EXPECT_FALSE(plan_bridge_net("10.0.0.0/8", "br0").ok);
+    EXPECT_FALSE(plan_bridge_net("10.88.0.0/16", "br0").ok);
+}
+
+TEST(NetPlan, RejectsMalformed) {
+    EXPECT_FALSE(plan_bridge_net("not-a-cidr", "br0").ok);
+    EXPECT_FALSE(plan_bridge_net("10.88.0.0", "br0").ok);          // no prefix
+    EXPECT_FALSE(plan_bridge_net("10.88.0.999/24", "br0").ok);     // octet > 255
+    EXPECT_FALSE(plan_bridge_net("10.88.0/24", "br0").ok);         // 3 octets
+}
+
+TEST(NftRuleset, ScopedTableWithMasquerade) {
+    auto rs = nft_container_ruleset("10.88.0.0/24", "iot-cni0");
+    // Own scoped table — must NOT touch net-router's iot_router table.
+    EXPECT_NE(rs.find("flush table inet iot_containers"), std::string::npos);
+    EXPECT_NE(rs.find("table inet iot_containers {"), std::string::npos);
+    EXPECT_EQ(rs.find("iot_router"), std::string::npos);
+    // Masquerade for the subnet leaving any non-bridge interface.
+    EXPECT_NE(rs.find("ip saddr 10.88.0.0/24 oifname != \"iot-cni0\" masquerade"),
+              std::string::npos);
+    EXPECT_NE(rs.find("type nat hook postrouting"), std::string::npos);
+}

--- a/modules/containers/test/oci_bundle_test.cpp
+++ b/modules/containers/test/oci_bundle_test.cpp
@@ -117,6 +117,17 @@ TEST(OciConfig, HostNetAndArgsAndLimits) {
     EXPECT_EQ(j["linux"]["resources"]["cpu"]["period"], 100000);
 }
 
+TEST(OciConfig, BridgeModeAddsNetworkNamespace) {
+    OciSpec s;
+    s.args = {"/bin/true"};
+    s.host_network = false;             // bridge mode → own netns
+    auto j = json::parse(generate_oci_config(s));
+    bool has_net = false;
+    for (const auto& n : j["linux"]["namespaces"])
+        if (n["type"] == "network") has_net = true;
+    EXPECT_TRUE(has_net);
+}
+
 TEST(OciConfig, NoLimitsOmitsResources) {
     OciSpec s;
     s.args = {"/bin/true"};

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -629,8 +629,9 @@ FILES:${PN}-containerd = "\
 "
 # curl: the registry-v2 HTTP transport (puller shells out to it, like the OTA
 # path). openssl: libcrypto for blob sha256. zlib: gzip layer decompression.
+# iproute2 + nftables: bridge-mode networking (veth/bridge/netns + masquerade).
 # (openssl/zlib are also auto-added by the shlib scan; listed for clarity.)
-RDEPENDS:${PN}-containerd = "ace-tao crun curl openssl zlib"
+RDEPENDS:${PN}-containerd = "ace-tao crun curl openssl zlib iproute2 nftables"
 RRECOMMENDS:${PN}-containerd = "\
     ${PN}-ds-server \
     ${PN}-config \

--- a/yocto/meta-iot/recipes-kernel/linux/files/container.cfg
+++ b/yocto/meta-iot/recipes-kernel/linux/files/container.cfg
@@ -27,3 +27,11 @@ CONFIG_CFS_BANDWIDTH=y
 # Seccomp — crun applies a default syscall filter to the container.
 CONFIG_SECCOMP=y
 CONFIG_SECCOMP_FILTER=y
+
+# Bridge-mode networking (opt-in container.net.mode=bridge): a host bridge +
+# veth pair into the container netns, with masquerade for egress. NAT/nf_tables
+# are already on (the device does masquerade today).
+CONFIG_BRIDGE=y
+CONFIG_VETH=y
+CONFIG_BRIDGE_NETFILTER=y
+CONFIG_NF_NAT=y


### PR DESCRIPTION
Implements the deferred **bridge+NAT networking** item from #401: an opt-in mode that gives a container **its own IP** (veth → host bridge → masquerade), surfaced in the device-ui. **Host networking stays the default** — selected per-run via `container.net.mode` (`host` | `bridge`), so existing behavior is unchanged.

## Topology
```
container netns (10.88.0.2/24)              host
  eth0 ──veth── vh-c0 ── iot-cni0 (10.88.0.1/24)
  default route → .1                    ip_forward=1
                                   nft inet iot_containers: masquerade
```

## What's here
- **`containers_core` / `container_net`** (+6 gtests): `plan_bridge_net` (/24 → gateway `.1`, container `.2`) and `nft_container_ruleset` — a **scoped `inet iot_containers` table** (separate from net-router's `iot_router`, the pattern that layer already uses, so neither flushes the other).
- **`oci_bundle`**: `OciSpec.host_network` — bridge mode adds a `network` namespace (own netns) instead of omitting it.
- **`net_bridge`** (daemon, root, via `ip`/`nft`): ensure bridge `iot-cni0` + gateway IP + `ip_forward`, install the masquerade table, create the veth pair, attach host end to the bridge, move the peer into the container netns as `eth0` with the IP + default route. Lifecycle: `crun create` → read pid → `bridge_up(pid)` → publish `container.net.ip`/`.gateway` → `crun start`; `bridge_down` on exit (veth deleted; bridge + table persist).
- **schema**: `container.net.{mode,subnet,ip,gateway}`.
- **device-ui**: a **Network** select in the run form + **Network**/**IP** rows in the status datagrid (shows `10.88.0.2` when bridge + running).
- **kernel cfg**: `BRIDGE`/`VETH`/`BRIDGE_NETFILTER`/`NF_NAT`. **RDEPENDS**: `iproute2`/`nftables`.

## Scope / notes
- Single container ⇒ static `.2` (no IPAM). Subnet overridable via `container.net.subnet` (a single /24).
- **Egress masquerade is generic** (`oifname != iot-cni0`) so it works across wifi/eth/cellular/tun without knowing the WAN iface.
- **Deferred:** container **port mapping** (host:port → container IP via DNAT) and multi-container IPAM.
- **Not built/run** — compiles only at CI-on-main; HW e2e steps added to TDD §11a (bridge gets `10.88.0.2`, masqueraded egress, UI shows the IP).

Builds on #401 (merged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)