### PR TITLE
fix(ui): match "Reset order" nav font to the other sidebar items

### DIFF
--- a/apps/cloud/ui/src/app/main/main.component.scss
+++ b/apps/cloud/ui/src/app/main/main.component.scss
@@ -10,8 +10,7 @@
 .nav-item.active { color:#2e7d32; border-left-color:#2e7d32; background:rgba(46,125,50,0.08); }
 .nav-item.active .nav-icon { opacity:1; filter:invert(32%) sepia(85%) saturate(540%) hue-rotate(82deg) brightness(40%) contrast(90%); }
 .nav-item.dragging { opacity:0.45; background:rgba(46,125,50,0.06); }
-.nav-reset { font-size:11px; color:#9a9a9a; padding-top:6px; padding-bottom:6px; }
-.nav-reset-glyph { display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; font-size:15px; opacity:0.6; }
+.nav-reset-glyph { display:inline-flex; align-items:center; justify-content:center; width:20px; height:20px; font-size:18px; opacity:0.5; }
 .sidebar-spacer { flex:1; }
 .nav-logout { border-top:1px solid #e0e0e0; margin-top:4px; color:#888; }
 .nav-logout:hover { color:#c62828; background:rgba(198,40,40,0.05); }

--- a/iot-ui/src/app/main/main.component.scss
+++ b/iot-ui/src/app/main/main.component.scss
@@ -134,8 +134,7 @@
 }
 
 .nav-item.dragging { opacity: 0.45; background: rgba(46,125,50,0.06); }
-.nav-reset { font-size: 11px; color: #9a9a9a; }
-.nav-reset-glyph { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; font-size: 15px; opacity: 0.6; }
+.nav-reset-glyph { display: inline-flex; align-items: center; justify-content: center; width: 20px; height: 20px; font-size: 18px; opacity: 0.5; }
 
 .sidebar-spacer { flex: 1; }
 


### PR DESCRIPTION
The drag-to-reorder **Reset order** link (#426) was styled `11px`/`#9a9a9a` — smaller + dimmer than the `13px`/`#555` nav items above it (visible in the sidebar). Dropped the `.nav-reset` font/color override so it inherits the standard `.nav-item` type, and matched the `↺` glyph (`18px`, opacity `0.5`) to the 20px icons. Both cloud-ui + device-ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)