### PR TITLE
fix(containers): registry pull broke on curl arg mangling (curl -K) + forgive 'docker pull' paste

### DIFF
--- a/modules/containers/daemon/http_client.cpp
+++ b/modules/containers/daemon/http_client.cpp
@@ -85,38 +85,61 @@ bool http_get(const std::string&              url,
 
     const std::string hdr_path = make_temp("hdr");
     const std::string err_path = make_temp("err");
-    if (hdr_path.empty() || err_path.empty()) {
+    const std::string cfg_path = make_temp("cfg");
+    if (hdr_path.empty() || err_path.empty() || cfg_path.empty()) {
         err = "could not create temp files";
         if (!hdr_path.empty()) ::unlink(hdr_path.c_str());
         if (!err_path.empty()) ::unlink(err_path.c_str());
+        if (!cfg_path.empty()) ::unlink(cfg_path.c_str());
         return false;
     }
 
-    // Build argv. No -f: a 401/404 must still return so the caller can react
-    // (bearer auth / not-found) rather than curl exiting with an error.
-    std::vector<std::string> args = {
-        curl_path(), "-sS", "--connect-timeout", "20",
-        "-m", std::to_string(timeout_sec),
-        "-D", hdr_path,
-        "-o", body_path.empty() ? std::string("/dev/null") : body_path,
+    // Pass EVERY option via a curl config file (-K), not argv tokens. ACE's
+    // command_line(argv[]) round-trips the argv through a single space-joined
+    // buffer and re-splits it on whitespace, which shattered the multi-word
+    // header values ("Accept: …", "Authorization: Bearer …") — curl then saw a
+    // bare -H ("option -H: requires parameter"). A config file keeps those
+    // values quoted and off the argv entirely; the only argv tokens are the
+    // space-free `curl -K <cfg>`. (mkstemp gives 0600, so the bearer token in
+    // the file is not world-readable; we unlink it right after the wait.)
+    // No -f: a 401/404 must still return so the caller can react (bearer auth /
+    // not-found) rather than curl exiting with an error.
+    auto q = [](const std::string& s) {            // curl-config quoted value
+        std::string out = "\"";
+        for (char c : s) { if (c == '\\' || c == '"') out.push_back('\\'); out.push_back(c); }
+        out.push_back('"');
+        return out;
     };
-    if (follow_redirects) args.push_back("-L");
-    for (const auto& a : accept) { args.push_back("-H"); args.push_back("Accept: " + a); }
-    if (!bearer.empty()) { args.push_back("-H"); args.push_back("Authorization: Bearer " + bearer); }
-    if (!basic.empty())  { args.push_back("-u"); args.push_back(basic); }
-    args.push_back(url);
+    {
+        std::ostringstream cfg;
+        cfg << "silent\nshow-error\n"
+            << "connect-timeout = 20\n"
+            << "max-time = " << timeout_sec << "\n"
+            << "dump-header = " << q(hdr_path) << "\n"
+            << "output = " << q(body_path.empty() ? std::string("/dev/null") : body_path) << "\n";
+        if (follow_redirects) cfg << "location\n";
+        for (const auto& a : accept) cfg << "header = " << q("Accept: " + a) << "\n";
+        if (!bearer.empty()) cfg << "header = " << q("Authorization: Bearer " + bearer) << "\n";
+        if (!basic.empty())  cfg << "user = " << q(basic) << "\n";
+        cfg << "url = " << q(url) << "\n";
+        const std::string text = cfg.str();
+        FILE* cf = std::fopen(cfg_path.c_str(), "wb");
+        if (!cf || std::fwrite(text.data(), 1, text.size(), cf) != text.size()) {
+            if (cf) std::fclose(cf);
+            err = "could not write curl config";
+            ::unlink(hdr_path.c_str()); ::unlink(err_path.c_str()); ::unlink(cfg_path.c_str());
+            return false;
+        }
+        std::fclose(cf);
+    }
 
-    // Mutable char* vector for the argv-array command_line() overload (avoids
-    // the const-qualification mismatch with const char**). std::string::data()
-    // is non-const since C++17.
+    std::vector<std::string> args = { curl_path(), "-K", cfg_path };
     std::vector<char*> argv;
     argv.reserve(args.size() + 1);
     for (auto& s : args) argv.push_back(s.data());
     argv.push_back(nullptr);
 
     ACE_Process_Options opts;
-    // argv-array form: no shell tokenization, so header values with spaces stay
-    // intact (vs the format-string command_line()).
     opts.command_line(argv.data());
 
     // Redirect the child's std handles: stdin/stdout → /dev/null (curl writes
@@ -135,6 +158,7 @@ bool http_get(const std::string&              url,
         err = "failed to spawn curl";
         ::unlink(hdr_path.c_str());
         ::unlink(err_path.c_str());
+        ::unlink(cfg_path.c_str());
         return false;
     }
 
@@ -147,6 +171,7 @@ bool http_get(const std::string&              url,
     const std::string curl_err = read_file(err_path);
     ::unlink(hdr_path.c_str());
     ::unlink(err_path.c_str());
+    ::unlink(cfg_path.c_str());   // holds the bearer token — remove promptly
 
     // Transport failure: curl exited non-zero AND we never saw an HTTP status.
     if (exit_code != 0 && resp.status == 0) {

--- a/modules/containers/src/image_ref.cpp
+++ b/modules/containers/src/image_ref.cpp
@@ -18,15 +18,25 @@ bool looks_like_registry(const std::string& s) {
 } // namespace
 
 bool parse_image_ref(const std::string& ref, ImageRef& out) {
-    if (ref.empty()) return false;
-
     out = ImageRef{};
+
+    // 0. Forgive a pasted command. An image ref never contains whitespace, so
+    //    if the input has any — e.g. "docker pull nginx", "podman pull nginx" —
+    //    take the LAST whitespace-separated token as the ref (and trim). A bare
+    //    "nginx" is unchanged.
+    std::string s = ref;
+    auto b = s.find_first_not_of(" \t\r\n");
+    if (b == std::string::npos) return false;       // all-whitespace / empty
+    s = s.substr(b, s.find_last_not_of(" \t\r\n") - b + 1);
+    auto ws = s.find_last_of(" \t");
+    if (ws != std::string::npos) s = s.substr(ws + 1);
+    if (s.empty()) return false;
 
     // 1. Peel an optional registry off the front (component before the first
     //    '/', if it looks like a host). This must run before the tag split so a
     //    registry port (host:5000/...) is not mistaken for a tag.
     std::string registry;
-    std::string name = ref;             // repository[:tag][@digest]
+    std::string name = s;               // repository[:tag][@digest]
     auto slash = name.find('/');
     if (slash != std::string::npos && looks_like_registry(name.substr(0, slash))) {
         registry = name.substr(0, slash);

--- a/modules/containers/test/image_ref_test.cpp
+++ b/modules/containers/test/image_ref_test.cpp
@@ -96,3 +96,24 @@ TEST(ImageRef, TrailingAtIsRejected) {
     ImageRef r;
     EXPECT_FALSE(parse_image_ref("nginx@", r));
 }
+
+TEST(ImageRef, PastedDockerPullCommandIsForgiven) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("docker pull arm64v8/hello-world", r));
+    EXPECT_EQ(r.registry, "registry-1.docker.io");
+    EXPECT_EQ(r.repository, "arm64v8/hello-world");
+    EXPECT_EQ(r.tag, "latest");
+}
+
+TEST(ImageRef, PastedPodmanPullWithTag) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("podman pull nginx:1.25", r));
+    EXPECT_EQ(r.repository, "library/nginx");
+    EXPECT_EQ(r.tag, "1.25");
+}
+
+TEST(ImageRef, SurroundingWhitespaceTrimmed) {
+    ImageRef r;
+    ASSERT_TRUE(parse_image_ref("  nginx  ", r));
+    EXPECT_EQ(r.repository, "library/nginx");
+}


### PR DESCRIPTION
## Symptom
On hardware (192.168.1.50), pulling **any** image failed:
```
container.error = registry unreachable: curl exit 2: curl: option -H: requires parameter
```

## Root cause
`http_client` built curl's argv as a vector and passed it via `ACE_Process_Options::command_line(argv[])` — which round-trips the argv through a single **space-joined buffer and re-splits it on whitespace**. That shattered the multi-word header values (`Accept: …`, `Authorization: Bearer …`) into separate tokens, leaving curl with a **bare `-H`**.

- `net_bridge.cpp` uses the same `ACE_Process` argv pattern but its `nft` args have no intra-arg spaces — so it never hit this. This was the **first HW container pull**.
- A manual `curl -H "Accept: …"` to the same registry returns `401 + www-authenticate` fine → egress/DNS/TLS were never the problem.

## Fix
Pass **every** curl option via a **config file** (`curl -K <cfg>`). Header/url/user values are quoted in the file, so no space-containing token ever rides the argv (only `curl -K <path>`, which is space-free). The temp config is `mkstemp` 0600 (the bearer token isn't world-readable) and unlinked right after the wait. **Verified the exact config-file format against real curl 8.7.1 on the device** — `401 + www-authenticate` as expected.

## Also: forgive a pasted command
The Image-reference field expects a bare ref, but it's natural to paste `docker pull …`. `parse_image_ref` now takes the **last whitespace-separated token** (an image ref never contains whitespace), so `docker pull arm64v8/hello-world`, `podman pull nginx:1.25`, and `  nginx  ` all work.

## Testing
- 3 new `ImageRef` gtest cases; the parser was **compiled + run standalone** (gcc 13, `-std=gnu++17`) — all green, incl. the existing cases as a regression check.
- The curl change can't be compiled on the dev host (needs ACE), but the config-file format is proven against real curl on-device; full e2e validates once the fixed `iot-containerd` binary is deployed.

> **Deploy note:** this is a compiled `iot-containerd` fix — there's no ds/config workaround. It reaches the device via the next `iot-*.ipk` OTA (or a reflash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)