### PR TITLE
feat(containers): Phase-2 multi-container foundation (schema + design)

### DIFF
--- a/apps/docs/tdd-device-containers.md
+++ b/apps/docs/tdd-device-containers.md
@@ -359,3 +359,75 @@ ds-cli set container.stop.request "$(date +%s)"
 rm -rf /var/lib/iot-containers/blobs /var/lib/iot-containers/layers \
        /var/lib/iot-containers/manifests   # drop cached images
 ```
+
+---
+
+## 13. Phase 2 — multiple containers (dynamic named)
+
+v1 runs **one** container (`kContainerId="c0"`, singular `container.*` keys). Phase 2
+lets an operator run **any number** of independently-named containers, each with its
+own bridge IP, shown one-per-row in a device-ui grid.
+
+### 13.1 Why a JSON document, not `container.<name>.*` keys
+
+The ds schema is **static** — keys are registered up-front in `container.lua`; there
+is no mechanism to register `container.web.state`, `container.db.state`, … at
+runtime. So multiplicity lives in **values, not key names** — exactly the pattern the
+cloud already uses for `cloud.endpoint.credentials` (a JSON array of per-endpoint
+records). Two new key groups (schema added):
+
+**Status (daemon → UI), volatile:**
+- `container.instances` — JSON array, one object per container:
+  `{name, image, imageId, size, state, ip, gateway, pid, exitCode, mem, cpus, net, started, error}`.
+  Republished on every state change; the UI grid renders it directly.
+
+**Command envelope (UI → daemon):** set the fields, then bump `container.cmd.request`:
+- `container.cmd.name`  — target container (the row's name; the create key for a new one)
+- `container.cmd.action` — `pull | run | stop | remove`
+- `container.cmd.image | .entrypoint | .cmd | .mem | .cpus | .net | .subnet` — run params
+
+One envelope + one monotonic token = the same baseline-at-startup, no-fire-on-boot
+semantics as the v1 `*.request` keys, and only one command is in flight at a time
+(a registry pull is the long pole; serialising is fine for an edge gateway).
+
+### 13.2 Daemon
+
+Refactor the per-container state out of `Containerd`'s members into a
+`ContainerInstance` struct — its own `state`, request flags, `pull`/`run` threads,
+`merged` rootfs path, crun id, bridge IP — and hold
+`std::map<std::string, std::unique_ptr<ContainerInstance>> m_containers` keyed by
+name. `on_command_event` parses the envelope, finds/creates the named instance, and
+dispatches `pull/run/stop/remove` to it. `publish_instances()` serialises the map to
+`container.instances`.
+
+- **crun id / paths** per name: `id = "c-"+sanitize(name)`, overlay/bundle under
+  `/run/iot-containers/<id>/`, image store stays shared in `/var/lib/iot-containers`.
+- **IP allocation**: a small allocator hands out `.2, .3, .4…` in the bridge /24,
+  tracking in-use IPs across running instances; freed on stop/remove. (v1's bridge
+  code hardcodes `.2` — generalise to "next free".)
+- **remove**: stop if running, then drop the instance from the map + republish.
+
+### 13.3 UI
+
+Replace the single-container key-value card with a `clr-datagrid`:
+
+| Name | Image | State | IP | Mem | CPU | Net | Actions |
+|------|-------|-------|----|-----|-----|-----|---------|
+
+Rows = parsed `container.instances`. **IP column** shows `ip` (bridge mode). An *Add
+container* form (name, image, net, mem, cpu) writes the envelope with `action=pull`
+then `run`; per-row **Run / Stop / Remove** buttons write the envelope for that
+`name`. Long-polls `container.instances` (+ the in-flight `container.pull.progress`).
+
+### 13.4 Migration / compatibility
+
+The legacy singular `container.*` keys stay registered and mirror the
+most-recently-touched instance during rollout, so an old UI keeps working until the
+grid ships. Once the grid lands they can be retired.
+
+### 13.5 Phasing
+
+1. **Schema + design** (this) — `container.instances` + `container.cmd.*` registered.
+2. **Daemon** — `ContainerInstance` map, envelope dispatch, IP allocator, `publish_instances()`.
+3. **UI** — datagrid + Add form + per-row actions.
+4. **Tests** — `container_net` IP-allocator unit test; daemon envelope-dispatch test.

--- a/modules/containers/schemas/container.lua
+++ b/modules/containers/schemas/container.lua
@@ -46,6 +46,33 @@ return {
     ["container.run.request"]   = { access = "Admin",  type = "string", default = "" },
     ["container.stop.request"]  = { access = "Admin",  type = "string", default = "" },
 
+    -- ── Phase 2: multi-container (dynamic named) ──────────────────────────
+    -- The ds schema is static (no per-name keys), so multiple containers are
+    -- carried as ONE JSON document the daemon publishes and the UI grid renders,
+    -- plus a single command envelope routed by name (mirrors the cloud's
+    -- cloud.endpoint.credentials JSON-array pattern). The legacy singular keys
+    -- above remain as a view of the most-recently-touched container during the
+    -- daemon migration.
+    --
+    --   container.instances  - JSON array; one object per container, e.g.
+    --       [{"name":"web","image":"docker.io/library/nginx:latest",
+    --         "state":"running","ip":"10.88.0.2","gateway":"10.88.0.1",
+    --         "pid":1234,"exitCode":null,"mem":"256M","cpus":"0.5",
+    --         "net":"bridge","error":""}]
+    --   container.cmd.*      - command envelope; set the fields then bump
+    --                          container.cmd.request to execute one action.
+    ["container.instances"]     = { access = "Viewer", type = "string", default = "[]" },
+    ["container.cmd.request"]   = { access = "Admin",  type = "string", default = "" },
+    ["container.cmd.name"]      = { access = "Admin",  type = "string", default = "" },
+    ["container.cmd.action"]    = { access = "Admin",  type = "string", default = "" },  -- pull|run|stop|remove
+    ["container.cmd.image"]     = { access = "Admin",  type = "string", default = "" },
+    ["container.cmd.entrypoint"]= { access = "Admin",  type = "string", default = "" },
+    ["container.cmd.cmd"]       = { access = "Admin",  type = "string", default = "" },
+    ["container.cmd.mem"]       = { access = "Admin",  type = "string", default = "" },
+    ["container.cmd.cpus"]      = { access = "Admin",  type = "string", default = "" },
+    ["container.cmd.net"]       = { access = "Admin",  type = "string", default = "host" },
+    ["container.cmd.subnet"]    = { access = "Admin",  type = "string", default = "10.88.0.0/24" },
+
     ["container.state"]         = { access = "Viewer", type = "string", default = "idle" },
     ["container.pull.progress"] = { access = "Viewer", type = "string", default = "0" },
     ["container.pull.detail"]   = { access = "Viewer", type = "string", default = "" },


### PR DESCRIPTION
First phase of **dynamic-named multi-container** support (you picked this model).

## What's here (low-risk foundation)
- **Schema** (`container.lua`): `container.instances` (JSON array — the grid source) + a `container.cmd.*` command envelope (name + action `pull|run|stop|remove` + run params). Static ds schema can't register `container.<name>.*`, so multiplicity lives in values — same pattern as `cloud.endpoint.credentials`.
- **Design** (TDD §13): daemon `ContainerInstance` map + IP allocator (.2/.3/.4…) + `publish_instances()`; device-ui datagrid (row/container, **IP column**, per-row run/stop/remove); migration plan (legacy singular keys kept during rollout).

## Next phases (the bulk — separate PRs)
2. **Daemon** — refactor single-container state into `ContainerInstance`, `std::map<name,…>`, envelope dispatch, next-free-IP allocator.
3. **UI** — `clr-datagrid` + Add form + per-row actions.

No build env locally, so phasing keeps each step reviewable/buildable rather than one giant untested rewrite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)