### PR TITLE
fix(cloud-ca): mint client certs with -rand_serial (fixes serial-collision brick)

### DIFF
--- a/modules/server/openvpn/src/cert_authority.cpp
+++ b/modules/server/openvpn/src/cert_authority.cpp
@@ -266,12 +266,19 @@ std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn) {
     // CA database (index.txt) and can be revoked later. `-notext` keeps the
     // output a clean PEM (no human-readable header). ensure_crl() first so the
     // database + openssl.cnf exist.
+    //
+    // `-rand_serial`: pick a large random serial instead of reading/incrementing
+    // the `serial` file. The file-based counter desyncs from index.txt whenever
+    // the PKI is wiped/restored unevenly (index.txt restored but serial reset to
+    // "01") — every subsequent mint then dies with "Serial number 01 has already
+    // been issued, check the database/serial_file for corruption". A random
+    // serial removes that coupling entirely (and is RFC 5280 best practice).
     bool ok =
         ensure_crl() &&
         run_openssl("genrsa -out '" + key + "' 2048") &&
         run_openssl("req -new -key '" + key + "' -out '" + csr +
                     "' -subj '/O=IoT Cloud/CN=" + safe + "'") &&
-        run_openssl("ca -batch -notext -config '" + m_p.ca_cnf + "' -days " +
+        run_openssl("ca -batch -notext -rand_serial -config '" + m_p.ca_cnf + "' -days " +
                     std::to_string(m_p.days) + " -in '" + csr + "' -out '" + crt + "'");
 
     MintedCert out;


### PR DESCRIPTION
## Symptom
Device registers (LwM2M up) but VPN stays down — `/etc/iot/vpn` empty, no Object-2048 push. Cloud log:
```
openssl failed rc=256: ca -batch -notext -config .../openssl.cnf -days 3650 ...
  ERROR:Serial number 01 has already been issued, check the database/serial_file for corruption
  Serial Number :01  Subject: /CN=rpi000000006556e041@cloud.local/O=IoT Cloud
mint_client(...) failed → provision failed (dup or exhausted)
```

## Cause
The X.509 **certificate serial number** (CA's per-issuance counter in the `serial` file) is separate state from `index.txt`. On a PKI wipe/restore, `index.txt` was restored (serial 01 already issued for this device) but the `serial` file reset to `01` → every re-mint collides. Note: the cert serial is **not** the device serial — the device serial is the **CN** (`rpi<serial>@cloud.local`), and re-provisioning mints a *new* cert for the *same* CN, which legitimately needs a *new* cert serial.

## Fix
Pass **`-rand_serial`** to `openssl ca` — a large random serial per cert, no dependency on the desync-prone counter file. `unique_subject = no` already allows the repeated CN. One-line change; RFC 5280 best practice.

## Note
Recovers all future mints. For an already-corrupted CA db, also bump/clear the stale `serial` file once (or re-mint picks a fresh random serial after this lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)