### PR TITLE
feat(containers): multi-container daemon (Phase 2)

### DIFF
--- a/modules/containers/daemon/containerd.cpp
+++ b/modules/containers/daemon/containerd.cpp
@@ -1,8 +1,10 @@
 #include "containerd.hpp"
 
+#include <cstdio>
 #include <ctime>
 #include <fstream>
 #include <sstream>
+#include <utility>
 #include <vector>
 
 #include <ace/Log_Msg.h>
@@ -27,9 +29,6 @@
 namespace containers {
 
 namespace {
-// v1 is single-container; a fixed id keeps the run/overlay paths stable.
-constexpr const char* kContainerId = "c0";
-
 std::string slurp(const std::string& path) {
     std::ifstream f(path, std::ios::binary);
     std::ostringstream ss;
@@ -42,14 +41,63 @@ bool spit(const std::string& path, const std::string& body) {
     f << body;
     return f.good();
 }
+
+// crun id / filesystem path component from an operator name: lower-case,
+// keep [a-z0-9-], everything else → '-'. Prefixed "c-" so it never collides
+// with crun internals and is a stable run/overlay dir name.
+std::string sanitize_name(const std::string& n) {
+    std::string s;
+    for (char c : n) {
+        if ((c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') || c == '-') s += c;
+        else if (c >= 'A' && c <= 'Z') s += static_cast<char>(c - 'A' + 'a');
+        else s += '-';
+    }
+    if (s.empty()) s = "x";
+    return s;
+}
+
+std::string json_escape(const std::string& s) {
+    std::string o;
+    o.reserve(s.size() + 8);
+    for (char c : s) {
+        switch (c) {
+            case '"':  o += "\\\""; break;
+            case '\\': o += "\\\\"; break;
+            case '\n': o += "\\n";  break;
+            case '\r': o += "\\r";  break;
+            case '\t': o += "\\t";  break;
+            default:
+                if (static_cast<unsigned char>(c) < 0x20) {
+                    char b[8];
+                    std::snprintf(b, sizeof b, "\\u%04x", static_cast<unsigned char>(c));
+                    o += b;
+                } else {
+                    o += c;
+                }
+        }
+    }
+    return o;
+}
 } // namespace
 
 Containerd::~Containerd() {
     m_pull_cancel.store(true);
-    m_shutdown.store(true);        // break the supervise loop fast (kills the container)
-    m_stop_requested.store(true);
+    m_shutdown.store(true);                // break every supervise loop fast (SIGKILL)
     if (m_pull_thread.joinable()) m_pull_thread.join();
-    if (m_run_thread.joinable())  m_run_thread.join();
+
+    // Signal + collect the run threads under the lock, then join WITHOUT it (the
+    // workers grab m_mtx to publish their final state — joining while holding it
+    // would deadlock).
+    std::vector<std::thread> threads;
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        for (auto& kv : m_containers) {
+            kv.second->stop_requested.store(true);
+            if (kv.second->run_thread.joinable())
+                threads.push_back(std::move(kv.second->run_thread));
+        }
+    }
+    for (auto& t : threads) if (t.joinable()) t.join();
 }
 
 // Captures this daemon's ACE log output to log.containerd.text and applies the
@@ -63,411 +111,505 @@ std::string Containerd::get_str(const std::string& key) {
     return {};
 }
 
-void Containerd::set_state(const char* state) {
-    m_ds.set_volatile(std::string("container.state"), data_store::Value{std::string(state)});
+// ── helpers (m_mtx held) ───────────────────────────────────────────────────
+
+ContainerInstance* Containerd::find_locked(const std::string& name) {
+    auto it = m_containers.find(name);
+    return it == m_containers.end() ? nullptr : it->second.get();
 }
 
-void Containerd::set_error(const std::string& msg) {
-    m_ds.set_volatile(std::string("container.error"), data_store::Value{msg});
+ContainerInstance* Containerd::ensure_locked(const std::string& name) {
+    if (auto* p = find_locked(name)) return p;
+    auto inst = std::make_unique<ContainerInstance>(name, "c-" + sanitize_name(name));
+    ContainerInstance* p = inst.get();
+    m_containers.emplace(name, std::move(inst));
+    return p;
 }
 
-void Containerd::publish_initial_status() {
-    std::vector<data_store::KV> kv;
-    kv.emplace_back("container.state",         data_store::Value{std::string("idle")});
-    kv.emplace_back("container.pull.progress", data_store::Value{std::string("0")});
-    kv.emplace_back("container.pull.detail",   data_store::Value{std::string("")});
-    kv.emplace_back("container.status",        data_store::Value{std::string("idle")});
-    kv.emplace_back("container.error",         data_store::Value{std::string("")});
-    m_ds.set_volatile(kv);
+int Containerd::alloc_octet_locked() {
+    for (int o = 2; o <= 254; ++o)            // .1 is the bridge gateway
+        if (!m_used_octets.count(o)) { m_used_octets.insert(o); return o; }
+    return 0;                                 // /24 exhausted
 }
+
+void Containerd::free_octet_locked(int octet) {
+    if (octet) m_used_octets.erase(octet);
+}
+
+void Containerd::publish_instances_locked() {
+    std::ostringstream ss;
+    ss << "[";
+    bool first = true;
+    for (auto& kv : m_containers) {
+        const ContainerInstance* c = kv.second.get();
+        if (!first) ss << ",";
+        first = false;
+        ss << "{"
+           << "\"name\":\""    << json_escape(c->name)       << "\","
+           << "\"image\":\""   << json_escape(c->image_ref)  << "\","
+           << "\"imageId\":\"" << json_escape(c->image_id)   << "\","
+           << "\"size\":\""    << json_escape(c->image_size) << "\","
+           << "\"state\":\""   << json_escape(c->state)      << "\","
+           << "\"ip\":\""      << json_escape(c->ip)         << "\","
+           << "\"gateway\":\"" << json_escape(c->gateway)    << "\","
+           << "\"net\":\""     << json_escape(c->net_mode)   << "\","
+           << "\"mem\":\""     << json_escape(c->mem)        << "\","
+           << "\"cpus\":\""    << json_escape(c->cpus)       << "\","
+           << "\"pid\":"       << c->pid                     << ","
+           << "\"exitCode\":"  << (c->exit_code < 0 ? std::string("null")
+                                                    : std::to_string(c->exit_code)) << ","
+           << "\"started\":"   << c->started                 << ","
+           << "\"error\":\""   << json_escape(c->error)      << "\"}";
+    }
+    ss << "]";
+    m_ds.set_volatile(std::string("container.instances"), data_store::Value{ss.str()});
+
+    // Legacy single-container mirror (first instance) so an un-migrated UI still
+    // shows something during rollout.
+    const ContainerInstance* lead =
+        m_containers.empty() ? nullptr : m_containers.begin()->second.get();
+    m_ds.set_volatile(std::vector<data_store::KV>{
+        {"container.state",  data_store::Value{lead ? lead->state : std::string("idle")}},
+        {"container.net.ip", data_store::Value{lead ? lead->ip    : std::string()}}});
+}
+
+// ── command intake (listener thread → reactor) ─────────────────────────────
 
 void Containerd::on_command_event(const data_store::Client::Event& ev) {
+    if (ev.key != "container.cmd.request") return;
     const std::string val = data_store::to_string(ev.value).value_or(std::string());
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        if (ev.key == "container.pull.request") {
-            if (val == m_pull_token) return;     // unchanged → ignore re-notify
-            m_pull_token = val; m_pull_pending = true;
-        } else if (ev.key == "container.run.request") {
-            if (val == m_run_token) return;
-            m_run_token = val; m_run_pending = true;
-        } else if (ev.key == "container.stop.request") {
-            if (val == m_stop_token) return;
-            m_stop_token = val; m_stop_pending = true;
-        } else {
-            return;
-        }
+        if (val == m_cmd_token) return;      // unchanged → ignore re-notify
+        m_cmd_token = val;
+        m_cmd_pending = true;
     }
-    // Hand off to the reactor thread; handle_exception() does the work.
     ACE_Reactor::instance()->notify(this);
 }
 
 int Containerd::handle_exception(ACE_HANDLE) {
-    bool pull, run, stop;
+    bool cmd;
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        pull = m_pull_pending; m_pull_pending = false;
-        run  = m_run_pending;  m_run_pending  = false;
-        stop = m_stop_pending; m_stop_pending = false;
+        cmd = m_cmd_pending; m_cmd_pending = false;
     }
-    if (stop) handle_stop();    // stop first so a stop+run pair restarts cleanly
-    if (pull) handle_pull();
-    if (run)  handle_run();
+    if (cmd) handle_command();
     return 0;
 }
 
-void Containerd::handle_pull() {
-    if (m_pull_active.load()) {
-        set_error("a pull is already in progress");
+void Containerd::handle_command() {
+    const std::string name   = get_str("container.cmd.name");
+    const std::string action = get_str("container.cmd.action");
+    if (name.empty() || action.empty()) {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] command missing name/action "
+                                      "(name=%C action=%C)\n"),
+                   name.c_str(), action.c_str()));
         return;
     }
-    const std::string ref_s = get_str("container.image.ref");
-    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] pull requested: ref=%C\n"),
-               ref_s.empty() ? "(unset)" : ref_s.c_str()));
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] cmd: action=%C name=%C\n"),
+               action.c_str(), name.c_str()));
+
+    if (action == "remove") { do_remove(name); return; }
+
+    if (action == "stop") {
+        ContainerInstance* inst;
+        { std::lock_guard<std::mutex> lk(m_mtx); inst = find_locked(name); }
+        if (inst) do_stop(inst);
+        else ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] stop: no such container %C\n"),
+                        name.c_str()));
+        return;
+    }
+
+    if (action != "pull" && action != "run") {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] unknown action %C\n"), action.c_str()));
+        return;
+    }
+
+    // pull/run carry the container's config in the envelope.
+    const std::string image = get_str("container.cmd.image");
+    const std::string net   = get_str("container.cmd.net");
+    const std::string sub   = get_str("container.cmd.subnet");
+    const std::string mem   = get_str("container.cmd.mem");
+    const std::string cpus  = get_str("container.cmd.cpus");
+    const std::string ep    = get_str("container.cmd.entrypoint");
+    const std::string cm    = get_str("container.cmd.cmd");
+
+    ContainerInstance* inst;
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst = ensure_locked(name);
+        if (!image.empty()) inst->image_ref = image;
+        if (!net.empty())   inst->net_mode  = net;
+        inst->net_subnet = sub.empty() ? std::string(kDefaultSubnet) : sub;
+        inst->mem = mem; inst->cpus = cpus; inst->entrypoint = ep; inst->cmd = cm;
+        publish_instances_locked();
+    }
+    if (action == "pull") do_pull(inst);
+    else                  do_run(inst);
+}
+
+// ── pull (serialised; one worker) ──────────────────────────────────────────
+
+void Containerd::do_pull(ContainerInstance* inst) {
+    if (m_pull_active.load()) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->error = "a pull is already in progress"; publish_instances_locked();
+        return;
+    }
+    std::string ref_s;
+    { std::lock_guard<std::mutex> lk(m_mtx); ref_s = inst->image_ref; }
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] pull %C: ref=%C\n"),
+               inst->name.c_str(), ref_s.empty() ? "(unset)" : ref_s.c_str()));
     if (ref_s.empty()) {
-        set_error("container.image.ref is empty — set an image to pull");
-        set_state("error");
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->error = "image ref is empty — set an image to pull"; inst->state = "error";
+        publish_instances_locked();
         return;
     }
     ImageRef ref;
     if (!parse_image_ref(ref_s, ref)) {
-        set_error("could not parse image ref: " + ref_s);
-        set_state("error");
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->error = "could not parse image ref: " + ref_s; inst->state = "error";
+        publish_instances_locked();
         return;
     }
     ACE_DEBUG((LM_INFO,
         ACE_TEXT("%D [ctr]   -> registry=%C repo=%C tag=%C digest=%C\n"),
-        ref.registry.c_str(), ref.repository.c_str(),
-        ref.tag.c_str(), ref.digest.c_str()));
+        ref.registry.c_str(), ref.repository.c_str(), ref.tag.c_str(), ref.digest.c_str()));
 
     const std::string user = get_str("container.registry.user");
     const std::string pass = get_str("container.registry.pass");
-    // Consume the secret: do not leave the registry password persisted in ds
-    // (it would otherwise sit on the SD card + in any ds snapshot). Cleared
-    // persistently; the operator re-enters it per pull (write-only by design).
+    // Consume the secret — never leave the registry password persisted in ds.
     if (!pass.empty())
         m_ds.set(std::string("container.registry.pass"), data_store::Value{std::string()});
 
-    // Reap a previously-finished worker before launching a new one.
     if (m_pull_thread.joinable()) m_pull_thread.join();
     m_pull_cancel.store(false);
     m_pull_active.store(true);
-
-    set_error("");
-    set_state("pulling");
-    m_ds.set_volatile(std::string("container.pull.progress"),
-                      data_store::Value{std::string("0")});
+    const std::string name = inst->name;
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        m_pull_name = name;
+        inst->error.clear(); inst->state = "pulling";
+        publish_instances_locked();
+    }
+    m_ds.set_volatile(std::string("container.pull.progress"), data_store::Value{std::string("0")});
 
     const std::string root = m_cfg.root;
-    m_pull_thread = std::thread([this, ref, user, pass, root]() {
-        auto progress = [this](int pct, const std::string& detail) {
+    m_pull_thread = std::thread([this, ref, user, pass, root, name]() {
+        auto progress = [this, name](int pct, const std::string& detail) {
             std::vector<data_store::KV> kv;
             kv.emplace_back("container.pull.progress", data_store::Value{std::to_string(pct)});
-            kv.emplace_back("container.pull.detail",   data_store::Value{detail});
+            kv.emplace_back("container.pull.detail",   data_store::Value{name + ": " + detail});
             m_ds.set_volatile(kv);
         };
         PullResult r = pull_image(ref, user, pass, root, progress, m_pull_cancel);
-        if (r.ok) {
-            std::vector<data_store::KV> kv;
-            kv.emplace_back("container.image.id",      data_store::Value{r.image_id});
-            kv.emplace_back("container.image.size",    data_store::Value{std::to_string(r.total_size)});
-            kv.emplace_back("container.pull.progress", data_store::Value{std::string("100")});
-            kv.emplace_back("container.pull.detail",   data_store::Value{std::string("pull complete")});
-            kv.emplace_back("container.error",         data_store::Value{std::string()});
-            kv.emplace_back("container.state",         data_store::Value{std::string("pulled")});
-            m_ds.set_volatile(kv);
-            ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] pull ok: %C (%lld bytes)\n"),
-                       r.image_id.c_str(), static_cast<long long>(r.total_size)));
-        } else {
-            set_error(r.error);
-            set_state("error");
-            ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] pull failed: %C\n"), r.error.c_str()));
-        }
-        m_pull_active.store(false);
-    });
-}
-
-void Containerd::handle_run() {
-    if (m_run_active.load()) { set_error("a run/stop is already in progress"); return; }
-
-    const std::string image_id = get_str("container.image.id");
-    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] run requested (image=%C)\n"),
-               image_id.empty() ? "(none)" : image_id.c_str()));
-    if (image_id.empty() || !is_valid_digest(image_id)) {
-        set_error("no image pulled yet — pull an image first");
-        set_state("error");
-        return;
-    }
-
-    // Process overrides + resource limits + network mode (reactor thread).
-    const std::string ov_entrypoint = get_str("container.entrypoint");
-    const std::string ov_cmd        = get_str("container.cmd");
-    const std::string lim_mem       = get_str("container.limit.mem");
-    const std::string lim_cpus      = get_str("container.limit.cpus");
-    const std::string net_mode      = get_str("container.net.mode");      // "host" (default) | "bridge"
-    std::string       net_subnet    = get_str("container.net.subnet");
-    if (net_subnet.empty()) net_subnet = kDefaultSubnet;
-
-    if (m_run_thread.joinable()) m_run_thread.join();
-    m_stop_requested.store(false);
-    m_run_active.store(true);
-    set_error("");
-    set_state("mounting");
-    m_ds.set_volatile(std::string("container.pull.detail"),
-                      data_store::Value{std::string("extracting layers")});
-
-    const std::string root     = m_cfg.root;
-    const std::string run_root = m_cfg.run;
-    m_run_thread = std::thread([this, image_id, root, run_root,
-                                ov_entrypoint, ov_cmd, lim_mem, lim_cpus,
-                                net_mode, net_subnet]() {
-        const bool bridge = (net_mode == "bridge");
-        const std::string hex  = image_id.substr(7);
-        const std::string body = slurp(root + "/manifests/" + hex + ".json");
-        ImageManifest im = parse_image_manifest(body);
-        if (!im.ok) {
-            set_error("image manifest missing/corrupt — re-pull the image");
-            set_state("error");
-            m_run_active.store(false);
-            return;
-        }
-
-        std::vector<std::string> digests;
-        for (const auto& l : im.layers) digests.push_back(l.digest);
-
-        std::string err;
-        std::vector<std::string> layer_dirs;
-        if (!ensure_layers_extracted(root, digests, layer_dirs, err)) {
-            set_error("layer extraction failed: " + err);
-            set_state("error");
-            m_run_active.store(false);
-            return;
-        }
-
-        MountResult mr = mount_overlay(layer_dirs, run_root, kContainerId);
-        if (!mr.ok) {
-            set_error("overlay mount failed: " + mr.error);
-            set_state("error");
-            m_run_active.store(false);
-            return;
-        }
-
         {
             std::lock_guard<std::mutex> lk(m_mtx);
-            m_merged = mr.merged;
-        }
-        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] overlay mounted: %C (%u layers)\n"),
-                   mr.merged.c_str(), static_cast<unsigned>(layer_dirs.size())));
-
-        // ── Build the OCI bundle (config.json next to the rootfs) ──────────
-        const std::string bundle = run_root + "/" + kContainerId;   // mr.merged == bundle/rootfs
-        ImageConfig ic = parse_image_config(slurp(blob_path(root, im.config.digest)));
-
-        std::vector<std::string> args = resolve_process_args(
-            ic.entrypoint, ic.cmd,
-            parse_args_field(ov_entrypoint), !ov_entrypoint.empty(),
-            parse_args_field(ov_cmd),        !ov_cmd.empty());
-        if (args.empty()) {
-            set_error("image has no Entrypoint/Cmd — set a CMD/Entrypoint to run");
-            set_state("error");
-            unmount_overlay(run_root, kContainerId, err);
-            m_run_active.store(false);
-            return;
-        }
-
-        OciSpec spec;
-        spec.args = args;
-        spec.env  = ic.env;
-        spec.cwd  = ic.working_dir.empty() ? "/" : ic.working_dir;
-        resolve_user(ic.user, spec.uid, spec.gid);
-        spec.mem_limit_bytes = parse_mem_limit(lim_mem);
-        spec.cpu_quota       = parse_cpu_quota(lim_cpus, spec.cpu_period);
-        spec.host_network    = !bridge;   // bridge → own netns (IP wired below)
-
-        if (!spit(bundle + "/config.json", generate_oci_config(spec))) {
-            set_error("could not write OCI bundle config.json");
-            set_state("error");
-            unmount_overlay(run_root, kContainerId, err);
-            m_run_active.store(false);
-            return;
-        }
-
-        // ── crun create + start ────────────────────────────────────────────
-        const std::string state_root = run_root + "/state";
-        mkdir_p(state_root);
-        CrunRuntime crun(state_root);
-        crun.remove(kContainerId, true, err);   // clear any stale container
-
-        set_state("created");
-        if (!crun.create(kContainerId, bundle, err)) {
-            set_error("crun create failed: " + err);
-            set_state("error");
-            unmount_overlay(run_root, kContainerId, err);
-            m_run_active.store(false);
-            return;
-        }
-
-        // crun create has set up the namespaces (incl. an empty netns in bridge
-        // mode); the init pid is available now, before start.
-        const long pid = crun.state(kContainerId).pid;
-
-        // Bridge mode: wire a veth + IP into the container netns before start.
-        if (bridge) {
-            BridgeNet bn = bridge_up(pid, net_subnet, kContainerId);
-            if (!bn.ok) {
-                set_error("bridge networking failed: " + bn.error);
-                set_state("error");
-                crun.remove(kContainerId, true, err);
-                bridge_down(kContainerId);
-                unmount_overlay(run_root, kContainerId, err);
-                m_run_active.store(false);
-                return;
-            }
-            std::vector<data_store::KV> net;
-            net.emplace_back("container.net.ip",      data_store::Value{bn.ip});
-            net.emplace_back("container.net.gateway", data_store::Value{bn.gateway});
-            m_ds.set_volatile(net);
-        }
-
-        if (!crun.start(kContainerId, err)) {
-            set_error("crun start failed: " + err);
-            set_state("error");
-            crun.remove(kContainerId, true, err);
-            if (bridge) bridge_down(kContainerId);
-            unmount_overlay(run_root, kContainerId, err);
-            m_run_active.store(false);
-            return;
-        }
-
-        // Announce running (pid already known from above).
-        std::vector<data_store::KV> kv;
-        kv.emplace_back("container.run.pid",     data_store::Value{std::to_string(pid)});
-        kv.emplace_back("container.run.started", data_store::Value{std::to_string(
-                                                     static_cast<long long>(std::time(nullptr)))});
-        kv.emplace_back("container.exit.code",   data_store::Value{std::string()});
-        kv.emplace_back("container.status",      data_store::Value{std::string("running")});
-        kv.emplace_back("container.error",       data_store::Value{std::string()});
-        kv.emplace_back("container.state",       data_store::Value{std::string("running")});
-        m_ds.set_volatile(kv);
-        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] container started: pid=%d\n"),
-                   static_cast<int>(pid)));
-
-        // ── Supervise: poll until the container exits, honoring stop ───────
-        bool term_sent = false;
-        int  grace_ticks = 0;
-        while (true) {
-            // ~2s poll, but wake every 250ms so daemon shutdown is responsive.
-            bool shutting = false;
-            for (int i = 0; i < 8; ++i) {
-                ACE_OS::sleep(ACE_Time_Value(0, 250000));
-                if (m_shutdown.load()) { shutting = true; break; }
-            }
-            if (shutting) { crun.kill(kContainerId, "KILL", err); break; }
-
-            CrunStatus st = crun.state(kContainerId);
-            if (!st.exists || st.status == "stopped") break;   // exited
-            if (m_stop_requested.load()) {
-                if (!term_sent) {
-                    crun.kill(kContainerId, "TERM", err);
-                    term_sent = true;
-                    grace_ticks = 0;
-                    m_ds.set_volatile(std::string("container.status"),
-                                      data_store::Value{std::string("stopping")});
-                } else if (++grace_ticks >= 5) {               // ~10s grace → SIGKILL
-                    crun.kill(kContainerId, "KILL", err);
+            if (ContainerInstance* in = find_locked(name)) {   // re-find (still present)
+                if (r.ok) {
+                    in->image_id = r.image_id;
+                    in->image_size = std::to_string(r.total_size);
+                    in->error.clear(); in->state = "pulled";
+                } else {
+                    in->error = r.error; in->state = "error";
                 }
             }
+            publish_instances_locked();
         }
-
-        // ── Exited: clean up + report ──────────────────────────────────────
-        crun.remove(kContainerId, true, err);
-        if (bridge) bridge_down(kContainerId);
-        unmount_overlay(run_root, kContainerId, err);
-        {
-            std::lock_guard<std::mutex> lk(m_mtx);
-            m_merged.clear();
-        }
-        std::vector<data_store::KV> done;
-        done.emplace_back("container.run.pid", data_store::Value{std::string()});
-        done.emplace_back("container.net.ip",  data_store::Value{std::string()});
-        done.emplace_back("container.status",  data_store::Value{std::string("stopped")});
-        done.emplace_back("container.state",   data_store::Value{std::string("stopped")});
-        m_ds.set_volatile(done);
-        ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] container stopped%C\n"),
-                   m_stop_requested.load() ? " (by request)" : " (exited)"));
-        m_run_active.store(false);
+        m_ds.set_volatile(std::vector<data_store::KV>{
+            {"container.pull.progress", data_store::Value{std::string(r.ok ? "100" : "0")}},
+            {"container.pull.detail",   data_store::Value{name + (r.ok ? ": pull complete"
+                                                                       : ": " + r.error)}}});
+        m_pull_active.store(false);
+        if (r.ok)
+            ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] pull ok %C: %C (%lld bytes)\n"),
+                       name.c_str(), r.image_id.c_str(),
+                       static_cast<long long>(r.total_size)));
+        else
+            ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] pull failed %C: %C\n"),
+                       name.c_str(), r.error.c_str()));
     });
 }
 
-void Containerd::handle_stop() {
-    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] stop requested\n")));
-    if (m_run_active.load()) {
-        // The run worker owns the container + overlay; ask it to tear down
-        // (SIGTERM → grace → SIGKILL → delete + unmount). All crun calls stay
-        // on the worker thread to avoid racing on the crun state dir.
-        m_stop_requested.store(true);
-        m_ds.set_volatile(std::string("container.status"),
-                          data_store::Value{std::string("stopping")});
+// ── run (per-instance supervise thread) ────────────────────────────────────
+
+void Containerd::do_run(ContainerInstance* inst) {
+    if (inst->run_active.load()) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->error = "container is already running"; publish_instances_locked();
         return;
     }
-    // Nothing running: clear any stale crun state + overlay mount + veth.
-    std::string err;
-    CrunRuntime crun(m_cfg.run + "/state");
-    crun.remove(kContainerId, true, err);
-    bridge_down(kContainerId);
-    unmount_overlay(m_cfg.run, kContainerId, err);
+    std::string image_id, net_mode, net_subnet, mem, cpus, ep, cm, id;
     {
         std::lock_guard<std::mutex> lk(m_mtx);
-        m_merged.clear();
+        image_id   = inst->image_id;
+        net_mode   = inst->net_mode;
+        net_subnet = inst->net_subnet.empty() ? std::string(kDefaultSubnet) : inst->net_subnet;
+        mem = inst->mem; cpus = inst->cpus; ep = inst->entrypoint; cm = inst->cmd;
+        id = inst->id;
     }
-    m_ds.set_volatile(std::vector<data_store::KV>{
-        {"container.net.ip", data_store::Value{std::string()}},
-        {"container.status", data_store::Value{std::string("stopped")}}});
-    set_error("");
-    set_state("stopped");
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] run %C (image=%C)\n"),
+               inst->name.c_str(), image_id.empty() ? "(none)" : image_id.c_str()));
+    if (image_id.empty() || !is_valid_digest(image_id)) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->error = "no image pulled yet — pull an image first"; inst->state = "error";
+        publish_instances_locked();
+        return;
+    }
+
+    const bool bridge = (net_mode == "bridge");
+    int octet = 0;
+    if (bridge) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        octet = alloc_octet_locked();
+        if (octet == 0) {
+            inst->error = "no free bridge IP (subnet exhausted)"; inst->state = "error";
+            publish_instances_locked();
+            return;
+        }
+        inst->host_octet = octet;
+    }
+
+    if (inst->run_thread.joinable()) inst->run_thread.join();
+    inst->stop_requested.store(false);
+    inst->run_active.store(true);
+    { std::lock_guard<std::mutex> lk(m_mtx); inst->error.clear(); inst->state = "mounting";
+      publish_instances_locked(); }
+
+    const std::string root = m_cfg.root, run_root = m_cfg.run;
+    inst->run_thread = std::thread(
+        [this, inst, image_id, root, run_root, ep, cm, mem, cpus, bridge, net_subnet, id, octet]() {
+            run_worker(inst, image_id, root, run_root, ep, cm, mem, cpus,
+                       bridge, net_subnet, id, octet);
+        });
+}
+
+void Containerd::run_worker(ContainerInstance* inst, std::string image_id,
+                            std::string root, std::string run_root,
+                            std::string ov_entrypoint, std::string ov_cmd,
+                            std::string lim_mem, std::string lim_cpus,
+                            bool bridge, std::string net_subnet, std::string id, int octet) {
+    std::string err;
+    auto fail = [&](const std::string& msg) {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->error = msg; inst->state = "error";
+        if (inst->host_octet) { free_octet_locked(inst->host_octet); inst->host_octet = 0; }
+        inst->ip.clear(); inst->gateway.clear();
+        publish_instances_locked();
+    };
+
+    const std::string hex  = image_id.substr(7);
+    ImageManifest im = parse_image_manifest(slurp(root + "/manifests/" + hex + ".json"));
+    if (!im.ok) { fail("image manifest missing/corrupt — re-pull the image");
+                  inst->run_active.store(false); return; }
+
+    std::vector<std::string> digests;
+    for (const auto& l : im.layers) digests.push_back(l.digest);
+    std::vector<std::string> layer_dirs;
+    if (!ensure_layers_extracted(root, digests, layer_dirs, err)) {
+        fail("layer extraction failed: " + err); inst->run_active.store(false); return;
+    }
+
+    MountResult mr = mount_overlay(layer_dirs, run_root, id);
+    if (!mr.ok) { fail("overlay mount failed: " + mr.error);
+                  inst->run_active.store(false); return; }
+    { std::lock_guard<std::mutex> lk(m_mtx); inst->merged = mr.merged; }
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] %C: overlay mounted: %C (%u layers)\n"),
+               id.c_str(), mr.merged.c_str(), static_cast<unsigned>(layer_dirs.size())));
+
+    const std::string bundle = run_root + "/" + id;   // mr.merged == bundle/rootfs
+    ImageConfig ic = parse_image_config(slurp(blob_path(root, im.config.digest)));
+    std::vector<std::string> args = resolve_process_args(
+        ic.entrypoint, ic.cmd,
+        parse_args_field(ov_entrypoint), !ov_entrypoint.empty(),
+        parse_args_field(ov_cmd),        !ov_cmd.empty());
+    if (args.empty()) {
+        unmount_overlay(run_root, id, err);
+        fail("image has no Entrypoint/Cmd — set a CMD/Entrypoint to run");
+        inst->run_active.store(false); return;
+    }
+
+    OciSpec spec;
+    spec.args = args; spec.env = ic.env;
+    spec.cwd  = ic.working_dir.empty() ? "/" : ic.working_dir;
+    resolve_user(ic.user, spec.uid, spec.gid);
+    spec.mem_limit_bytes = parse_mem_limit(lim_mem);
+    spec.cpu_quota       = parse_cpu_quota(lim_cpus, spec.cpu_period);
+    spec.host_network    = !bridge;   // bridge → own netns (IP wired below)
+
+    if (!spit(bundle + "/config.json", generate_oci_config(spec))) {
+        unmount_overlay(run_root, id, err);
+        fail("could not write OCI bundle config.json");
+        inst->run_active.store(false); return;
+    }
+
+    const std::string state_root = run_root + "/state";
+    mkdir_p(state_root);
+    CrunRuntime crun(state_root);
+    crun.remove(id, true, err);   // clear any stale container
+    { std::lock_guard<std::mutex> lk(m_mtx); inst->state = "created"; publish_instances_locked(); }
+    if (!crun.create(id, bundle, err)) {
+        unmount_overlay(run_root, id, err);
+        fail("crun create failed: " + err);
+        inst->run_active.store(false); return;
+    }
+    const long pid = crun.state(id).pid;
+
+    if (bridge) {
+        BridgeNet bn = bridge_up(pid, net_subnet, id, octet);
+        if (!bn.ok) {
+            crun.remove(id, true, err); bridge_down(id); unmount_overlay(run_root, id, err);
+            fail("bridge networking failed: " + bn.error);
+            inst->run_active.store(false); return;
+        }
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->ip = bn.ip; inst->gateway = bn.gateway; publish_instances_locked();
+    }
+
+    if (!crun.start(id, err)) {
+        crun.remove(id, true, err); if (bridge) bridge_down(id); unmount_overlay(run_root, id, err);
+        fail("crun start failed: " + err);
+        inst->run_active.store(false); return;
+    }
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        inst->pid = pid;
+        inst->started = static_cast<long long>(std::time(nullptr));
+        inst->exit_code = -1; inst->error.clear(); inst->state = "running";
+        publish_instances_locked();
+    }
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] %C: started pid=%d\n"),
+               id.c_str(), static_cast<int>(pid)));
+
+    // ── Supervise: poll until exit, honoring stop ──────────────────────────
+    bool term_sent = false;
+    int  grace_ticks = 0;
+    while (true) {
+        bool shutting = false;
+        for (int i = 0; i < 8; ++i) {        // ~2s poll, 250ms wakeups for fast teardown
+            ACE_OS::sleep(ACE_Time_Value(0, 250000));
+            if (m_shutdown.load()) { shutting = true; break; }
+        }
+        if (shutting) { crun.kill(id, "KILL", err); break; }
+
+        CrunStatus st = crun.state(id);
+        if (!st.exists || st.status == "stopped") break;   // exited
+        if (inst->stop_requested.load()) {
+            if (!term_sent) {
+                crun.kill(id, "TERM", err); term_sent = true; grace_ticks = 0;
+            } else if (++grace_ticks >= 5) {               // ~10s grace → SIGKILL
+                crun.kill(id, "KILL", err);
+            }
+        }
+    }
+
+    // ── Exited: clean up + report ──────────────────────────────────────────
+    crun.remove(id, true, err);
+    if (bridge) bridge_down(id);
+    unmount_overlay(run_root, id, err);
+    const bool by_req = inst->stop_requested.load();
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        if (inst->host_octet) { free_octet_locked(inst->host_octet); inst->host_octet = 0; }
+        inst->merged.clear(); inst->ip.clear(); inst->gateway.clear();
+        inst->pid = 0; inst->state = "stopped";
+        publish_instances_locked();
+    }
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] %C: stopped%C\n"),
+               id.c_str(), by_req ? " (by request)" : " (exited)"));
+    inst->run_active.store(false);
+}
+
+void Containerd::do_stop(ContainerInstance* inst) {
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] stop %C\n"), inst->name.c_str()));
+    if (inst->run_active.load()) {
+        // The run worker owns the container + overlay; ask it to tear down
+        // (SIGTERM → grace → SIGKILL → delete + unmount). All crun calls stay on
+        // that thread to avoid racing on the crun state dir.
+        inst->stop_requested.store(true);
+        return;
+    }
+    // Nothing running: best-effort clear any stale crun state + overlay + veth.
+    std::string err;
+    CrunRuntime crun(m_cfg.run + "/state");
+    crun.remove(inst->id, true, err);
+    bridge_down(inst->id);
+    unmount_overlay(m_cfg.run, inst->id, err);
+    std::lock_guard<std::mutex> lk(m_mtx);
+    if (inst->host_octet) { free_octet_locked(inst->host_octet); inst->host_octet = 0; }
+    inst->ip.clear(); inst->gateway.clear(); inst->error.clear();
+    inst->state = "stopped";
+    publish_instances_locked();
+}
+
+void Containerd::do_remove(const std::string& name) {
+    ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] remove %C\n"), name.c_str()));
+    std::unique_ptr<ContainerInstance> doomed;
+    {
+        std::lock_guard<std::mutex> lk(m_mtx);
+        auto it = m_containers.find(name);
+        if (it == m_containers.end()) return;
+        ContainerInstance* inst = it->second.get();
+        // Busy (running, or this instance is the in-flight pull): just signal a
+        // stop; the operator removes again once it has stopped. Avoids erasing an
+        // instance a worker thread still points at.
+        if (inst->run_active.load() || (m_pull_active.load() && m_pull_name == name)) {
+            inst->stop_requested.store(true);
+            ACE_DEBUG((LM_INFO, ACE_TEXT("%D [ctr] remove %C deferred (busy) — "
+                                         "stopping; remove again when stopped\n"),
+                       name.c_str()));
+            return;
+        }
+        if (inst->host_octet) free_octet_locked(inst->host_octet);
+        doomed = std::move(it->second);
+        m_containers.erase(it);
+        publish_instances_locked();
+    }
+    // The instance's run thread is already finished (run_active was false); join
+    // it and clear any residual crun/overlay/veth state OUTSIDE the lock.
+    if (doomed->run_thread.joinable()) doomed->run_thread.join();
+    std::string err;
+    CrunRuntime crun(m_cfg.run + "/state");
+    crun.remove(doomed->id, true, err);
+    bridge_down(doomed->id);
+    unmount_overlay(m_cfg.run, doomed->id, err);
 }
 
 int Containerd::run() {
     if (!m_ds.connect(m_cfg.ds_sock).ok)
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%D [ctr] ds connect failed\n")), 1);
 
-    // Baseline the request tokens BEFORE watching so a stale value (e.g. a
-    // previous session's request) does not fire a spurious command on boot.
-    {
-        std::lock_guard<std::mutex> lk(m_mtx);
-        m_pull_token = get_str("container.pull.request");
-        m_run_token  = get_str("container.run.request");
-        m_stop_token = get_str("container.stop.request");
-    }
+    // Baseline the command token BEFORE watching so a stale value (a previous
+    // session's request) does not fire on boot.
+    { std::lock_guard<std::mutex> lk(m_mtx); m_cmd_token = get_str("container.cmd.request"); }
 
-    publish_initial_status();
+    m_ds.set_volatile(std::vector<data_store::KV>{
+        {"container.instances",     data_store::Value{std::string("[]")}},
+        {"container.state",         data_store::Value{std::string("idle")}},
+        {"container.pull.progress", data_store::Value{std::string("0")}},
+        {"container.pull.detail",   data_store::Value{std::string("")}},
+        {"container.error",         data_store::Value{std::string("")}}});
 
     data_store::Client::WatchHandle h = data_store::Client::kInvalidHandle;
     if (!m_ds.watch(
-            std::vector<std::string>{"container.pull.request",
-                                     "container.run.request",
-                                     "container.stop.request"},
+            std::vector<std::string>{"container.cmd.request"},
             [this](const data_store::Client::Event& ev) { on_command_event(ev); },
             &h).ok) {
         ACE_ERROR_RETURN((LM_ERROR, ACE_TEXT("%D [ctr] command watch failed\n")), 2);
     }
 
-    // ACE is initialised now (reactor used above): capture logs to
-    // log.containerd.text, apply log.level.container, drive the flush timer.
     g_log.start();
     g_log.apply_level(m_ds);
     g_log.open(m_ds, 5, 1);
-    // Self-report for the Services page.
     m_ds.set(std::string("services.container.state"), data_store::Value{std::string("running")});
 
-    // L22 resource telemetry → services.container.{cpu,mem,fd,threads}. We pump
-    // the singleton reactor in-thread, so schedule on it (no extra thread).
     data_store::StatsPublisher stats("services.container",
         [this](const std::vector<data_store::KV>& kv) { m_ds.set(kv); });
     stats.open(data_store::StatsPublisher::STATS_FLUSH_SEC, false);
 
     ACE_DEBUG((LM_INFO,
-        ACE_TEXT("%D [ctr] up: root=%C run=%C (pull/run/stop ready)\n"),
+        ACE_TEXT("%D [ctr] up: root=%C run=%C (multi-container; cmd envelope ready)\n"),
         m_cfg.root.c_str(), m_cfg.run.c_str()));
 
     ACE_Reactor::instance()->run_reactor_event_loop();

--- a/modules/containers/daemon/containerd.cpp
+++ b/modules/containers/daemon/containerd.cpp
@@ -220,32 +220,42 @@ void Containerd::handle_command() {
         return;
     }
 
-    if (action != "pull" && action != "run") {
-        ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] unknown action %C\n"), action.c_str()));
+    // pull carries the container's config in the envelope and creates it if new.
+    // run/stop reuse the instance's stored config — the envelope is shared
+    // mutable state, so we must NOT re-read its param fields for a bare per-row
+    // Run (they may hold another container's values).
+    if (action == "pull") {
+        const std::string image = get_str("container.cmd.image");
+        const std::string net   = get_str("container.cmd.net");
+        const std::string sub   = get_str("container.cmd.subnet");
+        const std::string mem   = get_str("container.cmd.mem");
+        const std::string cpus  = get_str("container.cmd.cpus");
+        const std::string ep    = get_str("container.cmd.entrypoint");
+        const std::string cm    = get_str("container.cmd.cmd");
+        ContainerInstance* inst;
+        {
+            std::lock_guard<std::mutex> lk(m_mtx);
+            inst = ensure_locked(name);
+            if (!image.empty()) inst->image_ref = image;
+            if (!net.empty())   inst->net_mode  = net;
+            inst->net_subnet = sub.empty() ? std::string(kDefaultSubnet) : sub;
+            inst->mem = mem; inst->cpus = cpus; inst->entrypoint = ep; inst->cmd = cm;
+            publish_instances_locked();
+        }
+        do_pull(inst);
         return;
     }
 
-    // pull/run carry the container's config in the envelope.
-    const std::string image = get_str("container.cmd.image");
-    const std::string net   = get_str("container.cmd.net");
-    const std::string sub   = get_str("container.cmd.subnet");
-    const std::string mem   = get_str("container.cmd.mem");
-    const std::string cpus  = get_str("container.cmd.cpus");
-    const std::string ep    = get_str("container.cmd.entrypoint");
-    const std::string cm    = get_str("container.cmd.cmd");
-
-    ContainerInstance* inst;
-    {
-        std::lock_guard<std::mutex> lk(m_mtx);
-        inst = ensure_locked(name);
-        if (!image.empty()) inst->image_ref = image;
-        if (!net.empty())   inst->net_mode  = net;
-        inst->net_subnet = sub.empty() ? std::string(kDefaultSubnet) : sub;
-        inst->mem = mem; inst->cpus = cpus; inst->entrypoint = ep; inst->cmd = cm;
-        publish_instances_locked();
+    if (action == "run") {
+        ContainerInstance* inst;
+        { std::lock_guard<std::mutex> lk(m_mtx); inst = find_locked(name); }
+        if (inst) do_run(inst);
+        else ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] run: no such container %C "
+                                           "(pull it first)\n"), name.c_str()));
+        return;
     }
-    if (action == "pull") do_pull(inst);
-    else                  do_run(inst);
+
+    ACE_ERROR((LM_ERROR, ACE_TEXT("%D [ctr] unknown action %C\n"), action.c_str()));
 }
 
 // ── pull (serialised; one worker) ──────────────────────────────────────────

--- a/modules/containers/daemon/containerd.hpp
+++ b/modules/containers/daemon/containerd.hpp
@@ -3,7 +3,10 @@
 
 #include <atomic>
 #include <cstdint>
+#include <map>
+#include <memory>
 #include <mutex>
+#include <set>
 #include <string>
 #include <thread>
 
@@ -11,24 +14,61 @@
 
 #include "data_store/client.hpp"
 
-/// iot-containerd — privileged single-container runtime shim (crun-backed).
+/// iot-containerd — privileged multi-container runtime shim (crun-backed).
 ///
-/// Phase 1 (this build) is the control-plane skeleton. It connects to the
-/// data-store, publishes the container.* status keys (state=idle on boot) and
-/// watches the container.{pull,run,stop}.request command keys the device-ui
-/// bumps. Each command is acknowledged on the reactor thread; until the pull /
-/// overlay-mount / crun phases land, the action is reported back as
-/// not-yet-implemented via container.error. A `pull` does run the pure
-/// containers::parse_image_ref() so the parsed registry/repo/tag already shows
-/// up in the log. See apps/docs/tdd-device-containers.md.
+/// Phase 2 runs any number of independently-named containers. The ds schema is
+/// static (no per-name keys), so the set of containers is carried as ONE JSON
+/// document (`container.instances`) the daemon publishes and the device-ui grid
+/// renders, and commands arrive through a single envelope (`container.cmd.*`)
+/// routed by name. See apps/docs/tdd-device-containers.md §13.
 ///
-/// Reactor-driven and ACE-only by project convention. The ds watch callback
-/// fires on the client's listener thread; it only records the new request token
-/// and notify()s the reactor, so all command handling runs single-threaded on
-/// the reactor thread (handle_exception) — the home the future crun/mount work
-/// needs.
+/// Reactor-driven and ACE-only by convention. The ds watch callback fires on the
+/// client's listener thread; it only records the new command token and notify()s
+/// the reactor, so all command dispatch runs single-threaded on the reactor
+/// thread (handle_exception). Each running container has its own supervise
+/// thread; the registry pull is serialised (one at a time — the long pole).
+/// m_mtx guards the container map, every mutable per-instance field, the IP
+/// allocator, and the command token.
 
 namespace containers {
+
+/// One named container: its config, pulled-image handle, live runtime state, and
+/// (when running) a supervise thread. Non-copyable/movable (owns a thread +
+/// atomics) — held by unique_ptr in the daemon's map.
+struct ContainerInstance {
+    explicit ContainerInstance(std::string nm, std::string i)
+        : name(std::move(nm)), id(std::move(i)) {}
+
+    // identity
+    std::string name;                 ///< operator-chosen name (map key)
+    std::string id;                   ///< crun id / path component ("c-"+sanitized name)
+
+    // config (set on pull/run)
+    std::string image_ref;
+    std::string net_mode = "host";    ///< "host" | "bridge"
+    std::string net_subnet;
+    std::string mem, cpus;
+    std::string entrypoint, cmd;
+
+    // pulled image
+    std::string image_id;             ///< config digest ("sha256:…")
+    std::string image_size;           ///< total bytes (decimal)
+
+    // live state
+    std::string state = "idle";       ///< idle|pulling|pulled|mounting|created|running|stopped|error
+    std::string error;
+    std::string ip, gateway;          ///< bridge mode
+    int         host_octet = 0;       ///< allocated bridge octet (.N); 0 = none
+    long        pid = 0;
+    int         exit_code = -1;       ///< -1 = none
+    long long   started = 0;
+
+    // runtime
+    std::string       merged;         ///< mounted rootfs path
+    std::thread       run_thread;
+    std::atomic<bool> run_active{false};
+    std::atomic<bool> stop_requested{false};
+};
 
 class Containerd : public ACE_Event_Handler {
 public:
@@ -54,43 +94,49 @@ public:
 
 private:
     std::string get_str(const std::string& key);
-    void publish_initial_status();
+
     void on_command_event(const data_store::Client::Event& ev);
-    void handle_pull();
-    void handle_run();
-    void handle_stop();
-    void set_state(const char* state);
-    void set_error(const std::string& msg);
+    void handle_command();                           // dispatch one envelope
+
+    void do_pull(ContainerInstance* inst);
+    void do_run(ContainerInstance* inst);
+    void do_stop(ContainerInstance* inst);
+    void do_remove(const std::string& name);
+    // The supervise body of a running container (own thread). Args by value so
+    // the thread owns its copies; `inst` stays valid because do_remove refuses to
+    // erase a container while its run_active flag is set.
+    void run_worker(ContainerInstance* inst, std::string image_id,
+                    std::string root, std::string run_root,
+                    std::string ov_entrypoint, std::string ov_cmd,
+                    std::string lim_mem, std::string lim_cpus,
+                    bool bridge, std::string net_subnet, std::string id, int octet);
+
+    // m_mtx MUST be held for these.
+    ContainerInstance* find_locked(const std::string& name);
+    ContainerInstance* ensure_locked(const std::string& name);
+    int  alloc_octet_locked();                       // lowest free .N (>=2), 0 if full
+    void free_octet_locked(int octet);
+    void publish_instances_locked();                 // serialise map → container.instances
 
     Config             m_cfg;
     data_store::Client m_ds;
 
-    // Request tokens last seen + a per-command pending flag. The tokens are
-    // baselined at startup so a stale value (a previous session's request) does
-    // not fire on boot. Written on the listener thread (on_command_event),
-    // drained on the reactor thread (handle_exception) — guarded by m_mtx.
-    std::mutex  m_mtx;
-    std::string m_pull_token;
-    std::string m_run_token;
-    std::string m_stop_token;
-    bool        m_pull_pending = false;
-    bool        m_run_pending  = false;
-    bool        m_stop_pending = false;
+    std::mutex m_mtx;
+    std::map<std::string, std::unique_ptr<ContainerInstance>> m_containers;
+    std::set<int> m_used_octets;                     // bridge IPs in use (.2/.3/…)
 
-    // Pull runs on a worker thread (a registry pull can take minutes) so the
-    // reactor stays responsive; the ds Client is thread-safe, so the worker
-    // publishes container.* progress/state directly.
+    // Single command envelope, baselined at startup so a stale token does not
+    // fire on boot. Written on the listener thread, drained on the reactor.
+    std::string m_cmd_token;
+    bool        m_cmd_pending = false;
+
+    // Registry pull is serialised (one worker). m_pull_name is the target.
     std::thread       m_pull_thread;
     std::atomic<bool> m_pull_active{false};
     std::atomic<bool> m_pull_cancel{false};
+    std::string       m_pull_name;                   // guarded by m_mtx
 
-    // Run (layer extract + overlay mount + crun create/start + supervision)
-    // runs on a worker thread that lives for the container's lifetime.
-    std::thread       m_run_thread;
-    std::atomic<bool> m_run_active{false};
-    std::atomic<bool> m_stop_requested{false};   ///< set by handle_stop, honored by the run worker
-    std::atomic<bool> m_shutdown{false};         ///< daemon teardown — supervise loop exits fast (SIGKILL)
-    std::string       m_merged;   ///< mounted rootfs path (guarded by m_mtx)
+    std::atomic<bool> m_shutdown{false};             // teardown → supervise loops exit fast
 };
 
 } // namespace containers

--- a/modules/containers/daemon/main.cpp
+++ b/modules/containers/daemon/main.cpp
@@ -1,10 +1,11 @@
-/// iot-containerd — single-container runtime shim (crun-backed) entry.
+/// iot-containerd — multi-container runtime shim (crun-backed) entry.
 ///
-/// Reactor-driven (ACE): connects to the data-store, publishes container.*
-/// status, and watches the container.{pull,run,stop}.request command keys the
-/// device-ui bumps. Phase 1 is the control-plane skeleton — it acknowledges
-/// commands but the registry pull, overlay mount and crun lifecycle land in
-/// later phases. See apps/docs/tdd-device-containers.md.
+/// Reactor-driven (ACE): connects to the data-store, publishes the
+/// container.instances JSON array, and watches the container.cmd.request command
+/// envelope the device-ui bumps (action=pull|run|stop|remove, routed by name).
+/// Pulls images from an OCI/Docker registry, overlay-mounts the layers, and
+/// drives crun create/start/stop per named container. See
+/// apps/docs/tdd-device-containers.md §13.
 
 #include <cstdlib>
 #include <iostream>
@@ -16,7 +17,7 @@ namespace {
 
 void usage() {
     std::cout <<
-        "iot-containerd — single-container runtime shim (crun-backed)\n"
+        "iot-containerd — multi-container runtime shim (crun-backed)\n"
         "\n"
         "Usage: iot-containerd [--ds-sock=PATH] [--root=DIR] [--run=DIR] [--help]\n"
         "\n"

--- a/modules/containers/daemon/net_bridge.cpp
+++ b/modules/containers/daemon/net_bridge.cpp
@@ -104,10 +104,10 @@ void write_proc(const char* path, const char* val) {
 } // namespace
 
 BridgeNet bridge_up(long container_pid, const std::string& subnet_cidr,
-                    const std::string& id) {
+                    const std::string& id, int host_octet) {
     BridgeNet res;
-    const NetPlan plan = plan_bridge_net(subnet_cidr, kBridgeName);
-    if (!plan.ok) { res.error = "invalid bridge subnet: " + subnet_cidr; return res; }
+    const NetPlan plan = plan_bridge_net(subnet_cidr, kBridgeName, host_octet);
+    if (!plan.ok) { res.error = "invalid bridge subnet/octet: " + subnet_cidr; return res; }
 
     const std::string& ip = ip_tool();
     const std::string host_veth = "vh-" + id;   // host end (≤15 chars)

--- a/modules/containers/daemon/net_bridge.hpp
+++ b/modules/containers/daemon/net_bridge.hpp
@@ -23,10 +23,12 @@ struct BridgeNet {
 ///   3. install the scoped `inet iot_containers` masquerade nft table,
 ///   4. create a veth pair, attach the host end to the bridge, move the peer
 ///      into the container netns as eth0 with the container IP + default route.
-/// `subnet_cidr` is a /24 (default 10.88.0.0/24). Must run as root. On failure
-/// the partial setup is best-effort torn down and `.error` is set.
+/// `subnet_cidr` is a /24 (default 10.88.0.0/24). `host_octet` is the container's
+/// address within it (.2/.3/.4… — a distinct value per running container on the
+/// shared bridge). Must run as root. On failure the partial setup is best-effort
+/// torn down and `.error` is set.
 BridgeNet bridge_up(long container_pid, const std::string& subnet_cidr,
-                    const std::string& id);
+                    const std::string& id, int host_octet = 2);
 
 /// Tear down container `id`'s veth (its peer auto-removes when the container
 /// netns dies). Idempotent; the bridge + nft table persist for reuse.

--- a/modules/containers/inc/container_net.hpp
+++ b/modules/containers/inc/container_net.hpp
@@ -23,10 +23,13 @@ struct NetPlan {
     std::string container_ip;  ///< the container's address (.2)
 };
 
-/// Plan the single-container bridge network from `subnet_cidr` (a /24, e.g.
-/// "10.88.0.0/24") + `bridge`. gateway is host .1, the container gets .2.
-/// ok=false on a malformed or non-/24 CIDR (v1 supports a single /24).
-NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridge);
+/// Plan a bridge network from `subnet_cidr` (a /24, e.g. "10.88.0.0/24") +
+/// `bridge`. gateway is host .1; the container gets the `.host_octet` address
+/// (default .2). Multi-container assigns a distinct octet (.2/.3/.4…) per
+/// running container on the shared bridge. ok=false on a malformed or non-/24
+/// CIDR, or an out-of-range octet (must be 2..254).
+NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridge,
+                        int host_octet = 2);
 
 /// The nftables ruleset (an `nft -f` script) for container egress: a SCOPED
 /// `inet iot_containers` table (separate from net-router's `iot_router`, so the

--- a/modules/containers/src/container_net.cpp
+++ b/modules/containers/src/container_net.cpp
@@ -25,8 +25,10 @@ bool parse_ipv4(const std::string& s, int oct[4]) {
 
 } // namespace
 
-NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridge) {
+NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridge,
+                        int host_octet) {
     NetPlan p;
+    if (host_octet < 2 || host_octet > 254) return p;   // .1 is the gateway
     const auto slash = subnet_cidr.find('/');
     if (slash == std::string::npos) return p;
     const std::string net = subnet_cidr.substr(0, slash);
@@ -43,7 +45,7 @@ NetPlan plan_bridge_net(const std::string& subnet_cidr, const std::string& bridg
     p.cidr         = subnet_cidr;
     p.prefix       = prefix;
     p.gateway      = base + "1";
-    p.container_ip = base + "2";
+    p.container_ip = base + std::to_string(host_octet);
     return p;
 }
 

--- a/modules/containers/test/container_net_test.cpp
+++ b/modules/containers/test/container_net_test.cpp
@@ -20,6 +20,22 @@ TEST(NetPlan, OtherSubnet) {
     EXPECT_EQ(p.container_ip, "192.168.50.2");
 }
 
+TEST(NetPlan, HostOctetAssignsDistinctIPs) {
+    // Multi-container: each running container gets a distinct .N on the bridge.
+    EXPECT_EQ(plan_bridge_net("10.88.0.0/24", "br0").container_ip,      "10.88.0.2");  // default
+    EXPECT_EQ(plan_bridge_net("10.88.0.0/24", "br0", 2).container_ip,   "10.88.0.2");
+    EXPECT_EQ(plan_bridge_net("10.88.0.0/24", "br0", 3).container_ip,   "10.88.0.3");
+    EXPECT_EQ(plan_bridge_net("10.88.0.0/24", "br0", 254).container_ip, "10.88.0.254");
+    EXPECT_EQ(plan_bridge_net("10.88.0.0/24", "br0", 7).gateway,        "10.88.0.1");  // gw fixed
+}
+
+TEST(NetPlan, RejectsOutOfRangeOctet) {
+    EXPECT_FALSE(plan_bridge_net("10.88.0.0/24", "br0", 1).ok);    // .1 is the gateway
+    EXPECT_FALSE(plan_bridge_net("10.88.0.0/24", "br0", 0).ok);
+    EXPECT_FALSE(plan_bridge_net("10.88.0.0/24", "br0", 255).ok);  // broadcast / out of range
+    EXPECT_FALSE(plan_bridge_net("10.88.0.0/24", "br0", 999).ok);
+}
+
 TEST(NetPlan, RejectsNonSlash24) {
     EXPECT_FALSE(plan_bridge_net("10.0.0.0/8", "br0").ok);
     EXPECT_FALSE(plan_bridge_net("10.88.0.0/16", "br0").ok);


### PR DESCRIPTION
Phase 2 of dynamic-named multi-container (builds on the #445 schema). Rewrites `iot-containerd` from one fixed `c0` to **N named containers**.

## Daemon
- **`ContainerInstance`** struct (config + pulled image + live state + own supervise thread) in `std::map<name, unique_ptr<…>>` under `m_mtx`.
- **`handle_command()`** parses the `container.cmd.*` envelope (`name` + `action` pull|run|stop|remove + run params), finds/creates the instance, dispatches.
- **`run_worker()`** — the existing mount → bundle → crun create/bridge/start → supervise → cleanup flow, now **per-instance** (`id="c-"+sanitize(name)`, `/run/iot-containers/<id>/`).
- **IP allocator** — each running bridge container gets the next free `.N` (.2/.3/.4…) on the shared `iot-cni0`; freed on stop/remove (was hardcoded `.2`).
- **`publish_instances()`** serialises the map → `container.instances`; legacy singular keys mirror the first instance during UI migration.
- **Lifetime** — `do_remove` refuses a busy instance (running / mid-pull), erases under the lock, joins the finished thread outside it (no use-after-free).

## Net
- `plan_bridge_net()` / `bridge_up()` take `host_octet` (default 2) so distinct containers get distinct IPs on one bridge. Unit tests added.

## Note
No local C++ build env (compiles in CI/Yocto). Mirrors the prior single-container logic closely. **Phase 3 = device-ui `clr-datagrid` grid** (row/container, IP column, per-row run/stop/remove).

🤖 Generated with [Claude Code](https://claude.com/claude-code)