### PR TITLE
fix(ota): bundle runtime-lib deps + stop the spool-perms clobber

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-stage
@@ -69,6 +69,14 @@ case "$NAME" in
 esac
 
 mkdir -p "$SPOOL"
+# Restore the tmpfiles ownership/mode (group iot, g+w) — a prior root `mkdir -p`
+# (here or in iot-swupdate, when the spool was momentarily absent) can recreate it
+# 0755 root:root under the root umask, which then locks out the unprivileged,
+# group-iot lwm2m client that must write stage.req to launch the NEXT cloud OTA
+# (otherwise `write(stage.req) errno=13 EACCES` and the campaign hangs). Root-only,
+# which this stager is; harmless if already correct.
+chgrp iot "$SPOOL" 2>/dev/null || true
+chmod 2775 "$SPOOL" 2>/dev/null || true
 DL="$SPOOL/$NAME"
 
 # Surface what's being applied + reset the progress gauge for the UIs. The

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-swupdate
@@ -20,6 +20,11 @@ set -u
 # (/run is wiped on reboot, so the copy never lingers.)
 if [ "${IOT_SWUPDATE_REEXEC:-}" != "1" ]; then
     mkdir -p /run/iot/update 2>/dev/null || true
+    # Never leave the spool 0755 root:root (root umask on a fresh mkdir): that locks
+    # out the unprivileged group-iot lwm2m client from writing stage.req for the
+    # NEXT cloud OTA (errno=13). Restore the tmpfiles mode/group. See iot-ota-stage.
+    chgrp iot /run/iot/update 2>/dev/null || true
+    chmod 2775 /run/iot/update 2>/dev/null || true
     _self="/run/iot/update/.self.$$"
     if cp "$0" "$_self" 2>/dev/null; then
         IOT_SWUPDATE_REEXEC=1 exec sh "$_self" "$@"

--- a/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
@@ -26,6 +26,17 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 # so one task dependency guarantees the whole feed is written before we bundle.
 do_deploy[depends] += "iot:do_package_write_ipk"
 
+# Runtime shared-lib deps the iot-* binaries link but an OLDER on-device image may
+# not already carry. Incremental .ipk OTA installs only what's in the bundle, so a
+# NEW or version-bumped lib dep makes `opkg install` fail on a stale device with
+# "nothing provides <lib> >= <ver>" — observed 1.3.0→1.3.2: iot-lwm2m needs
+# libsqlite3-0>=3.45.3 (the SQLite DurableSampleBuffer) and iot-mqtt needs
+# libmosquitto1>=2.0.22, neither on the 1.3.0 image. Bundle them so the OTA is
+# self-contained. Bare package basenames; the newest matching .ipk is included.
+# Build-deps that drag these in so their .ipk is written to the feed before bundling.
+IOT_BUNDLE_EXTRA_PKGS ?= "libsqlite3-0 libmosquitto1"
+do_deploy[depends] += "sqlite3:do_package_write_ipk mosquitto:do_package_write_ipk"
+
 do_deploy() {
     feed="${DEPLOY_DIR_IPK}"
     stage="${WORKDIR}/bundle"
@@ -48,6 +59,20 @@ do_deploy() {
     if [ -z "$(ls -A "${stage}" 2>/dev/null)" ]; then
         bbfatal "iot-bundle: no iot-*.ipk found under ${feed} — is the 'iot' recipe built?"
     fi
+
+    # Add the runtime-lib deps (newest each) so a stale device that lacks them can
+    # still satisfy opkg. opkg ignores an already-current/newer lib, so including
+    # them is harmless when the device is already up to date.
+    for pkg in ${IOT_BUNDLE_EXTRA_PKGS}; do
+        dep="$(find "${feed}" -name "${pkg}_*.ipk" -type f -printf '%T@ %p\n' \
+                 | sort -rn | awk 'NR==1{print $2}')"
+        if [ -n "${dep}" ]; then
+            cp -f "${dep}" "${stage}/"
+            bbnote "iot-bundle: included dep $(basename "${dep}")"
+        else
+            bbwarn "iot-bundle: dep ${pkg} not found in ${feed} — stale devices may fail opkg"
+        fi
+    done
 
     name="iot-bundle-${PV}-${MACHINE}.tar.gz"
     # Archive root holds the flat .ipk files (extracted straight into the spool


### PR DESCRIPTION
Two field-found blockers while installing **v1.3.2 onto a stale 1.3.0 device** (incremental .ipk OTA).

## 1. `opkg install` fails — bundle isn't self-contained
```
nothing provides libsqlite3-0 >= 3.45.3  needed by iot-lwm2m-1.3.2
nothing provides libmosquitto1 >= 2.0.22 needed by iot-mqtt-1.3.2
```
The bundle packed **`iot-*.ipk` only**. A new/bumped **shared-lib** dep the old image lacks (`libsqlite3` from **#414**'s SQLite DurableSampleBuffer; `libmosquitto` from iot-mqtt) fails the whole install. Fix: `IOT_BUNDLE_EXTRA_PKGS` bundles those lib `.ipk`s (newest each) so the OTA is self-contained. opkg ignores an already-current lib, so it's harmless when present.

## 2. Cloud push can't even start — spool perms clobber
```
write(/run/iot/update/stage.req) errno=13 (EACCES)
```
The spool was **`0755 root:root`** instead of the tmpfiles **`0775 root:iot`** — a prior root `mkdir -p` (in `iot-ota-stage`/`iot-swupdate`, when the spool was momentarily absent) recreated it under the root umask, locking out the unprivileged group-`iot` lwm2m client. Both scripts now `chgrp iot` + `chmod 2775` right after their `mkdir`, so an OTA never leaves the spool unwritable for the next push. (On the live device I restored it with `systemd-tmpfiles --create`.)

Both scripts `sh -n` validated. **Carrying the libs needs a bundle rebuild** (next release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)