### PR TITLE
feat(telemetry): DurableSampleBuffer — SQLite store-and-forward outbox (PR-7)

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -253,6 +253,7 @@ target_link_libraries(lwm2m
                         ${MONGOCXX_LINK_LIB}
                         ssl
                         crypto
+                        sqlite3   # DurableSampleBuffer (lwm2m_durable_sample_buffer.cpp)
                         ${LUA_LINK_LIBS})
 
 option(BUILD_APPS_TESTS "Build apps-level gtest suite (lwm2m_test)" OFF)

--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -7,9 +7,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -o Acquire::Check-Date=false update && \
     apt-get install -y --no-install-recommends \
     build-essential cmake ninja-build pkg-config autoconf \
-    libssl-dev zlib1g-dev libreadline-dev \
+    libssl-dev zlib1g-dev libreadline-dev libsqlite3-dev \
     liblua5.3-dev lua5.3 wget ca-certificates \
     && rm -rf /var/lib/apt/lists/*
+# libsqlite3-dev: the lwm2m binary links DurableSampleBuffer (always compiled
+# in; the cloud just never enables it via iot.telemetry.db.path).
 
 # ACE/TAO 7.0.0 (~60s)
 RUN wget -q https://github.com/DOCGroup/ACE_TAO/releases/download/ACE%2BTAO-7_0_0/ACE+TAO-7.0.0.tar.gz \
@@ -118,7 +120,7 @@ FROM docker.io/library/ubuntu:22.04 AS runtime
 
 RUN apt-get -o Acquire::Check-Date=false update && \
     apt-get install -y --no-install-recommends \
-    libssl3 openssl zlib1g libreadline8 liblua5.3-0 iptables nftables openvpn ca-certificates \
+    libssl3 openssl zlib1g libreadline8 liblua5.3-0 libsqlite3-0 iptables nftables openvpn ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # PSK provisioning (task P): shared cloud service account/group. The cloud

--- a/apps/device/Dockerfile
+++ b/apps/device/Dockerfile
@@ -47,7 +47,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get -o Acquire::Check-Date=false update && \
     apt-get install -y --no-install-recommends \
     build-essential cmake ninja-build pkg-config autoconf \
-    libssl-dev zlib1g-dev libreadline-dev \
+    libssl-dev zlib1g-dev libreadline-dev libsqlite3-dev \
     liblua5.3-dev lua5.3 wget ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
@@ -127,7 +127,7 @@ ENV DEBIAN_FRONTEND=noninteractive
 # (net-router), wpa_supplicant + udhcpc (wifi-client).
 RUN apt-get -o Acquire::Check-Date=false update && \
     apt-get install -y --no-install-recommends \
-    libssl3 zlib1g libreadline8 liblua5.3-0 ca-certificates \
+    libssl3 zlib1g libreadline8 liblua5.3-0 libsqlite3-0 ca-certificates \
     openvpn nftables iproute2 wpasupplicant udhcpc wireless-tools \
     && rm -rf /var/lib/apt/lists/* /usr/share/doc/* /usr/share/man/*
 

--- a/apps/inc/lwm2m_durable_sample_buffer.hpp
+++ b/apps/inc/lwm2m_durable_sample_buffer.hpp
@@ -1,0 +1,84 @@
+#ifndef __lwm2m_durable_sample_buffer_hpp__
+#define __lwm2m_durable_sample_buffer_hpp__
+
+#include <cstdint>
+#include <ctime>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+#include "lwm2m_sample_buffer.hpp"
+
+struct sqlite3;
+
+/**
+ * @file lwm2m_durable_sample_buffer.hpp
+ * @brief SQLite-backed ISampleBuffer — the on-device store-and-forward buffer
+ *        (tdd-vehicle-telemetry.md §3a.1), the lightweight alternative to PR-7's
+ *        on-device mongod.
+ *
+ * Identical queue semantics to the in-RAM SampleBuffer (bounded FIFO, oldest-
+ * first take, requeue, overflow eviction) but DURABLE across reboot/crash and
+ * beyond RAM, so a device that is offline for hours can backfill the cloud with
+ * true per-point timestamps once the LwM2M/DTLS link returns.
+ *
+ * Crash-safety = lease, not delete: take() marks rows in-flight (sent=1) and
+ * keeps them; the Uploader calls commit() on the 2.04 ACK (DELETE the batch) or
+ * requeue() on timeout (sent=0, retried oldest-first). On open any sent=1 row is
+ * re-armed (sent=0), so a crash mid-flight re-sends — at-least-once; the cloud
+ * dedups by (endpoint, seq). No #ifdef IOT_ENABLE_MONGO: this compiles in both
+ * device and cloud builds; the cloud just never points iot.telemetry.db.path at
+ * a file.
+ */
+
+namespace lwm2m { namespace telemetry {
+
+class DurableSampleBuffer final : public ISampleBuffer {
+public:
+    /// Open (creating if needed) the SQLite outbox at `path`. `cap` bounds the
+    /// PENDING (sent=0) rows — over it, the oldest are evicted newest-wins like
+    /// the RAM buffer. `ttlSeconds` > 0 arms a safety-net reaper (call
+    /// reap_expired() from a timer). Throws std::runtime_error on open/bootstrap
+    /// failure so the factory can fall back to the in-RAM buffer.
+    DurableSampleBuffer(const std::string& path, std::size_t cap,
+                        std::int64_t ttlSeconds);
+    ~DurableSampleBuffer() override;
+
+    DurableSampleBuffer(const DurableSampleBuffer&)            = delete;
+    DurableSampleBuffer& operator=(const DurableSampleBuffer&) = delete;
+
+    void                push(const Sample& s) override;
+    std::size_t         size() const override;               ///< COUNT WHERE sent=0
+    bool                empty() const override;
+    std::size_t         dropped() const override;
+    std::vector<Sample> take(std::size_t n) override;        ///< lease oldest n
+    void                requeue(std::vector<Sample>&& b) override;  ///< un-lease
+    void                commit() override;                   ///< delete leased
+
+    /// DELETE rows older than ttlSeconds relative to `now` (epoch seconds).
+    /// Returns rows reaped. No-op when ttl <= 0. Drive from the client tick.
+    std::size_t reap_expired(std::time_t now);
+
+private:
+    void exec(const char* sql);                  ///< throw on error
+    std::int64_t count_pending() const;
+
+    sqlite3*                  m_db{nullptr};
+    std::size_t               m_cap;
+    std::int64_t              m_ttl;             ///< seconds; 0 = no reaper
+    std::vector<std::int64_t> m_leased;          ///< seqs of the in-flight batch
+    std::size_t               m_dropped{0};      ///< overflow + ttl evictions
+    mutable std::mutex        m_mtx;             ///< producer vs session thread
+};
+
+/// Pick a buffer at runtime: a non-empty `dbPath` (and a successful open) →
+/// DurableSampleBuffer; empty path OR open failure → in-RAM SampleBuffer (so
+/// telemetry still flows live, just without offline backfill). Never throws.
+std::unique_ptr<ISampleBuffer>
+make_sample_buffer(const std::string& dbPath, std::size_t cap,
+                   std::int64_t ttlSeconds);
+
+}} // namespace lwm2m::telemetry
+
+#endif /*__lwm2m_durable_sample_buffer_hpp__*/

--- a/apps/inc/lwm2m_sample_buffer.hpp
+++ b/apps/inc/lwm2m_sample_buffer.hpp
@@ -23,25 +23,44 @@
 
 namespace lwm2m { namespace telemetry {
 
-class SampleBuffer {
+/// The buffer surface the Uploader drives, so the in-RAM and durable (SQLite)
+/// backends are interchangeable at runtime (chosen by ds key, see
+/// make_sample_buffer). `take()` LEASES a batch (the durable backend keeps the
+/// rows so a crash mid-flight doesn't lose them); the Uploader then calls
+/// `commit()` on the 2.04 ACK (drop the leased batch) or `requeue()` on
+/// timeout (un-lease, retried oldest-first). The in-RAM SampleBuffer deletes on
+/// take(), so its commit() is a no-op — behaviour is identical to before.
+struct ISampleBuffer {
+    virtual ~ISampleBuffer() = default;
+    virtual void                push(const Sample& s)              = 0;
+    virtual std::size_t         size() const                       = 0;
+    virtual bool                empty() const                      = 0;
+    virtual std::size_t         dropped() const                    = 0;
+    virtual std::vector<Sample> take(std::size_t n)                = 0;
+    virtual void                requeue(std::vector<Sample>&& b)   = 0;
+    /// ACK'd → the last taken batch is delivered; free it. No-op for in-RAM.
+    virtual void                commit()                           = 0;
+};
+
+class SampleBuffer : public ISampleBuffer {
 public:
     /// `capacity` samples max (clamped to >= 1).
     explicit SampleBuffer(std::size_t capacity)
         : m_cap(capacity ? capacity : 1) {}
 
     /// Append a reading; evicts the oldest when full (counts it in dropped()).
-    void push(const Sample& s) {
+    void push(const Sample& s) override {
         if (m_q.size() >= m_cap) { m_q.pop_front(); ++m_dropped; }
         m_q.push_back(s);
     }
 
-    std::size_t size() const { return m_q.size(); }
-    bool        empty() const { return m_q.empty(); }
+    std::size_t size() const override { return m_q.size(); }
+    bool        empty() const override { return m_q.empty(); }
     /// Total samples evicted by overflow (here + requeue), for telemetry.
-    std::size_t dropped() const { return m_dropped; }
+    std::size_t dropped() const override { return m_dropped; }
 
     /// Remove and return up to `n` oldest samples — the batch to Send.
-    std::vector<Sample> take(std::size_t n) {
+    std::vector<Sample> take(std::size_t n) override {
         std::vector<Sample> out;
         const std::size_t k = n < m_q.size() ? n : m_q.size();
         out.reserve(k);
@@ -56,13 +75,16 @@ public:
     /// it retries first, preserving order. Honours capacity: if the buffer
     /// filled while the batch was in flight, the oldest overflow is dropped
     /// (newest-wins), counted in dropped().
-    void requeue(std::vector<Sample>&& batch) {
+    void requeue(std::vector<Sample>&& batch) override {
         for (auto it = batch.rbegin(); it != batch.rend(); ++it) {
             if (m_q.size() >= m_cap) { ++m_dropped; continue; }
             m_q.push_front(std::move(*it));
         }
         batch.clear();
     }
+
+    /// In-RAM take() already removed the batch — nothing to free.
+    void commit() override {}
 
 private:
     std::deque<Sample> m_q;

--- a/apps/inc/lwm2m_send_uploader.hpp
+++ b/apps/inc/lwm2m_send_uploader.hpp
@@ -2,6 +2,7 @@
 #define __lwm2m_send_uploader_hpp__
 
 #include <cstdint>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -29,20 +30,28 @@ class Uploader {
 public:
     /// `basePath` = SenML bn (e.g. "/33000/0/"); `capacity` = buffer depth;
     /// `maxBatch` = max samples per Send (keep small so packs stay < 1 block
-    /// until Block-Wise lands).
+    /// until Block-Wise lands). Convenience ctor — uses the in-RAM SampleBuffer.
     Uploader(std::string basePath, std::size_t capacity, std::size_t maxBatch,
              int contentFormat = CF_SENML_CBOR)
-        : m_buf(capacity), m_basePath(std::move(basePath)),
+        : Uploader(std::make_unique<telemetry::SampleBuffer>(capacity),
+                   std::move(basePath), maxBatch, contentFormat) {}
+
+    /// Inject any ISampleBuffer — e.g. DurableSampleBuffer (SQLite) for
+    /// offline backfill across reboots. Chosen at runtime by make_sample_buffer.
+    Uploader(std::unique_ptr<telemetry::ISampleBuffer> buf,
+             std::string basePath, std::size_t maxBatch,
+             int contentFormat = CF_SENML_CBOR)
+        : m_buf(std::move(buf)), m_basePath(std::move(basePath)),
           m_maxBatch(maxBatch ? maxBatch : 1), m_cf(contentFormat) {}
 
     /// Producer: enqueue a reading.
-    void offer(const telemetry::Sample& s) { m_buf.push(s); }
+    void offer(const telemetry::Sample& s) { m_buf->push(s); }
 
     /// Queued samples not counting the in-flight batch.
-    std::size_t pending() const { return m_buf.size(); }
+    std::size_t pending() const { return m_buf->size(); }
     bool in_flight() const { return m_inFlight; }
     std::uint16_t in_flight_msgid() const { return m_inflightMsgId; }
-    std::size_t dropped() const { return m_buf.dropped(); }
+    std::size_t dropped() const { return m_buf->dropped(); }
 
     /// Emit the next /dp Send frame when nothing is in flight and samples are
     /// pending; marks the taken batch in flight under (msgId, token). Returns
@@ -57,7 +66,7 @@ public:
     void on_timeout();
 
 private:
-    telemetry::SampleBuffer        m_buf;
+    std::unique_ptr<telemetry::ISampleBuffer> m_buf;
     std::string                    m_basePath;
     std::size_t                    m_maxBatch;
     int                            m_cf;

--- a/apps/src/lwm2m_durable_sample_buffer.cpp
+++ b/apps/src/lwm2m_durable_sample_buffer.cpp
@@ -1,0 +1,237 @@
+#include "lwm2m_durable_sample_buffer.hpp"
+
+#include <cmath>       // llround
+#include <stdexcept>
+#include <string>
+
+#include <sqlite3.h>
+#include <nlohmann/json.hpp>
+
+#include <ace/Log_Msg.h>
+
+namespace lwm2m { namespace telemetry {
+
+namespace {
+
+// Sample <-> compact JSON body. {"t":<unix secs>,"v":[["name",val],…]}.
+std::string serialize(const Sample& s) {
+    nlohmann::json j;
+    j["t"] = s.timeUnix;
+    auto& v = j["v"] = nlohmann::json::array();
+    for (const auto& kv : s.values) v.push_back({kv.first, kv.second});
+    return j.dump();
+}
+
+bool deserialize(const std::string& body, Sample& out) {
+    try {
+        auto j = nlohmann::json::parse(body);
+        out.timeUnix = j.value("t", 0.0);
+        out.values.clear();
+        if (j.contains("v") && j["v"].is_array()) {
+            for (const auto& p : j["v"]) {
+                if (p.is_array() && p.size() == 2 && p[0].is_string())
+                    out.values.emplace_back(p[0].get<std::string>(),
+                                            p[1].get<double>());
+            }
+        }
+        return true;
+    } catch (...) {
+        return false;
+    }
+}
+
+std::string join_seqs(const std::vector<std::int64_t>& seqs) {
+    std::string s;
+    for (std::size_t i = 0; i < seqs.size(); ++i) {
+        if (i) s.push_back(',');
+        s += std::to_string(seqs[i]);
+    }
+    return s;
+}
+
+} // namespace
+
+DurableSampleBuffer::DurableSampleBuffer(const std::string& path,
+                                         std::size_t cap,
+                                         std::int64_t ttlSeconds)
+    : m_cap(cap ? cap : 1), m_ttl(ttlSeconds) {
+    if (sqlite3_open_v2(path.c_str(), &m_db,
+                        SQLITE_OPEN_READWRITE | SQLITE_OPEN_CREATE,
+                        nullptr) != SQLITE_OK) {
+        std::string msg = m_db ? sqlite3_errmsg(m_db) : "open failed";
+        if (m_db) { sqlite3_close(m_db); m_db = nullptr; }
+        throw std::runtime_error("DurableSampleBuffer: " + msg);
+    }
+    // WAL = crash-safe + concurrent read; NORMAL fsyncs on checkpoint, not every
+    // txn (kind to flash). Bootstrap the outbox; re-arm any row left in-flight
+    // (sent=1) by a crash → at-least-once redelivery.
+    exec("PRAGMA journal_mode=WAL;");
+    exec("PRAGMA synchronous=NORMAL;");
+    exec("CREATE TABLE IF NOT EXISTS outbox("
+         "  seq  INTEGER PRIMARY KEY AUTOINCREMENT,"
+         "  ts   INTEGER NOT NULL,"     // epoch ms (timeUnix*1000), for TTL
+         "  body BLOB    NOT NULL,"     // serialized Sample
+         "  sent INTEGER NOT NULL DEFAULT 0);");
+    exec("CREATE INDEX IF NOT EXISTS ix_unsent ON outbox(seq) WHERE sent=0;");
+    exec("UPDATE outbox SET sent=0 WHERE sent=1;");   // crash recovery
+}
+
+DurableSampleBuffer::~DurableSampleBuffer() {
+    if (m_db) sqlite3_close(m_db);
+}
+
+void DurableSampleBuffer::exec(const char* sql) {
+    char* err = nullptr;
+    if (sqlite3_exec(m_db, sql, nullptr, nullptr, &err) != SQLITE_OK) {
+        std::string msg = err ? err : "exec failed";
+        sqlite3_free(err);
+        throw std::runtime_error("DurableSampleBuffer: " + msg);
+    }
+}
+
+std::int64_t DurableSampleBuffer::count_pending() const {
+    sqlite3_stmt* st = nullptr;
+    std::int64_t c = 0;
+    if (sqlite3_prepare_v2(m_db, "SELECT COUNT(*) FROM outbox WHERE sent=0;",
+                           -1, &st, nullptr) == SQLITE_OK) {
+        if (sqlite3_step(st) == SQLITE_ROW) c = sqlite3_column_int64(st, 0);
+    }
+    sqlite3_finalize(st);
+    return c;
+}
+
+void DurableSampleBuffer::push(const Sample& s) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    const std::string body = serialize(s);
+    const std::int64_t ts  = static_cast<std::int64_t>(std::llround(s.timeUnix * 1000.0));
+
+    sqlite3_stmt* st = nullptr;
+    if (sqlite3_prepare_v2(m_db, "INSERT INTO outbox(ts,body) VALUES(?1,?2);",
+                           -1, &st, nullptr) == SQLITE_OK) {
+        sqlite3_bind_int64(st, 1, ts);
+        sqlite3_bind_blob(st, 2, body.data(),
+                          static_cast<int>(body.size()), SQLITE_TRANSIENT);
+        sqlite3_step(st);
+    }
+    sqlite3_finalize(st);
+
+    // Bound the PENDING set: evict oldest over cap (newest-wins), like the RAM
+    // buffer. Leased (in-flight) rows are sent=1 → not counted, not evicted.
+    const std::int64_t pending = count_pending();
+    if (pending > static_cast<std::int64_t>(m_cap)) {
+        const std::int64_t excess = pending - static_cast<std::int64_t>(m_cap);
+        exec(("DELETE FROM outbox WHERE seq IN (SELECT seq FROM outbox "
+              "WHERE sent=0 ORDER BY seq ASC LIMIT " +
+              std::to_string(excess) + ");").c_str());
+        m_dropped += static_cast<std::size_t>(sqlite3_changes(m_db));
+    }
+}
+
+std::size_t DurableSampleBuffer::size() const {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    return static_cast<std::size_t>(count_pending());
+}
+
+bool DurableSampleBuffer::empty() const { return size() == 0; }
+
+std::size_t DurableSampleBuffer::dropped() const {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    return m_dropped;
+}
+
+std::vector<Sample> DurableSampleBuffer::take(std::size_t n) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    std::vector<Sample> out;
+    if (n == 0) return out;
+
+    std::vector<std::int64_t> seqs;
+    std::vector<std::int64_t> poison;   // un-deserializable rows → drop
+    sqlite3_stmt* st = nullptr;
+    if (sqlite3_prepare_v2(m_db,
+            "SELECT seq,body FROM outbox WHERE sent=0 ORDER BY seq ASC LIMIT ?1;",
+            -1, &st, nullptr) == SQLITE_OK) {
+        sqlite3_bind_int64(st, 1, static_cast<std::int64_t>(n));
+        while (sqlite3_step(st) == SQLITE_ROW) {
+            const std::int64_t seq = sqlite3_column_int64(st, 0);
+            const void* blob = sqlite3_column_blob(st, 1);
+            const int   len  = sqlite3_column_bytes(st, 1);
+            Sample s;
+            if (blob && deserialize(std::string(static_cast<const char*>(blob),
+                                                static_cast<std::size_t>(len)), s)) {
+                out.push_back(std::move(s));
+                seqs.push_back(seq);
+            } else {
+                poison.push_back(seq);
+            }
+        }
+    }
+    sqlite3_finalize(st);
+
+    if (!poison.empty()) {                // never re-select a corrupt row
+        exec(("DELETE FROM outbox WHERE seq IN (" + join_seqs(poison) + ");").c_str());
+        m_dropped += poison.size();
+    }
+    if (!seqs.empty()) {                  // lease the batch (keep rows for crash-safety)
+        exec(("UPDATE outbox SET sent=1 WHERE seq IN (" + join_seqs(seqs) + ");").c_str());
+        m_leased = std::move(seqs);
+    }
+    return out;
+}
+
+void DurableSampleBuffer::requeue(std::vector<Sample>&& batch) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    batch.clear();                        // rows live in the DB; arg is ignored
+    if (m_leased.empty()) return;
+    // Un-lease: sent=1 → 0. seqs unchanged → next take() re-selects them first
+    // (oldest-first retry preserved).
+    exec(("UPDATE outbox SET sent=0 WHERE seq IN (" + join_seqs(m_leased) + ");").c_str());
+    m_leased.clear();
+    // The buffer may have filled with newer samples while this batch was in
+    // flight; honour cap (newest-wins) — may drop the just-requeued oldest.
+    const std::int64_t pending = count_pending();
+    if (pending > static_cast<std::int64_t>(m_cap)) {
+        const std::int64_t excess = pending - static_cast<std::int64_t>(m_cap);
+        exec(("DELETE FROM outbox WHERE seq IN (SELECT seq FROM outbox "
+              "WHERE sent=0 ORDER BY seq ASC LIMIT " +
+              std::to_string(excess) + ");").c_str());
+        m_dropped += static_cast<std::size_t>(sqlite3_changes(m_db));
+    }
+}
+
+void DurableSampleBuffer::commit() {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    if (m_leased.empty()) return;
+    exec(("DELETE FROM outbox WHERE seq IN (" + join_seqs(m_leased) + ");").c_str());
+    m_leased.clear();
+}
+
+std::size_t DurableSampleBuffer::reap_expired(std::time_t now) {
+    std::lock_guard<std::mutex> lk(m_mtx);
+    if (m_ttl <= 0) return 0;
+    const std::int64_t cutoff_ms =
+        (static_cast<std::int64_t>(now) - m_ttl) * 1000;
+    // Only reap PENDING rows — never an in-flight (leased) batch.
+    exec(("DELETE FROM outbox WHERE sent=0 AND ts < " +
+          std::to_string(cutoff_ms) + ";").c_str());
+    const std::size_t reaped = static_cast<std::size_t>(sqlite3_changes(m_db));
+    m_dropped += reaped;
+    return reaped;
+}
+
+std::unique_ptr<ISampleBuffer>
+make_sample_buffer(const std::string& dbPath, std::size_t cap,
+                   std::int64_t ttlSeconds) {
+    if (!dbPath.empty()) {
+        try {
+            return std::make_unique<DurableSampleBuffer>(dbPath, cap, ttlSeconds);
+        } catch (const std::exception& e) {
+            ACE_ERROR((LM_ERROR,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l telemetry buffer: "
+                                "durable open failed (%C) — falling back to "
+                                "in-RAM (no offline backfill)\n"), e.what()));
+        }
+    }
+    return std::make_unique<SampleBuffer>(cap);
+}
+
+}} // namespace lwm2m::telemetry

--- a/apps/src/lwm2m_send_uploader.cpp
+++ b/apps/src/lwm2m_send_uploader.cpp
@@ -7,9 +7,9 @@ namespace lwm2m { namespace send {
 
 std::string Uploader::poll(std::uint16_t msgId, const std::string& token) {
     if (m_inFlight) return {};            // stop-and-wait: one batch at a time
-    if (m_buf.empty()) return {};
+    if (m_buf->empty()) return {};
 
-    m_inflight = m_buf.take(m_maxBatch);
+    m_inflight = m_buf->take(m_maxBatch);
     if (m_inflight.empty()) return {};
 
     auto recs = telemetry::build_pack(m_basePath, m_inflight);
@@ -22,6 +22,7 @@ std::string Uploader::poll(std::uint16_t msgId, const std::string& token) {
 
 void Uploader::on_ack(std::uint16_t msgId) {
     if (m_inFlight && msgId == m_inflightMsgId) {
+        m_buf->commit();                  // durable buffer frees the leased batch
         m_inflight.clear();
         m_inFlight = false;               // delivered → pruned
     }
@@ -29,7 +30,7 @@ void Uploader::on_ack(std::uint16_t msgId) {
 
 void Uploader::on_timeout() {
     if (m_inFlight) {
-        m_buf.requeue(std::move(m_inflight));   // retry first, oldest-first kept
+        m_buf->requeue(std::move(m_inflight));  // retry first, oldest-first kept
         m_inflight.clear();
         m_inFlight = false;
     }

--- a/apps/test/CMakeLists.txt
+++ b/apps/test/CMakeLists.txt
@@ -64,6 +64,7 @@ file(GLOB SOURCES "*.cpp"
                     "../src/lwm2m_send.cpp"
                     "../src/lwm2m_send_server.cpp"
                     "../src/lwm2m_send_uploader.cpp"
+                    "../src/lwm2m_durable_sample_buffer.cpp"
                     "../src/lwm2m_object_3_device.cpp"
                     "../src/lwm2m_object_sensors.cpp"
                     "../src/lwm2m_object_stubs.cpp"
@@ -85,6 +86,7 @@ target_link_libraries(lwm2m_test
     z
     ssl
     crypto
+    sqlite3
     ${LUA_LINK_LIBS})
 
 add_test(NAME lwm2m_gtests COMMAND lwm2m_test)

--- a/apps/test/durable_sample_buffer_test.cpp
+++ b/apps/test/durable_sample_buffer_test.cpp
@@ -1,0 +1,141 @@
+#include <gtest/gtest.h>
+
+#include <cstdio>    // std::remove
+#include <memory>
+#include <string>
+
+#include "lwm2m_durable_sample_buffer.hpp"
+
+namespace tp = ::lwm2m::telemetry;
+
+namespace {
+
+tp::Sample mk(double t, double v) {
+    tp::Sample s;
+    s.timeUnix = t;
+    s.values = { {"10", v} };
+    return s;
+}
+
+// Fixture: one temp DB path, wiped (incl. WAL/SHM sidecars) before + after each
+// test. gtest runs cases serially, so reusing one path is safe.
+class DurableBuf : public ::testing::Test {
+protected:
+    const std::string path = "/tmp/iot_dsb_test.db";
+    void wipe() {
+        std::remove(path.c_str());
+        std::remove((path + "-wal").c_str());
+        std::remove((path + "-shm").c_str());
+    }
+    void SetUp() override { wipe(); }
+    void TearDown() override { wipe(); }
+
+    std::unique_ptr<tp::DurableSampleBuffer> open(std::size_t cap = 10,
+                                                  std::int64_t ttl = 0) {
+        return std::make_unique<tp::DurableSampleBuffer>(path, cap, ttl);
+    }
+};
+
+// ── Contract parity with the in-RAM SampleBuffer (mirrors sample_buffer_test) ──
+
+TEST_F(DurableBuf, push_and_take_is_fifo_oldest_first) {
+    auto buf = open();
+    for (int k = 0; k < 5; ++k) buf->push(mk(1000 + k, 60 + k));
+    EXPECT_EQ(5u, buf->size());
+    EXPECT_FALSE(buf->empty());
+
+    auto batch = buf->take(3);
+    ASSERT_EQ(3u, batch.size());
+    EXPECT_EQ(1000.0, batch[0].timeUnix);          // oldest first
+    EXPECT_EQ(1002.0, batch[2].timeUnix);
+    ASSERT_EQ(1u, batch[0].values.size());
+    EXPECT_EQ("10", batch[0].values[0].first);
+    EXPECT_EQ(60.0, batch[0].values[0].second);    // payload round-trips
+    EXPECT_EQ(2u, buf->size());                     // 2 still pending (3 leased)
+}
+
+TEST_F(DurableBuf, take_more_than_present_returns_all) {
+    auto buf = open();
+    buf->push(mk(1, 1));
+    buf->push(mk(2, 2));
+    auto batch = buf->take(100);
+    EXPECT_EQ(2u, batch.size());
+    EXPECT_EQ(0u, buf->size());
+    EXPECT_TRUE(buf->take(5).empty());
+}
+
+TEST_F(DurableBuf, overflow_evicts_oldest_and_counts_dropped) {
+    auto buf = open(/*cap*/3);
+    for (int k = 0; k < 5; ++k) buf->push(mk(1000 + k, k));  // keep 1002,1003,1004
+    EXPECT_EQ(3u, buf->size());
+    EXPECT_EQ(2u, buf->dropped());
+    auto batch = buf->take(3);
+    EXPECT_EQ(1002.0, batch[0].timeUnix);
+    EXPECT_EQ(1004.0, batch[2].timeUnix);
+}
+
+TEST_F(DurableBuf, requeue_restores_order_and_retries_first) {
+    auto buf = open();
+    for (int k = 0; k < 4; ++k) buf->push(mk(1000 + k, k));
+    auto batch = buf->take(2);                       // lease [1000,1001]
+    EXPECT_EQ(2u, buf->size());                      // [1002,1003] pending
+    buf->requeue(std::move(batch));                  // failed Send → un-lease
+    EXPECT_EQ(4u, buf->size());
+    auto again = buf->take(4);
+    ASSERT_EQ(4u, again.size());
+    EXPECT_EQ(1000.0, again[0].timeUnix);            // requeued retries first
+    EXPECT_EQ(1003.0, again[3].timeUnix);
+}
+
+// ── Durability-specific ──
+
+TEST_F(DurableBuf, survives_reopen) {
+    { auto buf = open(); for (int k = 0; k < 5; ++k) buf->push(mk(1000 + k, k)); }
+    auto buf = open();                               // reopen same file
+    EXPECT_EQ(5u, buf->size());
+    auto b = buf->take(5);
+    ASSERT_EQ(5u, b.size());
+    EXPECT_EQ(1000.0, b[0].timeUnix);                // order preserved on disk
+    EXPECT_EQ(1004.0, b[4].timeUnix);
+}
+
+TEST_F(DurableBuf, crash_recovery_rearms_leased_uncommitted) {
+    { auto buf = open(); for (int k = 0; k < 4; ++k) buf->push(mk(1000 + k, k));
+      buf->take(2); /* leased, NOT committed */ }   // simulate crash mid-flight
+    auto buf = open();
+    EXPECT_EQ(4u, buf->size());                      // leased batch came back
+    EXPECT_EQ(4u, buf->take(4).size());
+}
+
+TEST_F(DurableBuf, commit_then_reopen_drops_delivered) {
+    { auto buf = open(); for (int k = 0; k < 4; ++k) buf->push(mk(1000 + k, k));
+      buf->take(2); buf->commit(); }                 // 2 delivered + pruned
+    auto buf = open();
+    EXPECT_EQ(2u, buf->size());
+    auto b = buf->take(2);
+    EXPECT_EQ(1002.0, b[0].timeUnix);                // only the undelivered remain
+}
+
+TEST_F(DurableBuf, ttl_reaps_old_pending_rows) {
+    auto buf = open(/*cap*/100, /*ttl*/100);
+    buf->push(mk(/*timeUnix*/1000, 1));              // ts=1000s → old
+    buf->push(mk(/*timeUnix*/9999, 2));              // ts=9999s → fresh
+    const std::size_t reaped = buf->reap_expired(/*now*/10000);  // cutoff 9900s
+    EXPECT_EQ(1u, reaped);
+    EXPECT_EQ(1u, buf->size());
+    EXPECT_EQ(9999.0, buf->take(1)[0].timeUnix);
+}
+
+TEST_F(DurableBuf, factory_falls_back_to_ram_on_empty_or_bad_path) {
+    auto ram = tp::make_sample_buffer("", 5, 0);     // empty → in-RAM
+    ASSERT_NE(nullptr, ram);
+    ram->push(mk(1, 1));
+    EXPECT_EQ(1u, ram->size());
+
+    auto bad = tp::make_sample_buffer("/no/such/dir/x.db", 5, 0);  // open fails → in-RAM
+    ASSERT_NE(nullptr, bad);
+    bad->push(mk(1, 1));
+    EXPECT_EQ(1u, bad->size());
+}
+
+} // namespace

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -9,7 +9,7 @@ FROM ubuntu:jammy
 #                                              uses wpa_cli for verify
 # None of them are link-time deps, just runtime.
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev python3-dev autoconf wget pkg-config \
+    apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev libsqlite3-dev python3-dev autoconf wget pkg-config \
                        openvpn netcat-openbsd nftables iproute2 \
                        wpasupplicant udhcpc wireless-tools
 

--- a/docker/Dockerfile.devbuild
+++ b/docker/Dockerfile.devbuild
@@ -9,7 +9,7 @@
 #       bash docker/devbuild.sh
 FROM ubuntu:jammy
 RUN apt-get update && apt-get -y upgrade && \
-    apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev python3-dev autoconf wget pkg-config \
+    apt-get install -y gcc g++ git make cmake libssl-dev zlib1g-dev libreadline-dev liblua5.3-dev libsqlite3-dev python3-dev autoconf wget pkg-config \
                        openvpn netcat-openbsd nftables iproute2 \
                        wpasupplicant udhcpc wireless-tools
 

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -129,7 +129,11 @@ DEPENDS = "\
     nlohmann-json \
     nodejs-native \
     mosquitto \
+    sqlite3 \
 "
+# sqlite3: DurableSampleBuffer — the on-device telemetry store-and-forward
+# outbox (lwm2m_durable_sample_buffer.cpp). Not behind IOT_ENABLE_MONGO; the
+# lwm2m binary always links it (runtime-gated by iot.telemetry.db.path).
 
 # ── PACKAGECONFIG ──────────────────────────────────────────────────
 # mongo:          Enables mongocxx/bsoncxx link (~15 MB in final image).
@@ -502,6 +506,7 @@ RDEPENDS:${PN}-lwm2m = "\
     readline \
     openssl \
     tinydtls-staticdev \
+    sqlite3 \
     ${@bb.utils.contains('PACKAGECONFIG', 'mongo', \
         'mongo-cxx-driver-bsoncxx mongo-cxx-driver mongo-c-driver-bson mongo-c-driver', \
         '', d)} \


### PR DESCRIPTION
Implements the on-device telemetry store-and-forward buffer from `tdd-vehicle-telemetry.md` **§3a.1** — the lightweight alternative to PR-7's on-device mongod. Offline backfill with true per-point timestamps and crash-safe at-least-once delivery, **without** a database server, the ARMv8.0→4.4 time-series cap, or any `#ifdef IOT_ENABLE_MONGO` (compiles in **both** device and cloud builds; runtime-gated by `iot.telemetry.db.path`).

## What
- **`ISampleBuffer`** interface extracted from `SampleBuffer` (`push`/`size`/`empty`/`dropped`/`take`/`requeue` + new **`commit()`**). The in-RAM `SampleBuffer` implements it with a no-op `commit()` — behaviour byte-identical to before.
- **`DurableSampleBuffer`** (SQLite outbox, WAL + `synchronous=NORMAL`). Same queue semantics as the RAM buffer, durable. **Crash-safety = lease-not-delete:** `take()` marks rows `sent=1` and *keeps* them; `on_ack`→`commit()` DELETEs the batch, `on_timeout`→`requeue()` un-leases (`sent=0`, retried oldest-first). On open, any `sent=1` row is re-armed (a crash mid-flight re-sends; the cloud dedups by `ep+seq` per §3b). Bounded by `cap` (newest-wins), TTL safety-net reaper, poison-row drop.
- **`Uploader`** now holds `unique_ptr<ISampleBuffer>` and calls `commit()` on ACK. A new ctor injects any buffer; the existing capacity ctor still makes the in-RAM one, so current callers/tests are unchanged. `make_sample_buffer()` picks durable (path set + opens) else in-RAM (telemetry still flows live).
- **Build:** link `sqlite3` (apps + apps/test CMake); `DEPENDS`/`RDEPENDS sqlite3` in `iot_git.bb`; `libsqlite3-dev`/`-0` added to the cloud, device, and dev/devbuild Dockerfiles (the `lwm2m` binary links it on every build surface).

## Testing
No C++ toolchain on the dev host, so the **real `.cpp` was compiled** (`-Wall -Wextra -std=gnu++17`) and **run against sqlite3 in a container** — all scenarios pass: FIFO + payload round-trip, overflow+`dropped`, requeue order, **survives-reopen**, **crash-recovery** (leased-uncommitted re-armed), **commit-then-reopen drops delivered**, **TTL reap**, factory fallback. The same cases ship as `durable_sample_buffer_test.cpp` (built into `lwm2m_test`; full suite runs in CI/podman).

## Scope
**Not yet wired into the live client** — that lands with the v2 Send session glue (§3b ⬜, the `onSendReport`→buffer + transmit/timer wiring). This PR is the buffer + factory + tests, ready to drop behind the `Uploader`. Follow-ups: the `iot.telemetry.db.path` / `iot.telemetry.ttl.secs` schema keys + client wiring + the 1 Hz `reap_expired()` tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)