### PR TITLE
feat(cloud): Abort button for a stuck OTA campaign

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -540,6 +540,15 @@ int main(int argc, char** argv) {
                             "cloud.update.request failed: %C\n"),
                    ws_update.err.c_str()));
     }
+    // OTA abort: cloud-ui writes cloud.update.abort = <serial> to cancel a stuck
+    // campaign (drop its lwm2m-dm push job + mark its status row cancelled).
+    auto ws_abort = ds.watch("cloud.update.abort", 1000);
+    if (!ws_abort.ok) {
+        ACE_ERROR((LM_ERROR,
+                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l watch "
+                            "cloud.update.abort failed: %C\n"),
+                   ws_abort.err.c_str()));
+    }
 
     // Seed initial VPN config in ds (subnet already seeded above from ds).
     ds.set("cloud.vpn.port.next",
@@ -1235,6 +1244,45 @@ int main(int argc, char** argv) {
                                      "failed: %C\n"), e.what()));
                     }
                     ds.set("cloud.update.request", data_store::Value{std::string()});
+                }
+            } else if (ev.key == "cloud.update.abort") {
+                // Cancel a stuck OTA campaign for one endpoint: drop its job from
+                // cloud.update.pending (lwm2m-dm stops re-pushing Object 5) and
+                // mark its status row cancelled (result 11). An in-flight opkg on
+                // the device can't be interrupted — this stops the cloud
+                // re-driving it and clears the stuck UI row.
+                std::string serial;
+                if (auto s = data_store::to_string(ev.value)) serial = *s;
+                if (!serial.empty()) {
+                    try {
+                        auto pend = nlohmann::json::parse(
+                            ds_str(ds, "cloud.update.pending", "[]"));
+                        nlohmann::json np = nlohmann::json::array();
+                        if (pend.is_array()) for (const auto& p : pend)
+                            if (p.value("endpoint", std::string()) != serial)
+                                np.push_back(p);
+                        ds.set("cloud.update.pending", data_store::Value{np.dump()});
+
+                        auto st = nlohmann::json::parse(
+                            ds_str(ds, "cloud.update.status", "[]"));
+                        bool ch = false;
+                        if (st.is_array()) for (auto& row : st)
+                            if (row.value("serial", std::string()) == serial &&
+                                row.value("result", 0) == 0) {   // only in-flight
+                                row["state"] = 0; row["result"] = 11;  // cancelled
+                                ch = true;
+                            }
+                        if (ch) ds.set("cloud.update.status",
+                                       data_store::Value{st.dump()});
+                        ACE_DEBUG((LM_INFO,
+                            ACE_TEXT("%D cloudd:thread:%t %M %N:%l OTA abort: %C\n"),
+                            serial.c_str()));
+                    } catch (const std::exception& e) {
+                        ACE_ERROR((LM_ERROR,
+                            ACE_TEXT("%D cloudd:thread:%t %M %N:%l OTA abort parse "
+                                     "failed: %C\n"), e.what()));
+                    }
+                    ds.set("cloud.update.abort", data_store::Value{std::string()});
                 }
             }
             // Sync after every event so the UI sees changes quickly, then

--- a/apps/cloud/ui/src/app/software-update/software-update.component.ts
+++ b/apps/cloud/ui/src/app/software-update/software-update.component.ts
@@ -98,6 +98,7 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
           <clr-dg-column>Progress</clr-dg-column>
           <clr-dg-column>Result</clr-dg-column>
           <clr-dg-column>Version</clr-dg-column>
+          <clr-dg-column>Actions</clr-dg-column>
 
           <clr-dg-row *clrDgItems="let s of status">
             <clr-dg-cell><code>{{ s.serial }}</code></clr-dg-cell>
@@ -116,6 +117,15 @@ interface UpdStatus { serial: string; state: number; result: number; version: st
                 [state]="s.result===1 ? 'connected' : (s.result>=5 ? 'exited' : 'idle')"></app-status-badge>
             </clr-dg-cell>
             <clr-dg-cell>{{ s.version || '—' }}</clr-dg-cell>
+            <clr-dg-cell>
+              <!-- Abort a stuck/in-flight campaign (result still pending). Stops
+                   the cloud re-pushing Object 5 and marks the row cancelled; an
+                   install already running on the device can't be interrupted. -->
+              <button class="btn btn-sm btn-danger-outline" *ngIf="s.result===0"
+                      [disabled]="aborting===s.serial" (click)="abort(s)">
+                {{ aborting===s.serial ? 'Aborting…' : 'Abort' }}
+              </button>
+            </clr-dg-cell>
           </clr-dg-row>
 
           <clr-dg-footer>{{ status.length }} job{{ status.length===1?'':'s' }}</clr-dg-footer>
@@ -152,6 +162,7 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
   selected: Ep[] = [];
   selectedUrl = '';
   pushing = false;
+  aborting = '';            // serial of the row whose abort is in flight
   // Firmware upload (browse / drag-drop into the feed)
   dragOver = false;
   uploading = false;
@@ -224,6 +235,8 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
     if (r === 5) return 'integrity error';
     if (r === 8) return 'uri error';
     if (r === 9) return 'install error';
+    if (r === 10) return 'skipped';
+    if (r === 11) return 'cancelled';
     return 'error ' + r;
   }
   // Cloud-side progress is PHASE-based (the device's byte-accurate % shows on the
@@ -254,6 +267,22 @@ export class SoftwareUpdateComponent implements OnInit, OnDestroy {
         else { this.toast.error(r.err || 'Update failed'); }
       },
       error: () => { this.pushing = false; this.toast.error('Update failed'); }
+    });
+  }
+
+  abort(s: UpdStatus): void {
+    this.aborting = s.serial;
+    this.http.dbSet([{ key: 'cloud.update.abort', value: s.serial }]).subscribe({
+      next: (r) => {
+        this.aborting = '';
+        if (r.ok) {
+          this.toast.success('Update aborted for ' + s.serial);
+          // Optimistic: mark the row cancelled now (iot-cloudd drops the pending
+          // job + sets result 11; observe() then confirms).
+          s.state = 0; s.result = 11;
+        } else { this.toast.error(r.err || 'Abort failed'); }
+      },
+      error: () => { this.aborting = ''; this.toast.error('Abort failed'); }
     });
   }
 

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -207,6 +207,15 @@ return {
         type    = "string",
         default = "",
     },
+    -- Cancel a stuck OTA campaign: cloud-ui writes the endpoint serial here;
+    -- iot-cloudd drops that endpoint's cloud.update.pending job (stops the
+    -- lwm2m-dm Object-5 re-push) and marks its cloud.update.status row cancelled
+    -- (result 11), then clears this key.
+    ["cloud.update.abort"] = {
+        access  = "Admin",
+        type    = "string",
+        default = "",
+    },
     -- Validated per-endpoint update jobs: written by iot-cloudd, consumed
     -- by the lwm2m-dm push tick. cloud-svc-only (mirrors the credentials
     -- two-writer-avoidance pattern). JSON array of


### PR DESCRIPTION
A push that never completes (device offline mid-push, repeated install failure — like the v1.3.1 spool-conflict) had **no operator off-switch**: `lwm2m-dm` kept re-pushing Object 5 and the Update Status row stayed stuck. Adds a per-row **Abort**.

## What
- **cloud-ui** — an **Abort** button on each *in-flight* Update Status row (`result` still pending) → writes `cloud.update.abort=<serial>`; optimistically marks the row cancelled. `resultLabel` gains `10=skipped` / `11=cancelled`.
- **iot-cloudd** — watches `cloud.update.abort` → drops that endpoint's `cloud.update.pending` job (stops the Object-5 re-push) and sets its `cloud.update.status` row to `{state:0, result:11}` (cancelled), then clears the key.
- **cloud.lua** — new `cloud.update.abort` key (Admin string); `luac`-validated.

## Semantics
An install already running on the device can't be interrupted (opkg is atomic). Abort stops the **cloud** re-driving a stuck campaign and clears the UI — the realistic meaning of "cancel" for a push-based OTA.

Can't compile the C++/Angular locally (no ACE/node); CI builds the cloud image + SPA.

🤖 Generated with [Claude Code](https://claude.com/claude-code)