### PR TITLE
fix(yocto): cold local build.sh — disable BB_HASHSERVE so the sstate mirror matches

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -203,6 +203,7 @@ build_machine() {
         -e "IOT_FRESH=${IOT_FRESH:-}" \
         -e "IOT_AB=${IOT_AB:-}" \
         -e "IOT_BRANCH=${IOT_BRANCH:-}" \
+        -e "IOT_HASH_LOCAL=1" \
         -v "$SCRIPT_DIR/meta-iot:/home/builduser/yocto/meta-iot:ro" \
         -v "${DOWNLOADS_VOLUME}:/home/builduser/yocto/build/downloads:U" \
         -v "${SSTATE_VOLUME}:/home/builduser/yocto/build/sstate-cache:U" \

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -205,6 +205,26 @@ fi
 echo 'SSTATE_MIRRORS += "file://.* http://sstate.yoctoproject.org/all/PATH;downloadfilename=PATH"' \
     >> conf/local.conf
 
+# Make the upstream network mirror actually usable on a COLD LOCAL build.
+# Poky defaults BB_HASHSERVE to a local hash-equivalence server whose unihashes
+# never match the upstream mirror's object names — so bitbake probes thousands
+# of objects that all MISS (a long, hangy "Checking sstate mirror object
+# availability" phase + a near-cold build). OEBasicHash makes task hashes match
+# the mirror so prebuilt sstate downloads.
+#   - Only when IOT_HASH_LOCAL is set (build.sh's `podman run` sets it; CI's
+#     `docker build` does NOT) → CI's warm sstate-cache (built under the default
+#     hash server) is never invalidated.
+#   - And only on a TRUE cold build: skip when a baked sstate-mirror is present
+#     (IOT_USE_CACHE builds), since that cache was built under hash-serve and
+#     would stop matching under OEBasicHash.
+if [ -n "${IOT_HASH_LOCAL:-}" ] && [ ! -d /home/builduser/yocto/sstate-mirror ]; then
+    echo '→ Cold local build: BB_HASHSERVE="" so the upstream sstate mirror matches'
+    cat >> conf/local.conf <<'HASHCONF'
+BB_HASHSERVE = ""
+BB_SIGNATURE_HANDLER = "OEBasicHash"
+HASHCONF
+fi
+
 # ── 4b. Force-refresh the iot recipe (opt-in: IOT_FRESH=1) ─────────
 # SRCREV = "${AUTOREV}" on IOT_BRANCH is meant to track the branch tip, but a
 # cached git mirror / the recipe's sstate (and the baked own-mirrors dl-mirror


### PR DESCRIPTION
Ports the kas-path fix (#404) to the **`build.sh` / Containerfile** path, gated so **CI is never touched**.

## Why
A cold local `./build.sh` hits the same hang the kas path did: bitbake's default local hash-equivalence server produces unihashes that never match the upstream `SSTATE_MIRRORS` object names, so it probes thousands of mirror objects that all miss → a long **"Checking sstate mirror object availability"** stall + a near-cold build.

## Fix (surgical + CI-safe)
- `build.sh`'s `podman run` now sets **`IOT_HASH_LOCAL=1`**.
- `entrypoint.sh` appends `BB_HASHSERVE=""` + `BB_SIGNATURE_HANDLER="OEBasicHash"` **only when**:
  1. `IOT_HASH_LOCAL` is set — i.e. invoked via `build.sh`. **CI builds via `docker build` (build-push-action), never `build.sh`**, so the flag is unset there and CI's warm sstate-cache (built under the default hash server) stays valid.
  2. **no baked `sstate-mirror` dir is present** — so `IOT_USE_CACHE` builds (which restore a cache built under hash-serve) keep hash-serve and still match.

Net: cold local builds get fast, matching mirror hits; CI and cache-restore builds are byte-for-byte unchanged.

## Use
```sh
git pull            # main, after merge
./build.sh          # cold build now downloads sstate instead of hanging
```

Note: if you'd previously run `build.sh` under hash-serve, the persistent sstate-cache volume has some now-unmatched (unihash) objects — those are simply ignored and rebuilt once under OEBasicHash; self-healing, no action needed.

Follows #404 (kas path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)