### PR TITLE
fix(ab): A/B HW bring-up — HDMI kernel console + iot-ota-confirm RAUC parsing

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -58,6 +58,11 @@
 #                                 # sstate+downloads into $CACHE_IMAGE and push
 #   IOT_USE_CACHE=1 ./build.sh    # pull $CACHE_IMAGE and build — only the
 #                                 # meta-iot recipes recompile (minutes, not hours)
+#
+# Interactive build-container shell (ad-hoc bitbake / bitbake-layers, e.g. to
+# clear a stale cache or trace where a value comes from):
+#   ./build.sh shell              # default machine; then: bitbake -c cleansstate base-files
+#   IOT_AB=1 ./build.sh shell raspberrypi3-64   # with the A/B layers added
 
 set -euo pipefail
 
@@ -275,6 +280,28 @@ EOF
     echo ""
 }
 
+# Interactive shell in the build container with the full bitbake env ready
+# (entrypoint does the layer + local.conf setup, then `exec bash` on IOT_SHELL=1).
+# For ad-hoc bitbake / bitbake-layers — e.g. `bitbake -c cleansstate base-files`,
+# `bitbake-layers show-layers`, grepping the other layers. Same volumes (sstate +
+# downloads) as a build, so changes here affect real builds.
+shell_into() {
+    local machine="$1"
+    local container="iot-shell-${machine//./-}"
+    $CR rm -f "$container" >/dev/null 2>&1 || true
+    log_section "Build-container shell ($machine)"
+    $CR run --rm -it --name "$container" \
+        -e "MACHINE=$machine" \
+        -e "IOT_AB=${IOT_AB:-}" \
+        -e "IOT_BRANCH=${IOT_BRANCH:-}" \
+        -e "IOT_HASH_LOCAL=1" \
+        -e "IOT_SHELL=1" \
+        -v "$SCRIPT_DIR/meta-iot:/home/builduser/yocto/meta-iot:ro" \
+        -v "${DOWNLOADS_VOLUME}:/home/builduser/yocto/build/downloads:U" \
+        -v "${SSTATE_VOLUME}:/home/builduser/yocto/build/sstate-cache:U" \
+        "$IMAGE_NAME"
+}
+
 # ── Main ──────────────────────────────────────────────────────────────
 main() {
     CR=$(detect_runtime)
@@ -283,6 +310,13 @@ main() {
     # Subcommand: publish the cache image (no machine build).
     if [ "${1:-}" = "publish" ]; then
         publish
+        return
+    fi
+
+    # Subcommand: interactive bitbake shell (no build).
+    if [ "${1:-}" = "shell" ]; then
+        prepare_image
+        shell_into "${2:-$DEFAULT_MACHINE}"
         return
     fi
 

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -284,6 +284,21 @@ fi
 # packagegroup-iot): the feed is enough there.
 case " $* " in *" iot-image "*) set -- "$@" iot-bundle ;; esac
 
+# Interactive shell (./build.sh shell): all the layer + local.conf + bitbake-env
+# setup above has run, so drop the operator into a ready-to-use bitbake shell
+# instead of building. Handy for `bitbake -c cleansstate base-files`,
+# `bitbake-layers show-layers`, `bitbake -e <recipe>`, grepping the other layers.
+if [ "${IOT_SHELL:-}" = "1" ]; then
+    echo ""
+    echo "→ bitbake env ready ($MACHINE). e.g.:"
+    echo "    bitbake -c cleansstate base-files   # clear a recipe's stale sstate"
+    echo "    bitbake-layers show-layers          # list configured layers + paths"
+    echo "    bitbake -e base-files | grep fstab  # where a value comes from"
+    echo "  Exit with Ctrl-D / 'exit'."
+    echo ""
+    exec bash
+fi
+
 echo ""
 echo "→ Starting bitbake for $MACHINE: $@ ..."
 echo ""

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -200,6 +200,11 @@ IMAGE_INSTALL:append = " rauc"
 WKS_FILE = "iot-ab.wks.in"
 # The bundle needs the rootfs as an ext4 alongside the flashable wic.bz2.
 IMAGE_FSTYPES:append = " ext4"
+# Bring-up aid: also put the kernel console on HDMI (tty1) so the boot — and any
+# rootfs-mount hang/panic — is visible on a monitor without a serial adapter
+# (ENABLE_UART only routes it to the GPIO UART; the framebuffer shows just the
+# raspberry logos). Both consoles get printk; remove once A/B boot is validated.
+CMDLINE:append = " console=tty1"
 ABCONF
         fi
         ;;

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ota-confirm
@@ -31,7 +31,6 @@ fi
 # system.conf), empty until that bank has been RAUC-installed. HW-validate the
 # RAUC_* field names against the deployed rauc version.
 publish_banks() {
-    booted="$1"
     iotver="$($DSCLI get iot.version 2>/dev/null | sed 's/^iot\.version=//' | tr -d "\"'")"
     # eval the shell-format status into RAUC_* vars (single-quoted values → safe).
     eval "$(rauc status --output-format=shell 2>/dev/null)" || true
@@ -41,12 +40,17 @@ publish_banks() {
     fi
     json="["; first=1
     for i in $RAUC_SLOTS; do
-        eval "name=\${RAUC_SLOT_NAME_$i:-}"
+        # This RAUC's shell output has NO RAUC_SLOT_NAME_$i — the slot name is the
+        # i-th word of RAUC_SYSTEM_SLOTS (RAUC_SLOTS indices align with it), and the
+        # active bank is the slot whose RAUC_SLOT_STATE_$i is "booted" (not a name
+        # match against a booted-slot var, which this RAUC version doesn't emit).
+        name="$(echo "$RAUC_SYSTEM_SLOTS" | cut -d' ' -f"$i")"
         eval "bn=\${RAUC_SLOT_BOOTNAME_$i:-}"
         eval "bs=\${RAUC_SLOT_BOOT_STATUS_$i:-unknown}"
-        eval "ver=\${RAUC_SLOT_BUNDLE_VERSION_$i:-}"
-        [ -n "$name" ] || continue
-        if [ "$name" = "$booted" ]; then isb=true; [ -n "$iotver" ] && ver="$iotver"; else isb=false; fi
+        eval "st=\${RAUC_SLOT_STATE_$i:-}"
+        eval "ver=\${RAUC_SLOT_BUNDLE_VERSION_$i:-}"   # absent in plain shell output → ""
+        [ -n "$bn" ] || continue
+        if [ "$st" = "booted" ]; then isb=true; [ -n "$iotver" ] && ver="$iotver"; else isb=false; fi
         [ -n "$bs" ] || bs="unknown"
         [ "$first" = 1 ] || json="$json,"; first=0
         json="$json{\"bootname\":\"$bn\",\"slot\":\"$name\",\"version\":\"$ver\",\"state\":\"$bs\",\"booted\":$isb}"
@@ -59,11 +63,12 @@ publish_banks() {
     $DSCLI set iot.boot.banks "\"$esc\"" >/dev/null 2>&1 || true
 }
 
-# Which rootfs bank booted (e.g. "rootfs.0"/"A"). Publish for the UI.
+# Which bank booted (bootname "A"/"B"). Publish for the UI. This RAUC emits
+# RAUC_SYSTEM_BOOTED_BOOTNAME (older versions used RAUC_SYSTEM_BOOTED_SLOT).
 BANK="$(rauc status --output-format=shell 2>/dev/null \
-        | sed -n 's/^RAUC_SYSTEM_BOOTED_SLOT=\(.*\)/\1/p' | tr -d "\"'")"
+        | sed -n 's/^RAUC_SYSTEM_BOOTED_BOOTNAME=//p' | tr -d "\"'")"
 [ -n "$BANK" ] && set_ds iot.boot.bank "\"$BANK\""
-publish_banks "$BANK"
+publish_banks
 
 # Healthy = ds answers AND the core daemons are active. (Deliberately NOT gating
 # on LwM2M registration — a transient cloud outage must not trigger a rollback
@@ -83,7 +88,7 @@ while [ "$i" -lt 90 ]; do          # up to ~90 s for the stack to come up
         set_ds iot.boot.confirmed true
         set_ds iot.update.result 1     # success
         set_ds iot.update.state  0     # idle
-        publish_banks "$BANK"          # re-emit so this bank now reads state=good
+        publish_banks          # re-emit so this bank now reads state=good
         log "boot ${BANK:-?} confirmed good (marked good)"
         exit 0
     fi


### PR DESCRIPTION
A/B bring-up aid: `ENABLE_UART` routes the kernel console to the GPIO serial UART, so on HDMI you only see the raspberry logos — a rootfs-mount hang/panic is invisible without a serial adapter. Adds `console=tty1` to the A/B kernel cmdline (`IOT_AB`-scoped) so the boot prints on a monitor. Remove once A/B boot is validated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)