### PR TITLE
fix(ota): reject firmware downgrades at the cloud push and device install gates

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -868,8 +868,12 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                     // cloud re-installing the SAME build or clobbering
                                     // a freshly-flashed unit with a stale-but-same/older
                                     // bundle (the downgrade loop). +build metadata is
-                                    // ignored. Unknown installed version → allow (first
-                                    // push before /3/0/3 has been read).
+                                    // ignored. Unknown installed version → DEFER (fail
+                                    // closed): the cloud Reads /3/0/3 right after
+                                    // registration, so a later pass pushes once the
+                                    // version is known. A blind push ~2 s after register
+                                    // is exactly what shipped a 1.2.0 bundle to a 1.3.0
+                                    // unit and wedged opkg on the cross-version deps.
                                     {
                                         std::string installed;
                                         {
@@ -882,13 +886,15 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                             std::sscanf(v.c_str(), "%ld.%ld.%ld", &a, &b, &c);
                                             return a * 1000000L + b * 1000L + c;
                                         };
-                                        if (!installed.empty() && !ver.empty() &&
-                                            semv(ver) <= semv(installed)) {
+                                        if (!ver.empty() &&
+                                            (installed.empty() ||
+                                             semv(ver) <= semv(installed))) {
                                             ACE_DEBUG((LM_INFO,
-                                                ACE_TEXT("%D lwm2m:thread:%t %M %N:%l skipping OTA to "
-                                                         "%C: ver=%C not newer than installed=%C\n"),
+                                                ACE_TEXT("%D lwm2m:thread:%t %M %N:%l deferring OTA to "
+                                                         "%C: ver=%C not strictly newer than "
+                                                         "installed=%C\n"),
                                                 reg.endpoint.c_str(), ver.c_str(),
-                                                installed.c_str()));
+                                                installed.empty() ? "?(unread)" : installed.c_str()));
                                             break;
                                         }
                                     }

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -246,7 +246,8 @@ return {
         default = 0,
     },
     ["iot.update.result"] = {       -- 0 initial,1 success,2 rolled-back (A/B),
-        access  = "Admin",          -- 5 integrity,8 uri,9 install
+        access  = "Admin",          -- 5 integrity,8 uri,9 install,
+                                    -- 10 skipped (offered not newer — downgrade refused)
         type    = "integer",
         default = 0,
     },

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
@@ -37,6 +37,19 @@ set_result()  { $DSCLI set iot.update.result  "$1" >/dev/null 2>&1 || true; }
 set_version() { $DSCLI set iot.update.version "\"$1\"" >/dev/null 2>&1 || true; }
 log() { logger -t iot-swupdate "$*" 2>/dev/null; echo "iot-swupdate: $*"; }
 
+# Parse "major.minor.patch" (ignoring any +build / -pre suffix) into one
+# comparable integer; non-numeric fields count as 0. Mirrors the cloud-side
+# semv() in apps/src/main.cpp so both downgrade gates agree.
+semv() {
+    v="${1%%+*}"; v="${v%%-*}"
+    oIFS="$IFS"; IFS=.; set -- $v; IFS="$oIFS"
+    a="${1:-0}"; b="${2:-0}"; c="${3:-0}"
+    case "$a" in ''|*[!0-9]*) a=0 ;; esac
+    case "$b" in ''|*[!0-9]*) b=0 ;; esac
+    case "$c" in ''|*[!0-9]*) c=0 ;; esac
+    echo $(( a * 1000000 + b * 1000 + c ))
+}
+
 # Wait for ds-server to answer after a (re)start; mirrors the compose healthcheck.
 ds_wait() {
     i=0
@@ -132,6 +145,27 @@ if [ -f "$WORK/update.meta" ]; then
     while IFS='=' read -r k v; do
         case "$k" in version) VER="$v" ;; reboot) REBOOT="$v" ;; esac
     done < "$WORK/update.meta"
+fi
+
+# ── downgrade guard ────────────────────────────────────────────────
+# Refuse a bundle whose semver is OLDER than what's running. The cloud has
+# its own push gate, but it fails closed only once it has read the device's
+# /3/0/3 version — a push ~2 s after registration (before that read) once
+# offered a 1.2.0 bundle to this 1.3.0 unit, and `opkg install` then died on
+# the cross-version dependency conflict and left this service failed. This is
+# the last line of defense. Same-semver re-installs (a newer +git build of the
+# same release) are allowed; only a strictly-lower semver is rejected.
+if [ -n "$VER" ]; then
+    CUR="$($DSCLI get iot.version 2>/dev/null | sed 's/^iot\.version=//')"
+    if [ -n "$CUR" ] && [ "$(semv "$VER")" -lt "$(semv "$CUR")" ]; then
+        log "refusing downgrade: offered=$VER < installed=$CUR; skipping"
+        set_version "$CUR"   # report what is actually installed, not the offer
+        set_result 10        # 10 = skipped (offered not newer) — NOT an error
+        set_state 0
+        rm -rf "$WORK"
+        rm -f "/run/iot/update/.self.$$"
+        exit 0
+    fi
 fi
 
 # ── 3. install ─────────────────────────────────────────────────────


### PR DESCRIPTION
## Problem

The cloud pushed firmware **ver=1.2.0** to a device already running **1.3.0** (a downgrade). The device's `opkg install` died on the cross-version dependency conflict:

```
* Solution 1:
*   - do not ask to install iot-mqtt-1.2.0+git0+5ebdbd5576-r0.cortexa53
```

…leaving `iot-swupdate.service` in `failed`.

Two gaps allowed it:

### 1. Cloud push gate failed *open*
`apps/src/main.cpp` skipped a push only when it **already knew** the device's `/3/0/3` firmware version. The push fired ~2 s after registration — before that Read completed — so `installed` was empty and the guard waved the 1.2.0 bundle through (its own comment even said "Unknown installed version → allow").

**Fix:** fail **closed**. If a job carries a version, require the installed version to be *known* **and** strictly older before pushing; otherwise **defer**. The cloud Reads `/3/0/3` right after registration, so a later pass pushes once the version is known — a slight delay instead of clobbering a freshly-flashed unit.

### 2. Device installer had no downgrade guard
`iot-swupdate` ran `opkg install --force-reinstall --force-downgrade` with no version check.

**Fix (last line of defense):** before installing, compare the staged bundle's semver against the running `iot.version`. If strictly older, **skip cleanly** — report the installed version, set `iot.update.result=10` (skipped: not newer), `exit 0` (no failed unit). Same-semver re-installs (a newer `+git` build of the same release) still proceed. A new `semv()` shell helper mirrors the cloud-side `semv()` so both gates agree.

`iot.lua` documents the new result code `10`.

## Verification
- `main.cpp` passes `-fsyntax-only` against real ACE headers.
- `iot-swupdate` passes `sh -n`.
- `semv()` unit-checked against the incident strings: `1.2.0+git0+...` < `1.3.0+0be35f2` → **REJECT**; `1.3.0` vs `1.3.0+git` → **ALLOW**; `1.4.0` > `1.3.0` → **ALLOW**; `1.10.0` > `1.9.0` → **ALLOW**.
- 17/17 `RegistrationClient` gtests still pass.

## Notes
- Both gates ship in the device image (the installer change) + cloud binary (the push change) on the next build.
- This is the follow-up to #406 (LwM2M ack-timeout + watchdog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)