### PR TITLE
feat(ui): drag-to-reorder sidebar nav (both UIs, per-browser, with reset)

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -4,8 +4,15 @@
       <img src="assets/iot-logo.svg" width="36" height="36" alt="IoT" />
       <span class="brand-text">IoT Cloud</span>
     </div>
-    <a class="nav-item" *ngFor="let m of menus" [class.active]="selectedMenu===m.id" (click)="onMenuSelect(m.id)">
+    <a class="nav-item" *ngFor="let m of menus; let i = index"
+       [class.active]="selectedMenu===m.id" [class.dragging]="dragIndex===i"
+       draggable="true" (dragstart)="onDragStart(i)"
+       (dragover)="onDragOver($event, i)" (dragend)="onDragEnd()"
+       (click)="onMenuSelect(m.id)" title="Drag to reorder">
       <img [src]="m.svg" class="nav-icon" alt="" /><span>{{m.label}}</span>
+    </a>
+    <a class="nav-item nav-reset" (click)="resetNav()" title="Reset menu order to default">
+      <span class="nav-icon nav-reset-glyph">↺</span><span>Reset order</span>
     </a>
     <div class="sidebar-spacer"></div>
     <a class="nav-item" (click)="theme.toggle()" title="Toggle theme">

--- a/apps/cloud/ui/src/app/main/main.component.scss
+++ b/apps/cloud/ui/src/app/main/main.component.scss
@@ -9,6 +9,9 @@
 .nav-item:hover .nav-icon { opacity:0.8; }
 .nav-item.active { color:#2e7d32; border-left-color:#2e7d32; background:rgba(46,125,50,0.08); }
 .nav-item.active .nav-icon { opacity:1; filter:invert(32%) sepia(85%) saturate(540%) hue-rotate(82deg) brightness(40%) contrast(90%); }
+.nav-item.dragging { opacity:0.45; background:rgba(46,125,50,0.06); }
+.nav-reset { font-size:11px; color:#9a9a9a; padding-top:6px; padding-bottom:6px; }
+.nav-reset-glyph { display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; font-size:15px; opacity:0.6; }
 .sidebar-spacer { flex:1; }
 .nav-logout { border-top:1px solid #e0e0e0; margin-top:4px; color:#888; }
 .nav-logout:hover { color:#c62828; background:rgba(198,40,40,0.05); }

--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -5,6 +5,7 @@ import { SessionService } from '../../common/session.service';
 import { ThemeService } from '../../common/theme.service';
 import { DebugService } from '../../common/debug.service';
 import { DataStoreService } from '../../common/datastore.service';
+import { NavOrderService } from '../../common/nav-order.service';
 
 @Component({
   selector: 'app-main',
@@ -14,7 +15,9 @@ import { DataStoreService } from '../../common/datastore.service';
 export class MainComponent implements OnInit {
   selectedMenu = 'dashboard';
   selectedSubNav = '';
-  menus = [
+  // Canonical order (the reset target). The displayed `menus` is reordered by
+  // the per-browser saved order in ngOnInit and on drag.
+  private readonly DEFAULT_MENUS = [
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg' },
     { id: 'endpoints', label: 'Endpoints', svg: 'assets/icons/endpoints.svg' },
     { id: 'map',       label: 'Map',       svg: 'assets/icons/map.svg' },
@@ -27,6 +30,8 @@ export class MainComponent implements OnInit {
     { id: 'users',     label: 'Users',     svg: 'assets/icons/users.svg' },
     { id: 'software',  label: 'Software',  svg: 'assets/icons/software.svg' },
   ];
+  menus = [...this.DEFAULT_MENUS];
+  dragIndex = -1;   // index of the item being dragged (-1 = none)
 
   version = '';   // running release (iot.version), shown in the sidebar footer
 
@@ -35,9 +40,12 @@ export class MainComponent implements OnInit {
   constructor(private http: HttpsvcService, private session: SessionService,
               private router: Router, public theme: ThemeService,
               public debug: DebugService,
-              private ds: DataStoreService) { this.theme.init(); this.debug.init(); }
+              private ds: DataStoreService,
+              private navOrder: NavOrderService) { this.theme.init(); this.debug.init(); }
 
   ngOnInit(): void {
+    // Apply the per-browser saved sidebar order (new pages append).
+    this.menus = this.navOrder.apply([...this.DEFAULT_MENUS]);
     // Authenticated shell: warm the shared data-store cache once so every
     // config page paints instantly, and start watching for live changes.
     this.ds.prefetchAll();
@@ -51,6 +59,25 @@ export class MainComponent implements OnInit {
   }
 
   onMenuSelect(id: string): void { this.selectedMenu = id; this.selectedSubNav = ''; }
+
+  // ── Drag-to-reorder the sidebar (HTML5 DnD; persisted per browser) ──
+  onDragStart(i: number): void { this.dragIndex = i; }
+  onDragOver(e: DragEvent, i: number): void {
+    e.preventDefault();                       // allow the drop
+    if (this.dragIndex < 0 || this.dragIndex === i) return;
+    const [moved] = this.menus.splice(this.dragIndex, 1);
+    this.menus.splice(i, 0, moved);           // live reorder as you hover
+    this.dragIndex = i;
+  }
+  onDragEnd(): void {
+    if (this.dragIndex < 0) return;
+    this.dragIndex = -1;
+    this.navOrder.save(this.menus.map((m) => m.id));
+  }
+  resetNav(): void {
+    this.navOrder.reset();
+    this.menus = [...this.DEFAULT_MENUS];
+  }
 
   /// Endpoints → "show on map": focus the Fleet Map on the clicked endpoint.
   mapFocus = '';

--- a/apps/cloud/ui/src/common/nav-order.service.ts
+++ b/apps/cloud/ui/src/common/nav-order.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+
+/// Persists the sidebar's drag-to-reorder order per browser (localStorage),
+/// mirroring the Theme/Debug toggles — no backend, no per-user sync. The order
+/// is a list of menu ids; `apply()` reorders a menu array by it and APPENDS any
+/// id not in the saved list (so a newly code-added page is never hidden).
+@Injectable({ providedIn: 'root' })
+export class NavOrderService {
+  private readonly KEY = 'iot-nav-order';
+
+  private read(): string[] {
+    try {
+      const v = JSON.parse(localStorage.getItem(this.KEY) || '[]');
+      return Array.isArray(v) ? v.filter((x) => typeof x === 'string') : [];
+    } catch { return []; }
+  }
+
+  save(ids: string[]): void {
+    try { localStorage.setItem(this.KEY, JSON.stringify(ids)); } catch { /* private mode */ }
+  }
+
+  reset(): void {
+    try { localStorage.removeItem(this.KEY); } catch { /* private mode */ }
+  }
+
+  /// Reorder `items` by the saved id order; ids present in `items` but not in
+  /// the saved order keep their original relative position at the end.
+  apply<T extends { id: string }>(items: T[]): T[] {
+    const order = this.read();
+    if (!order.length) return items;
+    const byId = new Map(items.map((i) => [i.id, i]));
+    const out: T[] = [];
+    for (const id of order) {
+      const it = byId.get(id);
+      if (it) { out.push(it); byId.delete(id); }
+    }
+    for (const it of items) if (byId.has(it.id)) out.push(it);   // appended
+    return out;
+  }
+}

--- a/iot-ui/src/app/main/main.component.html
+++ b/iot-ui/src/app/main/main.component.html
@@ -12,6 +12,10 @@
          [class.active]="selectedMenu === m.id && !selectedSubNav"
          [class.expanded]="expandedMenu === m.id"
          [class.has-children]="m.children.length"
+         [class.dragging]="dragId === m.id"
+         draggable="true" (dragstart)="onDragStart(m.id)"
+         (dragover)="onDragOver($event, m.id)" (dragend)="onDragEnd()"
+         title="Drag to reorder"
          (click)="m.children.length ? toggleMenu(m.id) : onMenuSelect(m.id)">
         <img [src]="m.svg" class="nav-icon" alt="" />
         <span>{{ m.label }}</span>
@@ -32,6 +36,11 @@
         </a>
       </div>
     </ng-container>
+
+    <a class="nav-item nav-reset" (click)="resetNav()" title="Reset menu order to default">
+      <span class="nav-icon nav-reset-glyph">↺</span>
+      <span>Reset order</span>
+    </a>
 
     <div class="sidebar-spacer"></div>
 

--- a/iot-ui/src/app/main/main.component.scss
+++ b/iot-ui/src/app/main/main.component.scss
@@ -133,6 +133,10 @@
   }
 }
 
+.nav-item.dragging { opacity: 0.45; background: rgba(46,125,50,0.06); }
+.nav-reset { font-size: 11px; color: #9a9a9a; }
+.nav-reset-glyph { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; font-size: 15px; opacity: 0.6; }
+
 .sidebar-spacer { flex: 1; }
 
 .nav-logout {

--- a/iot-ui/src/app/main/main.component.ts
+++ b/iot-ui/src/app/main/main.component.ts
@@ -6,6 +6,7 @@ import { PubSubService } from '../../common/pubsubsvc.service';
 import { ThemeService } from '../../common/theme.service';
 import { DebugService } from '../../common/debug.service';
 import { DataStoreService } from '../../common/datastore.service';
+import { NavOrderService } from '../../common/nav-order.service';
 import { StatusSnapshot, fmtDuration } from '../../common/app-globals';
 
 @Component({
@@ -24,7 +25,9 @@ export class MainComponent {
   status: StatusSnapshot | null = null;
 
   // Sidebar nav items with collapsible children
-  menus = [
+  // Canonical sidebar order (the reset target). The displayed `menus` is
+  // reordered by the per-browser saved order in ngOnInit and on drag.
+  private readonly DEFAULT_MENUS = [
     { id: 'dashboard', label: 'Dashboard', svg: 'assets/icons/dashboard.svg', children: [] as {id:string,label:string}[] },
     { id: 'vpn',       label: 'VPN',       svg: 'assets/icons/vpn.svg',
       children: [{id:'config',label:'Configuration'},{id:'status',label:'Status'}] },
@@ -49,6 +52,8 @@ export class MainComponent {
     { id: 'advanced',  label: 'Advanced',  svg: 'assets/icons/advanced.svg',
       children: [{id:'reboot',label:'Reboot'},{id:'factory',label:'Factory Reset'},{id:'transfer',label:'Transfer'}] },
   ];
+  menus = [...this.DEFAULT_MENUS];
+  dragId = '';   // id of the menu being dragged ('' = none)
 
   expandedMenu: string | null = null;  // which menu is expanded in sidebar
   version = '';                         // running release (iot.version)
@@ -73,13 +78,16 @@ export class MainComponent {
     private pubsub: PubSubService,
     public theme: ThemeService,
     public debug: DebugService,
-    private ds: DataStoreService
+    private ds: DataStoreService,
+    private navOrder: NavOrderService
   ) {
     this.theme.init();
     this.debug.init();
   }
 
   ngOnInit(): void {
+    // Apply the per-browser saved sidebar order (new pages append).
+    this.menus = this.navOrder.apply([...this.DEFAULT_MENUS]);
     // Authenticated shell: warm the shared data-store cache once so every
     // config page paints instantly, and start watching for live changes.
     this.ds.prefetchAll();
@@ -120,6 +128,28 @@ export class MainComponent {
     this.selectedMenu = menuId;
     this.selectedSubNav = '';
     this.pubsub.publish('menu', menuId);
+  }
+
+  // ── Drag-to-reorder the sidebar (HTML5 DnD; persisted per browser). Keyed by
+  //    id (not index) so it works against the filtered `navMenus` view. ──
+  onDragStart(id: string): void { this.dragId = id; }
+  onDragOver(e: DragEvent, overId: string): void {
+    e.preventDefault();                        // allow the drop
+    if (!this.dragId || this.dragId === overId) return;
+    const from = this.menus.findIndex(m => m.id === this.dragId);
+    const to   = this.menus.findIndex(m => m.id === overId);
+    if (from < 0 || to < 0) return;
+    const [moved] = this.menus.splice(from, 1);
+    this.menus.splice(to, 0, moved);           // live reorder; navMenus reflects it
+  }
+  onDragEnd(): void {
+    if (!this.dragId) return;
+    this.dragId = '';
+    this.navOrder.save(this.menus.map(m => m.id));
+  }
+  resetNav(): void {
+    this.navOrder.reset();
+    this.menus = [...this.DEFAULT_MENUS];
   }
 
   onSubNavSelect(item: string): void {

--- a/iot-ui/src/common/nav-order.service.ts
+++ b/iot-ui/src/common/nav-order.service.ts
@@ -1,0 +1,40 @@
+import { Injectable } from '@angular/core';
+
+/// Persists the sidebar's drag-to-reorder order per browser (localStorage),
+/// mirroring the Theme/Debug toggles — no backend, no per-user sync. The order
+/// is a list of menu ids; `apply()` reorders a menu array by it and APPENDS any
+/// id not in the saved list (so a newly code-added page is never hidden).
+@Injectable({ providedIn: 'root' })
+export class NavOrderService {
+  private readonly KEY = 'iot-nav-order';
+
+  private read(): string[] {
+    try {
+      const v = JSON.parse(localStorage.getItem(this.KEY) || '[]');
+      return Array.isArray(v) ? v.filter((x) => typeof x === 'string') : [];
+    } catch { return []; }
+  }
+
+  save(ids: string[]): void {
+    try { localStorage.setItem(this.KEY, JSON.stringify(ids)); } catch { /* private mode */ }
+  }
+
+  reset(): void {
+    try { localStorage.removeItem(this.KEY); } catch { /* private mode */ }
+  }
+
+  /// Reorder `items` by the saved id order; ids present in `items` but not in
+  /// the saved order keep their original relative position at the end.
+  apply<T extends { id: string }>(items: T[]): T[] {
+    const order = this.read();
+    if (!order.length) return items;
+    const byId = new Map(items.map((i) => [i.id, i]));
+    const out: T[] = [];
+    for (const id of order) {
+      const it = byId.get(id);
+      if (it) { out.push(it); byId.delete(id); }
+    }
+    for (const it of items) if (byId.has(it.id)) out.push(it);   // appended
+    return out;
+  }
+}


### PR DESCRIPTION
Operators can now **drag the sidebar items into the order they like** — in both the cloud-ui and the device-ui.

## How
- **`NavOrderService`** (`providedIn:'root'`) saves the menu-id order in **localStorage** — per browser, no backend, mirroring the existing **Theme**/**Debug** toggles. `apply()` reorders a menu array by the saved order and **appends** any id not in it, so a future code-added page is never hidden.
- **`main.component`** — the menu list becomes a canonical `DEFAULT_MENUS` (the reset target) + a displayed `menus` reordered in `ngOnInit`. Native HTML5 drag handlers reorder live as you hover and persist on drop. A **"↺ Reset order"** item restores the default.
- **cloud-ui** reorders by **index** (unfiltered list); **device-ui** reorders by **id** so it works against the filtered `navMenus` view (Terminal/Containers admin-gating).
- **Native HTML5 DnD — no new dependency** (`@angular/cdk` drag-drop isn't installed here). Dragging still click-selects.

## Scope / decisions (as requested)
- **Both UIs**, **per-browser** persistence, **with reset** — exactly the ask.
- Per-user sync (across browsers) would need a server-side key; can be a follow-up.

Client-only; CI builds both SPAs (no node on the dev host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)