### PR TITLE
fix: show iot-containerd in the device-ui Services table

### DIFF
--- a/iot-ui/src/app/services/services-list/services-list.component.ts
+++ b/iot-ui/src/app/services/services-list/services-list.component.ts
@@ -73,6 +73,7 @@ export class ServicesListComponent implements OnInit, OnDestroy {
     { key: 'wifi_client',    name: 'Wi-Fi Client',   label: 'services.wifi.client',    info: {}, restarting: false, msg: '' },
     { key: 'vehicle',        name: 'Vehicle (OBD-II)', label: 'services.vehicle',     info: {}, restarting: false, msg: '' },
     { key: 'mqtt',           name: 'MQTT Mirror',    label: 'services.mqtt',           info: {}, restarting: false, msg: '' },
+    { key: 'container',      name: 'Containers',     label: 'services.container',      info: {}, restarting: false, msg: '' },
   ];
   private sub = new Subscription();
 

--- a/modules/data-store/schemas/services.lua
+++ b/modules/data-store/schemas/services.lua
@@ -73,6 +73,15 @@ local keys = {
     ["services.mqtt.state"]                = {
         access  = "Viewer", type = "string",  default = "stopped" },
 
+    -- container (iot-containerd, crun-backed single-container shim). Systemd-
+    -- enabled, idle until a pull/run. The daemon self-reports .state on startup
+    -- + L22 telemetry; without these keys ds-server rejected the writes and the
+    -- daemon never appeared on the Services page.
+    ["services.container.enable"]          = {
+        access  = "Admin", type = "boolean", default = true, write_acl = {"uid:0"} },
+    ["services.container.state"]           = {
+        access  = "Viewer", type = "string",  default = "stopped" },
+
     -- wifi-client — the WAN uplink, so NO dependency on net.router (routing
     -- layers on top of the uplink; the inverse dep deadlocked WiFi whenever
     -- net-router was down). Matches the (lack of) DepWatch in supervisor.cpp.
@@ -130,6 +139,7 @@ local stats_services = {
   "services.wifi.client",
   "services.vehicle",
   "services.mqtt",
+  "services.container",
   "services.cloud.iot.cloudd",
   "services.cloud.iot.httpd",
   "services.cloud.openvpn.server",


### PR DESCRIPTION
`iot-containerd` was running (systemd active) but never showed on the device-ui **Services** page. Two gaps:

1. **Schema** — `services.lua` had no `services.container.*` keys, so ds-server (schema-enforced) **rejected** the daemon's self-report: `services.container.state` and the L22 `StatsPublisher` writes (cpu/mem/fd/threads) silently dropped → the key reads `(null)` on the device.
2. **UI** — the device-ui Services list is a hardcoded array with no container row.

## Fix
- Declare `services.container.enable` + `services.container.state` (parity with the `mqtt`/`vehicle` producer daemons) and add `"services.container"` to `stats_services` so the L22 telemetry keys exist.
- Add a **Containers** row (`label: services.container`) to the device-ui list.

The daemon already self-reports `services.container.state="running"` and `StatsPublisher("services.container", …)` (containerd.cpp:461/465) — **no daemon change needed**.

## Note
Wiring the **Enabled** toggle to actually park the daemon is a follow-up — `iot-containerd` doesn't use a `ServiceGate` yet (it's systemd-enabled, idle until a pull/run), so the toggle/restart is display-only for now, same as `vehicle`/`mqtt`.

## Testing
Schema validated with `luac` against the device's Lua 5.3. Not in the in-flight v1.3.1 bundle — ships in the next cut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)