### PR TITLE
fix(lwm2m): pet the watchdog while awaiting provisioning (stop the 60s crash-loop)

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1889,6 +1889,13 @@ int main(std::int32_t argc, char *argv[]) {
                                     "(iot.bs.uri + BS PSK via device-ui commissioning)\n")));
                 logged_wait = true;
             }
+            // Pet the systemd watchdog while we wait — the reactor that normally
+            // pings it (run_reactor_event_loop) hasn't started yet, so without
+            // this an un(der)-provisioned device (or one that briefly reads empty
+            // creds during a ds-load race after a restart) is SIGABRT'd every
+            // WatchdogSec (#406) → a 60s crash-loop that defeats this loop's
+            // "stay alive until commissioned" intent.
+            systemd_watchdog_ping();
             ACE_OS::sleep(ACE_Time_Value(5, 0));
         }
         UDPAdapter::Scheme_t bsScheme;


### PR DESCRIPTION
## Investigating *why* the watchdog fired (the upstream cause of the DM issue)
Field timeline showed **two back-to-back watchdog timeouts** (15:32:05, 15:33:10), each process dying ~60 s after logging `awaiting provisioning` — a **crash-loop**.

## Root cause
The client startup has a **pre-reactor** wait loop (`for(;;)` reading `iot.bs.uri` + BS PSK, `sleep 5s`), deliberately designed so an unprovisioned device *"stays alive … and resumes as soon as the ds watch sees the values appear."* But it **never pets the systemd watchdog**, and the reactor that normally does (`run_reactor_event_loop`) hasn't started yet. So once **#406** added `WatchdogSec=60s`, a device that sees empty provisioning — even *transiently* (a ds-load race: the client reads creds before `ds-server` finishes loading `data_store.lua` after the OTA-triggered restart cascade) — is **SIGABRT'd every 60 s**. The watchdog firing wasn't a real hang; it was this loop being killed.

## Fix
Call `systemd_watchdog_ping()` each iteration of the wait. The device stays alive (and keeps its log buffer) until commissioning / the persisted creds finish loading — exactly the loop's stated intent — instead of crash-looping.

## Relationship to the other fix
This is the **upstream cause**; the separate **#421** (`reset_and_connect` on bootstrap timeout) handles the **aftermath** — the stale-DTLS bootstrap loop the device fell into after one of these watchdog restarts. Both ride the next OTA.

Can't compile locally (ACE); one-line addition of an existing helper, CI compiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)