### PR TITLE
feat(telemetry): wire LwM2M Send live — DurableSampleBuffer → /dp uploader (TDD §3b #1)

### DIFF
--- a/apps/docs/tdd-vehicle-telemetry.md
+++ b/apps/docs/tdd-vehicle-telemetry.md
@@ -135,8 +135,16 @@ CAN/vehicle needed to validate** — synthesize samples with `ds-cli`.
     Send (after #1), and confirm a new row lands in Mongo `telemetry` with the
     sample's real `ts` (not just arrival time).
 
-- ⬜ **#1 — client session I/O glue.** Instantiate a `send::Uploader` in the
-  registered DM client (one per registered server, base path `"/33000/0/"`).
+- 🟡 **#1 — client session I/O glue. WIRED (gated off; HW-validation pending).**
+  `apps/src/main.cpp` builds a `send::Uploader` over `make_sample_buffer(
+  iot.telemetry.db.path, …)` and, in the 1 Hz client tick, samples the numeric
+  `vehicle.*` signals → `offer`, transmits one CON `/dp` batch when idle, times
+  out + requeues a lost ack, and routes the 2.04 back via the adapter's new
+  `sendAckHandler` (matched by msg-id). Send vs registration Update are
+  serialized so their 2.04s never overlap. OFF unless `iot.telemetry.send.enable`
+  (schema keys `iot.telemetry.*`); the Uploader/buffer/Send pipeline API was
+  compiled + run end-to-end in the podman dev-build. Still needs the acceptance
+  run below on real HW (and #2 server-persist) to close.
   - **Feed:** on the client tick, read `vehicle.*` from ds → build a
     `telemetry::Sample{timeUnix=now, values=[{"10",speed},{"11",rpm},…]}` →
     `uploader.offer(s)` (only while registered + link up — direct DTLS, never

--- a/apps/inc/coap_adapter.hpp
+++ b/apps/inc/coap_adapter.hpp
@@ -393,6 +393,16 @@ class CoAPAdapter {
             m_dmRspHandler = std::move(h);
         }
 
+        /// Client-side hook for the 2.04 ACK to one of OUR confirmable Sends
+        /// (POST /dp). Fired for every inbound Acknowledgement alongside the
+        /// RegistrationClient FSM; the callback correlates by message-id
+        /// (CoAPMessage.coapheader.msgid) against the in-flight Send and ignores
+        /// non-matching acks. Send and registration Update are serialized by the
+        /// client tick so their 2.04s never overlap. nullptr → no-op.
+        void sendAckHandler(std::function<void(const CoAPMessage&)> h) {
+            m_sendAckCb = std::move(h);
+        }
+
         std::vector<std::string> handleLwM2MObjects(const CoAPAdapter::CoAPMessage& message, std::string uri, std::uint32_t oid,
                                                     std::uint32_t oiid, std::uint32_t rid, std::uint32_t riid);
 
@@ -405,6 +415,7 @@ class CoAPAdapter {
         std::shared_ptr<lwm2m::bootstrap::Client>     m_bsClient;
         std::shared_ptr<lwm2m::RegistrationClient>    m_regClient;
         std::function<void(const CoAPMessage&)>       m_dmRspHandler;
+        std::function<void(const CoAPMessage&)>       m_sendAckCb;
 
         std::unordered_map<std::uint32_t, std::string> OptionNumber;
         std::unordered_map<std::uint32_t, std::string> ContentFormat;

--- a/apps/src/coap_adapter.cpp
+++ b/apps/src/coap_adapter.cpp
@@ -1083,6 +1083,10 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
         if (isAmIClient && m_regClient) {
             m_regClient->on_response(coapmessage, *this);
         }
+        // Also offer the ack to the telemetry Send uploader (matches by msg-id;
+        // ignores non-Send acks). Safe alongside the reg FSM — the client tick
+        // serializes Send vs registration Update so only one is ever in flight.
+        if (isAmIClient && m_sendAckCb) m_sendAckCb(coapmessage);
         return 0;
     }
 
@@ -1317,6 +1321,10 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
         if (isAmIClient && m_regClient) {
             m_regClient->on_response(coapmessage, *this);
         }
+        // Also offer the ack to the telemetry Send uploader (matches by msg-id;
+        // ignores non-Send acks). Safe alongside the reg FSM — the client tick
+        // serializes Send vs registration Update so only one is ever in flight.
+        if (isAmIClient && m_sendAckCb) m_sendAckCb(coapmessage);
         return 0;
     }
 

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -58,6 +58,8 @@
 #include "lwm2m_registration_client.hpp"
 #include "lwm2m_registration_server.hpp"
 #include "lwm2m_send_server.hpp"
+#include "lwm2m_send_uploader.hpp"            // v2 Send telemetry (TDD §3b #1)
+#include "lwm2m_durable_sample_buffer.hpp"    // make_sample_buffer / DurableSampleBuffer
 
 #include "ds_config.hpp"
 #include "rpi_serial.hpp"
@@ -154,6 +156,38 @@ namespace {
 /// wrapping after ~64K outgoing messages is well within spec.
 std::atomic<std::uint16_t> g_next_msgid{0x1000};
 inline std::uint16_t next_msgid() { return ++g_next_msgid; }
+
+namespace {
+// ── v2 Send telemetry (TDD §3b #1) — numeric Object-33000 vehicle signals,
+// mapped ds key ↔ resource id (under base "/33000/0/"). link (/10) + dtc (/8)
+// are non-numeric, so they are not part of a SenML telemetry batch.
+struct VehSig { const char* key; const char* rid; };
+constexpr VehSig kVehSigs[] = {
+    {"vehicle.speed", "0"}, {"vehicle.rpm", "1"},   {"vehicle.coolant", "2"},
+    {"vehicle.throttle", "3"}, {"vehicle.load", "4"}, {"vehicle.fuel", "5"},
+    {"vehicle.iat", "6"},   {"vehicle.maf", "7"},
+};
+// Read the numeric vehicle.* signals from ds into a timestamped Sample.
+// Returns false when none are present/numeric (nothing to offer this tick).
+bool build_vehicle_sample(data_store::Client* cli, double now_unix,
+                          ::lwm2m::telemetry::Sample& out) {
+    if (!cli) return false;
+    std::vector<std::string> keys;
+    for (const auto& s : kVehSigs) keys.emplace_back(s.key);
+    std::vector<data_store::Client::GetResult> got;
+    if (!cli->get(keys, got).ok || got.size() != keys.size()) return false;
+    out = ::lwm2m::telemetry::Sample{};
+    out.timeUnix = now_unix;
+    for (std::size_t i = 0; i < got.size(); ++i) {
+        if (!got[i].has_value) continue;
+        auto s = data_store::to_string(got[i].value);
+        if (!s || s->empty()) continue;
+        try { out.values.emplace_back(kVehSigs[i].rid, std::stod(*s)); }
+        catch (...) { /* non-numeric → skip this signal */ }
+    }
+    return !out.values.empty();
+}
+} // namespace
 
 /// Convenience tx wrapper — UDPAdapter::tx takes non-const lvalue refs
 /// for historical reasons, so callers need locals.
@@ -1498,6 +1532,70 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     auto rebind = std::make_shared<ClientPlumbing::Rebind>();
     plumb.rebind = rebind;
 
+    // ── v2 Send telemetry uploader (TDD §3b #1). OFF unless
+    // iot.telemetry.send.enable — otherwise `sendst->up` stays null and the tick
+    // block below is a no-op (zero change to the registration path). When on, it
+    // buffers numeric vehicle.* signals and pushes them as SenML packs over the
+    // registered DM session (direct DTLS), with offline backfill via the
+    // DurableSampleBuffer when iot.telemetry.db.path names a file.
+    struct SendState {
+        std::shared_ptr<::lwm2m::send::Uploader> up;
+        std::chrono::steady_clock::time_point    inflight_since{};
+        std::chrono::steady_clock::time_point    last_sample{};
+        int sample_secs   = 5;
+        int ack_timeout_s = 6;     // < the 30s update margin → no keepalive risk
+    };
+    auto sendst = std::make_shared<SendState>();
+    {
+        auto* cli = ds.client();
+        std::vector<data_store::Client::GetResult> g;
+        bool enable = false;
+        std::string dbpath, basepath = "/33000/0/";
+        int cap = 1000, maxbatch = 8, ttl = 0;
+        if (cli && cli->get({std::string("iot.telemetry.send.enable"),
+                             std::string("iot.telemetry.db.path"),
+                             std::string("iot.telemetry.basepath"),
+                             std::string("iot.telemetry.capacity"),
+                             std::string("iot.telemetry.maxbatch"),
+                             std::string("iot.telemetry.sample.secs"),
+                             std::string("iot.telemetry.ttl.secs")}, g).ok
+            && g.size() == 7) {
+            if (auto b = data_store::to_bool(g[0].value))   enable   = *b;
+            if (auto s = data_store::to_string(g[1].value)) dbpath   = *s;
+            if (auto s = data_store::to_string(g[2].value); s && !s->empty()) basepath = *s;
+            if (auto i = data_store::to_int32(g[3].value))  cap      = *i;
+            if (auto i = data_store::to_int32(g[4].value))  maxbatch = *i;
+            if (auto i = data_store::to_int32(g[5].value))  sendst->sample_secs = *i > 0 ? *i : 1;
+            if (auto i = data_store::to_int32(g[6].value))  ttl      = *i;
+        }
+        if (enable) {
+            sendst->up = std::make_shared<::lwm2m::send::Uploader>(
+                ::lwm2m::telemetry::make_sample_buffer(
+                    dbpath, static_cast<std::size_t>(cap < 1 ? 1 : cap),
+                    static_cast<std::int64_t>(ttl)),
+                basepath, static_cast<std::size_t>(maxbatch < 1 ? 1 : maxbatch));
+            // Route the 2.04 Send ack (matched by msg-id) on every client adapter.
+            std::weak_ptr<SendState> wsend = sendst;
+            for (auto& [type, ctx] : app->udpAdapter()->services()) {
+                (void)type;
+                ctx->coapAdapter()->sendAckHandler(
+                    [wsend](const CoAPAdapter::CoAPMessage& m) {
+                        auto st = wsend.lock();
+                        if (!st || !st->up || !st->up->in_flight()) return;
+                        if (m.coapheader.msgid != st->up->in_flight_msgid()) return;
+                        if ((m.coapheader.code >> 5) == 2)
+                            st->up->on_ack(m.coapheader.msgid);
+                        // non-2.xx → leave it; the tick's timeout requeues+retries
+                    });
+            }
+            ACE_DEBUG((LM_INFO,
+                ACE_TEXT("%D lwm2m:thread:%t %M %N:%l telemetry Send enabled "
+                         "(base=%C buf=%C cap=%d batch=%d every=%ds)\n"),
+                basepath.c_str(), dbpath.empty() ? "ram" : dbpath.c_str(),
+                cap, maxbatch, sendst->sample_secs));
+        }
+    }
+
     // 1 Hz ticker: drives Update emission + Observe pmax + (TODO) initial
     // Register once bootstrap completes.
     std::weak_ptr<::lwm2m::RegistrationClient> wreg = plumb.reg;
@@ -1545,7 +1643,7 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     app->udpAdapter()->on_tick_client([wreg, wdm, wapp, rebind, wbs,
                                        reboot_after, bootPhase, bootDeadline,
                                        bootRetryAfter, bootBackoff, bsHost, bsPort,
-                                       dtls, &ds, lastConn]() {
+                                       dtls, &ds, lastConn, sendst]() {
         // Liveness first: petting the watchdog here ties it to the reactor
         // actually dispatching this 1 Hz tick. If the reactor stalls (the
         // alive-but-wedged failure this guards against), the pings stop and
@@ -1723,14 +1821,51 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
             reg->clear_pending_reregister();
         }
 
-        // L9 stub 2 — Update POST when the lifetime margin elapses.
-        if (reg->should_send_update(now)) {
+        // L9 stub 2 — Update POST when the lifetime margin elapses. Defer it one
+        // tick while a telemetry Send is in flight so the registration Update and
+        // the Send never have overlapping 2.04 acks (the receive path can't tell
+        // them apart). The Send acks within ack_timeout_s (6s) ≪ the 30s update
+        // margin, so the keepalive is never starved.
+        if (reg->should_send_update(now) &&
+            !(sendst->up && sendst->up->in_flight())) {
             auto payload = reg->build_update_request(
                 next_msgid(),
                 std::string{static_cast<char>(0x02)},
                 /*withAdvertisedSet*/ false);
             tx_via(*a, payload, svc);
             reg->note_update_sent(now);
+        }
+
+        // ── v2 Send telemetry (TDD §3b #1). Only while cleanly Registered —
+        // never mid-Update/Register/Deregister — so a Send's 2.04 can't be
+        // mistaken for a registration ack. No-op unless enabled (sendst->up set).
+        if (sendst->up &&
+            reg->state() == ::lwm2m::RegistrationState::Registered) {
+            auto& up = *sendst->up;
+            // 1. sample numeric vehicle.* into the buffer at the cadence.
+            if (now - sendst->last_sample >=
+                std::chrono::seconds(sendst->sample_secs)) {
+                sendst->last_sample = now;
+                const double tnow = std::chrono::duration<double>(
+                    std::chrono::system_clock::now().time_since_epoch()).count();
+                ::lwm2m::telemetry::Sample s;
+                if (build_vehicle_sample(ds.client(), tnow, s)) up.offer(s);
+            }
+            // 2. time out an unacked Send → requeue (retried on the next poll).
+            if (up.in_flight() &&
+                now - sendst->inflight_since >=
+                    std::chrono::seconds(sendst->ack_timeout_s)) {
+                up.on_timeout();
+            }
+            // 3. transmit the next batch (one CON /dp at a time) when idle.
+            if (!up.in_flight() && up.pending() > 0) {
+                auto wire = up.poll(next_msgid(),
+                                    std::string{static_cast<char>(0x30)});
+                if (!wire.empty()) {
+                    tx_via(*a, wire, svc);
+                    sendst->inflight_since = now;
+                }
+            }
         }
 
         // Task K — DM rejected us (registration FSM in Failed after a

--- a/modules/data-store/schemas/iot.lua
+++ b/modules/data-store/schemas/iot.lua
@@ -448,5 +448,25 @@ return {
       type    = "string",
       default = "",
     },
+
+    -- ── v2 LwM2M Send telemetry (TDD §3b #1; OFF by default) ──────────
+    -- When .send.enable is true the registered DM client samples numeric
+    -- vehicle.* signals (Object 33000) and pushes them as SenML packs over the
+    -- direct DTLS link (LwM2M Send, POST /dp), buffered for offline backfill by
+    -- the DurableSampleBuffer when .db.path names a file (empty → in-RAM).
+    ["iot.telemetry.send.enable"] = {
+        access = "Admin", type = "boolean", default = false, write_acl = {"uid:0"} },
+    ["iot.telemetry.db.path"] = {
+        access = "Admin", type = "string",  default = "" },
+    ["iot.telemetry.basepath"] = {
+        access = "Admin", type = "string",  default = "/33000/0/" },
+    ["iot.telemetry.capacity"] = {
+        access = "Admin", type = "integer", default = 1000, min = 1, max = 1000000 },
+    ["iot.telemetry.maxbatch"] = {
+        access = "Admin", type = "integer", default = 8,    min = 1, max = 64 },
+    ["iot.telemetry.sample.secs"] = {
+        access = "Admin", type = "integer", default = 5,    min = 1, max = 3600 },
+    ["iot.telemetry.ttl.secs"] = {
+        access = "Admin", type = "integer", default = 0,    min = 0, max = 2592000 },
   },
 }


### PR DESCRIPTION
Wires the v2 **Send** client glue so the registered DM client actually buffers + uploads telemetry — the `DurableSampleBuffer` (#414) now has a producer and a transmit path. **Gated OFF by default** (`iot.telemetry.send.enable=false`): inert, **zero change to the registration path**, until an operator enables it.

## What (when enabled), in the 1 Hz client tick
- Samples numeric `vehicle.*` signals (Object 33000 RIDs 0..7) → `telemetry::Sample` → `uploader.offer()` at `iot.telemetry.sample.secs`.
- Transmits one CON `POST /dp` SenML batch when idle (`!in_flight && pending`).
- Times out an unacked Send (6s) → `on_timeout` → requeue → retried oldest-first.
- Buffer = `make_sample_buffer(iot.telemetry.db.path, capacity, ttl)` — durable SQLite outbox (offline backfill) when a path is set, else in-RAM.

## ACK routing (the subtle bit)
New `CoAPAdapter::sendAckHandler` fires for every inbound 2.04 → `uploader.on_ack` matched by **msg-id**. Safe alongside the registration FSM because the tick **serializes Send vs registration Update**: an Update is deferred one tick while a Send is in flight, and a Send only starts while cleanly `Registered` — so their 2.04s never overlap (the receive path can't otherwise tell them apart). The 6s Send-ack budget ≪ the 30s update margin → keepalive never starved.

## Config
New `iot.telemetry.*` schema keys: `send.enable` / `db.path` / `basepath` / `capacity` / `maxbatch` / `sample.secs` / `ttl.secs`.

## Validation
- The **Uploader/buffer/Send/SenML pipeline** (real sources) was **compiled + run end-to-end in a container**, exercising the exact API the glue drives (`make_sample_buffer`→`Uploader`, `offer`/`poll`/`in_flight`/`in_flight_msgid`/`pending`/`on_ack`/`on_timeout`, durable commit) — all green.
- `iot.lua` validated with `luac`.
- The ACE/ds glue compiles in CI (no ACE on the dev host).

## Scope / not done
Per the TDD §3b runbook (item #1 now 🟡): the **acceptance run on real HW** + **#2 server-persist** (`onSendReport` → spool → Mongo) are needed to fully close. This PR is the client glue; it's safe to merge (gated off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)