### PR TITLE
fix(device-ui): custom BS PSK identity+key fields never appeared / unusable

### DIFF
--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.html
@@ -108,8 +108,7 @@
       <div style="margin-top:24px;border-top:1px solid #ccc;padding-top:16px;">
         <clr-checkbox-container>
           <clr-checkbox-wrapper>
-            <input type="checkbox" clrCheckbox [disabled]="!devMode"
-                   formControlName="bs_override" />
+            <input type="checkbox" clrCheckbox formControlName="bs_override" />
             <label>Use custom Bootstrap PSK (third-party vendor)</label>
           </clr-checkbox-wrapper>
           <clr-control-helper>
@@ -121,21 +120,21 @@
         <div class="form-grid" *ngIf="overrideOn" style="margin-top:12px;">
           <clr-input-container>
             <label>BS PSK Identity</label>
-            <input clrInput formControlName="bs_identity" [readonly]="!devMode"
+            <input clrInput formControlName="bs_identity" [readonly]="!isAdmin"
                    placeholder="vendor bootstrap identity" />
             <clr-control-helper>Used verbatim as the DTLS PSK identity</clr-control-helper>
             <clr-control-helper *dsDebug><app-ds-hint key="iot.bs.psk.identity"></app-ds-hint></clr-control-helper>
           </clr-input-container>
           <clr-input-container>
             <label>BS PSK Key (hex)</label>
-            <input clrInput type="password" formControlName="bs_key" [readonly]="!devMode"
+            <input clrInput type="password" formControlName="bs_key" [readonly]="!isAdmin"
                    autocomplete="new-password" placeholder="hex, e.g. 64 chars — leave blank to keep current" />
             <clr-control-helper>Write-only. Blank on save keeps the stored key.</clr-control-helper>
           </clr-input-container>
         </div>
 
         <button type="button" class="btn btn-outline" style="margin-top:12px;"
-                [disabled]="savingOverride || !devMode" (click)="saveBsOverride()">
+                [disabled]="savingOverride || !isAdmin" (click)="saveBsOverride()">
           {{ savingOverride ? 'Saving…' : 'Save custom BS PSK' }}
         </button>
         <p *ngIf="overrideOn" class="hint" style="margin-top:8px;">

--- a/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
+++ b/iot-ui/src/app/lwm2m/lwm2m-config/lwm2m-config.component.ts
@@ -184,10 +184,12 @@ export class Lwm2mConfigComponent implements OnInit, OnDestroy {
    * enabled) the operator-supplied identity. The hex key is written only when a
    * new value was typed, so re-saving without re-entering it leaves the stored
    * secret intact (write-only). The client must be restarted to pick the new
-   * credentials up. Requires commissioning mode.
+   * credentials up. Admin-only (entering a third-party vendor's BS credentials is
+   * a normal commissioning action — it does not require dev mode, which only
+   * gates revealing/regenerating the device's OWN derived PSK).
    */
   saveBsOverride(): void {
-    if (!this.devMode || !this.isAdmin) return;
+    if (!this.isAdmin) return;
     const on = this.overrideOn;
     const identity = (this.serverForm.get('bs_identity')?.value || '').trim();
     const key = (this.serverForm.get('bs_key')?.value || '').trim();


### PR DESCRIPTION
## Symptom
Ticking **Use custom Bootstrap PSK (third-party vendor)** does nothing — the **BS PSK Identity** and **BS PSK Key** inputs never appear (your screenshots).

## Cause
1. The whole section was gated behind **`iot.dev.mode`**, but **nothing in the UI sets dev mode** — so an operator can never enable it. `saveBsOverride()` also bailed `if (!this.devMode …)`.
2. The checkbox used the **`[disabled]`+`formControlName` reactive-forms anti-pattern**, which desyncs the control value — so ticking it didn't flip `overrideOn`, and `*ngIf="overrideOn"` never rendered the fields.

## Fix
Entering a third-party vendor's BS identity+key is a normal **Admin** commissioning action (it doesn't reveal/regenerate the device's own derived PSK), so gate it on **`isAdmin`**:
- drop `[disabled]="!devMode"` from the checkbox (kills the anti-pattern → the toggle reliably reveals the fields),
- inputs `[readonly]="!isAdmin"`, Save `[disabled]="!isAdmin"`,
- `saveBsOverride()` guards on `isAdmin` only.

`dev.mode` still gates revealing/regenerating the device's OWN PSK (Generate BS PSK). Now: tick the box → Identity + Key inputs appear → enter vendor creds → Save.

🤖 Generated with [Claude Code](https://claude.com/claude-code)