### PR TITLE
fix(containers): nft ruleset must add table before flush table

### DIFF
--- a/modules/containers/src/container_net.cpp
+++ b/modules/containers/src/container_net.cpp
@@ -49,8 +49,13 @@ NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridg
 
 std::string nft_container_ruleset(const std::string& cidr, const std::string& bridge) {
     std::ostringstream ss;
-    // Flush our scoped table first so re-apply is idempotent — mirrors
-    // net-router's `flush table inet iot_router`. We never touch other tables.
+    // `add table` BEFORE `flush table`: on the very first container run the table
+    // doesn't exist yet, and `flush table` on a missing table errors out
+    // ("No such file or directory") — which aborts bridge setup and fails the run.
+    // `add table` is idempotent (no-op if present), so this makes re-apply safe
+    // whether or not the table already exists. Mirrors device_dnat.cpp. We only
+    // ever touch our own scoped table, never net-router's iot_router.
+    ss << "add table inet iot_containers\n";
     ss << "flush table inet iot_containers\n";
     ss << "table inet iot_containers {\n";
     ss << "    chain postrouting {\n";

--- a/modules/containers/test/container_net_test.cpp
+++ b/modules/containers/test/container_net_test.cpp
@@ -37,6 +37,11 @@ TEST(NftRuleset, ScopedTableWithMasquerade) {
     // Own scoped table — must NOT touch net-router's iot_router table.
     EXPECT_NE(rs.find("flush table inet iot_containers"), std::string::npos);
     EXPECT_NE(rs.find("table inet iot_containers {"), std::string::npos);
+    // `add table` MUST precede `flush table` so the first container run (no table
+    // yet) doesn't die on "flush table … No such file or directory".
+    EXPECT_NE(rs.find("add table inet iot_containers"), std::string::npos);
+    EXPECT_LT(rs.find("add table inet iot_containers"),
+              rs.find("flush table inet iot_containers"));
     EXPECT_EQ(rs.find("iot_router"), std::string::npos);
     // Masquerade for the subnet leaving any non-bridge interface.
     EXPECT_NE(rs.find("ip saddr 10.88.0.0/24 oifname != \"iot-cni0\" masquerade"),


### PR DESCRIPTION
## Symptom (first HW run of bridge networking, PR#402)
```
container.state=error
container.error=bridge networking failed: nft masquerade failed:
  flush table inet iot_containers — Error: No such file or directory
```
Pull + overlay mount succeed; the **run** dies setting up the bridge.

## Cause
`container_net.cpp` emitted `flush table inet iot_containers` with no preceding `add table`. On the first run the table doesn't exist, and `flush table` on a missing table is a hard nft error → bridge setup aborts → container never starts.

## Fix
Prepend idempotent **`add table inet iot_containers`** before the flush — the add-then-flush idiom `device_dnat.cpp`/net-router already use. Test asserts `add` precedes `flush`.

Verified live on the RPi3B by pre-creating the table (`nft add table inet iot_containers`) and re-running — container then starts cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)