### PR TITLE
feat(image): fstab sanity precheck — reject a self-bricking image at build time

### DIFF
--- a/yocto/meta-iot/recipes-iot/images/iot-image.bb
+++ b/yocto/meta-iot/recipes-iot/images/iot-image.bb
@@ -59,3 +59,37 @@ IMAGE_ROOTFS_EXTRA_SPACE = "524288"
 # On a Linux host whose build fs supports FIEMAP, append "wic.bmap" below to
 # re-enable fast/verified bmaptool writes.
 IMAGE_FSTYPES = "wic.bz2"
+
+# ── Pre-flight: fstab sanity (reject a self-bricking image at BUILD time) ──
+# A baked /etc/fstab that references a block device the target won't have makes
+# systemd's local-fs.target time out (~90 s) and drop to EMERGENCY mode on first
+# boot — a silent brick (and on A/B BOTH banks brick before rollback can help).
+# Seen in the field from a stale base-files sstate that injected /dev/sda4 +
+# /dev/mmcblk0p5/6. Fail the build on the classic offenders so a bad fstab never
+# ships as an update / flash:
+#   * /dev/sd*               — these images boot from mmc, never a SATA/USB disk
+#   * /dev/mmcblk0p<N>, N>4  — no wks layout here has more than 4 partitions
+fstab_sanity_check () {
+    fstab="${IMAGE_ROOTFS}/etc/fstab"
+    [ -f "$fstab" ] || return 0
+    bad=0
+    while read -r src mnt rest; do
+        case "$src" in
+            ''|'#'*) continue ;;
+            /dev/sd*)
+                bberror "fstab precheck: $src -> ${mnt:-?} — no SATA/USB disk on an mmc image"
+                bad=1 ;;
+            /dev/mmcblk0p*)
+                if [ "${src#/dev/mmcblk0p}" -gt 4 ] 2>/dev/null; then
+                    bberror "fstab precheck: $src -> ${mnt:-?} — no such partition"
+                    bad=1
+                fi ;;
+        esac
+    done < "$fstab"
+    if [ "$bad" = 1 ]; then
+        bbwarn "Offending /etc/fstab:
+$(cat "$fstab")"
+        bbfatal "fstab precheck FAILED — this image would hang at boot / drop to emergency mode. Usually a stale base-files sstate or a bad bbappend: run 'bitbake -c cleansstate base-files iot-image' then rebuild."
+    fi
+}
+ROOTFS_POSTPROCESS_COMMAND:append = " fstab_sanity_check;"


### PR DESCRIPTION
Adds a build-time **fstab precheck** so an image that would hang at boot can't ship — the exact failure from A/B bring-up.

## Why
A baked `/etc/fstab` referencing a device the target won't have makes systemd's `local-fs.target` time out (~90 s) → **emergency mode** on first boot (silent brick; on A/B *both* banks brick before rollback helps). In the field a **stale `base-files` sstate** injected `/dev/sda4` + `/dev/mmcblk0p5/6` → device dropped to emergency mode, no SSH/network.

## What
A `ROOTFS_POSTPROCESS_COMMAND` (`fstab_sanity_check`) **fails the build** if the image's `/etc/fstab` references:
- any **`/dev/sd*`** — these images boot from mmc, never SATA/USB
- a **`/dev/mmcblk0p<N>`, N > 4** — no wks layout here has > 4 partitions

It aborts with the offending fstab + the fix (`bitbake -c cleansstate base-files iot-image`), so a bricking image never ships as a `.wic` flash or `.raucb` OTA. (`.raucb` OTAs are *also* covered at runtime by the A/B mark-good/rollback gate; this catches it earlier, at build.)

Can't run bitbake locally; the shell logic is standard POSIX + the `bbfatal`/`ROOTFS_POSTPROCESS_COMMAND` pattern. Validates on the next image build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)