### PR TITLE
fix(ota): RDEPENDS runtime libs (libsqlite3-0/libmosquitto1), not sqlite3 CLI/mosquitto broker

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -506,7 +506,7 @@ RDEPENDS:${PN}-lwm2m = "\
     readline \
     openssl \
     tinydtls-staticdev \
-    sqlite3 \
+    libsqlite3-0 \
     ${@bb.utils.contains('PACKAGECONFIG', 'mongo', \
         'mongo-cxx-driver-bsoncxx mongo-cxx-driver mongo-c-driver-bson mongo-c-driver', \
         '', d)} \
@@ -665,7 +665,7 @@ FILES:${PN}-mqtt = "\
     ${bindir}/iot-mqttd \
     ${systemd_system_unitdir}/iot-mqttd.service \
 "
-RDEPENDS:${PN}-mqtt = "ace-tao mosquitto"
+RDEPENDS:${PN}-mqtt = "ace-tao libmosquitto1"
 RRECOMMENDS:${PN}-mqtt = "\
     ${PN}-ds-server \
     ${PN}-config \


### PR DESCRIPTION
Next install blocker after #428. With the libs bundled, opkg got past the shlib deps but hit explicit RDEPENDS on the **base packages**:
```
nothing provides sqlite3   needed by iot-lwm2m-1.3.3
nothing provides mosquitto needed by iot-mqtt-1.3.3
```
The daemons only **link the libraries** — iot-lwm2m uses libsqlite3 (DurableSampleBuffer), iot-mqtt is a libmosquitto **client** (not a broker). Point RDEPENDS at `libsqlite3-0`/`libmosquitto1` (which the bundle ships since #428), so the install resolves and the unused CLI/broker don't land on the device.

Needs a bundle rebuild (next release) to take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)