### PR TITLE
fix(yocto): auto-enable IOT_WIFI_SEED when wifi_credentials.lua is present (restores drop-the-file seed)

### DIFF
--- a/apps/docs/tdd-wifi-credentials-seed.md
+++ b/apps/docs/tdd-wifi-credentials-seed.md
@@ -19,19 +19,23 @@ Test cmd: `python3 -m unittest discover -s yocto/meta-iot/recipes-iot/lwm2m/file
 
 ## 1. Goal
 
-Let a build integrator opt in with `IOT_WIFI_SEED = "1"` **and** drop a
-**gitignored** `wifi_credentials.lua` into the recipe's designated dir; the Yocto
-build reads it and bakes the credentials into the `wifi.networks` schema default
-so a freshly-flashed image associates to the operator's AP with no runtime step.
-When `IOT_WIFI_SEED` is unset/`"0"` (the default), the build is a no-op and the
+Let a build integrator just **drop a gitignored `wifi_credentials.lua`** into the
+recipe's designated dir; the Yocto build reads it and bakes the credentials into
+the `wifi.networks` schema default so a freshly-flashed image associates to the
+operator's AP with no runtime step. With no file the build is a no-op and the
 committed `changeme` placeholder default stands ("don't care").
 
-> **Why a variable and not "file present"?** An earlier version gated `SRC_URI`
-> on `os.path.exists(... wifi_credentials.lua)`. That makes `do_fetch`'s basehash
-> depend on parse-time filesystem state, which bitbake rejects as
-> non-deterministic metadata ("the basehash value changed … on reparse"). The
-> gate is now the `IOT_WIFI_SEED` variable (part of the signature), so the file's
-> presence no longer perturbs the hash; set the var in `local.conf` / kas.
+> **How the "just drop the file" trigger works (and why it's not `os.path.exists`).**
+> The recipe gates `SRC_URI` on the **`IOT_WIFI_SEED`** variable, not on the file's
+> presence — an `os.path.exists(... wifi_credentials.lua)` inside `SRC_URI` makes
+> `do_fetch`'s basehash depend on parse-time filesystem state, which bitbake
+> rejects as non-deterministic metadata ("the basehash value changed … on
+> reparse"). To keep the drop-the-file UX, the **build wrapper `yocto/entrypoint.sh`
+> detects the file once (before bitbake parses) and writes `IOT_WIFI_SEED = "1"`
+> into `local.conf`** — a fixed var for the whole build, so the recipe metadata
+> stays reproducible. **If you build WITHOUT `entrypoint.sh`** (raw bitbake / kas /
+> a different CI), set `IOT_WIFI_SEED = "1"` yourself in `local.conf` — dropping
+> the file alone won't seed it there.
 
 This keeps real WiFi credentials **out of source control** — the committed
 `wifi.lua` always carries only the placeholder.

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -97,6 +97,23 @@ INHERIT += "rm_work"
 # below at run time (RAM-aware) — see the "resource guards" block.
 YOCONF
 
+# ── WiFi credential seed auto-enable ───────────────────────────────
+# If the integrator dropped meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua,
+# turn on the build-time seed (bakes the SSID/PSK into the wifi.networks schema
+# default — apps/docs/tdd-wifi-credentials-seed.md). The presence check lives
+# HERE, in the build wrapper, NOT in the recipe: iot_git.bb must gate SRC_URI on
+# the IOT_WIFI_SEED *variable*, because an os.path.exists() in SRC_URI makes
+# do_fetch's basehash non-deterministic (bitbake reparse error). Detecting the
+# file once here and writing a fixed local.conf var keeps "just drop the file"
+# working AND the recipe metadata reproducible.
+WIFI_SEED_FILE=/home/builduser/yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua
+if [ -f "$WIFI_SEED_FILE" ]; then
+    echo "→ wifi_credentials.lua present → IOT_WIFI_SEED=1 (seeding wifi.networks default)"
+    echo 'IOT_WIFI_SEED = "1"' >> conf/local.conf
+else
+    echo "→ no wifi_credentials.lua → IOT_WIFI_SEED stays 0 (placeholder default)"
+fi
+
 # ── Build-host resource guards (avoid OOM-killed compiles) ─────────
 # Cross-gcc and nodejs-native compiles peak around ~2 GB per job, and the
 # default podman VM has no swap, so two heavy recipes building at once OOM-kill


### PR DESCRIPTION
## Regression from #410

#410 fixed a `do_fetch` basehash non-determinism by replacing the recipe's parse-time `os.path.exists(wifi_credentials.lua)` `SRC_URI` gate with an **`IOT_WIFI_SEED`** variable gate — but **nothing set the variable**. So dropping `wifi_credentials.lua` silently stopped seeding `wifi.networks`, and built images shipped **without SSID/PSK** (reported in the field).

## Fix

Restore the "just drop the file" workflow **without** reintroducing the non-determinism: detect the file in the **build wrapper** `yocto/entrypoint.sh` (which writes `local.conf` *before* bitbake parses) and set `IOT_WIFI_SEED = "1"` there.

- The presence check now lives in the shell wrapper, **not** recipe metadata → the `local.conf` var is fixed for the whole build (reproducible), and bitbake never sees an `os.path.exists` in `SRC_URI`. Best of both: drop-the-file UX **and** deterministic `do_fetch`.
- Builds that bypass `entrypoint.sh` (raw bitbake / kas / other CI) must set `IOT_WIFI_SEED = "1"` themselves — documented in `tdd-wifi-credentials-seed.md`.

## Validation
No bitbake on the dev host; validates on the next image build (entrypoint.sh runs in the build container). The shell `if [ -f ]` is trivially correct; worst case (file absent) it leaves the prior default behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)