### PR TITLE
feat(flash): zero-touch BS personalisation in flash-sd.sh

### DIFF
--- a/yocto/flash-sd.sh
+++ b/yocto/flash-sd.sh
@@ -25,6 +25,19 @@
 #   MACHINE=qemuarm64 ./flash-sd.sh /dev/sdX     # pick another machine's image
 #   IMAGE=/path/to/custom.wic.bz2 ./flash-sd.sh /dev/sdX
 #
+# Zero-touch personalisation (apps/docs/tdd-bs-hkdf-zerotouch.md): after writing
+# the image, drop a per-unit BS PSK seed onto the FAT `boot` partition (which
+# macOS/Windows can mount — the ext4 `data` partition they cannot). On first
+# boot iot-ds-seed applies it and the device registers with no manual step.
+#
+#   ./flash-sd.sh --personalize --master @master.hex --serial 100000003d1f9c2e
+#   ./flash-sd.sh --personalize --seed /path/to/bs-seed.json   # pre-built seed
+#
+#   --master is 64-hex or @/path (the SAME master you wrapped into the cloud
+#   with bs-master-wrap). --serial is the device's raw serial (RPi: the
+#   /proc/cpuinfo Serial). The master never lands on the card — only the
+#   derived key does.
+#
 # Safety: refuses internal/system disks (override with --force), refuses a card
 # too small for the image's on-card layout (the A/B image is ~2.4GB — needs a
 # ≥4GB card), shows the image + target, and requires you to type "yes".
@@ -125,6 +138,7 @@ detect_sd() {
 
 # ── Argument parsing ──────────────────────────────────────────────────
 ASSUME_YES=0; DO_LIST=0; FORCE=0; SKIP_FORMAT=0
+PERSONALIZE=0; BS_MASTER=""; BS_SERIAL=""; SEED_FILE=""
 POSARGS=()
 while [ $# -gt 0 ]; do
     case "$1" in
@@ -132,6 +146,10 @@ while [ $# -gt 0 ]; do
         -l|--list)             DO_LIST=1 ;;
         --force)               FORCE=1 ;;
         --no-format|--skip-format) SKIP_FORMAT=1 ;;
+        --personalize)         PERSONALIZE=1 ;;
+        --master)              BS_MASTER="${2:-}"; [ $# -ge 2 ] && shift ;;
+        --serial)              BS_SERIAL="${2:-}"; [ $# -ge 2 ] && shift ;;
+        --seed)                SEED_FILE="${2:-}"; [ $# -ge 2 ] && shift ;;
         -h|--help)             usage; exit 0 ;;
         -*)                    log_error "unknown option: $1"; usage; exit 1 ;;
         *)                     POSARGS+=("$1") ;;
@@ -143,6 +161,26 @@ set -- ${POSARGS[@]+"${POSARGS[@]}"}
 if [ "$DO_LIST" -eq 1 ]; then
     list_disks
     exit 0
+fi
+
+# ── Validate personalisation inputs up front (before the destructive flash) ──
+PERSONALIZE_TOOL="$SCRIPT_DIR/meta-iot/recipes-iot/lwm2m/files/iot-bs-personalize"
+if [ "$PERSONALIZE" -eq 1 ]; then
+    if [ -n "$SEED_FILE" ]; then
+        [ -f "$SEED_FILE" ] || { log_error "--seed: no such file: $SEED_FILE"; exit 1; }
+        SEED_TEXT="$(cat "$SEED_FILE")"
+    else
+        [ -n "$BS_MASTER" ] && [ -n "$BS_SERIAL" ] || {
+            log_error "--personalize needs --master <hex|@file> + --serial <serial>, or --seed <file>."
+            exit 1; }
+        [ -x "$PERSONALIZE_TOOL" ] || command -v python3 >/dev/null 2>&1 || {
+            log_error "iot-bs-personalize needs python3 (not found)."; exit 1; }
+        [ -f "$PERSONALIZE_TOOL" ] || { log_error "tool missing: $PERSONALIZE_TOOL"; exit 1; }
+        # Derive the seed NOW so a bad master/serial fails before we wipe the card.
+        if ! SEED_TEXT="$(python3 "$PERSONALIZE_TOOL" "$BS_MASTER" "$BS_SERIAL")"; then
+            log_error "iot-bs-personalize failed (bad master or serial?)."; exit 1
+        fi
+    fi
 fi
 
 # ── Resolve the image ─────────────────────────────────────────────────
@@ -279,7 +317,8 @@ echo "           ($IMG_SIZE compressed)"
 echo "  Machine: $MACHINE"
 echo "  Target : $DEV  ${DEV_SIZE:+($DEV_SIZE${DEV_NAME:+, $DEV_NAME})}"
 [ -n "${REQ_MB:-}" ] && echo "  Layout : ~${REQ_MB}MB on-card (whole-disk wic image)"
-echo "  Steps  : unmount → $([ "$SKIP_FORMAT" -eq 1 ] && echo '(skip format)' || echo 'wipe partition table') → write image → sync/eject"
+echo "  Steps  : unmount → $([ "$SKIP_FORMAT" -eq 1 ] && echo '(skip format)' || echo 'wipe partition table') → write image →$([ "$PERSONALIZE" -eq 1 ] && echo ' personalise (boot partition) →') sync/eject"
+[ "$PERSONALIZE" -eq 1 ] && echo "  Seed   : zero-touch BS PSK → boot partition${BS_SERIAL:+ (serial $BS_SERIAL)}"
 echo ""
 echo -e "${RED}  ⚠  ALL DATA ON $DEV WILL BE DESTROYED.${NC}"
 
@@ -348,12 +387,56 @@ else
     kill "$progress_ticker" 2>/dev/null || true
 fi
 
+# ── 3.5 Personalise (zero-touch BS PSK → FAT boot partition) ──────────
+# The wic image just laid down a fresh partition table; mount the FAT `boot`
+# partition (p1 — the only one macOS/Windows can mount) and drop bs-seed.json.
+# iot-ds-seed reads /boot/bs-seed.json on first boot, applies it, and shreds it.
+if [ "$PERSONALIZE" -eq 1 ]; then
+    log_section "Personalising (BS PSK seed → boot partition)"
+    sync
+    BOOT_MNT=""
+    if [ "$OS" = "Darwin" ]; then
+        # Re-read the new table and mount p1 (diskNs1). It often auto-mounts.
+        diskutil mountDisk "$DEV" >/dev/null 2>&1 || true
+        diskutil mount "${DEV}s1" >/dev/null 2>&1 || true
+        BOOT_MNT="$(diskutil info "${DEV}s1" 2>/dev/null \
+                    | awk -F: '/Mount Point/{sub(/^[ \t]+/,"",$2); print $2; exit}')"
+        WRITE=(tee)                              # /Volumes/boot is user-writable
+        UNMOUNT_BOOT=(diskutil unmount "${DEV}s1")
+    else
+        sudo partprobe "$DEV" 2>/dev/null || true
+        # The FAT partition by label, robust across sdb1 vs mmcblk0p1.
+        BOOTPART="$(lsblk -rno NAME,LABEL "$DEV" 2>/dev/null | awk '$2=="boot"{print "/dev/"$1; exit}')"
+        [ -n "$BOOTPART" ] || BOOTPART="$(lsblk -rno NAME "$DEV" 2>/dev/null | sed -n '2p' | sed 's|^|/dev/|')"
+        BOOT_MNT="$(mktemp -d)"
+        sudo mount "$BOOTPART" "$BOOT_MNT" 2>/dev/null || BOOT_MNT=""
+        WRITE=(sudo tee)
+        UNMOUNT_BOOT=(sudo umount "$BOOTPART")
+    fi
+    if [ -z "$BOOT_MNT" ] || [ ! -d "$BOOT_MNT" ]; then
+        log_error "Could not mount the boot partition to write the seed."
+        log_error "Image is flashed; personalise manually: copy a bs-seed.json"
+        log_error "(from iot-bs-personalize) onto the card's boot partition."
+    else
+        printf '%s\n' "$SEED_TEXT" | "${WRITE[@]}" "$BOOT_MNT/bs-seed.json" >/dev/null
+        sync
+        "${UNMOUNT_BOOT[@]}" >/dev/null 2>&1 || true
+        [ "$OS" = "Darwin" ] || rmdir "$BOOT_MNT" 2>/dev/null || true
+        log_info "Seeded bs-seed.json onto the boot partition${BS_SERIAL:+ (serial $BS_SERIAL)}."
+    fi
+fi
+
 # ── 4. Flush + eject ──────────────────────────────────────────────────
 log_section "Flushing"
 sync
 "${EJECT[@]}" 2>/dev/null || true
 
 log_info "Done. $DEV is flashed and safe to remove."
+if [ "$PERSONALIZE" -eq 1 ]; then
+    echo ""
+    echo "  Zero-touch: the device applies bs-seed.json on first boot. Ensure the"
+    echo "  cloud has the matching master+KEK (cloud.bs.master.key + IOT_BS_MASTER_KEK)."
+fi
 echo ""
 echo "  Boot the Pi, then ssh in (sshd is baked in; debug-tweaks → empty root pw):"
 echo "    ssh root@<pi-ip>"

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-bs-personalize
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-bs-personalize
@@ -9,9 +9,12 @@ seed file that the device's first-boot iot-ds-seed applies, then shreds.
     psk = HKDF(master, serial)        # = gen_bs_psk.derive_bs_psk_hex
     seed = {"serial": "<raw serial>", "key": "<64-hex psk>"}
 
-Drop the seed at `/var/lib/iot/bs-seed.json` on the device's DATA partition
-(NOT the shared rootfs) before first boot. The cloud re-derives the same key
-from the serial, so no per-device cloud row is needed.
+Drop the seed onto the card before first boot — `iot-ds-seed` applies it then
+shreds it. Either the ext4 `data` partition (`/var/lib/iot/bs-seed.json`,
+Linux flashers) or the FAT `boot` partition (`/bs-seed.json` → mounts at
+`/boot`; what `flash-sd.sh --personalize` uses, so macOS/Windows can write it
+without ext4 support). The cloud re-derives the same key from the serial, so no
+per-device cloud row is needed.
 
 The `<master>` is the HKDF root — the SAME secret you wrapped into the cloud
 with bs-master-wrap. Keep it in your manufacturing vault; it never ships on the

--- a/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
+++ b/yocto/meta-iot/recipes-iot/lwm2m/files/iot-ds-seed
@@ -25,13 +25,24 @@ set -eu
 SOCK="${IOT_DS_SOCK:-/run/iot/data_store.sock}"
 STATE="${IOT_DS_STATE:-/var/lib/iot}"
 FLAG="$STATE/.seeded"
-BS_SEED="$STATE/bs-seed.json"
 DSCLI="ds-cli --socket=$SOCK"
+
+# Zero-touch BS personalisation seed (apps/docs/tdd-bs-hkdf-zerotouch.md). The
+# host tool iot-bs-personalize drops bs-seed.json onto the card at flash time.
+# Search the data partition (Linux flashers) AND the FAT /boot partition
+# (flash-sd.sh writes there so macOS/Windows can personalise — they can't mount
+# the ext4 data partition). First found wins.
+bs_seed_path() {
+    for c in "$STATE/bs-seed.json" /boot/bs-seed.json /boot/firmware/bs-seed.json; do
+        [ -f "$c" ] && { echo "$c"; return 0; }
+    done
+    return 1
+}
 
 # Nothing to do only when BOTH the one-time seed has run AND there is no pending
 # zero-touch BS personalisation file. (The BS block below is independent of the
 # engineer-account flag so a unit personalised after first boot still applies.)
-[ -f "$FLAG" ] && [ ! -f "$BS_SEED" ] && exit 0
+[ -f "$FLAG" ] && ! bs_seed_path >/dev/null && exit 0
 
 # After=iot-ds orders start, not readiness — wait for the socket to appear.
 i=0
@@ -49,7 +60,8 @@ fi
 # host tool iot-bs-personalize: {"serial":"<raw>","key":"<64-hex derived PSK>"}.
 # Apply it ONCE (when iot.bs.psk.key is still empty), then shred the file. This
 # is what lets a freshly-flashed device reach the BS with no device-ui step.
-if [ -f "$BS_SEED" ]; then
+BS_SEED="$(bs_seed_path || true)"
+if [ -n "$BS_SEED" ]; then
     # Only personalise if not already done (idempotent). dev-mode is on at first
     # boot, so root's ds-cli may read/write the gid:engineer PSK keys.
     CUR_KEY=$($DSCLI get iot.bs.psk.key 2>/dev/null || true)
@@ -64,7 +76,8 @@ if [ -f "$BS_SEED" ]; then
                && $DSCLI set iot.bs.psk.override true; then
                 # Best-effort shred (busybox has no shred): zero, then remove.
                 # The key also lives in the ds persist file, so this is only
-                # belt-and-suspenders against the seed lingering on the FS.
+                # belt-and-suspenders against the seed lingering on the FS
+                # (esp. the FAT /boot partition, readable off the card).
                 dd if=/dev/zero of="$BS_SEED" bs=1 \
                    count="$(wc -c < "$BS_SEED")" conv=notrunc 2>/dev/null || true
                 rm -f "$BS_SEED"
@@ -75,6 +88,10 @@ if [ -f "$BS_SEED" ]; then
         else
             echo "iot-ds-seed: bs-seed.json malformed (need serial+key); ignoring" >&2
         fi
+    else
+        # Already personalised but a seed lingers (e.g. on the FAT /boot
+        # partition) — remove it so the derived key doesn't sit on the card.
+        rm -f "$BS_SEED" 2>/dev/null || true
     fi
 fi
 


### PR DESCRIPTION
`flash-sd.sh --personalize` drops a per-unit Bootstrap PSK seed onto the card right after writing the image, so a freshly-flashed device registers with **no manual step** (apps/docs/tdd-bs-hkdf-zerotouch.md, P3).

## Why the boot partition, not data
The wic layout puts `/var/lib/iot` on the **ext4 `data`** partition — which **macOS/Windows can't mount**. Only the **FAT `boot`** partition is writable from any host. So the seed goes there, and the device picks it up from `/boot`.

## Changes
- **`iot-ds-seed`**: searches `/var/lib/iot`, `/boot`, `/boot/firmware` for `bs-seed.json` (first found wins), applies it (`iot.bs.psk.*` + `override=true`) and shreds it — including removing a lingering seed off the FAT `/boot` once the key is already set.
- **`flash-sd.sh`**: new `--personalize` / `--master <hex|@file>` / `--serial <serial>` / `--seed <file>`. Derives the seed **up front** (fails before the destructive wipe on a bad master/serial), then after `dd` mounts p1 (the FAT `boot` vol — `diskutil` on macOS, label-matched mount on Linux), writes `bs-seed.json`, unmounts. The **master never lands on the card** — only the derived per-unit key.
- **`iot-bs-personalize`**: docstring updated for the boot-partition path.

## Usage
```sh
./flash-sd.sh --personalize --master @master.hex --serial 100000003d1f9c2e
./flash-sd.sh --personalize --seed /path/to/bs-seed.json     # pre-built seed
```

## Verified
`bash -n` / `sh -n` clean; the script's seed derivation matches the shared cross-check vector; device-side `sed`-parse round-trips; fail-fast validation triggers before any disk action; `test_iot_bs_personalize` 7/7. (The actual SD mount/write path needs a real card — exercised on first hardware run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)