### PR TITLE
fix(ota): purge stale spool artifacts before staging (opkg version conflict → install fail)

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
@@ -157,6 +157,20 @@ if [ -n "$SHA" ]; then
     log "sha256 verified"
 fi
 
+# Clean any stale artifacts a previous (interrupted) campaign left in the spool.
+# iot-swupdate globs $SPOOL/*.ipk, so a leftover package set POISONS this install:
+# a stale 1.1.0 set left beside the freshly-staged 1.3.1 set made `opkg install`
+# die on "cannot install both iot-X-1.3.1 and iot-X-1.1.0" conflicts (observed in
+# the field — the install failed with result 9 and the device stayed on the old
+# version). Purge every prior .ipk/.raucb/bundle here, keeping only this
+# campaign's just-verified $DL.
+for _stale in "$SPOOL"/*.ipk "$SPOOL"/*.raucb "$SPOOL"/*.tar "$SPOOL"/*.tar.gz "$SPOOL"/*.tgz; do
+    [ -e "$_stale" ] || continue
+    [ "$_stale" = "$DL" ] && continue
+    rm -f "$_stale"
+done
+rm -f "$SPOOL/update.meta"
+
 # A bundle expands into the spool so iot-swupdate's `opkg install *.ipk` glob
 # applies every package atomically. Compression is detected by CONTENT (gzip -t)
 # rather than the extension, so a plain .tar (e.g. a .tar.gz auto-decompressed by


### PR DESCRIPTION
## Why the v1.3.1 "software update" hung
The cloud showed it ongoing because the **device install failed** and it stayed on `1.3.0+da62134`. The stager succeeded (`sha256 verified`, extracted 19 packages), but `iot-swupdate`'s `opkg install $SPOOL/*.ipk` died — from the device's `last.log`:
```
cannot install both iot-ds-server-1.3.1+… and iot-ds-server-1.1.0+…  — conflicting requests
cannot install both iot-dev-1.3.1+… and iot-dev-1.1.0+…
… (5 such conflicts)   → result=9
```

## Root cause
The spool (`/run/iot/update`) still held a **previous campaign's `1.1.0` .ipk set** — left behind when that earlier OTA was interrupted (the watchdog crash-loop, #422). `iot-ota-stage` extracts each bundle **straight into `$SPOOL`** but never purges prior contents, so `iot-swupdate`'s `*.ipk` glob fed opkg **two versions of every package** → conflict.

## Fix
Add a **clean-slate purge** after sha-verify in `iot-ota-stage`: remove any pre-existing `.ipk`/`.raucb`/bundle tarball (+ stale `update.meta`), keeping only this campaign's just-verified download. Each OTA now installs exactly its own packages. (Validated `sh -n`.)

## Immediate recovery (no fix needed for this push)
The spool is **clean now** (the failed run's work dir was removed). **Re-push the 1.3.1 bundle from the cloud-ui** and it should install cleanly. `1.3.1 > 1.3.0`, so the downgrade guard won't block it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)