### PR TITLE
build: RM_OLD_IMAGE=1 — keep only the current local image

### DIFF
--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -93,6 +93,15 @@ SSTATE_HARDLINK = "0"
 # reruns fast, so this costs little. The image recipe is auto-excluded.
 INHERIT += "rm_work"
 
+# Keep only the CURRENT image locally: when a new image is built, delete the
+# previous build's image of the same name from tmp/deploy/images/<machine>
+# (old .wic/.wic.bz2/.ext4/.manifest) instead of accumulating every build's
+# artifacts on the builder. The <image>-<machine>.<type> symlinks still resolve
+# to the latest. (Versioned deploy artifacts — the iot-bundle .tar.gz / .raucb —
+# are not images and aren't covered here; iot-bundle already picks the newest
+# .ipk per package, so the bundle never ships two versions of a package.)
+RM_OLD_IMAGE = "1"
+
 # BB_NUMBER_THREADS / PARALLEL_MAKE + memory-pressure regulation are appended
 # below at run time (RAM-aware) — see the "resource guards" block.
 YOCONF


### PR DESCRIPTION
Per request: in the **local device build**, keep only the current image for the machine (e.g. raspberrypi3-64) and delete older ones.

The build accumulated every build's image artifacts in `tmp/deploy/images/<machine>` (old `.wic`/`.wic.bz2`/`.ext4`/`.manifest`). Setting **`RM_OLD_IMAGE = "1"`** in the build's `local.conf` (assembled by `entrypoint.sh`, which `build.sh` runs in-container) makes a new build delete the previous same-named image — keeping only the current; the `<image>-<machine>.<type>` symlinks still resolve to the latest.

Note: versioned deploy artifacts (the `iot-bundle .tar.gz` / `.raucb`) are **not** images and aren't covered by `RM_OLD_IMAGE`; the iot-bundle recipe already de-dupes to the newest `.ipk` per package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)