### PR TITLE
fix(build): don't install bs-master-wrap in the device image (Yocto QA)

### DIFF
--- a/apps/CMakeLists.txt
+++ b/apps/CMakeLists.txt
@@ -264,9 +264,15 @@ endif()
 # bs-master-wrap — zero-touch HKDF master KMS-wrap operator tool. Lives under
 # tools/ (not src/) so the GLOB above doesn't pull its main() into lwm2m. Links
 # only psk_gen.cpp + OpenSSL.
+#
+# Deliberately NOT install()ed: it is a cloud/manufacturing-side tool, not a
+# device binary. The Yocto device recipe runs `make install`, and an installed
+# /usr/bin/bs-master-wrap that the recipe's FILES doesn't ship fails the
+# do_package QA "installed-vs-shipped" check. The cloud image instead copies the
+# built binary straight out of the build dir (apps/cloud/Dockerfile). The target
+# still builds everywhere; it just isn't installed by `make install`.
 add_executable(bs-master-wrap tools/bs_master_wrap.cpp src/psk_gen.cpp)
 target_link_libraries(bs-master-wrap crypto)
-install(TARGETS bs-master-wrap RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR})
 
 include(GNUInstallDirs)
 

--- a/apps/cloud/Dockerfile
+++ b/apps/cloud/Dockerfile
@@ -149,6 +149,11 @@ COPY --from=builder /tmp/bds/ds-cli /usr/local/bin/
 COPY --from=builder /tmp/bcloud/iot-cloudd /usr/local/bin/
 COPY --from=builder /tmp/bhttp/iot-httpd /usr/local/bin/
 COPY --from=builder /tmp/blwm2m/lwm2m /usr/local/bin/
+# bs-master-wrap: zero-touch HKDF master KMS-wrap operator tool (apps/docs/
+# tdd-bs-hkdf-zerotouch.md). Copied straight from the build dir — it is not
+# install()ed (would fail the Yocto device do_package QA), so the cloud picks it
+# up here.
+COPY --from=builder /tmp/blwm2m/bs-master-wrap /usr/local/bin/
 
 # Static assets — both cloud UI (webui/) and device UI (webui/) served
 # by iot-httpd depending on www-dir.


### PR DESCRIPTION
## The break
The Yocto device build (`iot_git.bb`) failed `do_package`:
```
QA Issue: iot: Files/directories were installed but not shipped in any package:
  /usr/bin/bs-master-wrap
... [installed-vs-shipped]
```
`install(TARGETS bs-master-wrap)` (added with the tool in the P2b series) makes the recipe's `make install` (`cmake_do_install`) drop the binary into the rootfs, but the recipe's `FILES` doesn't ship it — and it **shouldn't**: `bs-master-wrap` wraps the fleet HKDF master and is a cloud/manufacturing operator tool, not a device binary.

## Fix
- Remove the `install(TARGETS bs-master-wrap)` rule. The target still **builds** everywhere (`add_executable` kept) — it's just no longer installed by `make install`, so Yocto `do_install` won't place it and the QA check passes.
- The **cloud** image keeps it by copying the built binary straight from the build dir (`apps/cloud/Dockerfile`), exactly like `lwm2m` / `ds-server` / `iot-cloudd` are already copied. (Cloud builds all targets via `ninja`, so the binary is present.)

## Verified (podman)
- `bs-master-wrap` **absent** from every `cmake_install.cmake` install rule.
- `lwm2m` install rule **still present**.
- `bs-master-wrap` **still builds**.

No device-facing behaviour change; `bs-master-wrap` was never meant to ship on devices. Unblocks the full-image Yocto build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)