### PR TITLE
feat(bs): HKDF zero-touch bootstrap — P1 (crypto+parity) + P2a (master envelope + resolver helpers)

### DIFF
--- a/apps/docs/tdd-bs-hkdf-zerotouch.md
+++ b/apps/docs/tdd-bs-hkdf-zerotouch.md
@@ -1,0 +1,320 @@
+# TDD Plan — Zero-touch Bootstrap via HKDF-derived per-device PSK
+
+Status: **PROPOSED — design only, not yet implemented.**
+
+This is the zero-touch / plug-and-play bootstrap design that replaces the
+manual device-ui commissioning step **without** introducing a fleet-wide class
+secret. It is the agreed alternative to the shared baked-in default PSK scheme
+analysed and rejected in `apps/docs/tdd-bs-default-bootstrap.md` — read that
+first; this doc only restates the parts of it that matter here.
+
+Related:
+- `apps/docs/tdd-bs-default-bootstrap.md` — the REJECTED shared-default scheme
+  (why a single baked PSK is unsafe).
+- `apps/docs/tdd-psk-provisioning.md` — the SHIPPED per-device PSK + serial
+  design this builds directly on (`iot.bs.psk.*`, `cloud.endpoint.credentials`,
+  the `engineer`/`cloud-svc` accounts, derived identity).
+- `apps/docs/tdd-wifi-credentials-seed.md` — the image-bake pattern (mirrored
+  here for the cloud master only).
+
+---
+
+## 1. Goal & definition of "zero-touch"
+
+A device should go **flash → power on → LwM2M registered + VPN up** with no
+device-ui step and no per-device action in the cloud UI. Concretely, remove
+both manual steps that the shipped flow still requires:
+
+1. device-ui generating a random `iot.bs.psk.key` and the operator revealing
+   it; and
+2. the operator pasting that key into the cloud Endpoints provision form so
+   `cloud.endpoint.credentials` gains a row.
+
+The replacement: every device boots already holding a **per-unit** BS PSK that
+the cloud can **re-derive on demand** from a single master secret it alone
+holds. No shared device secret; no per-device row to pre-create in the cloud.
+
+### 1.1 The one hard constraint (why this is not "bake one file like WiFi")
+
+DTLS-PSK here is `TLS_PSK_WITH_AES_128_CCM_8` — **symmetric**. Both ends need
+the *same* secret, and the device must hold its secret **before first contact**
+(it is what authenticates the very first `/bs` handshake). Therefore:
+
+- You **cannot** bake a single shared file into the rootfs image and stay
+  secure — every device flashed from that image would share one PSK, which is
+  exactly the rejected class-secret design.
+- The per-device secret **must be injected per unit** at flash/personalisation
+  time. There is no symmetric scheme that avoids this.
+
+What HKDF buys is **not** "skip per-unit injection." It buys:
+- the cloud needs **no per-device registration DB** for BS — it derives the
+  expected PSK from the presented serial instead of looking up a stored row; and
+- the flashing tool needs **no call to the cloud** — it derives the same PSK
+  locally from the master, so manufacturing is offline-capable.
+
+So the WiFi-style "copy a file before the build" applies to the **cloud master
+key**, baked into the **cloud image only**. The device side is a per-unit inject.
+
+---
+
+## 2. Architecture
+
+```
+        ┌──────────────────────── manufacturing / flashing host ───────────────┐
+        │  holds MASTER (offline)                                               │
+        │  iot-bs-personalize <serial>:                                         │
+        │     psk = HKDF(MASTER, serial)  ──────┐  inject per-unit              │
+        └───────────────────────────────────────┼──────────────────────────────┘
+                                                 ▼
+   device (per unit)                       iot.bs.psk.key   = psk      (persisted)
+   ───────────────────                     iot.bs.psk.identity = serial
+   first boot, no UI:                      iot.bs.psk.override = true  (identity verbatim)
+     present identity = serial  ─────DTLS PSK handshake────►  cloud BS server
+     present key      = psk                                   holds MASTER (cloud-only)
+                                                              psk' = HKDF(MASTER, serial)
+                                                              auth ⇔ psk == psk'
+     ◄──── /bs response: BS account + minted DM creds ────
+     persist DM creds, register to DM, VPN up
+```
+
+### 2.1 Why identity must be the **raw serial**, not `sha256(serial)`
+
+The DTLS PSK resolver on the server sees only the **presented PSK identity**
+during the handshake — the CoAP `/bs` request (which carries `ep=<serial>`)
+arrives *after* the handshake completes. Today the identity is
+`sha256(serial)[:32]` (`apps/src/main.cpp:2093`), which is one-way: the server
+**cannot** recover the serial to feed HKDF.
+
+So the HKDF tier puts the **raw serial on the wire as the PSK identity**, reusing
+the existing `iot.bs.psk.override` path (override ⇒ identity used verbatim,
+`apps/src/main.cpp:2081-2084`). The serial is not a secret — it is on the device
+label and readable from `/proc/cpuinfo` — so cleartext on the wire is acceptable
+(the `sha256` wrapper was light obfuscation, never an access control).
+
+### 2.2 Why this is safe where the shared-default was not
+
+Possession of `HKDF(MASTER, serial)` **is** the authentication. To impersonate
+serial *X* an attacker must produce `HKDF(MASTER, X)`, which requires the master.
+
+| Rejected shared-default flaw | This design |
+| --- | --- |
+| 🔴 class secret on every device → crack one, decrypt the fleet's stage-0 | each device holds only its **own** derived key; crack one → that unit only. Master never ships to a device. |
+| 🔴 no device auth in stage 0 → spoof any `ep=` | to auth as serial *X* you need `HKDF(MASTER,X)`; an attacker can't mint it. No allow-list needed — the key gates access. |
+| 🟠 collides with "identity is derived, not stored" | reuses the existing `override` verbatim-identity path; serial is the identity. No new identity concept. |
+| 🟠 extra reconnect hop | none — DM creds are minted in the same `/bs` cycle (§4.3), device proceeds straight to DM. |
+
+Residual risks (documented, accepted, or mitigated):
+- **Master compromise = fleet compromise.** Mitigation: master lives **cloud-only**,
+  ideally KMS/HSM-wrapped; never in a device image. Versioned (`v1`) for rotation.
+- **At-rest key on device** (`iot.bs.psk.key` plaintext in `/var/lib/iot`): same
+  posture as the shipped per-device key, but now one-per-unit, so extraction
+  leaks one unit. Acceptable for the device-ui-commissioning threat model already
+  in production.
+- **Serial enumeration:** RPi serials are guessable, but guessing a serial does
+  not yield its key (needs master). DM-tier creds remain per-endpoint random.
+
+---
+
+## 3. The HKDF construction (MUST be byte-identical on both impls)
+
+Two independent implementations must agree: the **flashing tool** (host) and the
+**cloud BS server**. Pin every parameter:
+
+```
+PRK/OKM = HKDF-SHA256(
+    ikm   = MASTER_KEY_BYTES,        # raw bytes of the master (see §3.1)
+    salt  = "" (zero-length)         # RFC 5869 §2.2: defaults to HashLen zeros
+    info  = "iot-bs-psk:v1:" + serial   # ASCII; serial = raw device serial
+    L     = 32                       # 32-byte / 256-bit output
+)
+iot.bs.psk.key (stored) = lowercase_hex(OKM)   # 64 hex chars, opaque type
+```
+
+- **`info` includes a version tag (`v1`)** so the master can be rotated /
+  re-keyed by bumping to `v2` without changing the serial namespace.
+- **`info` binds the serial** so each unit's key is independent.
+- **Output is hex-encoded** to match the existing `opaque`/hex convention for
+  `iot.bs.psk.key` and `cloud.endpoint.credentials[].bs.psk.key`.
+
+### 3.1 Master key format
+
+- `cloud.bs.master.key` is the master, stored as **hex** (opaque), e.g. 32 bytes
+  → 64 hex chars. The IKM fed to HKDF is the **decoded raw bytes** (`hex_decode`),
+  not the hex string, so both impls agree.
+
+### 3.2 Implementations
+
+- **C++ (cloud):** add `hkdf_sha256(ikm, salt, info, L)` to
+  `apps/src/psk_gen.cpp` / `apps/inc/psk_gen.hpp` using OpenSSL
+  `EVP_PKEY_derive` with `EVP_PKEY_HKDF` (OpenSSL ≥ 1.1.0; already the crypto
+  lib — `apps/src/psk_gen.cpp` includes `<openssl/evp.h>`). Add a convenience
+  `derive_bs_psk_hex(master_hex, serial)` that does
+  `hex(HKDF(hex_decode(master_hex), "", "iot-bs-psk:v1:"+serial, 32))`.
+- **Host flashing tool:** `yocto/meta-iot/recipes-iot/lwm2m/files/gen_bs_psk.py`
+  (sibling of `gen_wifi_default.py`), HKDF via `hmac`+`hashlib` stdlib (no
+  `cryptography` dep), producing the identical 64-hex string. Ship a
+  `test_gen_bs_psk.py` with RFC 5869 test vectors **and** a cross-check vector
+  shared with the C++ unit test so drift is caught.
+
+---
+
+## 4. Component changes (mapped to current code)
+
+### 4.1 New schema keys
+
+**Cloud** — `modules/server/lwm2m/schemas/cloud.lua` (next to `cloud.bs.psk.*`,
+`cloud.endpoint.credentials` at ~:262):
+
+```lua
+["cloud.bs.master.key"] = {           -- NEW: HKDF master, cloud-only
+    access    = "Admin",
+    type      = "opaque",
+    default   = "",                   -- empty ⇒ HKDF tier disabled (see §4.3)
+    write_acl = {"gid:cloud-svc"},
+    read_acl  = {"gid:cloud-svc"},    -- write-only to ds-cli, like the PSK keys
+}
+```
+
+**Device** — no new keys. The HKDF tier **reuses** the shipped keys:
+`iot.bs.psk.identity` (= serial), `iot.bs.psk.key` (= derived), `iot.bs.psk.override`
+(= true). See `modules/data-store/schemas/iot.lua`.
+
+### 4.2 Cloud master seed (WiFi-pattern, cloud image only)
+
+Mirror the WiFi seed exactly, scoped to the cloud build:
+- `bs_master.lua.sample` (tracked) + gitignored `bs_master.lua` holding
+  `return { master = "<64 hex>" }`.
+- `gen_bs_master.py` rewrites the `cloud.bs.master.key` `default = '…'` in the
+  installed `cloud.lua` when `bs_master.lua` is present, exactly as
+  `gen_wifi_default.py` rewrites `wifi.networks` (`iot_git.bb:421-431`, gated by
+  an `IOT_BS_SEED == '1'` SRC_URI add mirroring `IOT_WIFI_SEED` at
+  `iot_git.bb:99`).
+- **Cloud build only.** The device image must NOT carry the master — assert this
+  in review and (ideally) a build check that `cloud.bs.master.key` default is
+  empty in the device rootfs `iot.lua`.
+
+### 4.3 Cloud BS server: derive-or-lookup + mint DM
+
+**Server PSK resolver** (`apps/src/main.cpp:2160-2189`, `is_bs` branch). Today it
+iterates `cloud.endpoint.credentials` matching `sha256(serial)[:32] == presented`.
+Change to **lookup-then-derive**:
+
+```
+if is_bs:
+    1. existing behaviour: scan cloud.endpoint.credentials for a row whose
+       sha256(serial)[:32] == presented  → return its bs.psk.key   (commissioned tier)
+    2. NEW: if no row AND cloud.bs.master.key is non-empty AND `presented`
+       is a plausible raw serial → return derive_bs_psk_hex(master, presented)
+```
+
+Both tiers coexist → existing commissioned devices keep working; new devices use
+the derived path. Empty master ⇒ step 2 is skipped ⇒ behaviour is unchanged.
+
+**Provisioning resolver** (`apps/src/main.cpp:252-389`). It receives `ep=serial`
+directly from the `/bs` CoAP request, so HKDF is trivially available here.
+For a serial with **no** `cloud.endpoint.credentials` row (zero-touch first
+contact):
+- `bs.identity` = serial verbatim (not `sha256(ep)`) when serving the derived
+  tier, so the device's stored `override` identity matches what the BS expects.
+  (Keep `sha256(ep)` for the legacy commissioned tier.)
+- **Mint DM creds on the fly**: `generate_psk_hex()` → `dmKey`,
+  `format_identity(serial)` → `dmId`, then `upsert_credential(...)` into
+  `cloud.endpoint.credentials` so the DM server's resolver finds it on the next
+  handshake. Minting happens **inside the HKDF-authenticated BS session**, so it
+  carries none of the rejected design's "mint under a shared-key channel" risk.
+  - **Mint-once idempotency (rejected-design flaw 🟡6):** gate the mint on "no
+    existing row for this serial"; a `/bs` retry after packet loss must reuse the
+    already-minted row, never re-mint. `upsert_credential` is idempotent on the
+    record but the **generate** step must be guarded by a read-check.
+
+### 4.4 Device: personalisation inject (the per-unit step)
+
+The device must boot already holding `iot.bs.psk.{identity,key,override}`.
+**Recommended (Option I):** flash-time personalisation.
+
+- New host tool `iot-bs-personalize <serial>` (wraps `gen_bs_psk.py`): after the
+  SD image is written, derive the PSK and drop a per-unit file onto the device's
+  **data/boot partition** (e.g. `/var/lib/iot/bs-seed.json`
+  `{ "serial":"…", "key":"<hex>" }`), NOT the shared rootfs.
+- Extend **first-boot seed** `yocto/.../files/iot-ds-seed` (runs once, before
+  `iot-httpd`, guarded by `/var/lib/iot/.seeded`): if `bs-seed.json` exists and
+  `iot.bs.psk.key` is empty, `ds-cli set` `iot.serial`, `iot.bs.psk.identity`
+  (=serial), `iot.bs.psk.key` (=derived), `iot.bs.psk.override=true`, then
+  **shred** `bs-seed.json`. Idempotent and one-shot like the existing seed.
+- On RPi the serial is also auto-read by the client (`set_serial`,
+  `ds_config.cpp:237-261`); personalisation supplies the **key**, which is the
+  only thing the device cannot self-derive.
+
+This keeps the client unprivileged and **adds no crypto to the device** — it
+stores an injected key, it never runs HKDF (the master is never on-device).
+
+**Alternatives considered** (decision point — see §6):
+- *Option II — LAN auto-commission:* a one-shot local tool reads the serial from
+  the booted device and pushes the derived key over the device-ui/ds socket on
+  the LAN. No flash-time step, but not headless.
+- *Option III — secure element:* derive on-device from a key in an ATECC/TPM.
+  Out of scope for current RPi3B hardware (no secure element).
+
+### 4.5 Self-restart interplay (rejected-design flaw 🟡5)
+
+The first-boot seed writes `iot.bs.psk.key` **before the client starts** (seed is
+`Before=iot-httpd` and the client parks until the key exists,
+`apps/src/main.cpp:2023-2037`). So the empty→derived transition happens
+pre-init and does **not** trip `should_restart_on_psk_change`
+(`apps/src/main.cpp:2467-2480`, `provisioning_policy.cpp:29-32`) — that guard
+only fires on a change *after* `started_bs_psk` is captured. A genuine rekey
+(master `v1→v2`, re-personalise) still self-restarts cleanly via systemd
+`Restart=always`, which is the intended behaviour.
+
+---
+
+## 5. Test plan
+
+**Unit (apps, podman per `tdd-psk-provisioning.md` §test cmd):**
+- `hkdf_sha256` against the **RFC 5869** test vectors (cases 1–3).
+- `derive_bs_psk_hex(master, serial)` cross-check vector shared verbatim with
+  `test_gen_bs_psk.py` (catches C++/Python drift — the single most important
+  test).
+- Resolver: presented serial with master set & no row → derived key; with a row
+  → the row's key (commissioned tier still wins); empty master → "" (disabled).
+- Provisioning resolver mint-once: two `/bs` for the same fresh serial → one
+  mint, identical DM creds (idempotency).
+
+**Host:** `test_gen_bs_psk.py` — RFC 5869 vectors + the shared cross-check +
+malformed-master / odd-hex rejection (mirror `test_gen_wifi_default.py`).
+
+**Integration (needs BS+DM+device, deferred like the N-wire/P tasks in
+`tdd-psk-provisioning.md`):**
+- Personalise a serial, boot a fresh device with **no** cloud row, confirm
+  flash→registered with zero UI steps; confirm a DM row was minted.
+- Negative: device with a key NOT derived from the master → BS handshake fails.
+- Rekey: bump `info` to `v2` + re-personalise → device self-restarts and
+  re-registers; old key rejected.
+
+---
+
+## 6. Open decisions (resolve before coding)
+
+| Decision | Options | Recommendation |
+| --- | --- | --- |
+| Device-side inject mechanism | I flash-time file+seed / II LAN auto-commission / III secure element | **I** — fully headless, no extra hardware, matches the existing one-shot `iot-ds-seed` pattern. |
+| "Plausible raw serial" check in the resolver | length/charset heuristic vs. an explicit prefix vs. accept-anything-and-let-HKDF-gate | length+hex/charset sanity only; HKDF-key possession is the real gate, so keep it permissive. |
+| Master rotation policy | `info` version tag (`v1→v2`) + dual-accept window vs. flag day | version tag + **dual-derive** (accept `v1` and `v2` during a migration window); document in DEPLOY.md. |
+| Mint DM at BS time vs. keep device-ui paste for DM | mint-on-/bs (full zero-touch) vs. retain manual DM | **mint-on-/bs**, gated by the same `cloud.dev.mode` / master-present condition, with mint-once idempotency. |
+| Master at rest in cloud | plaintext ds opaque (current pattern) vs. KMS/HSM-wrapped | ship as ds opaque to match today; **flag KMS as the production hardening follow-up** (this is the whole fleet's trust root). |
+
+---
+
+## 7. Phasing
+
+1. **P1 — crypto + parity:** `hkdf_sha256` + `derive_bs_psk_hex` (C++) and
+   `gen_bs_psk.py` + tests with the shared cross-check vector. No behaviour
+   change yet. *(Lowest risk, unblocks everything, fully unit-testable in podman.)*
+2. **P2 — cloud derive-or-lookup:** `cloud.bs.master.key` schema + seed
+   (`gen_bs_master.py`, `IOT_BS_SEED`) + resolver step 2 + mint-on-`/bs` with
+   idempotency. Guarded by empty-master = no-op, so it's inert until a master is
+   seeded.
+3. **P3 — device personalisation:** `iot-bs-personalize` + `iot-ds-seed`
+   extension + `iot.bs.psk.override` wiring.
+4. **P4 — DEPLOY.md** "Zero-touch bootstrap (HKDF)" section + master-rotation
+   runbook; integration validation on real BS+DM+device hardware.

--- a/apps/docs/tdd-bs-hkdf-zerotouch.md
+++ b/apps/docs/tdd-bs-hkdf-zerotouch.md
@@ -104,8 +104,13 @@ serial *X* an attacker must produce `HKDF(MASTER, X)`, which requires the master
 | 🟠 extra reconnect hop | none — DM creds are minted in the same `/bs` cycle (§4.3), device proceeds straight to DM. |
 
 Residual risks (documented, accepted, or mitigated):
-- **Master compromise = fleet compromise.** Mitigation: master lives **cloud-only**,
-  ideally KMS/HSM-wrapped; never in a device image. Versioned (`v1`) for rotation.
+- **Master compromise = fleet compromise.** Mitigation: master lives **cloud-only**
+  and **never in the clear** — stored AES-256-GCM-wrapped (`cloud.bs.master.key`)
+  under a KEK delivered out-of-band (systemd `LoadCredential` / `IOT_BS_MASTER_KEK`),
+  unwrapped into process memory only (§3.3). Extracting the cloud's data-store
+  without the KEK yields ciphertext. Versioned (`v1` in both the HKDF `info` and the
+  envelope AAD) for rotation. Upgrades to a managed KMS by swapping only the KEK
+  source.
 - **At-rest key on device** (`iot.bs.psk.key` plaintext in `/var/lib/iot`): same
   posture as the shipped per-device key, but now one-per-unit, so extraction
   leaks one unit. Acceptable for the device-ui-commissioning threat model already
@@ -156,6 +161,43 @@ iot.bs.psk.key (stored) = lowercase_hex(OKM)   # 64 hex chars, opaque type
   `test_gen_bs_psk.py` with RFC 5869 test vectors **and** a cross-check vector
   shared with the C++ unit test so drift is caught.
 
+> **Status (P1, done):** `iot::hkdf_sha256` + `iot::derive_bs_psk_hex` shipped;
+> `gen_bs_psk.py` + `test_gen_bs_psk.py` shipped. Cross-check vector
+> `master=0001…1e1f, serial=100000003d1f9c2e → 223a82da…600d4fe5` asserted on
+> both sides. Verified: Python 13/13, C++ in the `lwm2m_test` gtest suite.
+
+### 3.3 Master at rest — AES-256-GCM envelope (decided: KMS-wrapped)
+
+The master is **never stored in the clear**. `cloud.bs.master.key` holds:
+
+```
+base64( nonce(12) || AES-256-GCM(KEK, master)_ciphertext || tag(16) )
+   AAD = "iot-bs-master:v1"     # binds the blob to purpose+version
+```
+
+- **KEK** (32-byte AES-256 key) is delivered to `iot-lwm2m-server` **out-of-band**
+  — systemd `LoadCredential=bs_kek:/etc/iot/bs-master.kek` (root-only 0400) or env
+  `IOT_BS_MASTER_KEK` — and is **never** written to the data-store. The server
+  unwraps once at startup and holds the master in process memory only.
+- No external service: this is envelope encryption local to the cloud box (fits the
+  Vultr self-hosted deployment). To upgrade to a managed KMS later, swap only the
+  KEK source (or replace the GCM open with a KMS `Decrypt`) — the wire/at-rest
+  format and the resolver are unchanged.
+- **Single implementation:** wrap+unwrap are C++/OpenSSL only (`iot::wrap_bs_master`
+  / `iot::unwrap_bs_master_hex`), because Python here has no AES-GCM. The host
+  `bs-master-wrap` CLI (P2b) reuses the same code, so there is no cross-language
+  envelope to keep in sync — only the HKDF tool stays pure-stdlib.
+- **Fail-closed:** a bad/missing KEK, wrong KEK, or a tampered blob yields
+  `nullopt` → the master is treated as absent → HKDF tier disabled (the
+  commissioned per-device tier still serves). Never derive against a bad master.
+
+> **Status (P2, this PR):** `base64_encode/decode`, `wrap_bs_master`,
+> `unwrap_bs_master_hex` shipped + tested (fixed-vector + round-trip + tamper +
+> wrong-key + fail-closed). The `resolve_bs_psk` / `should_mint_dm` decision
+> helpers (§4.3) shipped + tested. `cloud.bs.master.key` schema + `gen_bs_master.py`
+> shipped. **Not yet wired:** the `main.cpp` BS-server resolver/mint call sites,
+> the `bs-master-wrap` CLI, the `IOT_BS_SEED` recipe bake, and KEK delivery — P2b.
+
 ---
 
 ## 4. Component changes (mapped to current code)
@@ -166,9 +208,9 @@ iot.bs.psk.key (stored) = lowercase_hex(OKM)   # 64 hex chars, opaque type
 `cloud.endpoint.credentials` at ~:262):
 
 ```lua
-["cloud.bs.master.key"] = {           -- NEW: HKDF master, cloud-only
-    access    = "Admin",
-    type      = "opaque",
+["cloud.bs.master.key"] = {           -- HKDF master, cloud-only, AES-256-GCM-
+    access    = "Admin",              -- wrapped (§3.3). Stores the base64 envelope,
+    type      = "opaque",             -- NOT the raw master.
     default   = "",                   -- empty ⇒ HKDF tier disabled (see §4.3)
     write_acl = {"gid:cloud-svc"},
     read_acl  = {"gid:cloud-svc"},    -- write-only to ds-cli, like the PSK keys
@@ -293,28 +335,35 @@ malformed-master / odd-hex rejection (mirror `test_gen_wifi_default.py`).
 
 ---
 
-## 6. Open decisions (resolve before coding)
+## 6. Decisions
 
-| Decision | Options | Recommendation |
-| --- | --- | --- |
-| Device-side inject mechanism | I flash-time file+seed / II LAN auto-commission / III secure element | **I** — fully headless, no extra hardware, matches the existing one-shot `iot-ds-seed` pattern. |
-| "Plausible raw serial" check in the resolver | length/charset heuristic vs. an explicit prefix vs. accept-anything-and-let-HKDF-gate | length+hex/charset sanity only; HKDF-key possession is the real gate, so keep it permissive. |
-| Master rotation policy | `info` version tag (`v1→v2`) + dual-accept window vs. flag day | version tag + **dual-derive** (accept `v1` and `v2` during a migration window); document in DEPLOY.md. |
-| Mint DM at BS time vs. keep device-ui paste for DM | mint-on-/bs (full zero-touch) vs. retain manual DM | **mint-on-/bs**, gated by the same `cloud.dev.mode` / master-present condition, with mint-once idempotency. |
-| Master at rest in cloud | plaintext ds opaque (current pattern) vs. KMS/HSM-wrapped | ship as ds opaque to match today; **flag KMS as the production hardening follow-up** (this is the whole fleet's trust root). |
+| Decision | Resolution |
+| --- | --- |
+| **Device-side inject mechanism** | ✅ **Decided: Option I — flash-time file + `iot-ds-seed`** (fully headless, no extra hardware, matches the existing one-shot seed). P3. |
+| **Master at rest in cloud** | ✅ **Decided: AES-256-GCM envelope + KEK via systemd credential** (§3.3) — no external service, fits Vultr; upgrades to a managed KMS by swapping the KEK source. Implemented in P2. |
+| "Plausible raw serial" check in the resolver | ✅ Permissive — step 2 derives for any non-empty `presented` once a master is set (`resolve_bs_psk`). HKDF-key possession is the real gate; a wrong guess just fails the handshake. |
+| Mint DM at BS time vs. keep device-ui paste for DM | ✅ **mint-on-`/bs`** with mint-once idempotency (`should_mint_dm`), gated by `cloud.dev.mode` / master-present. Wiring in P2b. |
+| Master rotation policy | `info`+AAD version tag (`v1→v2`) + **dual-derive** accept window; document in DEPLOY.md (P4). |
 
 ---
 
 ## 7. Phasing
 
-1. **P1 — crypto + parity:** `hkdf_sha256` + `derive_bs_psk_hex` (C++) and
-   `gen_bs_psk.py` + tests with the shared cross-check vector. No behaviour
-   change yet. *(Lowest risk, unblocks everything, fully unit-testable in podman.)*
-2. **P2 — cloud derive-or-lookup:** `cloud.bs.master.key` schema + seed
-   (`gen_bs_master.py`, `IOT_BS_SEED`) + resolver step 2 + mint-on-`/bs` with
-   idempotency. Guarded by empty-master = no-op, so it's inert until a master is
-   seeded.
+1. ✅ **P1 — crypto + parity (done):** `hkdf_sha256` + `derive_bs_psk_hex` (C++)
+   and `gen_bs_psk.py` + tests with the shared cross-check vector. No behaviour
+   change. Verified in podman (`lwm2m_test`) + Python.
+2. **P2 — cloud derive-or-lookup.** Split:
+   - ✅ **P2a (this PR) — testable foundation, inert:** envelope crypto
+     (`base64_*`, `wrap_bs_master`, `unwrap_bs_master_hex`), the resolver
+     decision helpers (`resolve_bs_psk`, `should_mint_dm`), `cloud.bs.master.key`
+     schema, and `gen_bs_master.py`. All unit-tested; nothing calls them yet.
+   - ⬜ **P2b — wiring + deployment:** call `resolve_bs_psk` in the BS PSK
+     resolver and `should_mint_dm` + mint at `/bs` in the provisioning resolver
+     (`apps/src/main.cpp`); the `BsMasterProvider` startup unwrap (KEK from
+     `IOT_BS_MASTER_KEK` / systemd cred); the `bs-master-wrap` CLI; the
+     `IOT_BS_SEED` recipe bake of a wrapped master into the cloud image. Guarded
+     by empty-master = no-op, so it stays inert until a master is seeded.
 3. **P3 — device personalisation:** `iot-bs-personalize` + `iot-ds-seed`
-   extension + `iot.bs.psk.override` wiring.
+   extension + `iot.bs.psk.override` wiring (Option I, flash-time).
 4. **P4 — DEPLOY.md** "Zero-touch bootstrap (HKDF)" section + master-rotation
    runbook; integration validation on real BS+DM+device hardware.

--- a/apps/inc/provisioning_policy.hpp
+++ b/apps/inc/provisioning_policy.hpp
@@ -52,6 +52,33 @@ bool is_coap_client_error(std::uint8_t coap_code);
 /// registration rejection (4.0x). Cooldown/backoff is the caller's job.
 bool should_rebootstrap(bool dm_dtls_failed, bool dm_registration_rejected);
 
+// ── Zero-touch BS PSK resolver (HKDF tier) — tdd-bs-hkdf-zerotouch.md ─────────
+
+/// Cloud BS-server decision for which PSK to present for an incoming DTLS
+/// handshake. `credentials_json` is `cloud.endpoint.credentials` (array of
+/// {serial, identity, bs.psk.key, dm.psk.id, dm.psk.key}); `presented` is the
+/// PSK identity the peer sent; `master_hex` is the unwrapped HKDF master ("" if
+/// the zero-touch tier is unconfigured). Resolution order:
+///   1. a commissioned row whose sha256(serial)[:32] == presented → its
+///      bs.psk.key (existing device-ui-provisioned tier, unchanged);
+///   2. else, if a master is configured, HKDF-derive from the presented raw
+///      serial (zero-touch tier — the device presents its serial verbatim);
+///   3. else "" (no match → the handshake fails).
+/// Step 2 is intentionally permissive about `presented`: possession of the
+/// derived key IS the authentication, so a wrong guess just yields a key the
+/// peer cannot match (failed handshake), never an information leak.
+std::string resolve_bs_psk(const std::string& credentials_json,
+                           const std::string& presented,
+                           const std::string& master_hex);
+
+/// Mint-once gate for zero-touch DM provisioning. True when no row in
+/// `credentials_json` already covers `serial` (the BS should mint+persist DM
+/// creds during /bs); false when a row exists (reuse — a /bs retry after packet
+/// loss must NOT re-mint, or the device that stored the first key can no longer
+/// authenticate). Empty serial → false.
+bool should_mint_dm(const std::string& credentials_json,
+                    const std::string& serial);
+
 } // namespace iot
 
 #endif /* __iot_provisioning_policy_hpp__ */

--- a/apps/inc/psk_gen.hpp
+++ b/apps/inc/psk_gen.hpp
@@ -33,6 +33,32 @@ std::string hex_decode(const std::string& hex);
 /// never has to be stored/commissioned — only the endpoint + secret.
 std::string sha256_hex(const std::string& input);
 
+/// HKDF-SHA256 (RFC 5869, extract-then-expand) over raw bytes, returning the
+/// `out_len`-byte output key material as lowercase hex (2*out_len chars).
+/// A zero-length `salt` is substituted with HashLen (32) zero bytes per
+/// RFC 5869 §2.2 so callers and the host-side Python generator agree exactly.
+/// Throws std::runtime_error on any OpenSSL failure.
+std::string hkdf_sha256(const std::string& ikm,
+                        const std::string& salt,
+                        const std::string& info,
+                        std::size_t        out_len = 32);
+
+/// Derive a device's per-unit Bootstrap PSK from the cloud master + the device
+/// serial (zero-touch HKDF tier — see apps/docs/tdd-bs-hkdf-zerotouch.md).
+///
+///   psk = HKDF-SHA256(ikm = hex_decode(master_hex),
+///                     salt = "" (-> 32 zero bytes),
+///                     info = "iot-bs-psk:v1:" + serial,
+///                     L    = 32)
+///
+/// Returns the 64-char lowercase-hex PSK. Both the cloud BS server (to
+/// authenticate the handshake) and the host flashing tool (gen_bs_psk.py, to
+/// inject the key) call this and MUST agree byte-for-byte. The `v1` tag in
+/// `info` versions the master for rotation. Returns "" when `master_hex` is
+/// empty or not valid hex — the caller treats that as "HKDF tier disabled".
+std::string derive_bs_psk_hex(const std::string& master_hex,
+                              const std::string& serial);
+
 } // namespace iot
 
 #endif /* __iot_psk_gen_hpp__ */

--- a/apps/inc/psk_gen.hpp
+++ b/apps/inc/psk_gen.hpp
@@ -11,6 +11,7 @@
 /// See apps/docs/tdd-psk-provisioning.md.
 
 #include <cstddef>
+#include <optional>
 #include <string>
 
 namespace iot {
@@ -58,6 +59,40 @@ std::string hkdf_sha256(const std::string& ikm,
 /// empty or not valid hex — the caller treats that as "HKDF tier disabled".
 std::string derive_bs_psk_hex(const std::string& master_hex,
                               const std::string& serial);
+
+/// Standard base64 (RFC 4648, '+/' alphabet, '=' padding).
+std::string base64_encode(const std::string& bin);
+/// Decode standard base64. Returns "" on any invalid character or length.
+std::string base64_decode(const std::string& b64);
+
+// ── BS master key at rest: AES-256-GCM envelope (KMS-wrapped) ────────────────
+//
+// The HKDF master is never stored in the clear. It lives in the data-store
+// (`cloud.bs.master.key`) as `base64( nonce(12) || ciphertext || tag(16) )`,
+// AES-256-GCM under a Key-Encryption-Key (KEK) that is delivered to the cloud
+// BS process out-of-band (systemd LoadCredential / env), never via the
+// data-store. The process unwraps once at startup and holds the master in
+// memory only. AAD binds the blob to its purpose. See
+// apps/docs/tdd-bs-hkdf-zerotouch.md.
+
+/// AAD tag tying a wrapped blob to its purpose+version (rotate with the key).
+constexpr const char* kBsMasterAad = "iot-bs-master:v1";
+
+/// Wrap a hex master under a hex KEK with the given 12-byte (24-hex) nonce,
+/// returning the base64 envelope. Production callers (the bs-master-wrap tool)
+/// pass a fresh random nonce; tests pin it for a deterministic vector. Returns
+/// "" if the KEK is not 32 bytes, the nonce not 12 bytes, or the master not
+/// valid hex.
+std::string wrap_bs_master(const std::string& kek_hex,
+                           const std::string& master_hex,
+                           const std::string& nonce_hex);
+
+/// Unwrap a base64 envelope under a hex KEK, returning the master as hex.
+/// Returns std::nullopt on any failure — empty inputs, bad base64, wrong KEK,
+/// or a failed GCM tag (tamper) — which the caller treats as "HKDF tier
+/// unavailable / disabled" (fail closed; never derive against a bad master).
+std::optional<std::string> unwrap_bs_master_hex(const std::string& kek_hex,
+                                                const std::string& wrapped_b64);
 
 } // namespace iot
 

--- a/apps/src/provisioning_policy.cpp
+++ b/apps/src/provisioning_policy.cpp
@@ -1,5 +1,9 @@
 #include "provisioning_policy.hpp"
 
+#include <nlohmann/json.hpp>
+
+#include "psk_gen.hpp"
+
 namespace iot {
 
 EndpointResolution resolve_endpoint(
@@ -38,6 +42,49 @@ bool is_coap_client_error(std::uint8_t coap_code) {
 
 bool should_rebootstrap(bool dm_dtls_failed, bool dm_registration_rejected) {
     return dm_dtls_failed || dm_registration_rejected;
+}
+
+std::string resolve_bs_psk(const std::string& credentials_json,
+                           const std::string& presented,
+                           const std::string& master_hex) {
+    if (presented.empty()) return {};
+
+    // 1) Commissioned tier: a row whose sha256(serial)[:32] == presented.
+    const auto arr =
+        nlohmann::json::parse(credentials_json, /*cb*/nullptr,
+                              /*allow_exceptions*/false);
+    if (arr.is_array()) {
+        for (const auto& e : arr) {
+            if (!e.is_object()) continue;
+            const std::string serial = e.value("serial", std::string());
+            const std::string key    = e.value("bs.psk.key", std::string());
+            if (!serial.empty() && !key.empty() &&
+                sha256_hex(serial).substr(0, 32) == presented)
+                return key;
+        }
+    }
+
+    // 2) Zero-touch tier: derive from the presented raw serial (verbatim).
+    if (!master_hex.empty())
+        return derive_bs_psk_hex(master_hex, presented);
+
+    // 3) No match — handshake fails.
+    return {};
+}
+
+bool should_mint_dm(const std::string& credentials_json,
+                    const std::string& serial) {
+    if (serial.empty()) return false;
+    const auto arr =
+        nlohmann::json::parse(credentials_json, /*cb*/nullptr,
+                              /*allow_exceptions*/false);
+    if (arr.is_array()) {
+        for (const auto& e : arr) {
+            if (e.is_object() && e.value("serial", std::string()) == serial)
+                return false;   // already provisioned → reuse, don't re-mint
+        }
+    }
+    return true;                // no row → mint
 }
 
 } // namespace iot

--- a/apps/src/psk_gen.cpp
+++ b/apps/src/psk_gen.cpp
@@ -5,6 +5,7 @@
 #include <vector>
 
 #include <openssl/evp.h>
+#include <openssl/kdf.h>
 
 namespace iot {
 
@@ -72,6 +73,50 @@ std::string sha256_hex(const std::string& input) {
     }
     EVP_MD_CTX_free(ctx);
     return hex_encode(digest, dlen);
+}
+
+std::string hkdf_sha256(const std::string& ikm,
+                        const std::string& salt,
+                        const std::string& info,
+                        std::size_t        out_len) {
+    // RFC 5869 §2.2: an empty salt is substituted with HashLen zero bytes.
+    // Doing this explicitly (rather than relying on OpenSSL's no-salt default)
+    // keeps the result identical to the host-side Python generator, which does
+    // the same substitution.
+    static const unsigned char zeros[32] = {0};
+    const unsigned char* salt_ptr =
+        salt.empty() ? zeros
+                     : reinterpret_cast<const unsigned char*>(salt.data());
+    const int salt_len = salt.empty() ? static_cast<int>(sizeof zeros)
+                                       : static_cast<int>(salt.size());
+
+    EVP_PKEY_CTX* pctx = EVP_PKEY_CTX_new_id(EVP_PKEY_HKDF, nullptr);
+    if (!pctx) throw std::runtime_error("hkdf_sha256: ctx alloc failed");
+
+    std::vector<unsigned char> out(out_len);
+    std::size_t outlen = out_len;
+    const bool ok =
+        EVP_PKEY_derive_init(pctx) == 1 &&
+        EVP_PKEY_CTX_set_hkdf_md(pctx, EVP_sha256()) == 1 &&
+        EVP_PKEY_CTX_set1_hkdf_salt(pctx, salt_ptr, salt_len) == 1 &&
+        EVP_PKEY_CTX_set1_hkdf_key(
+            pctx, reinterpret_cast<const unsigned char*>(ikm.data()),
+            static_cast<int>(ikm.size())) == 1 &&
+        EVP_PKEY_CTX_add1_hkdf_info(
+            pctx, reinterpret_cast<const unsigned char*>(info.data()),
+            static_cast<int>(info.size())) == 1 &&
+        EVP_PKEY_derive(pctx, out.data(), &outlen) == 1 &&
+        outlen == out_len;
+    EVP_PKEY_CTX_free(pctx);
+    if (!ok) throw std::runtime_error("hkdf_sha256: derive failed");
+    return hex_encode(out.data(), out_len);
+}
+
+std::string derive_bs_psk_hex(const std::string& master_hex,
+                              const std::string& serial) {
+    const std::string ikm = hex_decode(master_hex);
+    if (ikm.empty()) return {};   // empty or malformed master ⇒ tier disabled
+    return hkdf_sha256(ikm, /*salt=*/"", "iot-bs-psk:v1:" + serial, 32);
 }
 
 } // namespace iot

--- a/apps/src/psk_gen.cpp
+++ b/apps/src/psk_gen.cpp
@@ -119,4 +119,152 @@ std::string derive_bs_psk_hex(const std::string& master_hex,
     return hkdf_sha256(ikm, /*salt=*/"", "iot-bs-psk:v1:" + serial, 32);
 }
 
+namespace {
+
+const char kB64Alpha[] =
+    "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+int b64_val(char c) {
+    if (c >= 'A' && c <= 'Z') return c - 'A';
+    if (c >= 'a' && c <= 'z') return c - 'a' + 26;
+    if (c >= '0' && c <= '9') return c - '0' + 52;
+    if (c == '+') return 62;
+    if (c == '/') return 63;
+    return -1;
+}
+
+} // namespace
+
+std::string base64_encode(const std::string& bin) {
+    std::string out;
+    out.reserve((bin.size() + 2) / 3 * 4);
+    std::size_t i = 0;
+    const auto* p = reinterpret_cast<const unsigned char*>(bin.data());
+    for (; i + 3 <= bin.size(); i += 3) {
+        const unsigned n = (p[i] << 16) | (p[i + 1] << 8) | p[i + 2];
+        out.push_back(kB64Alpha[(n >> 18) & 0x3F]);
+        out.push_back(kB64Alpha[(n >> 12) & 0x3F]);
+        out.push_back(kB64Alpha[(n >> 6) & 0x3F]);
+        out.push_back(kB64Alpha[n & 0x3F]);
+    }
+    if (i + 1 == bin.size()) {
+        const unsigned n = p[i] << 16;
+        out.push_back(kB64Alpha[(n >> 18) & 0x3F]);
+        out.push_back(kB64Alpha[(n >> 12) & 0x3F]);
+        out.append("==");
+    } else if (i + 2 == bin.size()) {
+        const unsigned n = (p[i] << 16) | (p[i + 1] << 8);
+        out.push_back(kB64Alpha[(n >> 18) & 0x3F]);
+        out.push_back(kB64Alpha[(n >> 12) & 0x3F]);
+        out.push_back(kB64Alpha[(n >> 6) & 0x3F]);
+        out.push_back('=');
+    }
+    return out;
+}
+
+std::string base64_decode(const std::string& b64) {
+    if (b64.size() % 4 != 0) return {};
+    std::string out;
+    out.reserve(b64.size() / 4 * 3);
+    for (std::size_t i = 0; i < b64.size(); i += 4) {
+        const char c0 = b64[i], c1 = b64[i + 1], c2 = b64[i + 2], c3 = b64[i + 3];
+        const int v0 = b64_val(c0), v1 = b64_val(c1);
+        if (v0 < 0 || v1 < 0) return {};
+        out.push_back(static_cast<char>((v0 << 2) | (v1 >> 4)));
+        if (c2 == '=') {
+            if (c3 != '=' || i + 4 != b64.size()) return {};
+            break;
+        }
+        const int v2 = b64_val(c2);
+        if (v2 < 0) return {};
+        out.push_back(static_cast<char>(((v1 & 0xF) << 4) | (v2 >> 2)));
+        if (c3 == '=') {
+            if (i + 4 != b64.size()) return {};
+            break;
+        }
+        const int v3 = b64_val(c3);
+        if (v3 < 0) return {};
+        out.push_back(static_cast<char>(((v2 & 0x3) << 6) | v3));
+    }
+    return out;
+}
+
+std::string wrap_bs_master(const std::string& kek_hex,
+                           const std::string& master_hex,
+                           const std::string& nonce_hex) {
+    const std::string kek   = hex_decode(kek_hex);
+    const std::string ptext = hex_decode(master_hex);
+    const std::string nonce = hex_decode(nonce_hex);
+    if (kek.size() != 32 || nonce.size() != 12 || ptext.empty()) return {};
+
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) throw std::runtime_error("wrap_bs_master: ctx alloc failed");
+    std::string ct(ptext.size(), '\0');
+    unsigned char tag[16];
+    int len = 0;
+    int aad_len = 0;
+    const bool ok =
+        EVP_EncryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) == 1 &&
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 12, nullptr) == 1 &&
+        EVP_EncryptInit_ex(ctx, nullptr, nullptr,
+            reinterpret_cast<const unsigned char*>(kek.data()),
+            reinterpret_cast<const unsigned char*>(nonce.data())) == 1 &&
+        EVP_EncryptUpdate(ctx, nullptr, &aad_len,
+            reinterpret_cast<const unsigned char*>(kBsMasterAad),
+            static_cast<int>(std::char_traits<char>::length(kBsMasterAad))) == 1 &&
+        EVP_EncryptUpdate(ctx,
+            reinterpret_cast<unsigned char*>(&ct[0]), &len,
+            reinterpret_cast<const unsigned char*>(ptext.data()),
+            static_cast<int>(ptext.size())) == 1 &&
+        EVP_EncryptFinal_ex(ctx,
+            reinterpret_cast<unsigned char*>(&ct[0]) + len, &len) == 1 &&
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_GET_TAG, 16, tag) == 1;
+    EVP_CIPHER_CTX_free(ctx);
+    if (!ok) throw std::runtime_error("wrap_bs_master: encrypt failed");
+
+    std::string blob = nonce + ct +
+        std::string(reinterpret_cast<char*>(tag), sizeof tag);
+    return base64_encode(blob);
+}
+
+std::optional<std::string> unwrap_bs_master_hex(const std::string& kek_hex,
+                                                const std::string& wrapped_b64) {
+    const std::string kek = hex_decode(kek_hex);
+    if (kek.size() != 32) return std::nullopt;
+    const std::string blob = base64_decode(wrapped_b64);
+    if (blob.size() < 12 + 16 + 1) return std::nullopt;   // nonce+tag+≥1B ct
+
+    const std::string nonce = blob.substr(0, 12);
+    const std::string tag   = blob.substr(blob.size() - 16);
+    const std::string ct    = blob.substr(12, blob.size() - 12 - 16);
+
+    EVP_CIPHER_CTX* ctx = EVP_CIPHER_CTX_new();
+    if (!ctx) throw std::runtime_error("unwrap_bs_master_hex: ctx alloc failed");
+    std::string ptext(ct.size(), '\0');
+    int len = 0, aad_len = 0;
+    bool ok =
+        EVP_DecryptInit_ex(ctx, EVP_aes_256_gcm(), nullptr, nullptr, nullptr) == 1 &&
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_IVLEN, 12, nullptr) == 1 &&
+        EVP_DecryptInit_ex(ctx, nullptr, nullptr,
+            reinterpret_cast<const unsigned char*>(kek.data()),
+            reinterpret_cast<const unsigned char*>(nonce.data())) == 1 &&
+        EVP_DecryptUpdate(ctx, nullptr, &aad_len,
+            reinterpret_cast<const unsigned char*>(kBsMasterAad),
+            static_cast<int>(std::char_traits<char>::length(kBsMasterAad))) == 1 &&
+        EVP_DecryptUpdate(ctx,
+            reinterpret_cast<unsigned char*>(&ptext[0]), &len,
+            reinterpret_cast<const unsigned char*>(ct.data()),
+            static_cast<int>(ct.size())) == 1 &&
+        EVP_CIPHER_CTX_ctrl(ctx, EVP_CTRL_GCM_SET_TAG, 16,
+            const_cast<char*>(tag.data())) == 1;
+    // Final verifies the tag: >0 ⇒ authentic, ≤0 ⇒ tamper/wrong key.
+    if (ok)
+        ok = EVP_DecryptFinal_ex(
+                 ctx, reinterpret_cast<unsigned char*>(&ptext[0]) + len, &len) == 1;
+    EVP_CIPHER_CTX_free(ctx);
+    if (!ok) return std::nullopt;
+    return hex_encode(reinterpret_cast<const unsigned char*>(ptext.data()),
+                      ptext.size());
+}
+
 } // namespace iot

--- a/apps/test/provisioning_policy_test.cpp
+++ b/apps/test/provisioning_policy_test.cpp
@@ -80,3 +80,59 @@ TEST(Rebootstrap, TriggersOnRegistrationReject) {
 TEST(Rebootstrap, NoTriggerWhenHealthy) {
     EXPECT_FALSE(iot::should_rebootstrap(false, false));
 }
+
+// ── Zero-touch BS PSK resolver — tdd-bs-hkdf-zerotouch.md ─────────────────────
+
+namespace {
+// Shared with apps/test/psk_gen_test.cpp / test_gen_bs_psk.py.
+const char* kMaster = "000102030405060708090a0b0c0d0e0f"
+                      "101112131415161718191a1b1c1d1e1f";
+const char* kSerial = "100000003d1f9c2e";
+const char* kDerivedPsk = "223a82da7acb983c1372ec5e72c77d00"
+                          "8fc40281e737bb4aea689f53600d4fe5";
+// sha256("100000003d1f9c2e")[:32] — the commissioned-tier wire identity.
+const char* kSha256Id = "c5dd8a100c796a384fdaec5334b0da71";
+} // namespace
+
+TEST(ResolveBsPsk, CommissionedRowWinsOverDerivation) {
+    // A row keyed by sha256(serial)[:32] returns its stored key even when a
+    // master is set — the device-ui-provisioned tier is unchanged.
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","bs.psk.key":"feedface"}])";
+    EXPECT_EQ("feedface", iot::resolve_bs_psk(creds, kSha256Id, kMaster));
+}
+
+TEST(ResolveBsPsk, DerivesFromRawSerialWhenNoRow) {
+    // Zero-touch: no row, master set, peer presented its raw serial verbatim.
+    EXPECT_EQ(kDerivedPsk, iot::resolve_bs_psk("[]", kSerial, kMaster));
+}
+
+TEST(ResolveBsPsk, NoMasterAndNoRowYieldsEmpty) {
+    EXPECT_EQ("", iot::resolve_bs_psk("[]", kSerial, ""));
+}
+
+TEST(ResolveBsPsk, EmptyPresentedYieldsEmpty) {
+    EXPECT_EQ("", iot::resolve_bs_psk("[]", "", kMaster));
+}
+
+TEST(ResolveBsPsk, MalformedCredentialsFallsThroughToDerive) {
+    // Garbage credentials must not crash; with a master we still derive.
+    EXPECT_EQ(kDerivedPsk, iot::resolve_bs_psk("not json", kSerial, kMaster));
+    EXPECT_EQ("", iot::resolve_bs_psk("not json", kSerial, ""));
+}
+
+TEST(ShouldMintDm, MintsWhenNoRow) {
+    EXPECT_TRUE(iot::should_mint_dm("[]", kSerial));
+    EXPECT_TRUE(iot::should_mint_dm(
+        R"([{"serial":"other"}])", kSerial));
+}
+
+TEST(ShouldMintDm, ReusesWhenRowExists) {
+    EXPECT_FALSE(iot::should_mint_dm(
+        R"([{"serial":"100000003d1f9c2e","dm.psk.key":"x"}])", kSerial));
+}
+
+TEST(ShouldMintDm, EmptySerialOrBadJsonNeverMints) {
+    EXPECT_FALSE(iot::should_mint_dm("[]", ""));
+    EXPECT_TRUE(iot::should_mint_dm("not json", kSerial));  // no row → mint
+}

--- a/apps/test/psk_gen_test.cpp
+++ b/apps/test/psk_gen_test.cpp
@@ -44,3 +44,63 @@ TEST(PskGen, NotConstantAcrossCalls) {
     for (int i = 0; i < 5; ++i) seen.insert(iot::generate_psk_hex(32));
     EXPECT_EQ(5u, seen.size());
 }
+
+// ── HKDF (zero-touch BS PSK derivation) — apps/docs/tdd-bs-hkdf-zerotouch.md ──
+
+TEST(Hkdf, Rfc5869TestCase1) {
+    // RFC 5869 Appendix A.1 — SHA-256, with salt + info.
+    std::string ikm  = iot::hex_decode(
+        "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    std::string salt = iot::hex_decode("000102030405060708090a0b0c");
+    std::string info = iot::hex_decode("f0f1f2f3f4f5f6f7f8f9");
+    EXPECT_EQ("3cb25f25faacd57a90434f64d0362f2a"
+              "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+              "34007208d5b887185865",
+              iot::hkdf_sha256(ikm, salt, info, 42));
+}
+
+TEST(Hkdf, Rfc5869TestCase3ZeroLengthSaltAndInfo) {
+    // RFC 5869 Appendix A.3 — empty salt (→ HashLen zeros) and empty info.
+    std::string ikm = iot::hex_decode(
+        "0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b0b");
+    EXPECT_EQ("8da4e775a563c18f715f802a063c5a31"
+              "b8a11f5c5ee1879ec3454e5f3c738d2d"
+              "9d201395faa4b61a96c8",
+              iot::hkdf_sha256(ikm, /*salt=*/"", /*info=*/"", 42));
+}
+
+TEST(Hkdf, EmptySaltEqualsHashLenZeros) {
+    // The "" salt path must equal an explicit 32-zero-byte salt.
+    std::string ikm  = iot::hex_decode("0b0b0b0b0b0b0b0b");
+    std::string info = "ctx";
+    std::string zeros32(32, '\0');
+    EXPECT_EQ(iot::hkdf_sha256(ikm, zeros32, info, 32),
+              iot::hkdf_sha256(ikm, /*salt=*/"", info, 32));
+}
+
+TEST(DeriveBsPsk, MatchesSharedCrossCheckVector) {
+    // This vector is shared VERBATIM with test_gen_bs_psk.py so the cloud C++
+    // and the host Python flashing tool can never drift. Do not change one
+    // side without the other — they MUST produce identical keys.
+    const std::string master_hex =
+        "000102030405060708090a0b0c0d0e0f"
+        "101112131415161718191a1b1c1d1e1f";
+    EXPECT_EQ("223a82da7acb983c1372ec5e72c77d00"
+              "8fc40281e737bb4aea689f53600d4fe5",
+              iot::derive_bs_psk_hex(master_hex, "100000003d1f9c2e"));
+}
+
+TEST(DeriveBsPsk, IsDeterministicAndSerialBound) {
+    const std::string m = iot::generate_psk_hex(32);
+    EXPECT_EQ(iot::derive_bs_psk_hex(m, "serialA"),
+              iot::derive_bs_psk_hex(m, "serialA"));   // deterministic
+    EXPECT_NE(iot::derive_bs_psk_hex(m, "serialA"),
+              iot::derive_bs_psk_hex(m, "serialB"));   // bound to serial
+    EXPECT_EQ(64u, iot::derive_bs_psk_hex(m, "serialA").size());
+}
+
+TEST(DeriveBsPsk, EmptyOrBadMasterDisablesTier) {
+    EXPECT_EQ("", iot::derive_bs_psk_hex("", "serial"));      // no master
+    EXPECT_EQ("", iot::derive_bs_psk_hex("abc", "serial"));   // odd length
+    EXPECT_EQ("", iot::derive_bs_psk_hex("zz", "serial"));    // non-hex
+}

--- a/apps/test/psk_gen_test.cpp
+++ b/apps/test/psk_gen_test.cpp
@@ -2,6 +2,7 @@
 
 #include <gtest/gtest.h>
 
+#include <optional>
 #include <set>
 #include <string>
 
@@ -103,4 +104,76 @@ TEST(DeriveBsPsk, EmptyOrBadMasterDisablesTier) {
     EXPECT_EQ("", iot::derive_bs_psk_hex("", "serial"));      // no master
     EXPECT_EQ("", iot::derive_bs_psk_hex("abc", "serial"));   // odd length
     EXPECT_EQ("", iot::derive_bs_psk_hex("zz", "serial"));    // non-hex
+}
+
+// ── base64 ───────────────────────────────────────────────────────────────────
+
+TEST(Base64, RoundTripsIncludingNulAndEmpty) {
+    EXPECT_EQ("", iot::base64_encode(""));
+    EXPECT_EQ("", iot::base64_decode(""));
+    EXPECT_EQ("aGVsbG8=", iot::base64_encode("hello"));   // known vector
+    const std::string raw("\x00\x01\x02\xff\x10z", 6);
+    EXPECT_EQ(raw, iot::base64_decode(iot::base64_encode(raw)));
+}
+
+TEST(Base64, RejectsMalformed) {
+    EXPECT_EQ("", iot::base64_decode("abc"));     // length not multiple of 4
+    EXPECT_EQ("", iot::base64_decode("a!=="));    // invalid char
+    EXPECT_EQ("", iot::base64_decode("a=b="));    // misplaced padding
+}
+
+// ── BS master AES-256-GCM envelope ───────────────────────────────────────────
+
+namespace {
+// Deterministic vector — wrap_bs_master(KEK, MASTER, NONCE) produced this blob
+// (verified in podman). Locks the on-disk envelope format so a future refactor
+// that changes layout/AAD/base64 fails loudly.
+const char* kEnvKek    = "0101010101010101010101010101010101010101010101010101010101010101";
+const char* kEnvMaster = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f";
+const char* kEnvNonce  = "0b0b0b0b0b0b0b0b0b0b0b0b";
+const char* kEnvBlob   =
+    "CwsLCwsLCwsLCwsLvSPRai0N5R/JTXdybWG5SZ/lsc2/iF2o+2QR4pd/067Rwn3QtVkJvc/fXbVrVwBb";
+} // namespace
+
+TEST(BsMasterEnvelope, FixedVectorWrapsToKnownBlob) {
+    EXPECT_EQ(kEnvBlob, iot::wrap_bs_master(kEnvKek, kEnvMaster, kEnvNonce));
+}
+
+TEST(BsMasterEnvelope, UnwrapRecoversMaster) {
+    auto m = iot::unwrap_bs_master_hex(kEnvKek, kEnvBlob);
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(kEnvMaster, *m);
+    // …and the recovered master derives the same per-device PSK.
+    EXPECT_EQ("223a82da7acb983c1372ec5e72c77d00"
+              "8fc40281e737bb4aea689f53600d4fe5",
+              iot::derive_bs_psk_hex(*m, "100000003d1f9c2e"));
+}
+
+TEST(BsMasterEnvelope, RoundTripWithRandomNonce) {
+    const std::string kek = iot::generate_psk_hex(32);
+    const std::string master = iot::generate_psk_hex(32);
+    const std::string nonce = iot::generate_psk_hex(12);
+    auto m = iot::unwrap_bs_master_hex(kek, iot::wrap_bs_master(kek, master, nonce));
+    ASSERT_TRUE(m.has_value());
+    EXPECT_EQ(master, *m);
+}
+
+TEST(BsMasterEnvelope, FailsClosedOnTamperWrongKeyAndGarbage) {
+    std::string bad = kEnvBlob;
+    bad[5] = (bad[5] == 'A') ? 'B' : 'A';
+    EXPECT_FALSE(iot::unwrap_bs_master_hex(kEnvKek, bad).has_value());   // tamper
+
+    std::string kek2 = kEnvKek;
+    kek2[0] = (kek2[0] == '0') ? '2' : '0';
+    EXPECT_FALSE(iot::unwrap_bs_master_hex(kek2, kEnvBlob).has_value());  // wrong KEK
+
+    EXPECT_FALSE(iot::unwrap_bs_master_hex("", kEnvBlob).has_value());    // no KEK
+    EXPECT_FALSE(iot::unwrap_bs_master_hex(kEnvKek, "").has_value());     // empty
+    EXPECT_FALSE(iot::unwrap_bs_master_hex(kEnvKek, "!!!!").has_value()); // bad b64
+}
+
+TEST(BsMasterEnvelope, WrapRejectsBadSizes) {
+    EXPECT_EQ("", iot::wrap_bs_master("ab", kEnvMaster, kEnvNonce));      // KEK ≠ 32B
+    EXPECT_EQ("", iot::wrap_bs_master(kEnvKek, kEnvMaster, "0b0b"));      // nonce ≠ 12B
+    EXPECT_EQ("", iot::wrap_bs_master(kEnvKek, "", kEnvNonce));           // empty master
 }

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -266,6 +266,23 @@ return {
         write_acl = {"gid:cloud-svc"},
         read_acl  = {"gid:cloud-svc"},
     },
+    -- Zero-touch bootstrap (HKDF tier) — apps/docs/tdd-bs-hkdf-zerotouch.md.
+    -- The HKDF master that lets the BS server re-derive any device's BS PSK
+    -- from its serial, so no per-device row has to be pre-created here. Stored
+    -- AES-256-GCM-wrapped (KMS envelope): base64(nonce || ct || tag) under a
+    -- KEK delivered to iot-lwm2m-server out-of-band (systemd LoadCredential /
+    -- env IOT_BS_MASTER_KEK) — never via the data-store. The server unwraps
+    -- once at startup and holds the master in memory only. Empty default ⇒
+    -- HKDF tier disabled (commissioned per-device tier still works). The build
+    -- bakes a wrapped master here from a gitignored bs_master.lua (cloud image
+    -- only). Write-only to ds-cli, like the per-device PSK keys.
+    ["cloud.bs.master.key"] = {
+        access    = "Admin",
+        type      = "opaque",
+        default   = "",
+        write_acl = {"gid:cloud-svc"},
+        read_acl  = {"gid:cloud-svc"},
+    },
     -- Provision carrier: the engineer pastes the device-generated BS PSK
     -- here, then sets cloud.provision.request = serial (the trigger).
     -- iot-cloudd reads this, mints the DM PSK, upserts the credential

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/gen_bs_master.py
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/gen_bs_master.py
@@ -1,0 +1,87 @@
+#!/usr/bin/env python3
+"""Build-time generator: bake a wrapped BS HKDF master into the cloud schema.
+
+Zero-touch bootstrap (apps/docs/tdd-bs-hkdf-zerotouch.md). Mirrors
+gen_wifi_default.py, but for the CLOUD image only: when an (optional,
+gitignored) bs_master.lua is present, rewrite the `cloud.bs.master.key`
+`default = "…"` of the already-installed schemas/cloud.lua in place with the
+AES-256-GCM-wrapped master.
+
+Pure schema rewrite — NO crypto here. The master is wrapped out-of-band by the
+`bs-master-wrap` tool (C++/OpenSSL), and bs_master.lua carries only the already
+-wrapped base64 envelope:
+
+    return { wrapped = "<base64( nonce || ciphertext || tag )>" }
+
+The wrapping KEK is NEVER baked into the image — it is delivered to the cloud
+BS server at runtime (systemd LoadCredential / env IOT_BS_MASTER_KEK). So the
+image holds only ciphertext; without the KEK it is inert.
+
+Usage:  gen_bs_master.py <bs_master.lua> <installed cloud.lua>
+"""
+
+import re
+import sys
+
+# The wrapped blob is standard base64 (A–Z a–z 0–9 + / =). No quotes, so a
+# simple double-quoted literal capture is unambiguous.
+_WRAPPED_RE = re.compile(r"""wrapped\s*=\s*["']([A-Za-z0-9+/=]+)["']""")
+
+# Anchor on the cloud.bs.master.key key, then its double-quoted default literal.
+_DEFAULT_RE = re.compile(
+    r'(\["cloud\.bs\.master\.key"\]\s*=\s*\{.*?default\s*=\s*)"([^"]*)"',
+    re.DOTALL)
+
+
+def parse_wrapped(text):
+    """Return the base64 wrapped-master string from a bs_master.lua file."""
+    m = _WRAPPED_RE.search(text)
+    if not m:
+        raise ValueError("no `wrapped = \"<base64>\"` found in bs_master.lua")
+    blob = m.group(1)
+    # base64 of (12B nonce + ≥1B ct + 16B tag) = ≥29 bytes → ≥40 b64 chars.
+    if len(blob) < 40 or len(blob) % 4 != 0:
+        raise ValueError("wrapped master is not a plausible base64 envelope")
+    return blob
+
+
+def rewrite_master_default(schema_text, wrapped):
+    """Return schema_text with the cloud.bs.master.key default set to wrapped."""
+    if not _DEFAULT_RE.search(schema_text):
+        raise ValueError("cloud.bs.master.key default not found in schema")
+    return _DEFAULT_RE.sub(lambda m: m.group(1) + '"' + wrapped + '"',
+                           schema_text, count=1)
+
+
+def extract_master_default(schema_text):
+    """Return the cloud.bs.master.key default string from a schema."""
+    m = _DEFAULT_RE.search(schema_text)
+    if not m:
+        raise ValueError("cloud.bs.master.key default not found in schema")
+    return m.group(2)
+
+
+def main(argv):
+    if len(argv) != 3:
+        sys.stderr.write("usage: gen_bs_master.py "
+                         "<bs_master.lua> <installed cloud.lua>\n")
+        return 2
+    master_path, schema_path = argv[1], argv[2]
+    try:
+        with open(master_path, encoding="utf-8") as fh:
+            wrapped = parse_wrapped(fh.read())
+        with open(schema_path, encoding="utf-8") as fh:
+            schema = fh.read()
+        out = rewrite_master_default(schema, wrapped)
+        with open(schema_path, "w", encoding="utf-8") as fh:
+            fh.write(out)
+    except (ValueError, OSError) as exc:
+        sys.stderr.write("gen_bs_master: %s\n" % exc)
+        return 2
+    sys.stderr.write("gen_bs_master: seeded cloud.bs.master.key from %s\n"
+                     % master_path)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/gen_bs_psk.py
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/gen_bs_psk.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Host-side derivation of a device's per-unit Bootstrap (BS) PSK.
+
+Zero-touch bootstrap (see apps/docs/tdd-bs-hkdf-zerotouch.md): the cloud holds a
+single master secret and re-derives each device's BS PSK on demand from the
+device serial; the manufacturing/flashing host derives the SAME key locally
+(offline, no cloud call) and injects it into the unit being flashed.
+
+This module is the host half. It MUST produce byte-for-byte the same key as the
+cloud C++ `iot::derive_bs_psk_hex` (apps/src/psk_gen.cpp). The shared
+cross-check vector in test_gen_bs_psk.py (mirrored in apps/test/psk_gen_test.cpp)
+guards against the two implementations drifting.
+
+Construction (pinned — do not change without bumping the `v1` tag and both
+implementations):
+
+    psk = HKDF-SHA256(ikm  = bytes.fromhex(master_hex),
+                      salt = "" -> 32 zero bytes  (RFC 5869 §2.2),
+                      info = b"iot-bs-psk:v1:" + serial,
+                      L    = 32)
+    iot.bs.psk.key = psk.hex()        # 64 lowercase hex chars
+
+Pure stdlib (hmac + hashlib) so it runs on a bare manufacturing host with no
+`cryptography` package.
+
+Usage:
+    gen_bs_psk.py <master> <serial>
+
+`<master>` is either a 64-hex master key directly, or a path to a
+`bs_master.lua` file of the form `return { master = "<hex>" }`. Prints the
+64-hex per-unit BS PSK to stdout.
+"""
+
+import hashlib
+import hmac
+import os
+import re
+import sys
+
+INFO_PREFIX = b"iot-bs-psk:v1:"   # MUST match iot::derive_bs_psk_hex
+PSK_BYTES = 32
+
+
+# ───────────────────────────────── HKDF ─────────────────────────────────────
+
+def hkdf_sha256(ikm: bytes, salt: bytes, info: bytes, length: int) -> bytes:
+    """HKDF-SHA256 (RFC 5869), extract-then-expand.
+
+    A zero-length salt is substituted with HashLen zero bytes per RFC 5869
+    §2.2 — matching the C++ side, which does the same substitution.
+    """
+    hash_len = hashlib.sha256().digest_size
+    if not salt:
+        salt = b"\x00" * hash_len
+    prk = hmac.new(salt, ikm, hashlib.sha256).digest()       # extract
+    okm, block, counter = b"", b"", 1                        # expand
+    while len(okm) < length:
+        block = hmac.new(prk, block + info + bytes([counter]),
+                         hashlib.sha256).digest()
+        okm += block
+        counter += 1
+    return okm[:length]
+
+
+def derive_bs_psk_hex(master_hex: str, serial: str) -> str:
+    """Per-unit BS PSK as 64 lowercase hex chars. Mirrors the C++ helper.
+
+    Raises ValueError on an empty / non-hex / odd-length master so the build or
+    flashing step fails loudly rather than injecting a wrong key. (The C++ side
+    returns "" to mean "tier disabled"; here we hard-fail because a host asked
+    to derive a key must have a real master.)
+    """
+    master_hex = master_hex.strip().lower()
+    if not master_hex:
+        raise ValueError("master key is empty")
+    if len(master_hex) % 2 != 0 or not re.fullmatch(r"[0-9a-f]+", master_hex):
+        raise ValueError("master key is not valid lowercase hex")
+    serial = serial.strip()
+    if not serial:
+        raise ValueError("serial is empty")
+    ikm = bytes.fromhex(master_hex)
+    info = INFO_PREFIX + serial.encode()
+    return hkdf_sha256(ikm, b"", info, PSK_BYTES).hex()
+
+
+# ──────────────────────────── master key loading ────────────────────────────
+
+_MASTER_RE = re.compile(
+    r"""master\s*=\s*['"]([0-9a-fA-F]+)['"]""")
+
+
+def load_master(master_or_path: str) -> str:
+    """Return a hex master from either a literal hex string or a bs_master.lua
+    file (`return { master = "<hex>" }`)."""
+    if os.path.isfile(master_or_path):
+        with open(master_or_path, encoding="utf-8") as fh:
+            text = fh.read()
+        m = _MASTER_RE.search(text)
+        if not m:
+            raise ValueError("no `master = \"<hex>\"` found in %s"
+                             % master_or_path)
+        return m.group(1)
+    return master_or_path
+
+
+# ───────────────────────────────── CLI ──────────────────────────────────────
+
+def main(argv):
+    if len(argv) != 3:
+        sys.stderr.write("usage: gen_bs_psk.py <master|bs_master.lua> "
+                         "<serial>\n")
+        return 2
+    try:
+        master_hex = load_master(argv[1])
+        sys.stdout.write(derive_bs_psk_hex(master_hex, argv[2]) + "\n")
+    except (ValueError, OSError) as exc:
+        sys.stderr.write("gen_bs_psk: %s\n" % exc)
+        return 2
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/test_gen_bs_master.py
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/test_gen_bs_master.py
@@ -1,0 +1,79 @@
+#!/usr/bin/env python3
+"""Unit tests for gen_bs_master.py — the build-time generator that bakes a
+wrapped BS HKDF master into the cloud.bs.master.key schema default.
+
+Pure-Python, no toolchain:
+    python3 -m unittest discover -s <this dir> -p 'test_gen_bs_master.py'
+"""
+
+import unittest
+
+import gen_bs_master as g
+
+
+# Minimal stand-in for schemas/cloud.lua: the cloud.bs.master.key default plus
+# sibling keys whose `default =` lines MUST stay untouched by the rewrite.
+SCHEMA = '''return {
+  namespace = "cloud",
+  keys = {
+    ["cloud.bs.psk.key"]    = { access = "Admin", type = "opaque", default = "" },
+    ["cloud.bs.master.key"] = {
+        access = "Admin", type = "opaque", default = "",
+        write_acl = {"gid:cloud-svc"}, read_acl = {"gid:cloud-svc"} },
+    ["cloud.dm.psk.key"]    = { access = "Admin", type = "opaque", default = "keepme" },
+  },
+}
+'''
+
+# A plausible base64 envelope (the deterministic test vector from
+# apps/test/psk_gen_test.cpp BsMasterEnvelope — base64 of nonce||ct||tag).
+BLOB = ("CwsLCwsLCwsLCwsLvSPRai0N5R/JTXdybWG5"
+        "SZ/lsc2/iF2o+2QR4pd/067Rwn3QtVkJvc/fXbVrVwBb")
+
+
+class ParseWrapped(unittest.TestCase):
+    def test_extracts_blob(self):
+        self.assertEqual(
+            g.parse_wrapped('return { wrapped = "%s" }' % BLOB), BLOB)
+
+    def test_single_quotes_ok(self):
+        self.assertEqual(
+            g.parse_wrapped("return { wrapped = '%s' }" % BLOB), BLOB)
+
+    def test_missing_wrapped_raises(self):
+        with self.assertRaises(ValueError):
+            g.parse_wrapped('return { nope = "x" }')
+
+    def test_short_or_misaligned_blob_raises(self):
+        with self.assertRaises(ValueError):
+            g.parse_wrapped('return { wrapped = "AAAA" }')        # too short
+        with self.assertRaises(ValueError):
+            g.parse_wrapped('return { wrapped = "%s" }' % (BLOB[:-1]))  # not %4
+
+
+class RewriteDefault(unittest.TestCase):
+    def test_rewrites_only_master_default(self):
+        out = g.rewrite_master_default(SCHEMA, BLOB)
+        self.assertEqual(g.extract_master_default(out), BLOB)
+        # siblings untouched
+        self.assertIn('["cloud.bs.psk.key"]    = { access = "Admin", '
+                      'type = "opaque", default = "" }', out)
+        self.assertIn('default = "keepme"', out)
+
+    def test_is_idempotent(self):
+        once = g.rewrite_master_default(SCHEMA, BLOB)
+        twice = g.rewrite_master_default(once, BLOB)
+        self.assertEqual(once, twice)
+
+    def test_missing_key_raises(self):
+        with self.assertRaises(ValueError):
+            g.rewrite_master_default('return { keys = {} }', BLOB)
+
+
+class Cli(unittest.TestCase):
+    def test_main_bad_args(self):
+        self.assertEqual(g.main(["gen_bs_master.py"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/test_gen_bs_psk.py
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/test_gen_bs_psk.py
@@ -1,0 +1,120 @@
+#!/usr/bin/env python3
+"""Unit tests for gen_bs_psk.py — the host-side per-unit Bootstrap PSK
+derivation used by zero-touch provisioning.
+
+Pure-Python, no toolchain:
+    python3 -m unittest discover -s <this dir> -p 'test_gen_bs_psk.py'
+"""
+
+import os
+import tempfile
+import unittest
+
+import gen_bs_psk as g
+
+
+class Hkdf(unittest.TestCase):
+    """RFC 5869 test vectors — proves the HKDF primitive itself is correct."""
+
+    def test_rfc5869_case1(self):
+        ikm = bytes.fromhex("0b" * 22)
+        salt = bytes.fromhex("000102030405060708090a0b0c")
+        info = bytes.fromhex("f0f1f2f3f4f5f6f7f8f9")
+        self.assertEqual(
+            g.hkdf_sha256(ikm, salt, info, 42).hex(),
+            "3cb25f25faacd57a90434f64d0362f2a"
+            "2d2d0a90cf1a5a4c5db02d56ecc4c5bf"
+            "34007208d5b887185865")
+
+    def test_rfc5869_case3_zero_len_salt_and_info(self):
+        ikm = bytes.fromhex("0b" * 22)
+        self.assertEqual(
+            g.hkdf_sha256(ikm, b"", b"", 42).hex(),
+            "8da4e775a563c18f715f802a063c5a31"
+            "b8a11f5c5ee1879ec3454e5f3c738d2d"
+            "9d201395faa4b61a96c8")
+
+    def test_empty_salt_equals_hashlen_zeros(self):
+        ikm, info = bytes.fromhex("0b0b0b0b0b0b0b0b"), b"ctx"
+        self.assertEqual(
+            g.hkdf_sha256(ikm, b"\x00" * 32, info, 32),
+            g.hkdf_sha256(ikm, b"", info, 32))
+
+
+class DeriveBsPsk(unittest.TestCase):
+
+    # Shared VERBATIM with apps/test/psk_gen_test.cpp
+    # (DeriveBsPsk.MatchesSharedCrossCheckVector). Do not change one side
+    # without the other — the C++ cloud server and this host tool MUST agree.
+    MASTER_HEX = ("000102030405060708090a0b0c0d0e0f"
+                  "101112131415161718191a1b1c1d1e1f")
+    SERIAL = "100000003d1f9c2e"
+    EXPECT = ("223a82da7acb983c1372ec5e72c77d00"
+              "8fc40281e737bb4aea689f53600d4fe5")
+
+    def test_shared_cross_check_vector(self):
+        self.assertEqual(
+            g.derive_bs_psk_hex(self.MASTER_HEX, self.SERIAL), self.EXPECT)
+
+    def test_deterministic_and_serial_bound(self):
+        m = "ab" * 32
+        self.assertEqual(g.derive_bs_psk_hex(m, "A"),
+                         g.derive_bs_psk_hex(m, "A"))
+        self.assertNotEqual(g.derive_bs_psk_hex(m, "A"),
+                            g.derive_bs_psk_hex(m, "B"))
+        self.assertEqual(len(g.derive_bs_psk_hex(m, "A")), 64)
+
+    def test_case_insensitive_master(self):
+        self.assertEqual(
+            g.derive_bs_psk_hex(self.MASTER_HEX.upper(), self.SERIAL),
+            self.EXPECT)
+
+    def test_bad_master_raises(self):
+        for bad in ("", "abc", "zz", "12g4"):
+            with self.assertRaises(ValueError):
+                g.derive_bs_psk_hex(bad, "serial")
+
+    def test_empty_serial_raises(self):
+        with self.assertRaises(ValueError):
+            g.derive_bs_psk_hex(self.MASTER_HEX, "  ")
+
+
+class LoadMaster(unittest.TestCase):
+
+    def test_literal_hex_passthrough(self):
+        self.assertEqual(g.load_master("deadbeef"), "deadbeef")
+
+    def test_reads_bs_master_lua(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "bs_master.lua")
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write('return { master = "00ff00ff" }\n')
+            self.assertEqual(g.load_master(p), "00ff00ff")
+
+    def test_lua_without_master_raises(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = os.path.join(d, "bs_master.lua")
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.write('return { nope = "x" }\n')
+            with self.assertRaises(ValueError):
+                g.load_master(p)
+
+
+class Cli(unittest.TestCase):
+
+    def test_main_prints_derived_key(self):
+        import io
+        from contextlib import redirect_stdout
+        buf = io.StringIO()
+        with redirect_stdout(buf):
+            rc = g.main(["gen_bs_psk.py", DeriveBsPsk.MASTER_HEX,
+                         DeriveBsPsk.SERIAL])
+        self.assertEqual(rc, 0)
+        self.assertEqual(buf.getvalue().strip(), DeriveBsPsk.EXPECT)
+
+    def test_main_bad_args(self):
+        self.assertEqual(g.main(["gen_bs_psk.py"]), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Zero-touch / plug-and-play bootstrap without a fleet-wide class secret (design: `apps/docs/tdd-bs-hkdf-zerotouch.md`; the rejected shared-default alternative is `tdd-bs-default-bootstrap.md`). The cloud holds **one master**; each device's BS PSK is `HKDF-SHA256(master, serial)`, re-derived on demand cloud-side and injected per-unit at flash time. No per-device cloud registration row.

This PR is the **inert, fully-tested foundation** — no behaviour change. Server wiring + deployment is P2b.

## P1 — crypto + parity
- `iot::hkdf_sha256` (OpenSSL `EVP_PKEY_HKDF`, RFC 5869) + `iot::derive_bs_psk_hex(master_hex, serial)` → `HKDF(salt="", info="iot-bs-psk:v1:"+serial, L=32)`, hex.
- Host `gen_bs_psk.py` — pure stdlib (`hmac`+`hashlib`) for bare manufacturing hosts.
- RFC 5869 TC1+TC3 on both sides + a **shared cross-check vector** mirrored verbatim in C++ and Python so the two derivations can never drift.

## P2a — master at rest + resolver decision (this push)
Decisions locked: **flash-time inject** (device) and **AES-256-GCM envelope + KEK via systemd credential** (master at rest — no external KMS, fits Vultr; upgrades to a managed KMS by swapping the KEK source).

- **Envelope crypto** (`base64_*`, `wrap_bs_master`, `unwrap_bs_master_hex`): `base64(nonce||ct||tag)`, AAD `iot-bs-master:v1`. Fail-closed — bad/wrong KEK or tampered blob → `nullopt` → HKDF tier disabled. One implementation only (C++/OpenSSL; Python has no AES-GCM, so the P2b `bs-master-wrap` CLI reuses this — no cross-language envelope to sync).
- **Resolver helpers** (`provisioning_policy`, pure/testable): `resolve_bs_psk` (commissioned-row lookup wins → else HKDF-derive from the presented raw serial → else "") and `should_mint_dm` (mint-once gate so a `/bs` retry never re-mints).
- **Schema**: `cloud.bs.master.key` (opaque, `gid:cloud-svc`, default `""` = tier disabled) — stores the wrapped envelope, not the raw master.
- **Host tool**: `gen_bs_master.py` (+ tests) — pure-stdlib schema rewrite baking a wrapped master into the cloud image (WiFi-seed pattern, cloud-only).

## Verification
- C++: full `lwm2m_test` gtest suite built in `localhost/iot-devbuild` (needs `libsqlite3-dev`+`zlib1g-dev`); **35/35** in the crypto/policy filter (Hkdf, DeriveBsPsk, Base64, BsMasterEnvelope, ResolveBsPsk, ShouldMintDm, + existing).
- Python: **21/21** (`test_gen_bs_psk` + `test_gen_bs_master`).
- The deterministic envelope blob and the HKDF cross-check vector are pinned in the tests as drift guards.

## Not in this PR (P2b+)
`main.cpp` BS-server resolver/mint call sites, the `BsMasterProvider` startup unwrap + KEK delivery, the `bs-master-wrap` CLI, the `IOT_BS_SEED` recipe bake (P2b); device personalisation `iot-bs-personalize` + `iot-ds-seed` (P3); DEPLOY runbook + HW integration (P4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)