### PR TITLE
feat(debug): on-demand DTLS wire capture (iot-pcap) + PSK key-dump for pcap decryption

### DIFF
--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -11,6 +11,8 @@
 
 #include <ace/Log_Msg.h>
 #include <cctype>
+#include <cstdio>   // keylog dump (fopen/fprintf) — see dtlsGetPskInfoCb
+#include <cstdlib>  // getenv($IOT_DTLS_KEYLOG)
 
 log_t dtls_level_from_string(const std::string& s) {
     std::string up;
@@ -226,6 +228,22 @@ std::int32_t dtlsGetPskInfoCb(dtls_context_t *ctx, const session_t *session, dtl
                 dtls_warn("PSK (%zu B) exceeds caller buffer (%zu B)\n",
                           bin.size(), result_length);
                 return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+            }
+            // Debug key-dump for offline pcap decryption. The negotiated suite
+            // is TLS_PSK_WITH_AES_128_CCM_8 (no ECDHE), so the PSK alone lets
+            // Wireshark derive the session keys: paste `secret` into DTLS ->
+            // Pre-Shared-Key. Both the BS and DM handshakes pass through here,
+            // so a single tap captures every session as the device connects.
+            // OFF unless $IOT_DTLS_KEYLOG names a file (SSLKEYLOGFILE-style) —
+            // NEVER the journal: the surrounding code deliberately keeps PSKs
+            // off the logs (BUG-001 / NFR-SEC-001). The file holds live PSKs;
+            // keep it root-only and wipe it after pulling the pcap.
+            if (const char* kl = ::getenv("IOT_DTLS_KEYLOG"); kl && *kl) {
+                if (FILE* f = ::fopen(kl, "ae")) {   // append, close-on-exec
+                    ::fprintf(f, "identity=%s key=%s\n", in.c_str(),
+                              secret.c_str());
+                    ::fclose(f);
+                }
             }
             ::memcpy(result, bin.data(), bin.size());
             return static_cast<std::int32_t>(bin.size());

--- a/packaging/systemd/iot-pcap.service
+++ b/packaging/systemd/iot-pcap.service
@@ -1,0 +1,52 @@
+[Unit]
+Description=IoT wire capture (tcpdump ring buffer for DTLS/CoAP debugging)
+Documentation=file:///etc/iot/pcap.env
+# DEBUG aid — ships DISABLED (SYSTEMD_AUTO_ENABLE=disable + an explicit
+# `disable` in 90-iot.preset so preset-all keeps it off). Start on demand:
+#   systemctl start iot-pcap          # capture until stopped or reboot
+#   systemctl enable --now iot-pcap   # capture across reboots (disable when done)
+# The DTLS payload on the wire is ciphertext; for the decrypted view set
+# log.level.dtls=debug via ds-cli (the dtlsReadCb/dtlsWriteCb trace).
+After=network-online.target iot-ds.service iot-lwm2m-client.service
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+# Optional override file — `-` so a missing pcap.env is not an error. The
+# Environment= lines below are the defaults; pcap.env documents how to widen
+# the filter / change rotation.
+EnvironmentFile=-/etc/iot/pcap.env
+Environment=IOT_PCAP_BIN=tcpdump
+Environment=IOT_PCAP_IFACE=any
+Environment=IOT_PCAP_DIR=/var/log/iot
+Environment=IOT_PCAP_FILES=10
+Environment=IOT_PCAP_SIZE=5
+Environment="IOT_PCAP_FILTER=udp port 5683 or udp port 5684"
+# Bounded ring buffer: IOT_PCAP_FILES files of IOT_PCAP_SIZE MB each (default
+# 10x5 = 50 MB total) so a forgotten capture can't fill the RPi flash. Run via
+# sh -c so the multi-word BPF filter word-splits ($IOT_PCAP_FILTER, unquoted)
+# and $IOT_PCAP_BIN resolves on PATH (tcpdump installs to /usr/sbin).
+ExecStart=/bin/sh -c 'exec "$IOT_PCAP_BIN" -i "$IOT_PCAP_IFACE" -n -p -s 0 -U -w "$IOT_PCAP_DIR/lwm2m.pcap" -C "$IOT_PCAP_SIZE" -W "$IOT_PCAP_FILES" $IOT_PCAP_FILTER'
+
+# tcpdump on -i any needs a raw socket. Runs as root (no User=) so CAP_NET_RAW
+# is held; no -Z privilege drop (that would need NoNewPrivileges=no).
+LogsDirectory=iot
+LogsDirectoryMode=0750
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_DAC_OVERRIDE
+
+Restart=on-failure
+RestartSec=10s
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/90-iot.preset
@@ -32,3 +32,7 @@ enable iot-transfer.path
 # iot-containerd: single-container runtime shim. Enabled so the device-ui
 # container feature works out of the box; idle until an Admin issues a pull/run.
 enable iot-containerd.service
+# iot-pcap: on-demand tcpdump capture for field debugging. Explicitly DISABLED —
+# a continuous packet capture is a debug aid, not a boot service (flash wear +
+# captures user traffic). Operator `systemctl start iot-pcap` while diagnosing.
+disable iot-pcap.service

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-pcap.service
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-pcap.service
@@ -1,0 +1,52 @@
+[Unit]
+Description=IoT wire capture (tcpdump ring buffer for DTLS/CoAP debugging)
+Documentation=file:///etc/iot/pcap.env
+# DEBUG aid — ships DISABLED (SYSTEMD_AUTO_ENABLE=disable + an explicit
+# `disable` in 90-iot.preset so preset-all keeps it off). Start on demand:
+#   systemctl start iot-pcap          # capture until stopped or reboot
+#   systemctl enable --now iot-pcap   # capture across reboots (disable when done)
+# The DTLS payload on the wire is ciphertext; for the decrypted view set
+# log.level.dtls=debug via ds-cli (the dtlsReadCb/dtlsWriteCb trace).
+After=network-online.target iot-ds.service iot-lwm2m-client.service
+Wants=network-online.target
+StartLimitBurst=5
+StartLimitIntervalSec=60s
+
+[Service]
+Type=simple
+# Optional override file — `-` so a missing pcap.env is not an error. The
+# Environment= lines below are the defaults; pcap.env documents how to widen
+# the filter / change rotation.
+EnvironmentFile=-/etc/iot/pcap.env
+Environment=IOT_PCAP_BIN=tcpdump
+Environment=IOT_PCAP_IFACE=any
+Environment=IOT_PCAP_DIR=/var/log/iot
+Environment=IOT_PCAP_FILES=10
+Environment=IOT_PCAP_SIZE=5
+Environment="IOT_PCAP_FILTER=udp port 5683 or udp port 5684"
+# Bounded ring buffer: IOT_PCAP_FILES files of IOT_PCAP_SIZE MB each (default
+# 10x5 = 50 MB total) so a forgotten capture can't fill the RPi flash. Run via
+# sh -c so the multi-word BPF filter word-splits ($IOT_PCAP_FILTER, unquoted)
+# and $IOT_PCAP_BIN resolves on PATH (tcpdump installs to /usr/sbin).
+ExecStart=/bin/sh -c 'exec "$IOT_PCAP_BIN" -i "$IOT_PCAP_IFACE" -n -p -s 0 -U -w "$IOT_PCAP_DIR/lwm2m.pcap" -C "$IOT_PCAP_SIZE" -W "$IOT_PCAP_FILES" $IOT_PCAP_FILTER'
+
+# tcpdump on -i any needs a raw socket. Runs as root (no User=) so CAP_NET_RAW
+# is held; no -Z privilege drop (that would need NoNewPrivileges=no).
+LogsDirectory=iot
+LogsDirectoryMode=0750
+CapabilityBoundingSet=CAP_NET_RAW CAP_NET_ADMIN CAP_DAC_OVERRIDE
+
+Restart=on-failure
+RestartSec=10s
+StandardOutput=journal
+StandardError=journal
+
+NoNewPrivileges=yes
+PrivateTmp=yes
+ProtectHome=yes
+ProtectKernelTunables=yes
+ProtectControlGroups=yes
+RestrictRealtime=yes
+
+[Install]
+WantedBy=multi-user.target

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-client.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/lwm2m-client.env
@@ -21,3 +21,15 @@
 # See /etc/iot/ds-schemas/iot.lua for type + range constraints.
 
 LWM2M_ARGS="role=client config=/etc/iot/config ds-sock=/run/iot/data_store.sock"
+
+# DTLS key-dump for offline pcap decryption (debug only — OFF by default).
+# When set, the DTLS PSK callback appends `identity=… key=<hex>` for every
+# handshake (BS and DM) to this file. Pair with iot-pcap.service: the suite is
+# TLS_PSK_WITH_AES_128_CCM_8 (no ECDHE), so paste the hex key into Wireshark
+# (DTLS -> Pre-Shared-Key) to decrypt — BS and DM in separate passes.
+# Path must be writable by the client's `engineer` user: /run/iot works (it is
+# 2775 root:iot tmpfs and engineer is in group iot) and, being tmpfs, the live
+# PSKs never touch flash and vanish on reboot. Delete the file after use anyway.
+# Unset = no-op (nothing written, no journal exposure). `systemctl restart` to
+# apply.
+#IOT_DTLS_KEYLOG=/run/iot/dtls-keys.log

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/pcap.env
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/pcap.env
@@ -1,0 +1,25 @@
+# EnvironmentFile for iot-pcap.service — on-demand DTLS/CoAP wire capture.
+#
+# This unit is a DEBUG aid and ships DISABLED. Start it only while diagnosing:
+#   systemctl start iot-pcap          # capture until stopped or reboot
+#   systemctl enable --now iot-pcap   # capture across reboots (disable when done)
+#
+# Pcaps land in $IOT_PCAP_DIR as a bounded ring buffer (lwm2m.pcap, lwm2m.pcap1,
+# …); total size is capped at IOT_PCAP_FILES * IOT_PCAP_SIZE MB so a forgotten
+# capture can't fill the RPi flash. Pull them with scp. The DTLS payload is
+# ciphertext on the wire — for the decrypted CoAP view set log.level.dtls=debug
+# (ds-cli) and read the lwm2m journal (dtlsReadCb/dtlsWriteCb).
+#
+# All keys below are commented: the .service already sets these as defaults.
+# Uncomment to override. tcpdump on -i any needs a raw socket; the unit runs as
+# root with CAP_NET_RAW.
+
+#IOT_PCAP_BIN=tcpdump
+#IOT_PCAP_IFACE=any
+#IOT_PCAP_DIR=/var/log/iot
+#IOT_PCAP_FILES=10
+#IOT_PCAP_SIZE=5
+# BPF filter — default captures both LwM2M DTLS ports (DM/BS 5683, client 5684).
+# Widen to add the VPN/telemetry planes, e.g.:
+#   udp port 5683 or udp port 5684 or udp port 1194
+#IOT_PCAP_FILTER=udp port 5683 or udp port 5684

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -40,6 +40,7 @@ SRC_URI = "\
     file://iot-can0-up.service \
     file://iot-containerd.service \
     file://iot-mqttd.service \
+    file://iot-pcap.service \
     file://10-iot-wired.network \
     file://iot-wifi-client.service \
     file://iot-httpd.service \
@@ -51,6 +52,7 @@ SRC_URI = "\
     file://net-router.env \
     file://wifi-client.env \
     file://httpd.env \
+    file://pcap.env \
     file://iot-ota-stage \
     file://iot-ota-stage.path \
     file://iot-ota-stage.service \
@@ -349,6 +351,8 @@ do_install() {
         # iot-mqttd: MQTT telemetry mirror. Enabled by default but parks until a
         # broker is configured (mqtt.broker.host), so it is harmless when unused.
         install -m 0644 ${WORKDIR}/iot-mqttd.service           ${D}${systemd_system_unitdir}/
+        # iot-pcap: on-demand tcpdump capture, OFF by default (debug aid).
+        install -m 0644 ${WORKDIR}/iot-pcap.service            ${D}${systemd_system_unitdir}/
         # networkd wired profile: RequiredForOnline=no so a cable-less eth0 does
         # not pin the system "offline" and park systemd-timesyncd on a WiFi-only
         # unit (no-RTC clock would stay stale → TLS/VPN fails). See the file header.
@@ -386,6 +390,10 @@ do_install() {
         install -m 0644 ${WORKDIR}/net-router.env     ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/wifi-client.env    ${D}${sysconfdir}/iot/
         install -m 0644 ${WORKDIR}/httpd.env          ${D}${sysconfdir}/iot/
+        # pcap.env documents iot-pcap.service overrides; claimed by ${PN}-config
+        # via its ${sysconfdir}/iot glob (the unit reads it with a leading `-`,
+        # so it is optional).
+        install -m 0644 ${WORKDIR}/pcap.env           ${D}${sysconfdir}/iot/
 
         # Zero-touch mDNS device-UI discovery: derive iot-<serial> hostname at
         # boot and advertise iot-httpd (_http._tcp:8080) via Avahi. See
@@ -431,6 +439,7 @@ PACKAGE_BEFORE_PN = "\
     ${PN}-vehicle \
     ${PN}-containerd \
     ${PN}-mqtt \
+    ${PN}-pcap \
     ${PN}-config \
     ${PN}-bcm2837-selftest \
 "
@@ -649,6 +658,19 @@ RRECOMMENDS:${PN}-mqtt = "\
     ${PN}-ds-server \
     ${PN}-config \
 "
+
+# pcap — iot-pcap.service: on-demand tcpdump ring-buffer capture of the LwM2M
+# DTLS planes, for field debugging. No iot binary of its own — just the unit;
+# tcpdump (+ libpcap, pulled transitively) is the runtime dep. Ships DISABLED
+# (SYSTEMD_AUTO_ENABLE below + an explicit `disable` in 90-iot.preset); the
+# operator starts it only while diagnosing. pcap.env ships in ${PN}-config.
+FILES:${PN}-pcap = "\
+    ${systemd_system_unitdir}/iot-pcap.service \
+"
+RDEPENDS:${PN}-pcap = "tcpdump"
+RRECOMMENDS:${PN}-pcap = "\
+    ${PN}-config \
+"
 # A real data path also wants a modem manager + tools on the image; left to the
 # integrator per WP firmware (ModemManager / libqmi / usb-modeswitch).
 RRECOMMENDS:${PN}-cellular = "\
@@ -724,6 +746,12 @@ SYSTEMD_AUTO_ENABLE:${PN}-containerd = "enable"
 # mqtt mirror enabled by default — it parks (no broker connection) until
 # mqtt.broker.host is configured, so it is a no-op until the operator sets it up.
 SYSTEMD_SERVICE:${PN}-mqtt = "iot-mqttd.service"
+# pcap capture registered but NOT auto-enabled: a continuous packet capture is a
+# debug aid, not a boot service (flash wear + captures user traffic). Operator
+# `systemctl start iot-pcap` while diagnosing. Also `disable`d in 90-iot.preset
+# so preset-all keeps it off on first boot.
+SYSTEMD_SERVICE:${PN}-pcap = "iot-pcap.service"
+SYSTEMD_AUTO_ENABLE:${PN}-pcap = "disable"
 
 # ds-server and wifi-client auto-start. wifi-client comes up on every boot
 # and reads wifi.networks from the data-store (schema default seeds a

--- a/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
+++ b/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
@@ -42,12 +42,16 @@ RDEPENDS:${PN}-full = "\
     iot-sensord \
     iot-cellular \
     iot-containerd \
+    iot-pcap \
     openvpn \
     nftables \
     iproute2 \
     wpa-supplicant \
     crun \
 "
+# iot-pcap: ships the iot-pcap.service capture unit (DISABLED by default) and
+# pulls tcpdump (+ libpcap) so field DTLS/CoAP capture is one `systemctl start`
+# away without a reflash.
 # crun: the OCI runtime iot-containerd shells out to (from meta-virtualization).
 # Also pulled transitively via RDEPENDS:iot-containerd, listed here explicitly.
 # Note: no wireless-tools (iwconfig/iwlist) — it was dropped from modern


### PR DESCRIPTION
## Why

While chasing the *"device-ui says `registered`, cloud says offline"* stall, the decrypted `dtlsReadCb`/`dtlsWriteCb` trace showed acks **do** arrive and **are** handled — so to keep digging we wanted an on-the-wire pcap. But the device has no `tcpdump` and no opkg feed to install one. This adds a permanent, operator-toggleable capture path plus the missing piece to actually *read* the capture (DTLS is encrypted).

## What

**`iot-pcap.service` — on-demand wire capture (image build)**
- `tcpdump` ring buffer (default 10×5 MB = 50 MB cap; filter `udp port 5683 or 5684`), runs as root with `CAP_NET_RAW`, writes `/var/log/iot`.
- Dedicated `${PN}-pcap` package `RDEPENDS tcpdump`; `packagegroup-iot-full` pulls it so `tcpdump` (+`libpcap`) ship on the gateway image — capture is one `systemctl start` away, no reflash.
- **Disabled by default** in both `SYSTEMD_AUTO_ENABLE` and `90-iot.preset` (continuous capture = flash wear + captures user traffic; it's a debug aid, not a boot service). `pcap.env` documents iface/filter/rotation overrides.

**DTLS PSK key-dump — makes the pcap decryptable (ships via OTA ipk)**
- Captured payload is ciphertext. tinydtls offers only `TLS_PSK_WITH_AES_128_CCM_8` (PSK path, no certs) and the ECDHE cert suite, so for our PSK sessions the **PSK alone** lets Wireshark derive the keys.
- `dtlsGetPskInfoCb` now appends `identity=… key=<hex>` for every BS/DM handshake to `$IOT_DTLS_KEYLOG`. **OFF** unless the env var names a file (SSLKEYLOGFILE-style), and **never** the journal — the surrounding code deliberately keeps PSKs off the logs (BUG-001 / NFR-SEC-001).
- Default path `/run/iot/dtls-keys.log`: tmpfs, writable by the client's `engineer` user (group `iot`) — keys never hit flash and vanish on reboot. Documented (commented) in `lwm2m-client.env`.

## Workflow
1. `systemctl start iot-pcap` → captures to `/var/log/iot/lwm2m.pcap*`.
2. Uncomment `IOT_DTLS_KEYLOG`, `systemctl restart iot-lwm2m-client` → reconnect writes BS+DM keys.
3. `scp` pcap + keyfile off; in Wireshark paste the hex into **DTLS → Pre-Shared-Key** (BS and DM in two passes).
4. Delete the keyfile.

## Delivery / testing
- The **key-dump** is a code change → rides the normal `iot-*.ipk` OTA; no image rebuild.
- The **unit + tcpdump** need a full **image build** (tcpdump can't be opkg-installed — no feed on the device).
- No C++ toolchain / bitbake on the dev host, so both validate **post-merge** on the CI image build (image workflows trigger on push to main, not PRs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)