### PR TITLE
fix(ota): drop unbuildable explicit lib RDEPENDS, rely on shlib auto-deps

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot_git.bb
@@ -499,6 +499,11 @@ FILES:${PN}-lwm2m = "\
     ${systemd_system_unitdir}/iot-swupdate.service \
     ${systemd_system_unitdir}/iot-ota-confirm.service \
 "
+# NOTE: do NOT add an explicit RDEPENDS on libsqlite3-0 (the SQLite
+# DurableSampleBuffer). That is a debian-renamed shlib package name — valid as an
+# installed .ipk but NOT build-time resolvable ("Nothing RPROVIDES libsqlite3-0").
+# The shlib auto-dependency already adds it from the linked .so; the OTA bundle
+# ships the .ipk (iot-bundle.bb IOT_BUNDLE_EXTRA_PKGS), so it resolves at install.
 RDEPENDS:${PN}-lwm2m = "\
     ace-tao \
     lua \
@@ -506,7 +511,6 @@ RDEPENDS:${PN}-lwm2m = "\
     readline \
     openssl \
     tinydtls-staticdev \
-    libsqlite3-0 \
     ${@bb.utils.contains('PACKAGECONFIG', 'mongo', \
         'mongo-cxx-driver-bsoncxx mongo-cxx-driver mongo-c-driver-bson mongo-c-driver', \
         '', d)} \
@@ -665,7 +669,7 @@ FILES:${PN}-mqtt = "\
     ${bindir}/iot-mqttd \
     ${systemd_system_unitdir}/iot-mqttd.service \
 "
-RDEPENDS:${PN}-mqtt = "ace-tao libmosquitto1"
+RDEPENDS:${PN}-mqtt = "ace-tao"
 RRECOMMENDS:${PN}-mqtt = "\
     ${PN}-ds-server \
     ${PN}-config \


### PR DESCRIPTION
Fixes the build error my **#430** introduced (caught on a real Yocto build):
```
ERROR: Nothing RPROVIDES 'libsqlite3-0' (iot_git.bb RDEPENDS on it)
ERROR: Required build target 'iot' has no buildable providers.
```

## Why #430 was wrong
`libsqlite3-0`/`libmosquitto1` are **debian-renamed shlib package names** (auto-generated at packaging from the `.so` SONAME). They're valid as *installed* `.ipk` names but **not build-time resolvable** as an explicit `RDEPENDS` — no recipe declares them as a provider.

## Correct fix
Remove the explicit runtime dep entirely. The **shlib auto-dependency** already records the right dep from the linked `.so` (that's exactly where the device's `libsqlite3-0 >= 3.45.3` / `libmosquitto1 >= 2.0.22` came from), and **#428** bundles those `.ipk`s — so install still resolves. The original `sqlite3`/`mosquitto` were the base CLI/broker (wrong); the daemons only link the libs.

- `RDEPENDS:${PN}-lwm2m` — drop the sqlite line (shlib adds `libsqlite3-0`).
- `RDEPENDS:${PN}-mqtt = "ace-tao"` (shlib adds `libmosquitto1`).
- Build-time `DEPENDS` on `sqlite3`/`mosquitto` (for linking) **unchanged**.
- Added a NOTE so nobody re-adds the explicit shlib dep.

Recipe now parses + builds; the bundle stays self-contained via #428.

🤖 Generated with [Claude Code](https://claude.com/claude-code)