### PR TITLE
fix(yocto): deterministic WiFi-seed SRC_URI (unblocks do_fetch) + DurableSampleBuffer spec

### DIFF
--- a/apps/docs/tdd-vehicle-telemetry.md
+++ b/apps/docs/tdd-vehicle-telemetry.md
@@ -95,10 +95,11 @@ dev-build, PR-26; see "validation" note below):**
 - ⬜ **Full RFC 7959 Block-Wise** (>1024 B packs) — only partial in the CoAP
   adapter; deferrable while `maxBatch` keeps packs sub-block. The one piece that
   *modifies the live adapter* (regression risk) rather than adding isolated units.
-- ⬜ **On-device Mongo buffer** (PR-7, §3a) — `iot-vehicled` store-and-forward
-  buffer for offline backfill. Needs `mongod` on the RPi (ARMv8.0 → mongod 4.4)
-  and `#ifdef IOT_ENABLE_MONGO` CMake gating so the cloud build (no mongocxx)
-  still links `iot-vehicled`. Only useful once the client uploader is live.
+- ⬜ **On-device durable buffer** (PR-7) — `iot-vehicled` store-and-forward
+  buffer for offline backfill. **Preferred impl: `DurableSampleBuffer` (SQLite
+  outbox, §3a.1)** — no `mongod` recipe, no ARMv8 cap, no `#ifdef`, compiles in
+  both builds. Original mongod-based design in §3a kept for reference. Only
+  useful once the client uploader is live.
 
 > **Validation note:** every pure piece above was compiled + run in the
 > **podman dev-build** (PR-26), not merely CI-built — the full `apps/` gtest
@@ -298,6 +299,60 @@ fills in `RegistryMirror`'s currently-stubbed `persist()` by example.
 > only the one-time collection-creation differs. Confirm what mongod (and which
 > arch) actually runs on the target before PR-7. (If Mongo runs in a container
 > or off-device, 5.0+ may be available.)
+
+## 3a.1 — Lightweight alternative to PR-7: `DurableSampleBuffer` (SQLite outbox)
+
+**Recommended over on-device mongod.** The buffer only needs *durability* across
+reboot/crash and beyond RAM — not a database server. The existing in-RAM
+`telemetry::SampleBuffer` (`apps/inc/lwm2m_sample_buffer.hpp`) already nails the
+queue semantics (bounded FIFO, oldest-first `take(n)`, `requeue()` on nack,
+overflow `dropped()`); make those operations durable behind the same interface
+and skip mongod entirely. This dodges all three PR-7 blockers at once: there is
+**no `mongod` server recipe** in the layers (only the C++ *driver*); the build
+disables mongo (`PACKAGECONFIG:remove:pn-iot = "mongo"` in `entrypoint.sh`); and
+mongod ≥5.0 (time-series) needs ARMv8.2 while the Pi 3B/4 is ARMv8.0 → capped at
+4.4. SQLite is in-process, ~1 MB, no daemon/port/auth, no `#ifdef IOT_ENABLE_MONGO`
+(compiles in **both** device and cloud builds; runtime-gated off in the cloud).
+
+**Design (full spec):**
+- **Interface extraction** — add an abstract `telemetry::ISampleBuffer`
+  (`push`/`size`/`empty`/`dropped`/`take`/`requeue`/**`commit`**). `SampleBuffer`
+  implements it (+ a no-op `commit()`); `DurableSampleBuffer` is the SQLite impl.
+  `send::Uploader` holds a `std::unique_ptr<ISampleBuffer>` instead of a concrete
+  buffer, chosen at runtime — so the buffer is selectable without templates.
+- **Lease, not delete (crash-safety).** Unlike the RAM buffer (which deletes on
+  `take()`), `take()` here marks rows in-flight (`sent=1`) and keeps them; the
+  Uploader's `on_ack` calls the new `commit()` (DELETE the leased batch),
+  `on_timeout`'s `requeue` un-leases (`sent=0`). Stop-and-wait ⇒ one leased batch,
+  tracked in `m_leased`. Crash recovery = `UPDATE outbox SET sent=0 WHERE sent=1`
+  at open → at-least-once (cloud dedups by `(ep, seq)`, already in §3b's schema).
+- **Schema** — `outbox(seq INTEGER PK AUTOINCREMENT, ts INTEGER, body BLOB,
+  sent INTEGER DEFAULT 0)`, partial index on `sent=0`, `journal_mode=WAL`,
+  `synchronous=NORMAL` (flash-friendly). `body` = Sample as compact JSON
+  (`{t, v:[[name,val]…]}`); `ts = llround(timeUnix*1000)` for the TTL reaper.
+- **Op map:** `push`→INSERT (+ evict oldest over `cap`, `dropped++`); `take(n)`→
+  SELECT `sent=0` oldest n then mark `sent=1`; `requeue`→`sent=0` (seqs unchanged
+  ⇒ order restored); `commit`→DELETE leased; `reap_expired()`→`DELETE ts<now-ttl`
+  off the client's 1 Hz tick.
+- **Uploader refactor:** ctor takes the `unique_ptr`; `m_buf.x()`→`m_buf->x()`;
+  **one new line** `m_buf->commit()` in `on_ack`. With the RAM buffer `commit()`
+  is the no-op, so behavior is byte-identical to today.
+- **Runtime gate:** `make_buffer()` factory — ds key `iot.telemetry.db.path`
+  empty (or open failure) → in-RAM `SampleBuffer`; set (e.g.
+  `/var/lib/iot/telemetry.db`) → `DurableSampleBuffer`. `iot.telemetry.ttl.secs`
+  → reaper window.
+- **Build:** system `libsqlite3` (oe-core `sqlite3` → `DEPENDS`/`RDEPENDS:${PN}-lwm2m`)
+  or vendor the amalgamation under `apps/3rdparty/` like tinydtls. No mongo.
+- **Tests** — `apps/test/durable_sample_buffer_test.cpp`: mirror the four
+  `sample_buffer_test.cpp` cases verbatim against a temp-file DB (proves
+  contract parity), then add: `survives_reopen`, `crash_recovery_rearms_leased`
+  (take without commit → reopen → batch back), `commit_then_reopen_drops_delivered`,
+  `ttl_reaps_old_rows`, and the factory fallback on empty/bad path.
+
+**Net:** offline backfill with true per-point timestamps and crash-safe
+at-least-once delivery — PR-7's entire goal — in ~150 LOC + a test, with none of
+mongod's packaging, RAM, or ARM-version cost. Keep §3a (on-device mongod) only if
+a future requirement specifically needs Mongo query semantics on the device.
 
 ## 3b. Cloud telemetry pipeline — LwM2M Send → cloud MongoDB (60-day)
 

--- a/apps/docs/tdd-wifi-credentials-seed.md
+++ b/apps/docs/tdd-wifi-credentials-seed.md
@@ -19,11 +19,19 @@ Test cmd: `python3 -m unittest discover -s yocto/meta-iot/recipes-iot/lwm2m/file
 
 ## 1. Goal
 
-Let a build integrator drop a **gitignored** `wifi_credentials.lua` into the
-recipe's designated dir; the Yocto build reads it and bakes the credentials
-into the `wifi.networks` schema default so a freshly-flashed image associates
-to the operator's AP with no runtime step. If the file is absent, the build is
-a no-op and the committed `changeme` placeholder default stands ("don't care").
+Let a build integrator opt in with `IOT_WIFI_SEED = "1"` **and** drop a
+**gitignored** `wifi_credentials.lua` into the recipe's designated dir; the Yocto
+build reads it and bakes the credentials into the `wifi.networks` schema default
+so a freshly-flashed image associates to the operator's AP with no runtime step.
+When `IOT_WIFI_SEED` is unset/`"0"` (the default), the build is a no-op and the
+committed `changeme` placeholder default stands ("don't care").
+
+> **Why a variable and not "file present"?** An earlier version gated `SRC_URI`
+> on `os.path.exists(... wifi_credentials.lua)`. That makes `do_fetch`'s basehash
+> depend on parse-time filesystem state, which bitbake rejects as
+> non-deterministic metadata ("the basehash value changed … on reparse"). The
+> gate is now the `IOT_WIFI_SEED` variable (part of the signature), so the file's
+> presence no longer perturbs the hash; set the var in `local.conf` / kas.
 
 This keeps real WiFi credentials **out of source control** — the committed
 `wifi.lua` always carries only the placeholder.
@@ -86,9 +94,11 @@ the committed source `wifi.lua` is untouched.
 ## 5. Recipe wiring (build-time, no-op when absent)
 
 ```python
-# Conditional — keeps the file optional AND part of the recipe signature so a
-# credential change triggers a rebuild.
-SRC_URI += "${@'file://wifi_credentials.lua' if os.path.exists(d.getVar('THISDIR') + '/files/wifi_credentials.lua') else ''}"
+# Variable-gated — keeps the file optional AND part of the recipe signature so a
+# credential change triggers a rebuild, WITHOUT a parse-time os.path.exists()
+# (which makes do_fetch's basehash non-deterministic; see §1 note).
+IOT_WIFI_SEED ??= "0"
+SRC_URI += "${@'file://wifi_credentials.lua' if d.getVar('IOT_WIFI_SEED') == '1' else ''}"
 SRC_URI += " file://gen_wifi_default.py"
 
 do_install:append() {

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -82,14 +82,21 @@ SRC_URI = "\
     file://bcm2837-selftest.service \
 "
 
-# Optional, gitignored WiFi credential seed. When an integrator drops
-# files/wifi_credentials.lua into this layer, bake it into the wifi.networks
-# schema default at build time (see do_install:append + apps/docs/
-# tdd-wifi-credentials-seed.md). Adding it to SRC_URI only when present keeps
-# it optional AND part of the recipe signature, so changing the credentials
-# triggers a rebuild. Absent => no-op, the committed "changeme" placeholder
-# stands.
-SRC_URI += "${@'file://wifi_credentials.lua' if os.path.exists(d.getVar('THISDIR') + '/files/wifi_credentials.lua') else ''}"
+# Optional, gitignored WiFi credential seed. When enabled, files/wifi_credentials.lua
+# is baked into the wifi.networks schema default at build time (see do_install:append
+# + apps/docs/tdd-wifi-credentials-seed.md).
+#
+# Gate on a VARIABLE, never os.path.exists(): a parse-time filesystem probe made
+# do_fetch's basehash non-deterministic — bitbake reparses (-Snone) and the hash
+# flips when the (gitignored) file's presence differs between passes, failing with
+# "the metadata is not deterministic". IOT_WIFI_SEED is part of the signature, so
+# toggling it (or editing the fetched file's contents) still triggers a rebuild;
+# the do_install:append below stays guarded on the file actually being fetched.
+#
+# Integrator: set IOT_WIFI_SEED = "1" (local.conf / kas) AND drop the file. Default
+# off => no-op, the committed "changeme" placeholder stands.
+IOT_WIFI_SEED ??= "0"
+SRC_URI += "${@'file://wifi_credentials.lua' if d.getVar('IOT_WIFI_SEED') == '1' else ''}"
 
 SRCREV = "${AUTOREV}"
 


### PR DESCRIPTION
## Build-breaker fix (commit 1)

bitbake aborts `do_fetch` with:

> ERROR: When reparsing …/iot_git.bb:do_fetch, the basehash value changed … The metadata is not deterministic

**Cause:** the optional WiFi credential seed added the file to `SRC_URI` via a parse-time filesystem probe:

```python
SRC_URI += "${@'file://wifi_credentials.lua' if os.path.exists(d.getVar('THISDIR') + '/files/wifi_credentials.lua') else ''}"
```

`os.path.exists()` feeding `SRC_URI` makes `do_fetch`'s basehash depend on whether the (gitignored) file is present, so it flips between bitbake's parse and `-Snone` reparse → non-deterministic metadata.

**Fix:** gate on a **variable** instead — `IOT_WIFI_SEED ?= "0"`; `SRC_URI` includes the file only when it's `"1"`. The variable is in the signature (toggling it / editing the file's contents still triggers a rebuild), but the file's mere presence no longer perturbs the hash. `do_install:append` stays guarded on `[ -f ${WORKDIR}/wifi_credentials.lua ]`, so `SEED=0` is a clean no-op.

**Integrator change:** set `IOT_WIFI_SEED = "1"` (local.conf / kas) **in addition** to dropping the file. Documented in `apps/docs/tdd-wifi-credentials-seed.md`.

## DurableSampleBuffer spec (commit 2, docs-only)

Adds §3a.1 to `tdd-vehicle-telemetry.md`: a lightweight SQLite-outbox store-and-forward buffer as the **preferred** PR-7 implementation (vs on-device mongod). Reuses the existing `SampleBuffer` queue semantics behind a new `ISampleBuffer` interface; lease-not-delete `take()` for crash-safety, `commit()` on ACK, TTL reaper. Dodges all three PR-7 blockers (no `mongod` server recipe in-layers, no ARMv8.0→4.4 time-series cap, no `#ifdef IOT_ENABLE_MONGO` — compiles in both builds, runtime-gated). Includes the `Uploader` refactor, schema, op-map, and gtest plan; cross-linked from the PR-7 status line. No code yet — spec only.

## Testing
- Recipe parse / `do_fetch -Snone` determinism validates on the builder (no bitbake on the dev host). Commit 2 is docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)