### PR TITLE
fix(yocto): disable BB_HASHSERVE in kas build so the sstate mirror matches

### DIFF
--- a/yocto/kas-iot.yml
+++ b/yocto/kas-iot.yml
@@ -87,11 +87,21 @@ local_conf_header:
     # Serial console on the GPIO header (no-op on qemu machines).
     ENABLE_UART = "1"
 
+    # Disable the local hash-equivalence server. Poky defaults BB_HASHSERVE to
+    # a local "auto" server whose unihashes never match the upstream sstate
+    # mirror's object names — so bitbake probes the mirror for thousands of
+    # objects that all MISS (a long, hangy "Checking sstate mirror object
+    # availability" phase, and a near-cold build). With OEBasicHash the task
+    # hashes match the mirror, so probes hit and prebuilt sstate downloads.
+    # (This is exactly what bitbake's own warning recommends.)
+    BB_HASHSERVE = ""
+    BB_SIGNATURE_HANDLER = "OEBasicHash"
+
     # Upstream shared-state mirror — download prebuilt sstate for stock
     # recipes (kernel, base distro, toolchain, ...) instead of compiling them
     # on a cold build. Best-effort: bitbake builds anything the mirror lacks,
     # and a local sstate-cache still takes precedence. Coverage varies by
-    # release (scarthgap) / MACHINE.
+    # release (scarthgap) / MACHINE. Requires BB_HASHSERVE="" above to match.
     SSTATE_MIRRORS ?= "file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"
 
 bblayers_conf_header:


### PR DESCRIPTION
## Symptom
A local `kas build` hangs at **"Checking sstate mirror object availability"** — bitbake stays alive but emits no task events for 1200s+ (empty `Active tasks:`). bitbake also warns at startup:

> You are using a local hash equivalence server but have configured an sstate mirror. This will likely mean no sstate will match from the mirror. You may wish to disable the hash equivalence use (BB_HASHSERVE)…

## Cause
Poky defaults `BB_HASHSERVE` to a local hash-equivalence server. Its *unihashes* never match the upstream `SSTATE_MIRRORS` object names, so bitbake probes the mirror for thousands of objects that **all miss** — each a slow HTTP request — before it can start building. Result: a long hang + a near-cold build.

## Fix
Add bitbake's own recommended setting to the kas `local_conf_header`:
```yaml
BB_HASHSERVE = ""
BB_SIGNATURE_HANDLER = "OEBasicHash"
```
Now task hashes match the mirror → probes hit → prebuilt sstate (kernel/toolchain/etc.) downloads, and the hang is gone.

## Scope — kas path only (deliberate)
The `Containerfile`/`entrypoint.sh` build path is **left unchanged**. CI's warm sstate-cache was populated under the default hash server; switching that path to `OEBasicHash` would invalidate the cache and force cold, timeout-risk CI builds. This hang only affects the local/cold **kas** path, which is what's patched.

## To use
Pull `main` after merge and re-run `kas build yocto/kas-iot.yml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)