### PR TITLE
fix(lwm2m): re-handshake BS DTLS on bootstrap timeout (self-recover stuck re-bootstrap)

### DIFF
--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -170,6 +170,11 @@ class DTLSAdapter {
         /// own requests use this fixed peer session.
         std::int32_t tx_peer(std::string& in);
         void connect(const std::string& ip, const std::uint16_t& port);
+        /// Like connect(), but force-tears-down even a *CONNECTED* peer first so
+        /// a known-suspect session (e.g. a bootstrap that never completed over a
+        /// stale "connected" peer) gets a fresh ClientHello instead of a doomed
+        /// renegotiation. Use when the session must be assumed dead.
+        void reset_and_connect(const std::string& ip, const std::uint16_t& port);
 
         /**
          * @brief 

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -312,6 +312,28 @@ void DTLSAdapter::connect(const std::string& ip, const std::uint16_t& port) {
     }
 }
 
+void DTLSAdapter::reset_and_connect(const std::string& ip, const std::uint16_t& port) {
+    session(ip, port);
+    m_peerSession = m_session;
+    isClient(true);
+    // Unlike connect(), reset the peer UNCONDITIONALLY — even DTLS_STATE_CONNECTED.
+    // The caller knows the session is dead (e.g. a bootstrap POST /bs that never
+    // got a reply: tinydtls still reports the peer "connected", so dtls_connect()
+    // would only renegotiate — emitting nothing — and the client loops forever
+    // POSTing into the void). A clean reset forces a fresh ClientHello.
+    dtls_peer_t* existing = dtls_get_peer(dtls_ctx(), &m_session);
+    if (existing) {
+        dtls_debug("DTLSAdapter::reset_and_connect force-resetting peer\n");
+        dtls_reset_peer(dtls_ctx(), existing);
+    }
+    clientState("");                       // drop the stale app-level state too
+    auto ret = dtls_connect(dtls_ctx(), &m_session);
+    if (ret > 0)
+        dtls_debug("DTLSAdapter::reset_and_connect new channel for Client Hello\n");
+    else if (ret < 0)
+        dtls_debug("DTLSAdapter::reset_and_connect error establishing channel\n");
+}
+
 std::int32_t DTLSAdapter::rx(std::int32_t fd) {
     std::int32_t ret = -1;
     std::vector<std::uint8_t> buf(DTLS_MAX_BUF);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1677,13 +1677,20 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
                 // else: within the backoff window; retry on a later tick.
             } else if (*bootPhase == BootPhase::InProgress &&
                        now >= *bootDeadline) {
-                // /bs didn't complete in time. Loop back and retry the whole
-                // bootstrap on a growing backoff instead of giving up — never
-                // wedge at "bootstrapping".
+                // /bs didn't complete in time. The BS DTLS session may be DEAD
+                // (cloud bs restart, NAT drop, or a stale session left after a
+                // watchdog restart) while clientState still reads "connected" —
+                // re-POSTing /bs over it transmits NOTHING and loops forever, and
+                // because the reactor keeps ticking the watchdog never catches it
+                // (observed: a device stuck "bootstrapping" 10h that a manual
+                // restart fixed in ~1s). Force a fresh BS handshake so the retry
+                // actually reaches the cloud instead of POSTing into the void.
+                if (dtls) dtls->reset_and_connect(bsHost, bsPort);
                 *bootRetryAfter = now + std::chrono::seconds(*bootBackoff);
                 ACE_ERROR((LM_WARNING,
                            ACE_TEXT("%D lwm2m:thread:%t %M %N:%l bootstrap did not "
-                                    "complete in time — retrying in %d s\n"),
+                                    "complete in time — reset BS DTLS, retrying "
+                                    "in %d s\n"),
                            *bootBackoff));
                 *bootBackoff = (*bootBackoff * 2 > 30) ? 30 : (*bootBackoff * 2);
                 *bootPhase = BootPhase::NotStarted;


### PR DESCRIPTION
## Field bug (the LwM2M DM issue that re-surfaced)
A device sat **"bootstrapping" for 10 h** — `iot.conn.state=bootstrapped`, logging `initiating bootstrap: POST /bs` → `bootstrap did not complete in time` every ~30 s, with **zero actual DTLS sends/receives**. A manual `systemctl restart iot-lwm2m-client` recovered it in **~1 s** (clean handshake → `bootstrap commit done` → `Registered`). So the cloud BS server was fine.

## Root cause
After the BS DTLS session goes dead (cloud bs restart, NAT drop, or a stale session inherited across a watchdog restart), tinydtls still reports the peer `DTLS_STATE_CONNECTED` and the app-level `clientState` stays `"connected"`. The bootstrap-retry loop sees `dtlsReady==true` and **re-POSTs `/bs` over the dead session**; `dtls_write` finds a "connected" peer so it only *renegotiates* (emits nothing) — the client loops forever POSTing into the void. The **#406 watchdog can't catch it**: the reactor keeps ticking; only the DTLS session is wedged.

## Fix
On the `InProgress → timeout` transition, force a fresh BS handshake:
- New `DTLSAdapter::reset_and_connect()` resets the peer **unconditionally** — even `DTLS_STATE_CONNECTED`, which `connect()` deliberately leaves alone — clears `clientState`, then `dtls_connect()` → a real ClientHello.
- The bootstrap-timeout branch calls it, so the next retry actually reaches the cloud. `connect()` is unchanged (the BS→DM handoff must still not tear down a healthy session).

## Notes
- Device already recovered (registered) via a manual restart; this makes it **self-recover** without one (or the watchdog). 
- Can't compile locally (ACE/tinydtls); `reset_and_connect()` mirrors `connect()` exactly except the unconditional reset. CI compiles. Validates fully on HW after the next OTA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)