### PR TITLE
docs(pitch): AETHER investor pitch deck (reveal.js + markdown)

### DIFF
--- a/pitch/README.md
+++ b/pitch/README.md
@@ -1,0 +1,40 @@
+# AETHER — investor pitch deck
+
+A [reveal.js](https://revealjs.com) slide deck for the device + cloud IoT
+platform (secure device management · multi-protocol telemetry · A/B OTA ·
+**edge container runtime**).
+
+## Files
+
+| File | What |
+|------|------|
+| `aether-pitch.md` | The deck content — **single source of truth**. Reads fine on its own (GitHub renders it); reveal.js splits it into slides on `---`. |
+| `index.html` | reveal.js shell that loads `aether-pitch.md` (CDN — no install). |
+
+## View it
+
+The reveal shell loads the markdown via `fetch`, so it needs to be served over
+http (opening `index.html` from `file://` will be blocked by the browser). From
+this folder:
+
+```sh
+cd pitch
+python3 -m http.server 8000
+# then open http://localhost:8000/  (press 'S' for speaker notes)
+```
+
+Keys: `→/Space` next · `←` back · `F` fullscreen · `S` speaker notes · `Esc` overview.
+
+## Edit
+
+Edit only `aether-pitch.md`. Slides are separated by a line containing just
+`---`; speaker notes start a line with `Note:`. No build step.
+
+## Export to PDF
+
+Append `?print-pdf` to the URL and use the browser's "Print → Save as PDF"
+(landscape, background graphics on):
+
+```
+http://localhost:8000/?print-pdf
+```

--- a/pitch/aether-pitch.md
+++ b/pitch/aether-pitch.md
@@ -1,0 +1,207 @@
+# 🌐 AETHER
+
+## One control plane from silicon to cloud
+
+**Edge-to-Cloud IoT, unified.** — Secure. Lightweight. Programmable.
+
+Manage a fleet of devices, stream their telemetry, and ship containerized
+apps to the edge — from a single pane of glass.
+
+Note: Hi, I'm the CEO of Aether Systems. In the next 5 minutes I'll show you
+why the next trillion dollars of IoT value is won at the edge — and why we're
+the operating layer for it.
+
+---
+
+## 📉 The Problem
+
+Today's IoT teams bolt together **5 disconnected tools**:
+
+```
+ ┌─────────┐  ┌──────────┐  ┌─────────┐  ┌────────┐  ┌─────────┐
+ │ Device  │  │ Telemetry│  │ Secure  │  │  OTA   │  │  Edge   │
+ │  Mgmt   │+ │ pipeline │+ │ tunnel  │+ │ update │+ │ compute │
+ └─────────┘  └──────────┘  └─────────┘  └────────┘  └─────────┘
+      ↓            ↓            ↓            ↓            ↓
+  💸 5 vendors  🔧 gluecode  🐛 brittle  🔓 sec gaps  ⏳ slow GTM
+```
+
+> **18-month integration projects. Fragile. Expensive. Insecure.**
+
+Note: Every IoT exec says the same thing — "We don't have an IoT problem, we
+have an integration problem."
+
+---
+
+## 💡 The Solution
+
+AETHER replaces all five with **one vertically-integrated platform**:
+
+```
+   ╔════════════════════════════════════════════╗
+   ║            🛰  AETHER PLATFORM             ║
+   ║                                            ║
+   ║   Provision → Connect → Stream → Update    ║
+   ║            → Run apps at the edge           ║
+   ╚════════════════════════════════════════════╝
+        one SDK · one console · one security model
+```
+
+Built on **open standards** — LwM2M 1.1.1, CoAP/DTLS, OCI containers.
+No black box. No lock-in.
+
+---
+
+## 🏗 Architecture
+
+```
+ ╭────────────────────── THE EDGE ───────────────────────╮
+ │  Raspberry Pi / industrial gateway · runs on 1 GB RAM  │
+ │  ┌───────┐ ┌────────┐ ┌────────┐ ┌────────────────┐    │
+ │  │Sensors│ │GPS/Cell│ │CAN/OBD2│ │ 📦 CONTAINERS  │    │
+ │  └───┬───┘ └───┬────┘ └───┬────┘ └───────┬────────┘    │
+ │      └──── data-store bus (in-memory K/V) ┘            │
+ │  LwM2M · device-UI · OTA · firewall · WiFi/cellular    │
+ ╰────────────────────────┬───────────────────────────────╯
+                          │  🔒 DTLS-PSK + OpenVPN (mutual-auth, CRL)
+ ╭────────────────────────┴───────────────── THE CLOUD ──╮
+ │  Registry · Time-series telemetry · VPN hub           │
+ │  Fleet dashboard · Multi-user RBAC · OTA feed · API    │
+ ╰────────────────────────────────────────────────────────╯
+```
+
+**One secure tunnel. Every device reachable from the cloud console.**
+
+---
+
+## ⭐ Killer Features
+
+| | |
+|---|---|
+| 🔐 **Zero-touch security** | Bootstrap → DTLS-PSK → VPN, automatic. Cert revocation built in. |
+| 📦 **Edge containers** | Pull any Docker image, run it on-device. No Docker daemon. 1 GB box. |
+| 🔄 **Bulletproof OTA** | A/B image + auto-rollback. Never brick a field device again. |
+| 📡 **Multi-protocol telemetry** | Sensors · GPS · cellular · vehicle CAN/OBD-II — one pipeline. |
+| 🖥 **Remote everything** | Per-device UI, remote shell, live config — through the tunnel. |
+
+---
+
+## 🚀 The Breakout: ship code to the edge like the cloud
+
+```
+ Before AETHER                     With AETHER
+ ──────────────                    ───────────────────────────
+ Cross-compile.                    ┌──────────────────────────┐
+ Flash firmware.        ──▶        │ $ pull nginx:latest      │
+ Hope it boots.                    │ [▓▓▓▓▓▓▓▓░░] 80%  pulled  │
+ Drive to the site.                │ $ run  --mem 256M         │
+ Repeat × 10,000. 😩                │ ● running    10.88.0.2    │
+                                   └──────────────────────────┘
+                                   Click "Run." Done. 🎉
+```
+
+> Your developers **already** build containers. Now they deploy to the
+> physical edge with the same workflow — no embedded PhD required.
+
+---
+
+## 🆚 Why We Win
+
+```
+                    AWS IoT  Azure IoT  Balena  AETHER
+ ──────────────────────────────────────────────────────
+ Open standards        ◐        ◐         ○       ●
+ Edge containers       ○        ◐         ●       ●
+ Runs on 1 GB RAM      ◐        ◐         ◐       ●
+ Built-in VPN mesh     ○        ○         ●       ●
+ Vehicle / CAN data    ○        ○         ○       ●
+ No cloud lock-in      ○        ○         ◐       ●
+ A/B OTA + rollback    ◐        ◐         ●       ●
+ ──────────────────────────────────────────────────────
+                              ● full   ◐ partial   ○ none
+```
+
+**Hyperscalers lock you in. Balena lacks device-management depth.**
+We do both — on open standards, at the lowest hardware floor in the market.
+
+---
+
+## 🔐 Security that actually ships
+
+```
+ Provision → Bootstrap → DTLS-PSK → VPN(mTLS) → Registered
+     │           │           │          │           │
+ write-only  per-device  128-bit   client cert  revocable
+ creds       identity    session   + CRL        on theft
+```
+
+Containers run **unprivileged · seccomp-filtered · resource-capped ·
+network-isolated** (own IP, masqueraded) — blast radius contained.
+
+> Security isn't a slide we added for investors.
+> It's the **first thing a device does on power-on.**
+
+---
+
+## 📈 Market
+
+```
+ IoT platform TAM      ████████████████████   $1T+ by 2030
+ Edge computing SAM    ████████░░░░░░░░░░░░   ~$150B · ~30% CAGR
+ Beachhead SOM         ██░░░░░░░░░░░░░░░░░░   industrial · fleet · vehicle
+```
+
+**Tailwinds:** 📶 5G · 🚗 connected vehicles · 🏭 Industry 4.0 ·
+🤖 **AI-at-the-edge needs a deployment runtime — that's us.**
+
+Note: Market ranges are widely-cited industry estimates; SOM is our wedge.
+Figures are directional, not audited.
+
+---
+
+## 🛣 Traction & Roadmap
+
+| Shipped ✅ | Next 📍 |
+|---|---|
+| Secure bootstrap + VPN mesh | Multi-container orchestration |
+| Multi-protocol telemetry | Edge-AI model deployment |
+| A/B OTA + rollback | Container port-mapping + IPAM |
+| Edge container runtime | Fleet-wide app rollouts |
+| Device + cloud dashboards | Edge-app marketplace |
+| Host + bridge networking | Managed cloud (SaaS tier) |
+
+> Velocity: a full edge container runtime — designed, built, CI-green,
+> merged — in **days, not quarters.**
+
+---
+
+## 💰 The Ask
+
+```
+ ╔══════════════════════════════════════════════════════════╗
+ ║  RAISING:  Seed — convert design lead → market lead       ║
+ ║                                                          ║
+ ║  USE OF FUNDS                                             ║
+ ║   ▸ 50%  Engineering — orchestration + edge-AI runtime    ║
+ ║   ▸ 25%  GTM — 3 lighthouse industrial customers          ║
+ ║   ▸ 15%  Managed-cloud SaaS tier (recurring revenue)      ║
+ ║   ▸ 10%  Security certs (SOC2 / IEC 62443)                ║
+ ║                                                          ║
+ ║  MODEL: Open-core + per-device/month managed cloud        ║
+ ║         → land on hardware, expand on recurring revenue    ║
+ ╚══════════════════════════════════════════════════════════╝
+```
+
+---
+
+## 🎤 The cloud already won the data center.
+
+# The next $1T is won at the **EDGE**.
+
+AETHER is the operating layer for that edge —
+**secure by birth, programmable by design, open by principle.**
+
+### Let's build the edge together. 🤝
+
+Note: Thank you. Happy to take questions — or give you a live demo of pulling
+and running a container on a $35 board, right now.

--- a/pitch/index.html
+++ b/pitch/index.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>AETHER — Investor Pitch</title>
+
+  <!-- reveal.js (CDN) -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/dist/reset.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/dist/reveal.css">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/dist/theme/black.css" id="theme">
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/plugin/highlight/monokai.css">
+
+  <style>
+    :root {
+      --aether-cyan: #2ee6d6;
+      --aether-blue: #0a84ff;
+    }
+    .reveal { font-family: "Inter", "Segoe UI", system-ui, sans-serif; }
+    .reveal h1, .reveal h2, .reveal h3 { letter-spacing: -0.01em; }
+    .reveal h1 { color: var(--aether-cyan); text-shadow: 0 2px 24px rgba(46,230,214,0.25); }
+    .reveal h2 { color: #fff; }
+    .reveal h3 { color: var(--aether-cyan); font-weight: 600; }
+    .reveal strong { color: var(--aether-cyan); }
+    .reveal blockquote {
+      border-left: 4px solid var(--aether-blue);
+      background: rgba(10,132,255,0.08);
+      width: 92%; font-style: normal; box-shadow: none;
+    }
+    /* ASCII diagrams: tight monospace that fits the slide */
+    .reveal pre { box-shadow: 0 1px 24px rgba(0,0,0,0.4); width: 100%; }
+    .reveal pre code {
+      font-family: "JetBrains Mono", "SFMono-Regular", Menlo, Consolas, monospace;
+      font-size: 0.46em; line-height: 1.32; padding: 16px 18px;
+      max-height: 620px; background: #11141b; color: #d7e0ea;
+      white-space: pre; overflow: auto;
+    }
+    .reveal table { font-size: 0.62em; }
+    .reveal table th { color: var(--aether-cyan); border-bottom: 2px solid var(--aether-blue); }
+    .reveal table td, .reveal table th { padding: 0.35em 0.7em; }
+    .reveal section img { border: none; box-shadow: none; }
+    /* subtle gradient backdrop */
+    .reveal .backgrounds { background:
+      radial-gradient(1200px 600px at 70% -10%, rgba(10,132,255,0.18), transparent 60%),
+      radial-gradient(900px 500px at 10% 110%, rgba(46,230,214,0.12), transparent 60%),
+      #0b0e14; }
+    .reveal .progress { color: var(--aether-cyan); }
+    .reveal .controls { color: var(--aether-cyan); }
+  </style>
+</head>
+<body>
+  <div class="reveal">
+    <div class="slides">
+      <!--
+        Single source of truth: the deck content lives in aether-pitch.md.
+        reveal's markdown plugin fetches + splits it on `---` slide breaks.
+        NOTE: loading an external .md requires serving over http(s) — run a
+        local server (see pitch/README.md), don't just open this via file://.
+      -->
+      <section
+        data-markdown="aether-pitch.md"
+        data-separator="\r?\n---\r?\n"
+        data-separator-notes="^Note:">
+      </section>
+    </div>
+  </div>
+
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/dist/reveal.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/plugin/markdown/markdown.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/plugin/highlight/highlight.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/reveal.js@4.6.1/plugin/notes/notes.js"></script>
+  <script>
+    Reveal.initialize({
+      width: 1280,
+      height: 800,
+      margin: 0.06,
+      minScale: 0.2,
+      maxScale: 1.6,
+      hash: true,
+      slideNumber: 'c/t',
+      transition: 'slide',
+      backgroundTransition: 'fade',
+      plugins: [ RevealMarkdown, RevealHighlight, RevealNotes ],
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
A reveal.js investor/CEO pitch deck for the device + cloud IoT platform — secure device management, multi-protocol telemetry, A/B OTA, and the new **edge container runtime**.

## Contents (`pitch/`)
| File | What |
|------|------|
| `aether-pitch.md` | Deck content — **single source of truth** (renders on GitHub; reveal splits on `---`). |
| `index.html` | reveal.js shell, loaded from CDN (no install/build). |
| `README.md` | How to view + export to PDF. |

## View
```sh
cd pitch && python3 -m http.server 8000   # open http://localhost:8000/  (S = speaker notes)
```

## Notes
- **Static docs only** — not referenced by any recipe/build; zero impact on the image or CI.
- 12 slides: Problem → Solution → Architecture → Features → *The Breakout (edge containers)* → Why We Win → Security → Market → Traction → Ask → Close. Speaker notes (`Note:`) included.
- Grounded in what the platform actually ships (LwM2M mgmt, VPN mesh, telemetry, OTA, crun-backed container runtime with host + bridge networking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)