### PR TITLE
docs: LwM2M lost-ack recovery, client watchdog, and OTA downgrade guards

### DIFF
--- a/apps/docs/lwm2m-design.md
+++ b/apps/docs/lwm2m-design.md
@@ -300,6 +300,43 @@ to advance the lifetime ticker. On expiry, schedule a registration update;
 the ACE handler `UDPAdapter::handle_exception` (the notify drain) then
 sends the CoAP frame.
 
+#### 5.3.1 Lost-ack recovery (`check_ack_timeout`)
+
+The FSM above advances *only* on a received response (`on_response`). With no
+timeout, a single dropped datagram strands it forever: a Register/Update/
+Deregister whose ack never arrives parks the FSM in an `Awaiting*Ack` state,
+`should_send_update()` (which only fires while `Registered`) goes quiet, the
+server expires the registration after the lifetime — yet `compute_conn_state()`
+still maps `AwaitingUpdateAck → "registered"`, so the device-ui shows
+**connected while the cloud lists it offline**. Observed in the field after a
+network blip dropped an in-flight Update.
+
+`RegistrationClient::check_ack_timeout(now)` runs each 1 Hz client tick and
+recovers (config in `ClientConfig`: `ackTimeoutSeconds` = 6, `maxAckRetransmits`
+= 3, sized so `maxAckRetransmits * ackTimeoutSeconds < updateMarginSeconds`,
+i.e. recovery completes inside the lifetime margin):
+
+| In state | After `ackTimeoutSeconds` with no response | Action returned to the tick |
+|----------|--------------------------------------------|-----------------------------|
+| `AwaitingUpdateAck`, budget left | likely a dropped datagram on a live session | `RetransmitUpdate` — tick resends the Update (FSM reverts to `Registered` so `build_update_request` re-arms it; `m_ackRetransmits++`) |
+| `AwaitingUpdateAck`, budget spent | session suspect | `ReRegister` — FSM → `Unregistered`; tick replays the boot path (`bootPhase = NotStarted`) to re-handshake DTLS, re-bootstrap and re-Register |
+| `AwaitingRegisterAck` / `AwaitingDeregisterAck` | lost Register/Deregister ack | `ReRegister` (same as above) |
+
+Any received ack resets the retransmit budget (`on_response`). `build_deregister_request`
+stamps `m_lastSendOrAck` like Register/Update so the Deregister deadline is
+measured from its own send.
+
+#### 5.3.2 systemd watchdog
+
+The recovery above handles a stuck *FSM*; a wedged *reactor* (alive process,
+no ticks) is a different failure class systemd should catch. `iot-lwm2m-client`
+sets `WatchdogSec=60s` and the client tick pets it via `systemd_watchdog_ping()`
+(the `sd_notify(WATCHDOG=1)` wire protocol written directly — no libsystemd
+dependency; a no-op when `$NOTIFY_SOCKET` is unset). If the reactor stalls the
+pings stop and systemd `SIGABRT`s + restarts the unit. **The unit's
+`WatchdogSec=` and the binary that sends `WATCHDOG=1` must ship together** — an
+older binary under a watchdog unit would be killed every 60 s.
+
 ### 5.4 Registration Server
 
 ```

--- a/apps/docs/lwm2m-rdd.md
+++ b/apps/docs/lwm2m-rdd.md
@@ -68,6 +68,7 @@ Priority is MoSCoW: **M**ust / **S**hould / **C**ould / **W**on't.
 | REQ-REG-009 | Server registry SHALL persist `(ep, loc, lt, peer, advertised set)` for the duration of the registration; persistence storage is in-memory by default. | M | Core §6.2 | §5.4 |
 | REQ-REG-010 | Server registry SHALL mirror Register / Update / Deregister events to MongoDB (`DbClient`) via an async worker `ACE_Task`, so registrations survive process restart. Reactor thread MUST NOT block on DB I/O. | S | — | §5.4 / D3 |
 | REQ-REG-011 | All per-Server-Object state (registrations, observers, write-attributes) SHALL be keyed by **Short Server ID** even in single-server v1 deployments, so adding a second Server Object instance is a localized change. | M | Core §6.3 | D2 |
+| REQ-REG-012 | Client SHALL NOT remain in an `Awaiting*Ack` state indefinitely: after `ackTimeoutSeconds` with no response it SHALL retransmit a lost Update (up to `maxAckRetransmits`), then re-establish the session (re-handshake DTLS + re-Register). A lost ack MUST NOT leave the device reporting `registered` while the server has expired it. | M | — | §5.3.1 |
 
 ### 3.3 Device Management & Service Enablement
 
@@ -212,6 +213,7 @@ artifact.
 | REQ-REG-009 | Core §6.2    | §5.4 | L3 | `client_registry_test.cpp::tracks_advertised_set` |
 | REQ-REG-010 | — (D3) | §5.4 | L3 | `client_registry_test.cpp::mongo_mirror_async`, `client_registry_test.cpp::reconstruct_on_restart` |
 | REQ-REG-011 | Core §6.3 (D2) | §3.1 / §5.4 | L1/L3 | `client_registry_test.cpp::keyed_by_short_server_id` |
+| REQ-REG-012 | — | §5.3.1 | L3 | `registration_client_test.cpp::ack_timeout_retransmits_lost_update_within_budget`, `::ack_timeout_escalates_to_reregister_after_budget`, `::ack_received_resets_retransmit_budget`, `::ack_timeout_on_lost_register_reregisters`, `::deregister_send_is_stamped_against_instant_timeout` |
 | REQ-DM-001 | Core §6.3.4 | §3.1 | L5 | `dm_test.cpp::GET_returns_resource` |
 | REQ-DM-002 | Core §6.3.4 | §4.4 | L2/L5 | `dm_test.cpp::GET_discover_link_format` |
 | REQ-DM-003 | Core §6.3.4 | §3.1 | L5 | `dm_test.cpp::PUT_replaces_resource` |

--- a/apps/docs/tdd-installed-version.md
+++ b/apps/docs/tdd-installed-version.md
@@ -121,6 +121,23 @@ updated by the response handler; `publish_regs` includes
 (We deliberately do **not** add `version` to `ServerRegistration` — that
 struct is rebuilt verbatim from registration frames and would clobber it.)
 
+### 3c. Downgrade guard (push gate)
+
+`epVersions` does double duty: besides the UI column, it gates the OTA push.
+Before writing `/5/0/1` + executing `/5/0/2` for a pending job, `lwm2m-dm`
+compares the job's `version` against `epVersions[endpoint]` (semver
+`major.minor.patch`, `+build` ignored) and pushes **only when it is strictly
+newer**. The check **fails closed**: if the device's version isn't known yet
+(the `/3/0/3` read is async and lands shortly *after* registration), the push
+is **deferred**, not sent — a later tick pushes once the version is known.
+
+This closes the original defect: a push fired ~2 s after registration, before
+the `/3/0/3` read completed, so `epVersions` was empty, the guard waved a 1.2.0
+bundle through, and the 1.3.0 device's `opkg install` died on the cross-version
+dependency conflict (`iot-swupdate.service` left failed). The device installer
+re-checks the same semver rule as a last line of defense — see
+`tdd-yocto-swupdate.md` step 4 (result code `10` = skipped, not newer).
+
 ## 4. The merge (`iot-cloudd`)
 
 `reconcile_registrations` (`apps/cloud/server/src/main.cpp:172-`) already

--- a/apps/docs/tdd-yocto-swupdate.md
+++ b/apps/docs/tdd-yocto-swupdate.md
@@ -187,19 +187,37 @@ ExecStart=/usr/bin/iot-swupdate
    campaign staged mid-install lands cleanly for the next activation and we never
    install a half-written new file.
 3. If no `.ipk` in the work dir → clean up, exit 0 (spurious trigger).
-4. `iot.update.state = 3` (updating).
-5. `opkg install --force-reinstall --force-downgrade <work>/*.ipk`
+4. **Downgrade guard:** if `update.meta` carries a `version=` and its semver
+   (`major.minor.patch`, `+build`/`-pre` ignored) is **strictly older** than the
+   running `iot.version`, skip the install: `iot.update.version` = the running
+   version, `iot.update.result = 10` (skipped — not newer), state 0, **exit 0**
+   (clean, *not* a failed unit). Same-semver re-installs (a newer `+git` build of
+   the same release) are allowed. This is the last line of defense — the cloud
+   push gate (`apps/src/main.cpp`, see `tdd-installed-version.md` §3b) also
+   refuses non-newer versions, but it fails closed only once it has read the
+   device's `/3/0/3` version; a push ~2 s after registration once slipped a
+   1.2.0 bundle onto a 1.3.0 unit and `opkg` blew up on the cross-version deps.
+   A `semv()` shell helper mirrors the cloud-side `semv()` so both gates agree.
+5. `iot.update.state = 3` (updating).
+6. `opkg install --force-reinstall --force-downgrade <work>/*.ipk`
    `> /run/iot/update/last.log 2>&1`. On failure: `iot.update.result = 9`,
    state 0, log tail, clean work dir, exit 1 (**no reboot, no restart**).
-6. Derive version (`update.meta` `version=` wins, else parsed from opkg log) →
+   (`--force-downgrade` remains for the allowed same-semver `+git` reinstall,
+   whose opkg version string can read as a downgrade; the step-4 guard already
+   blocked any real semver downgrade.)
+7. Derive version (`update.meta` `version=` wins, else parsed from opkg log) →
    `iot.update.version`.
-7. **Config/schema migration (§11)** — restart `ds-server` so it loads the new
+8. **Config/schema migration (§11)** — restart `ds-server` so it loads the new
    schemas, then run any pending migrations. On migration failure: `result=9`,
    skip the daemon restart, exit non-zero (operator intervention) — opkg is
    already applied, so we don't restart app daemons against a half-migrated ds.
-8. `iot.update.result = 1`; `iot.update.state = 0`.
-9. **Reboot decision (§4).**
-10. Clean `.work-$$/`.
+9. `iot.update.result = 1`; `iot.update.state = 0`.
+10. **Reboot decision (§4).**
+11. Clean `.work-$$/`.
+
+Result codes (`iot.update.result`): `0` initial, `1` success, `2` rolled-back
+(A/B), `5` integrity, `8` uri, `9` install/migration error, `10` skipped
+(offered not newer — downgrade refused).
 
 ds writes use `ds-cli --socket=/run/iot/data_store.sock` (root) — identical to
 today's script, and ds (`/var/lib/iot`) is persistent so the result survives a


### PR DESCRIPTION
Documents the fixes shipped in #406 (LwM2M ack-timeout recovery + systemd watchdog) and #407 (OTA downgrade guards).

- **`lwm2m-design.md` §5.3.1** — lost-ack recovery (`check_ack_timeout`: retransmit a lost Update within budget, then re-establish the session), and why a stranded `Awaiting*Ack` state reported `registered` on-device while the cloud had expired it. **§5.3.2** — the systemd watchdog (`sd_notify(WATCHDOG=1)` from the tick; unit + binary must ship together).
- **`lwm2m-rdd.md`** — new **REQ-REG-012** (client must not sit in `Awaiting*Ack` indefinitely) + traceability to the new `registration_client_test` cases.
- **`tdd-installed-version.md` §3c** — the cloud push downgrade gate (fail-closed: defer until `/3/0/3` is known).
- **`tdd-yocto-swupdate.md`** — device-side downgrade guard step + result code `10` (skipped — not newer); installer steps renumbered.

Docs-only, no code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)