### PR TITLE
feat(bs): HKDF zero-touch bootstrap — P2b (BS server wiring) + P3 (device personalisation) + P4 (deploy)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,11 @@ iot-cloud.tar.gz
 # Commit wifi_credentials.lua.sample instead. See apps/docs/tdd-wifi-credentials-seed.md
 yocto/meta-iot/recipes-iot/lwm2m/files/wifi_credentials.lua
 
+# Zero-touch BS HKDF master seed (AES-256-GCM-wrapped blob) — optional cloud
+# image bake. Commit bs_master.lua.sample instead. The raw master + KEK are
+# never committed. See apps/docs/tdd-bs-hkdf-zerotouch.md
+yocto/meta-iot/recipes-iot/lwm2m/files/bs_master.lua
+
 # Python bytecode cache (e.g. from the gen_wifi_default.py tests)
 __pycache__/
 *.pyc

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -308,6 +308,65 @@ journalctl -u iot-lwm2m-client -f
 > default `coaps://0.0.0.0:5683`, or the device bootstraps but can't find
 > the DM server afterwards. See [`apps/cloud/INSTALL.md`](apps/cloud/INSTALL.md) §6.
 
+### 4b. Zero-touch bootstrap (HKDF) — flash → boot → registered, no per-device step
+
+§4 above is the **manual** path: you set the BS PSK per device and commission a
+matching cloud row. The zero-touch path removes both. The cloud holds **one
+HKDF master** and re-derives every device's BS (and DM) PSK from its serial, so
+no per-device cloud row exists; each device is flashed with its own derived key.
+Full design + threat model: [`apps/docs/tdd-bs-hkdf-zerotouch.md`](apps/docs/tdd-bs-hkdf-zerotouch.md).
+
+It is **off by default** — with no master/KEK configured the cloud serves only
+the manual `cloud.endpoint.credentials` tier (nothing changes). Turn it on once:
+
+**One-time cloud setup.** Mint a master + a KEK, wrap the master, give the cloud
+the wrapped blob (data-store) and the KEK (runtime env — never the data-store):
+
+```sh
+# On a trusted host (manufacturing). Keep KEK + master OFF the device/image/git.
+KEK=$(head -c32 /dev/urandom | xxd -p -c64)        # 32-byte Key-Encryption-Key
+BLOB=$(bs-master-wrap "$KEK" --gen-master)         # mints + prints the master to stderr
+#   -> SAVE the printed master in your manufacturing vault (gen_bs_psk needs it)
+
+# Cloud: store the wrapped blob (ciphertext — inert without the KEK).
+ds-cli --socket=/run/iot/data_store.sock set cloud.bs.master.key "$BLOB"
+
+# Cloud: deliver the KEK to the BS+DM server OUT-OF-BAND.
+#   Docker/compose:  add to the lwm2m-server service:  environment:
+#                      - IOT_BS_MASTER_KEK=<the KEK hex>
+#   systemd:         echo -n "$KEK" > /etc/iot/bs-master.kek && chmod 0400 …
+#                    then uncomment LoadCredential= in iot-lwm2m-server.service
+systemctl restart iot-lwm2m-server   # (or recreate the cloud container)
+```
+
+**Per device, at flash time.** Derive the unit's key from the master + serial
+and drop the one-shot seed onto its data partition — the first boot applies and
+shreds it:
+
+```sh
+# RPi serial: cat /proc/cpuinfo | grep -i serial  (or read it off the board)
+iot-bs-personalize @master.hex 100000003d1f9c2e -o /mnt/data/bs-seed.json
+#   -> /mnt/data == the device's /var/lib/iot on the mounted SD data partition
+```
+
+Boot the device with no other step: `iot-ds-seed` sets `iot.bs.psk.*` +
+`iot.bs.psk.override=true` and the device registers. Verify as in §4 (the
+`iot.bs.psk.identity` will be the **raw serial**, not a `cloud.bs.psk.id`).
+
+**Rotation / revocation.**
+- *Rotate the master* (e.g. leak): bump the `v1` tag to `v2` in both
+  `derive_bs_psk_hex`/`derive_dm_psk_hex` (`info`) and re-mint+re-wrap, or run a
+  dual-derive window; re-personalise units and re-`set cloud.bs.master.key`.
+- *Rotate only the KEK:* `bs-master-wrap` the **same** master under a new KEK,
+  re-`set cloud.bs.master.key`, swap the runtime KEK. Devices unaffected.
+- *Revoke one device:* the derived tier has no per-device revocation; move that
+  unit to the manual tier (add a `cloud.endpoint.credentials` row — lookup wins)
+  or rotate the master. (Per-device revocation is a documented limitation.)
+
+> Manual and zero-touch **coexist**: the resolver tries the stored
+> `cloud.endpoint.credentials` row first, then derives. Already-commissioned
+> devices keep working after you enable the master.
+
 ### 5. Push app updates over ssh (the `.ipk` feed)
 
 After the device is up, ship new daemon builds without reflashing —

--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -261,6 +261,13 @@ if(BUILD_APPS_TESTS)
     add_subdirectory(test)
 endif()
 
+# bs-master-wrap — zero-touch HKDF master KMS-wrap operator tool. Lives under
+# tools/ (not src/) so the GLOB above doesn't pull its main() into lwm2m. Links
+# only psk_gen.cpp + OpenSSL.
+add_executable(bs-master-wrap tools/bs_master_wrap.cpp src/psk_gen.cpp)
+target_link_libraries(bs-master-wrap crypto)
+install(TARGETS bs-master-wrap RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
+
 include(GNUInstallDirs)
 
 # Drop the CONFIGURATIONS Release filter so `make install` works in

--- a/apps/docs/tdd-bs-hkdf-zerotouch.md
+++ b/apps/docs/tdd-bs-hkdf-zerotouch.md
@@ -191,12 +191,19 @@ base64( nonce(12) || AES-256-GCM(KEK, master)_ciphertext || tag(16) )
   `nullopt` → the master is treated as absent → HKDF tier disabled (the
   commissioned per-device tier still serves). Never derive against a bad master.
 
-> **Status (P2, this PR):** `base64_encode/decode`, `wrap_bs_master`,
-> `unwrap_bs_master_hex` shipped + tested (fixed-vector + round-trip + tamper +
-> wrong-key + fail-closed). The `resolve_bs_psk` / `should_mint_dm` decision
-> helpers (§4.3) shipped + tested. `cloud.bs.master.key` schema + `gen_bs_master.py`
-> shipped. **Not yet wired:** the `main.cpp` BS-server resolver/mint call sites,
-> the `bs-master-wrap` CLI, the `IOT_BS_SEED` recipe bake, and KEK delivery — P2b.
+> **Status (P2a, done):** `base64_encode/decode`, `wrap_bs_master`,
+> `unwrap_bs_master_hex` + the `resolve_bs_psk` / `should_mint_dm` decision
+> helpers + `cloud.bs.master.key` schema + `gen_bs_master.py`, all tested.
+>
+> **Status (P2b, done):** wired into the BS server — `main.cpp` PSK resolver now
+> calls `resolve_bs_psk` / `resolve_dm_psk`, and the provisioning resolver
+> HKDF-derives BS+DM creds for un-stored serials (stateless, **no mint/store** —
+> chosen over the documented mint to avoid the write-back race; DM is derived via
+> `derive_dm_psk_hex`, `info="iot-dm-psk:v1:"`). KEK loaded once via
+> `load_bs_master_kek_hex` (`IOT_BS_MASTER_KEK` / `IOT_BS_MASTER_KEK_FILE` /
+> systemd `$CREDENTIALS_DIRECTORY/bs_kek`). `bs-master-wrap` CLI + `bs_master.lua.sample`
+> shipped; KEK delivery documented in `iot-lwm2m-server.service`. Verified: full
+> `lwm2m` + `bs-master-wrap` build + 41-test gtest suite green in podman.
 
 ---
 

--- a/apps/docs/tdd-bs-hkdf-zerotouch.md
+++ b/apps/docs/tdd-bs-hkdf-zerotouch.md
@@ -370,7 +370,12 @@ malformed-master / odd-hex rejection (mirror `test_gen_wifi_default.py`).
      `IOT_BS_MASTER_KEK` / systemd cred); the `bs-master-wrap` CLI; the
      `IOT_BS_SEED` recipe bake of a wrapped master into the cloud image. Guarded
      by empty-master = no-op, so it stays inert until a master is seeded.
-3. **P3 — device personalisation:** `iot-bs-personalize` + `iot-ds-seed`
-   extension + `iot.bs.psk.override` wiring (Option I, flash-time).
+3. ✅ **P3 — device personalisation (done):** `iot-bs-personalize` host tool
+   emits a per-unit `bs-seed.json` (`{serial, key=HKDF(master,serial)}`);
+   `iot-ds-seed` applies it on first boot (sets `iot.serial` /
+   `iot.bs.psk.identity` / `iot.bs.psk.key` / `iot.bs.psk.override=true`) and
+   shreds the file — independent of the engineer-account `.seeded` flag so a
+   re-personalised unit re-applies. Tests: 7/7 (`test_iot_bs_personalize.py`),
+   `iot-ds-seed` `sh -n` clean, sed-parse round-trip verified.
 4. **P4 — DEPLOY.md** "Zero-touch bootstrap (HKDF)" section + master-rotation
    runbook; integration validation on real BS+DM+device hardware.

--- a/apps/docs/tdd-bs-hkdf-zerotouch.md
+++ b/apps/docs/tdd-bs-hkdf-zerotouch.md
@@ -377,5 +377,8 @@ malformed-master / odd-hex rejection (mirror `test_gen_wifi_default.py`).
    shreds the file — independent of the engineer-account `.seeded` flag so a
    re-personalised unit re-applies. Tests: 7/7 (`test_iot_bs_personalize.py`),
    `iot-ds-seed` `sh -n` clean, sed-parse round-trip verified.
-4. **P4 — DEPLOY.md** "Zero-touch bootstrap (HKDF)" section + master-rotation
-   runbook; integration validation on real BS+DM+device hardware.
+4. ✅ **P4 — DEPLOY.md (done):** "Zero-touch bootstrap (HKDF)" §4b — one-time
+   cloud setup (`bs-master-wrap` → `cloud.bs.master.key` + KEK delivery),
+   per-device flash (`iot-bs-personalize`), and the rotation/revocation runbook.
+   ⬜ **Remaining: integration validation on real BS+DM+device hardware** —
+   deferred like `tdd-psk-provisioning.md`'s N-wire/P (no integration env here).

--- a/apps/inc/provisioning_policy.hpp
+++ b/apps/inc/provisioning_policy.hpp
@@ -71,13 +71,32 @@ std::string resolve_bs_psk(const std::string& credentials_json,
                            const std::string& presented,
                            const std::string& master_hex);
 
-/// Mint-once gate for zero-touch DM provisioning. True when no row in
-/// `credentials_json` already covers `serial` (the BS should mint+persist DM
-/// creds during /bs); false when a row exists (reuse — a /bs retry after packet
-/// loss must NOT re-mint, or the device that stored the first key can no longer
-/// authenticate). Empty serial → false.
+/// Mint-once gate for a stored-DM variant: true when no row in
+/// `credentials_json` already covers `serial`. Unused by the shipped zero-touch
+/// path (which DERIVES DM creds statelessly — see `resolve_dm_psk`), kept for a
+/// future mint-and-store DM variant. Empty serial → false.
 bool should_mint_dm(const std::string& credentials_json,
                     const std::string& serial);
+
+/// The cloud's canonical DM identity for a device serial: `rpi<serial>@cloud.local`.
+/// MUST match `server::lwm2m::format_identity` (cloud_credentials.cpp) — the two
+/// live in separate binaries but key the same credential namespace.
+std::string format_dm_identity(const std::string& serial);
+
+/// Inverse of format_dm_identity: recover the serial from a DM identity, or ""
+/// if `identity` is not in the `rpi<serial>@cloud.local` form. Used by the DM
+/// PSK resolver to re-derive the per-device DM key from the presented identity.
+std::string serial_from_dm_identity(const std::string& identity);
+
+/// DM counterpart of resolve_bs_psk. `presented` is the DM PSK identity the peer
+/// sent (`rpi<serial>@cloud.local`). Resolution order:
+///   1. a commissioned row whose dm.psk.id == presented → its dm.psk.key; else
+///   2. if a master is configured and a serial parses out of `presented`,
+///      HKDF-derive the DM key (zero-touch, stateless); else
+///   3. "".
+std::string resolve_dm_psk(const std::string& credentials_json,
+                           const std::string& presented,
+                           const std::string& master_hex);
 
 } // namespace iot
 

--- a/apps/inc/psk_gen.hpp
+++ b/apps/inc/psk_gen.hpp
@@ -60,6 +60,17 @@ std::string hkdf_sha256(const std::string& ikm,
 std::string derive_bs_psk_hex(const std::string& master_hex,
                               const std::string& serial);
 
+/// Derive a device's per-unit Device-Management PSK from the same cloud master
+/// + serial, with a DM-specific `info` tag so the DM key is independent of the
+/// BS key:
+///   psk = HKDF-SHA256(hex_decode(master_hex), "", "iot-dm-psk:v1:"+serial, 32)
+/// Lets the zero-touch path stay fully stateless — the BS pushes derived DM
+/// creds during /bs and the DM server re-derives the same key from the
+/// presented identity, so nothing is minted or stored. Returns "" on an empty
+/// or invalid master.
+std::string derive_dm_psk_hex(const std::string& master_hex,
+                              const std::string& serial);
+
 /// Standard base64 (RFC 4648, '+/' alphabet, '=' padding).
 std::string base64_encode(const std::string& bin);
 /// Decode standard base64. Returns "" on any invalid character or length.

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -78,6 +78,34 @@ std::unordered_map<std::string, UDPAdapter::Role_t> roleMap = {
     {"client", UDPAdapter::Role_t::CLIENT}
 };
 
+// Zero-touch bootstrap (apps/docs/tdd-bs-hkdf-zerotouch.md): the Key-Encryption
+// -Key that unwraps cloud.bs.master.key. Delivered OUT-OF-BAND, never via the
+// data-store: a systemd credential ($CREDENTIALS_DIRECTORY/bs_kek, the
+// LoadCredential path), an explicit file (IOT_BS_MASTER_KEK_FILE), or the hex
+// value inline (IOT_BS_MASTER_KEK). Returns the KEK as hex, or "" when none is
+// configured → the HKDF tier stays disabled (the commissioned per-device tier
+// still serves). Read once at server wiring and captured by the resolvers.
+static std::string load_bs_master_kek_hex() {
+    auto read_first_line = [](const std::string& path) -> std::string {
+        std::ifstream f(path);
+        std::string line;
+        if (f.is_open()) std::getline(f, line);
+        // trim trailing CR/space/newline
+        while (!line.empty() &&
+               (line.back() == '\n' || line.back() == '\r' ||
+                line.back() == ' '  || line.back() == '\t'))
+            line.pop_back();
+        return line;
+    };
+    if (const char* inl = std::getenv("IOT_BS_MASTER_KEK"); inl && *inl)
+        return std::string(inl);
+    if (const char* fp = std::getenv("IOT_BS_MASTER_KEK_FILE"); fp && *fp)
+        return read_first_line(fp);
+    if (const char* cd = std::getenv("CREDENTIALS_DIRECTORY"); cd && *cd)
+        return read_first_line(std::string(cd) + "/bs_kek");
+    return std::string();
+}
+
 void parseCommandLineArgument(std::int32_t argc, char *argv[], std::unordered_map<std::string, std::string>& out) {
 
     if(argc > 1) {
@@ -250,8 +278,9 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
     // The /rd registration location is assigned by the DM at Register and
     // used by the client for periodic Update — it is not minted here.
     if (lwm2mInstance == "bs") {
+        const std::string bsKekHex = load_bs_master_kek_hex();
         bsServer->provisioning_resolver(
-            [&ds](const std::string& ep)
+            [&ds, bsKekHex](const std::string& ep)
                 -> std::optional<::lwm2m::bootstrap::AccountProvisioning> {
             auto* cli = ds.client();
             if (!cli) return std::nullopt;
@@ -261,7 +290,8 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                 std::string("cloud.dm.uri"),
                                 std::string("cloud.dm.lifetime"),
                                 std::string("cloud.dm.binding"),
-                                std::string("cloud.bs.uri")}, got);
+                                std::string("cloud.bs.uri"),
+                                std::string("cloud.bs.master.key")}, got);
             if (!rs.ok || got.size() < 5) return std::nullopt;
 
             auto str_at = [&](std::size_t i) -> std::string {
@@ -300,30 +330,59 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                            ep.c_str()));
                 return std::nullopt;
             }
-            if (credsJson.empty()) return std::nullopt;
+            // Unwrap the HKDF master (zero-touch tier) if a KEK is configured.
+            // str_at(5) is the AES-256-GCM-wrapped cloud.bs.master.key blob; a
+            // missing KEK or a bad/tampered blob → "" → tier disabled, fail
+            // closed to the commissioned per-device lookup below.
+            const std::string masterHex =
+                bsKekHex.empty()
+                    ? std::string()
+                    : iot::unwrap_bs_master_hex(bsKekHex, str_at(5)).value_or("");
 
             std::string dmId, dmKey, bsKey;
-            try {
-                auto arr = nlohmann::json::parse(credsJson);
-                if (!arr.is_array()) return std::nullopt;
-                for (auto& e : arr) {
-                    if (!e.is_object()) continue;
-                    const std::string serial   = e.value("serial",   std::string());
-                    const std::string identity = e.value("identity", std::string());
-                    if (serial == ep || identity == ep) {
-                        dmId  = e.value("dm.psk.id",  std::string());
-                        dmKey = e.value("dm.psk.key", std::string());
-                        bsKey = e.value("bs.psk.key", std::string());
-                        break;
+            bool zeroTouch = false;
+            if (!credsJson.empty()) {
+                try {
+                    auto arr = nlohmann::json::parse(credsJson);
+                    if (arr.is_array()) {
+                        for (auto& e : arr) {
+                            if (!e.is_object()) continue;
+                            const std::string serial   = e.value("serial",   std::string());
+                            const std::string identity = e.value("identity", std::string());
+                            if (serial == ep || identity == ep) {
+                                dmId  = e.value("dm.psk.id",  std::string());
+                                dmKey = e.value("dm.psk.key", std::string());
+                                bsKey = e.value("bs.psk.key", std::string());
+                                break;
+                            }
+                        }
                     }
+                } catch (const std::exception& ex) {
+                    // Don't fail outright — a master can still serve zero-touch.
+                    ACE_ERROR((LM_ERROR,
+                               ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: "
+                                        "cloud.endpoint.credentials parse: %C\n"),
+                               ep.c_str(), ex.what()));
                 }
-            } catch (const std::exception& ex) {
-                ACE_ERROR((LM_ERROR,
-                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: "
-                                    "cloud.endpoint.credentials parse: %C\n"),
-                           ep.c_str(), ex.what()));
-                return std::nullopt;
             }
+
+            // Zero-touch (HKDF) tier: no stored row, but a master is available →
+            // derive per-device BS+DM creds statelessly (nothing minted/stored).
+            // The device presents its RAW serial as the BS PSK identity (the
+            // override path), so the BS account handed back uses the raw serial
+            // verbatim — NOT sha256(ep) as in the commissioned tier.
+            if ((dmId.empty() || dmKey.empty()) && !masterHex.empty()) {
+                bsKey     = iot::derive_bs_psk_hex(masterHex, ep);
+                dmId      = iot::format_dm_identity(ep);
+                dmKey     = iot::derive_dm_psk_hex(masterHex, ep);
+                zeroTouch = true;
+                ACE_DEBUG((LM_INFO,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: "
+                                    "zero-touch HKDF-derived BS+DM creds (no "
+                                    "stored row)\n"),
+                           ep.c_str()));
+            }
+
             if (dmId.empty() || dmKey.empty()) {
                 ACE_ERROR((LM_WARNING,
                            ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: no "
@@ -347,7 +406,10 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                 bs.serverUri         = bsUri;
                 bs.isBootstrapServer = true;
                 bs.securityMode      = 0;       // PSK
-                bs.identity          = iot::sha256_hex(ep).substr(0, 32);
+                // Commissioned tier: derived identity sha256(ep)[:32].
+                // Zero-touch tier: the device presents its RAW serial verbatim.
+                bs.identity          = zeroTouch ? ep
+                                                 : iot::sha256_hex(ep).substr(0, 32);
                 bs.secretKey         = bsKey;   // hex (omitted by encoder if empty)
                 bs.shortServerId     = 0;       // ignored for a BS account
                 a.security.push_back(std::move(bs));
@@ -2157,35 +2219,31 @@ int main(std::int32_t argc, char *argv[]) {
         if (!dtls || UDPAdapter::Role_t::SERVER != role || !ds.client()) return;
         const bool is_bs = argValueMap["lwm2m-instance"] == "bs";
         auto* cli = ds.client();
-        dtls->set_psk_resolver([cli, is_bs](const std::string& presented) -> std::string {
+        // KEK for the zero-touch HKDF tier — read once, captured by value. Empty
+        // ⇒ tier disabled (commissioned per-device lookup still serves).
+        const std::string bsKekHex = load_bs_master_kek_hex();
+        dtls->set_psk_resolver([cli, is_bs, bsKekHex](const std::string& presented) -> std::string {
             std::vector<data_store::Client::GetResult> got;
-            auto rs = cli->get({std::string("cloud.endpoint.credentials")}, got);
-            if (!rs.ok || got.empty() || !got[0].has_value) return std::string();
-            auto s = data_store::to_string(got[0].value);
-            if (!s || s->empty()) return std::string();
-            try {
-                auto arr = nlohmann::json::parse(*s);
-                if (!arr.is_array()) return std::string();
-                for (auto& e : arr) {
-                    if (!e.is_object()) continue;
-                    if (is_bs) {
-                        const std::string serial = e.value("serial", std::string());
-                        // 128-bit identity (first 32 hex chars), matching the
-                        // device's iot::sha256_hex(endpoint).substr(0,32).
-                        if (!serial.empty() &&
-                            iot::sha256_hex(serial).substr(0, 32) == presented)
-                            return e.value("bs.psk.key", std::string());
-                    } else if (e.value("dm.psk.id", std::string()) == presented) {
-                        return e.value("dm.psk.key", std::string());
-                    }
-                }
-            } catch (const std::exception& ex) {
-                ACE_ERROR((LM_ERROR,
-                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l PSK resolver: "
-                                    "cloud.endpoint.credentials parse: %C\n"),
-                           ex.what()));
-            }
-            return std::string();
+            auto rs = cli->get({std::string("cloud.endpoint.credentials"),
+                                std::string("cloud.bs.master.key")}, got);
+            if (!rs.ok || got.empty()) return std::string();
+            const std::string credsJson =
+                got[0].has_value ? data_store::to_string(got[0].value).value_or("")
+                                 : std::string();
+            // Unwrap the HKDF master if a KEK is configured (bad/tampered → "").
+            const std::string wrapped =
+                (got.size() > 1 && got[1].has_value)
+                    ? data_store::to_string(got[1].value).value_or("")
+                    : std::string();
+            const std::string masterHex =
+                bsKekHex.empty()
+                    ? std::string()
+                    : iot::unwrap_bs_master_hex(bsKekHex, wrapped).value_or("");
+            // BS tier: commissioned sha256(serial)[:32] lookup → else derive from
+            // the presented raw serial. DM tier: dm.psk.id lookup → else derive
+            // from the serial embedded in the presented identity.
+            return is_bs ? iot::resolve_bs_psk(credsJson, presented, masterHex)
+                         : iot::resolve_dm_psk(credsJson, presented, masterHex);
         });
     };
 

--- a/apps/src/provisioning_policy.cpp
+++ b/apps/src/provisioning_policy.cpp
@@ -87,4 +87,52 @@ bool should_mint_dm(const std::string& credentials_json,
     return true;                // no row → mint
 }
 
+namespace {
+const char kDmPrefix[] = "rpi";
+const char kDmSuffix[] = "@cloud.local";
+} // namespace
+
+std::string format_dm_identity(const std::string& serial) {
+    return std::string(kDmPrefix) + serial + kDmSuffix;
+}
+
+std::string serial_from_dm_identity(const std::string& identity) {
+    const std::size_t plen = sizeof(kDmPrefix) - 1;
+    const std::size_t slen = sizeof(kDmSuffix) - 1;
+    if (identity.size() <= plen + slen) return {};
+    if (identity.compare(0, plen, kDmPrefix) != 0) return {};
+    if (identity.compare(identity.size() - slen, slen, kDmSuffix) != 0)
+        return {};
+    return identity.substr(plen, identity.size() - plen - slen);
+}
+
+std::string resolve_dm_psk(const std::string& credentials_json,
+                           const std::string& presented,
+                           const std::string& master_hex) {
+    if (presented.empty()) return {};
+
+    // 1) Commissioned tier: a row whose dm.psk.id == presented.
+    const auto arr =
+        nlohmann::json::parse(credentials_json, /*cb*/nullptr,
+                              /*allow_exceptions*/false);
+    if (arr.is_array()) {
+        for (const auto& e : arr) {
+            if (!e.is_object()) continue;
+            if (e.value("dm.psk.id", std::string()) == presented) {
+                const std::string key = e.value("dm.psk.key", std::string());
+                if (!key.empty()) return key;
+            }
+        }
+    }
+
+    // 2) Zero-touch tier: derive from the serial embedded in the DM identity.
+    if (!master_hex.empty()) {
+        const std::string serial = serial_from_dm_identity(presented);
+        if (!serial.empty()) return derive_dm_psk_hex(master_hex, serial);
+    }
+
+    // 3) No match.
+    return {};
+}
+
 } // namespace iot

--- a/apps/src/psk_gen.cpp
+++ b/apps/src/psk_gen.cpp
@@ -119,6 +119,13 @@ std::string derive_bs_psk_hex(const std::string& master_hex,
     return hkdf_sha256(ikm, /*salt=*/"", "iot-bs-psk:v1:" + serial, 32);
 }
 
+std::string derive_dm_psk_hex(const std::string& master_hex,
+                              const std::string& serial) {
+    const std::string ikm = hex_decode(master_hex);
+    if (ikm.empty()) return {};
+    return hkdf_sha256(ikm, /*salt=*/"", "iot-dm-psk:v1:" + serial, 32);
+}
+
 namespace {
 
 const char kB64Alpha[] =

--- a/apps/test/provisioning_policy_test.cpp
+++ b/apps/test/provisioning_policy_test.cpp
@@ -3,6 +3,7 @@
 #include <gtest/gtest.h>
 
 #include "provisioning_policy.hpp"
+#include "psk_gen.hpp"
 
 using iot::resolve_endpoint;
 
@@ -135,4 +136,51 @@ TEST(ShouldMintDm, ReusesWhenRowExists) {
 TEST(ShouldMintDm, EmptySerialOrBadJsonNeverMints) {
     EXPECT_FALSE(iot::should_mint_dm("[]", ""));
     EXPECT_TRUE(iot::should_mint_dm("not json", kSerial));  // no row → mint
+}
+
+// ── DM identity + zero-touch DM resolver ─────────────────────────────────────
+
+namespace {
+// derive_dm_psk_hex(kMaster, kSerial), computed independently.
+const char* kDerivedDm = "f9123ef9d4cc65bca1586fe27faff3e7"
+                         "0adde77d266b30fc3645f49466f5113a";
+} // namespace
+
+TEST(DmIdentity, FormatAndParseRoundTrip) {
+    EXPECT_EQ("rpi100000003d1f9c2e@cloud.local",
+              iot::format_dm_identity(kSerial));
+    EXPECT_EQ(kSerial,
+              iot::serial_from_dm_identity(iot::format_dm_identity(kSerial)));
+}
+
+TEST(DmIdentity, ParseRejectsNonMatching) {
+    EXPECT_EQ("", iot::serial_from_dm_identity("rpi@cloud.local"));     // no serial
+    EXPECT_EQ("", iot::serial_from_dm_identity("100000003d1f9c2e"));    // raw serial
+    EXPECT_EQ("", iot::serial_from_dm_identity("rpiX@example.com"));    // wrong suffix
+    EXPECT_EQ("", iot::serial_from_dm_identity(""));
+}
+
+TEST(DeriveDmPsk, DiffersFromBsAndIsDeterministic) {
+    EXPECT_EQ(kDerivedDm, iot::derive_dm_psk_hex(kMaster, kSerial));
+    EXPECT_NE(iot::derive_bs_psk_hex(kMaster, kSerial),
+              iot::derive_dm_psk_hex(kMaster, kSerial));   // domain-separated
+    EXPECT_EQ("", iot::derive_dm_psk_hex("", kSerial));    // no master
+}
+
+TEST(ResolveDmPsk, CommissionedRowWinsOverDerivation) {
+    const std::string creds =
+        R"([{"dm.psk.id":"rpi100000003d1f9c2e@cloud.local","dm.psk.key":"cafe"}])";
+    EXPECT_EQ("cafe", iot::resolve_dm_psk(
+        creds, "rpi100000003d1f9c2e@cloud.local", kMaster));
+}
+
+TEST(ResolveDmPsk, DerivesWhenNoRow) {
+    EXPECT_EQ(kDerivedDm, iot::resolve_dm_psk(
+        "[]", iot::format_dm_identity(kSerial), kMaster));
+}
+
+TEST(ResolveDmPsk, NoMasterOrUnparseableYieldsEmpty) {
+    EXPECT_EQ("", iot::resolve_dm_psk("[]", iot::format_dm_identity(kSerial), ""));
+    EXPECT_EQ("", iot::resolve_dm_psk("[]", "not-a-dm-id", kMaster));
+    EXPECT_EQ("", iot::resolve_dm_psk("[]", "", kMaster));
 }

--- a/apps/tools/bs_master_wrap.cpp
+++ b/apps/tools/bs_master_wrap.cpp
@@ -1,0 +1,90 @@
+/// bs-master-wrap — operator tool to KMS-wrap the zero-touch HKDF master.
+///
+/// Zero-touch bootstrap (apps/docs/tdd-bs-hkdf-zerotouch.md). Produces the
+/// AES-256-GCM envelope that goes into the cloud image's `cloud.bs.master.key`
+/// default (via bs_master.lua → gen_bs_master.py). One-time cloud-setup step,
+/// run where the operator holds the two secrets:
+///
+///   - the **master** (HKDF root; also fed to the device flashing tool
+///     gen_bs_psk.py — keep it in your manufacturing vault), and
+///   - the **KEK** (wraps the master; delivered to the cloud BS server at
+///     runtime via IOT_BS_MASTER_KEK / a systemd credential — NEVER baked).
+///
+/// The output base64 blob is ciphertext: useless without the KEK.
+///
+/// Usage:
+///   bs-master-wrap <kek> <master>
+///   bs-master-wrap <kek> --gen-master      # mint a random master, print it
+///
+/// <kek> and <master> are 64-hex (32-byte) values, or `@/path` to read the
+/// first line of a file. Prints the base64 envelope to stdout.
+
+#include <cstdio>
+#include <fstream>
+#include <string>
+
+#include "psk_gen.hpp"
+
+namespace {
+
+std::string read_arg(const std::string& a) {
+    if (!a.empty() && a[0] == '@') {
+        std::ifstream f(a.substr(1));
+        std::string line;
+        if (f.is_open()) std::getline(f, line);
+        while (!line.empty() &&
+               (line.back() == '\n' || line.back() == '\r' ||
+                line.back() == ' '  || line.back() == '\t'))
+            line.pop_back();
+        return line;
+    }
+    return a;
+}
+
+int usage() {
+    std::fprintf(stderr,
+        "usage: bs-master-wrap <kek> <master|--gen-master>\n"
+        "  <kek>/<master>: 64-hex (32-byte), or @/path to read from a file\n");
+    return 2;
+}
+
+} // namespace
+
+int main(int argc, char** argv) {
+    if (argc != 3) return usage();
+
+    const std::string kekHex = read_arg(argv[1]);
+    std::string masterHex;
+    bool generated = false;
+    if (std::string(argv[2]) == "--gen-master") {
+        masterHex = iot::generate_psk_hex(32);
+        generated = true;
+    } else {
+        masterHex = read_arg(argv[2]);
+    }
+
+    // Fresh random 12-byte nonce per wrap (GCM must never reuse a nonce/key).
+    const std::string nonceHex = iot::generate_psk_hex(12);
+    const std::string blob = iot::wrap_bs_master(kekHex, masterHex, nonceHex);
+    if (blob.empty()) {
+        std::fprintf(stderr,
+            "bs-master-wrap: wrap failed — KEK must be 64-hex (32 bytes) and "
+            "master valid hex\n");
+        return 1;
+    }
+
+    // Sanity: confirm it unwraps back under the same KEK before emitting.
+    auto check = iot::unwrap_bs_master_hex(kekHex, blob);
+    if (!check || *check != masterHex) {
+        std::fprintf(stderr, "bs-master-wrap: self-check failed\n");
+        return 1;
+    }
+
+    if (generated)
+        std::fprintf(stderr,
+            "bs-master-wrap: generated master (SAVE THIS — needed by "
+            "gen_bs_psk.py to flash devices):\n%s\n", masterHex.c_str());
+
+    std::printf("%s\n", blob.c_str());   // base64 envelope → bs_master.lua
+    return 0;
+}

--- a/packaging/systemd/iot-lwm2m-server.service
+++ b/packaging/systemd/iot-lwm2m-server.service
@@ -12,6 +12,13 @@ StartLimitIntervalSec=60s
 [Service]
 Type=simple
 EnvironmentFile=/etc/iot/lwm2m-server.env
+# Zero-touch bootstrap (apps/docs/tdd-bs-hkdf-zerotouch.md): deliver the KEK that
+# unwraps cloud.bs.master.key out-of-band, never via the data-store. Uncomment
+# ONE once a master is provisioned (leaving them off keeps the HKDF tier
+# disabled; the commissioned per-device tier still works):
+#   LoadCredential=bs_kek:/etc/iot/bs-master.kek   # 0400 root; sets $CREDENTIALS_DIRECTORY
+#   Environment=IOT_BS_MASTER_KEK_FILE=/etc/iot/bs-master.kek
+# (The Docker/compose cloud deploy passes IOT_BS_MASTER_KEK in the container env.)
 ExecStart=/usr/local/bin/lwm2m $LWM2M_ARGS
 
 DynamicUser=yes

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/bs_master.lua.sample
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/bs_master.lua.sample
@@ -1,0 +1,30 @@
+-- bs_master.lua — OPTIONAL zero-touch Bootstrap HKDF master seed (cloud only).
+--
+-- Zero-touch / plug-and-play bootstrap: the cloud holds one HKDF master and
+-- re-derives every device's per-unit BS PSK from its serial, so no per-device
+-- row has to be pre-created. See apps/docs/tdd-bs-hkdf-zerotouch.md.
+--
+-- This file carries the master ONLY as an AES-256-GCM-wrapped blob (ciphertext)
+-- — never the raw master, never the KEK. Produce the blob with:
+--
+--     bs-master-wrap <kek_hex> --gen-master       # mints + prints a master, or
+--     bs-master-wrap <kek_hex> <master_hex>        # wraps an existing master
+--
+-- Then either:
+--   (a) RECOMMENDED — set it on the running cloud directly (no rebuild):
+--         ds-cli set cloud.bs.master.key "<blob>"
+--   (b) bake it into the cloud image default: copy this file to `bs_master.lua`
+--       (same dir, gitignored) with the blob below, and run
+--         gen_bs_master.py bs_master.lua /etc/iot/ds-schemas/cloud.lua
+--       during the cloud image build.
+--
+-- The wrapping KEK is delivered to the cloud lwm2m-server at RUNTIME and is
+-- NEVER stored here or in the data-store:
+--   - Docker/compose:  environment: IOT_BS_MASTER_KEK=<kek_hex>
+--   - systemd:         LoadCredential=bs_kek:/etc/iot/bs-master.kek  (0400 root)
+--
+-- Security: the blob is inert without the KEK. The raw master is also needed by
+-- the device flashing tool (gen_bs_psk.py) — keep it in your manufacturing
+-- vault, out of git and out of the image.
+
+return { wrapped = "<base64( nonce || ciphertext || tag ) from bs-master-wrap>" }

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-bs-personalize
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-bs-personalize
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""iot-bs-personalize — flash-time per-unit Bootstrap PSK injector (host tool).
+
+Zero-touch / plug-and-play bootstrap (apps/docs/tdd-bs-hkdf-zerotouch.md).
+Symmetric PSK means each device must hold its OWN secret before first contact;
+this tool derives that secret on the manufacturing host and emits a one-shot
+seed file that the device's first-boot iot-ds-seed applies, then shreds.
+
+    psk = HKDF(master, serial)        # = gen_bs_psk.derive_bs_psk_hex
+    seed = {"serial": "<raw serial>", "key": "<64-hex psk>"}
+
+Drop the seed at `/var/lib/iot/bs-seed.json` on the device's DATA partition
+(NOT the shared rootfs) before first boot. The cloud re-derives the same key
+from the serial, so no per-device cloud row is needed.
+
+The `<master>` is the HKDF root — the SAME secret you wrapped into the cloud
+with bs-master-wrap. Keep it in your manufacturing vault; it never ships on the
+device (only the per-unit derived key does).
+
+Usage:
+    iot-bs-personalize <master> <serial> [-o OUT]
+
+`<master>` is 64-hex, or `@/path` to read it from a file. `-o OUT` writes the
+seed JSON to OUT (default: stdout). Example, writing straight onto a mounted
+data partition:
+
+    iot-bs-personalize @master.hex 100000003d1f9c2e -o /mnt/data/bs-seed.json
+"""
+
+import json
+import sys
+
+import gen_bs_psk as g
+
+
+def _read_master(arg):
+    if arg.startswith("@"):
+        with open(arg[1:], encoding="utf-8") as fh:
+            return fh.readline().strip()
+    return arg
+
+
+def build_seed(master_hex, serial):
+    """Return the seed dict the device first-boot expects. Raises ValueError on
+    a bad master/serial (via derive_bs_psk_hex)."""
+    serial = serial.strip()
+    key = g.derive_bs_psk_hex(master_hex, serial)   # validates master + serial
+    return {"serial": serial, "key": key}
+
+
+def main(argv):
+    args = [a for a in argv[1:] if a != "-o"]
+    out_path = None
+    if "-o" in argv[1:]:
+        i = argv.index("-o")
+        if i + 1 >= len(argv):
+            sys.stderr.write("iot-bs-personalize: -o needs a path\n")
+            return 2
+        out_path = argv[i + 1]
+        args = [a for a in argv[1:] if a not in ("-o", out_path)]
+    if len(args) != 2:
+        sys.stderr.write("usage: iot-bs-personalize <master|@file> <serial> "
+                         "[-o OUT]\n")
+        return 2
+    try:
+        seed = build_seed(_read_master(args[0]), args[1])
+    except (ValueError, OSError) as exc:
+        sys.stderr.write("iot-bs-personalize: %s\n" % exc)
+        return 2
+    # Compact, single-line JSON — the device parses it with sed (no jq).
+    text = json.dumps(seed, separators=(",", ":")) + "\n"
+    if out_path:
+        with open(out_path, "w", encoding="utf-8") as fh:
+            fh.write(text)
+        sys.stderr.write("iot-bs-personalize: wrote seed for %s -> %s\n"
+                         % (seed["serial"], out_path))
+    else:
+        sys.stdout.write(text)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
@@ -25,10 +25,13 @@ set -eu
 SOCK="${IOT_DS_SOCK:-/run/iot/data_store.sock}"
 STATE="${IOT_DS_STATE:-/var/lib/iot}"
 FLAG="$STATE/.seeded"
+BS_SEED="$STATE/bs-seed.json"
 DSCLI="ds-cli --socket=$SOCK"
 
-# Already seeded → nothing to do (idempotent, preserves operator changes).
-[ -f "$FLAG" ] && exit 0
+# Nothing to do only when BOTH the one-time seed has run AND there is no pending
+# zero-touch BS personalisation file. (The BS block below is independent of the
+# engineer-account flag so a unit personalised after first boot still applies.)
+[ -f "$FLAG" ] && [ ! -f "$BS_SEED" ] && exit 0
 
 # After=iot-ds orders start, not readiness — wait for the socket to appear.
 i=0
@@ -40,6 +43,43 @@ if [ ! -S "$SOCK" ]; then
     echo "iot-ds-seed: ds socket $SOCK not ready after ${i}s; will retry next boot" >&2
     exit 0   # don't fail the boot; no flag written, so it retries
 fi
+
+# ── Zero-touch BS personalisation (apps/docs/tdd-bs-hkdf-zerotouch.md) ────────
+# A per-unit bs-seed.json dropped onto the data partition at flash time by the
+# host tool iot-bs-personalize: {"serial":"<raw>","key":"<64-hex derived PSK>"}.
+# Apply it ONCE (when iot.bs.psk.key is still empty), then shred the file. This
+# is what lets a freshly-flashed device reach the BS with no device-ui step.
+if [ -f "$BS_SEED" ]; then
+    # Only personalise if not already done (idempotent). dev-mode is on at first
+    # boot, so root's ds-cli may read/write the gid:engineer PSK keys.
+    CUR_KEY=$($DSCLI get iot.bs.psk.key 2>/dev/null || true)
+    if [ -z "$CUR_KEY" ]; then
+        # Parse without jq (busybox): single-line {"serial":"..","key":".."}.
+        SER=$(sed -n 's/.*"serial"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$BS_SEED")
+        KEY=$(sed -n 's/.*"key"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$BS_SEED")
+        if [ -n "$SER" ] && [ -n "$KEY" ]; then
+            if $DSCLI set iot.serial "$SER" \
+               && $DSCLI set iot.bs.psk.identity "$SER" \
+               && $DSCLI set iot.bs.psk.key "$KEY" \
+               && $DSCLI set iot.bs.psk.override true; then
+                # Best-effort shred (busybox has no shred): zero, then remove.
+                # The key also lives in the ds persist file, so this is only
+                # belt-and-suspenders against the seed lingering on the FS.
+                dd if=/dev/zero of="$BS_SEED" bs=1 \
+                   count="$(wc -c < "$BS_SEED")" conv=notrunc 2>/dev/null || true
+                rm -f "$BS_SEED"
+                echo "iot-ds-seed: personalised zero-touch BS PSK for serial $SER"
+            else
+                echo "iot-ds-seed: BS personalise set failed; retry next boot" >&2
+            fi
+        else
+            echo "iot-ds-seed: bs-seed.json malformed (need serial+key); ignoring" >&2
+        fi
+    fi
+fi
+
+# The one-time engineer-account seed runs only on the very first boot.
+[ -f "$FLAG" ] && exit 0
 
 # Default read-only "engineer" device-ui account, seeded alongside the built-in
 # admin (admin/admin). access=Viewer (view-only; cannot change config, run the

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/test_iot_bs_personalize.py
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/test_iot_bs_personalize.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+"""Tests for iot-bs-personalize — the flash-time per-unit BS PSK seed emitter.
+
+The tool has no .py extension (it's a CLI), so we load it via importlib and also
+exercise its CLI through subprocess.
+
+    python3 -m unittest discover -s <this dir> -p 'test_iot_bs_personalize.py'
+"""
+
+import importlib.util
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from importlib.machinery import SourceFileLoader
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+TOOL = os.path.join(HERE, "iot-bs-personalize")
+
+sys.path.insert(0, HERE)          # so its `import gen_bs_psk` resolves
+# The tool has no .py extension, so give importlib an explicit source loader.
+loader = SourceFileLoader("iot_bs_personalize", TOOL)
+spec = importlib.util.spec_from_loader(loader.name, loader)
+ibp = importlib.util.module_from_spec(spec)
+loader.exec_module(ibp)
+
+# Shared cross-check vector (psk_gen_test.cpp / test_gen_bs_psk.py).
+MASTER = "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f"
+SERIAL = "100000003d1f9c2e"
+KEY = "223a82da7acb983c1372ec5e72c77d008fc40281e737bb4aea689f53600d4fe5"
+
+
+class BuildSeed(unittest.TestCase):
+    def test_matches_cross_check_vector(self):
+        self.assertEqual(ibp.build_seed(MASTER, SERIAL),
+                         {"serial": SERIAL, "key": KEY})
+
+    def test_trims_serial(self):
+        self.assertEqual(ibp.build_seed(MASTER, "  " + SERIAL + " ")["serial"],
+                         SERIAL)
+
+    def test_bad_master_raises(self):
+        with self.assertRaises(ValueError):
+            ibp.build_seed("zz", SERIAL)
+
+
+class Cli(unittest.TestCase):
+    def _run(self, args):
+        return subprocess.run([sys.executable, TOOL] + args,
+                              capture_output=True, text=True, cwd=HERE)
+
+    def test_stdout_single_line_json(self):
+        r = self._run([MASTER, SERIAL])
+        self.assertEqual(r.returncode, 0)
+        line = r.stdout.strip()
+        self.assertNotIn("\n", line)                 # single line for sed
+        self.assertEqual(json.loads(line), {"serial": SERIAL, "key": KEY})
+
+    def test_writes_output_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = os.path.join(d, "bs-seed.json")
+            r = self._run([MASTER, SERIAL, "-o", out])
+            self.assertEqual(r.returncode, 0)
+            with open(out, encoding="utf-8") as fh:
+                self.assertEqual(json.load(fh), {"serial": SERIAL, "key": KEY})
+
+    def test_master_from_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            mf = os.path.join(d, "master.hex")
+            with open(mf, "w", encoding="utf-8") as fh:
+                fh.write(MASTER + "\n")
+            r = self._run(["@" + mf, SERIAL])
+            self.assertEqual(r.returncode, 0)
+            self.assertEqual(json.loads(r.stdout), {"serial": SERIAL, "key": KEY})
+
+    def test_bad_args(self):
+        self.assertEqual(self._run([MASTER]).returncode, 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Completes the zero-touch / plug-and-play bootstrap initiative on top of the merged P1+P2a foundation (#449). Design: `apps/docs/tdd-bs-hkdf-zerotouch.md`.

The cloud holds **one HKDF master**; each device's BS **and** DM PSK is `HKDF(master, serial)`, re-derived on demand cloud-side and injected per-unit at flash time. **flash → boot → registered**, no device-ui step and no per-device cloud row.

## P2b — wire the BS server (behaviour change)
- **Stateless DM** (improvement over the documented mint-and-store): instead of minting a random DM PSK at `/bs` and writing it back to `cloud.endpoint.credentials` (a read-modify-write race), the BS **derives** the DM key too — `derive_dm_psk_hex(master, serial)`, `info="iot-dm-psk:v1:"`. The DM server re-derives from the presented identity. Nothing minted or stored.
- `main.cpp`: `load_bs_master_kek_hex` (KEK from `IOT_BS_MASTER_KEK` / `IOT_BS_MASTER_KEK_FILE` / systemd `$CREDENTIALS_DIRECTORY/bs_kek`, read once); the PSK resolver now calls `resolve_bs_psk` / `resolve_dm_psk` with the unwrapped master; the provisioning resolver derives BS+DM accounts for un-stored serials and hands back the **raw serial** as the BS identity (override path). Empty KEK / bad blob → **fail closed** to the commissioned tier.
- `apps/provisioning_policy`: `format_dm_identity` / `serial_from_dm_identity` / `resolve_dm_psk`. `apps/psk_gen`: `derive_dm_psk_hex`.
- `bs-master-wrap` CLI (`apps/tools`, own target so the `src/*` glob doesn't grab its `main()`): AES-256-GCM-wrap a master under a KEK, self-checks the unwrap. `bs_master.lua.sample` + `.gitignore`. KEK-delivery example in `iot-lwm2m-server.service`.

## P3 — device personalisation (flash-time inject)
- `iot-bs-personalize` (host): `psk = HKDF(master, serial)` → one-shot `bs-seed.json` (compact single-line JSON, device parses with `sed`, no `jq`).
- `iot-ds-seed` (first boot): applies the seed (`iot.serial` / `iot.bs.psk.identity` / `iot.bs.psk.key` / `iot.bs.psk.override=true`) when the key is still empty, then shreds it. Runs **independently of the engineer-account `.seeded` flag** so a unit personalised after first boot still applies. The device never holds the master or runs HKDF.

## P4 — deploy
- DEPLOY.md §4b: one-time cloud setup, per-device flash, and rotation/revocation runbook. Manual + derived tiers **coexist** (stored row wins); feature is **off** until a master+KEK are set.

## Verification (podman `localhost/iot-devbuild`)
- Full `lwm2m` binary + `bs-master-wrap` link clean.
- `lwm2m_test` **41/41** (Hkdf, DeriveBsPsk, DeriveDmPsk, Base64, BsMasterEnvelope, ResolveBsPsk, ResolveDmPsk, DmIdentity, ShouldMintDm + existing).
- Python **48/48** (gen_bs_psk, gen_bs_master, iot_bs_personalize, gen_wifi_default); `iot-ds-seed` `sh -n` clean; personalize→sed-parse round-trip verified.
- Cross-check vectors (BS + DM derivation, envelope blob) pinned in tests as drift guards.

## Deferred
Live BS+DM+device integration on real hardware — no integration env here, deferred like `tdd-psk-provisioning.md`'s N-wire/P.

🤖 Generated with [Claude Code](https://claude.com/claude-code)