### PR TITLE
fix(lwm2m): CoAP-ping NAT keepalive to stop registration churn behind NAT

### DIFF
--- a/apps/docs/lwm2m-design.md
+++ b/apps/docs/lwm2m-design.md
@@ -409,6 +409,21 @@ can strand the FSM, while `check_ack_timeout` stops a lost one from stranding it
 *permanently*. Both are wanted; neither replaces the other. The split-keepalive
 is a follow-up to the lost-ack recovery, not a prerequisite.
 
+**Implemented (transport keepalive).** Timer 2 ships as `ClientConfig.keepaliveSeconds`
+(default 20 s; 0 disables). The 1 Hz client tick sends an empty CoAP `CON`
+(`RegistrationClient::build_keepalive_ping`) on the DM session once that many
+seconds elapse with no other client→DM traffic — the timer is reset by every
+Update **and** every telemetry Send, so it is genuinely idle-suppressed and a
+busy device emits no extra pings. The DM answers with a `RST`
+(`CoAPAdapter::handleEmptyMessage` → `buildReset`); both ends treat empty CoAP
+messages (ping/RST) outside the request dispatcher, so a ping never triggers the
+`buildResponse` echo. This was added after a field failure: with the 90 s
+lifetime → 60 s Update cadence, devices on a NAT/CGNAT link whose UDP idle
+timeout was ~30 s lost their port mapping between Updates — the source port
+rebound (visible cloud-side as DTLS records from a new `ip:port` for the same
+WAN IP → "unknown peer" alerts and `expired registration`). 20 s holds a ~30 s
+NAT; lower `keepaliveSeconds` for more aggressive links.
+
 ### 5.4 Registration Server
 
 ```

--- a/apps/inc/coap_adapter.hpp
+++ b/apps/inc/coap_adapter.hpp
@@ -80,11 +80,20 @@ class CoAPAdapter {
          * @return std::string 
          */
         std::string buildResponse(const CoAPMessage& message);
+        /// Build a 4-byte CoAP Reset (RST) echoing `message`'s message-id. The
+        /// RFC 7252 §4.3 answer to an empty Confirmable (a CoAP ping / NAT
+        /// keepalive); also the safe reply to anything we can't process.
+        std::string buildReset(const CoAPMessage& message);
+        /// True (and consumes the message) when `m` is an empty CoAP message
+        /// (code 0.00): a Confirmable empty → RST appended to `out` (ping reply);
+        /// a Reset / empty Non-confirmable → dropped. Keeps empties out of the
+        /// request dispatcher. Caller returns immediately when this returns true.
+        bool handleEmptyMessage(const CoAPMessage& m, std::vector<std::string>& out);
         /**
-         * @brief 
-         * 
-         * @param message 
-         * @return std::string 
+         * @brief
+         *
+         * @param message
+         * @return std::string
          */
         std::string buildRegistrationAck(const CoAPMessage& message);
         /**

--- a/apps/inc/lwm2m_registration_client.hpp
+++ b/apps/inc/lwm2m_registration_client.hpp
@@ -62,11 +62,29 @@ struct ClientConfig {
     /// server's lifetime expires.
     std::uint32_t  ackTimeoutSeconds{6};
     std::uint32_t  maxAckRetransmits{3};
+    /// NAT keepalive cadence. The registration Update doubles as the keepalive,
+    /// but it only fires at `lifetime − updateMarginSeconds` (e.g. 60 s with a
+    /// 90 s lifetime) — longer than a typical NAT/CGNAT UDP idle timeout (~30 s),
+    /// so the mapping dies between Updates and the source port rebinds, breaking
+    /// the DTLS session. A small CoAP ping (empty CON) every keepaliveSeconds
+    /// holds the mapping without perturbing the registration lifetime. 0
+    /// disables it. Keep it below the link's NAT timeout (20 s is safe for a
+    /// ~30 s timeout; lower for aggressive CGNAT/cellular).
+    std::uint32_t  keepaliveSeconds{20};
 };
 
 class RegistrationClient {
 public:
     RegistrationClient(ClientConfig cfg, const ObjectStore& store);
+
+    /// CoAP ping — an empty Confirmable (RFC 7252 §4.3): ver=1, type=CON,
+    /// TKL=0, code=0.00, the given message-id; 4 bytes. The DM answers RST.
+    /// Sent on the DTLS socket between Updates as a NAT keepalive. Static (no
+    /// FSM state): the reply is correlated by nothing and simply dropped.
+    static std::string build_keepalive_ping(std::uint16_t messageId);
+
+    /// Configured NAT keepalive cadence in seconds (0 = disabled).
+    std::uint32_t keepalive_seconds() const { return m_cfg.keepaliveSeconds; }
 
     /// Build POST /rd request bytes per REQ-REG-001 / 007. Caller supplies
     /// a fresh message ID and 0..8 token bytes; we echo them in the

--- a/apps/src/coap_adapter.cpp
+++ b/apps/src/coap_adapter.cpp
@@ -1044,6 +1044,29 @@ std::vector<std::string> CoAPAdapter::handleLwM2MObjects(const CoAPAdapter::CoAP
     return(out);
 }
 
+std::string CoAPAdapter::buildReset(const CoAPMessage& message) {
+    // ver=1, type=RST(3), TKL=0, code=0.00; echo the message-id (big-endian).
+    std::string s;
+    s.push_back(static_cast<char>((1u << 6) | (3u << 4)));            // 0x70
+    s.push_back(static_cast<char>(0x00));                            // code 0.00
+    s.push_back(static_cast<char>((message.coapheader.msgid >> 8) & 0xFF));
+    s.push_back(static_cast<char>(message.coapheader.msgid & 0xFF));
+    return s;
+}
+
+// Empty CoAP message (code 0.00) that is NOT an Acknowledgement: a Confirmable
+// empty is a ping (NAT keepalive + liveness, RFC 7252 §4.3) → answer RST; a
+// Reset or empty Non-confirmable is dropped. Returns true when it consumed the
+// message (caller should return immediately) so empties never reach the request
+// dispatcher, which would reflexively buildResponse() and echo a bogus frame.
+bool CoAPAdapter::handleEmptyMessage(const CoAPMessage& m, std::vector<std::string>& out) {
+    if (m.coapheader.code != 0) return false;
+    if (!RequestType[m.coapheader.type].compare("Confirmable"))
+        out.push_back(buildReset(m));     // ping → RST
+    // else Reset / empty Non-confirmable → drop quietly.
+    return true;
+}
+
 std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in, std::vector<std::string>& out) {
     cumulativeOptionNumber = 0;
     CoAPMessage coapmessage;
@@ -1089,6 +1112,11 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, const std::string& in
         if (isAmIClient && m_sendAckCb) m_sendAckCb(coapmessage);
         return 0;
     }
+
+    // CoAP ping / RST / empty (code 0.00): server answers a ping with RST, both
+    // sides drop a RST. Keeps NAT-keepalive pings out of the request dispatcher.
+    if (handleEmptyMessage(coapmessage, out))
+        return static_cast<std::int32_t>(out.size());
 
     // L4 hot path: Bootstrap dispatch (no DTLS session variant).
     if (!isAmIClient && m_bsServer) {
@@ -1327,6 +1355,11 @@ std::int32_t CoAPAdapter::processRequest(bool isAmIClient, session_t* session, s
         if (isAmIClient && m_sendAckCb) m_sendAckCb(coapmessage);
         return 0;
     }
+
+    // CoAP ping / RST / empty (code 0.00): server answers a ping with RST, both
+    // sides drop a RST. Keeps NAT-keepalive pings out of the request dispatcher.
+    if (handleEmptyMessage(coapmessage, out))
+        return static_cast<std::int32_t>(out.size());
 
     // L4 hot path: if a Bootstrap Server is attached, give it first
     // refusal on /bs CoAP messages.

--- a/apps/src/lwm2m_registration_client.cpp
+++ b/apps/src/lwm2m_registration_client.cpp
@@ -18,6 +18,13 @@ RegistrationClient::RegistrationClient(ClientConfig cfg,
       m_endpoint(m_cfg.endpoint),
       m_store(store) {}
 
+std::string RegistrationClient::build_keepalive_ping(std::uint16_t messageId) {
+    // RFC 7252 §4.3: an empty Confirmable (no token, code 0.00) is a CoAP ping.
+    std::ostringstream ss;
+    emit_header(ss, messageId, /*token*/"", /*code 0.00*/0x00, TYPE_CON);
+    return ss.str();
+}
+
 void RegistrationClient::set_endpoint(std::string ep) {
     {
         std::lock_guard<std::mutex> g(m_endpoint_mtx);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1712,10 +1712,14 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
     // runs at 1 Hz; we only re-publish on a transition so the device-ui
     // long-poll fires on real changes, not every second.
     auto lastConn = std::make_shared<std::string>();
+    // NAT keepalive — last time we emitted a CoAP ping (or an Update, which
+    // also holds the mapping). Epoch ⇒ first Registered tick pings immediately.
+    auto lastKeepalive =
+        std::make_shared<std::chrono::steady_clock::time_point>();
     app->udpAdapter()->on_tick_client([wreg, wdm, wapp, rebind, wbs,
                                        reboot_after, bootPhase, bootDeadline,
                                        bootRetryAfter, bootBackoff, bsHost, bsPort,
-                                       dtls, &ds, lastConn, sendst]() {
+                                       dtls, &ds, lastConn, lastKeepalive, sendst]() {
         // Liveness first: petting the watchdog here ties it to the reactor
         // actually dispatching this 1 Hz tick. If the reactor stalls (the
         // alive-but-wedged failure this guards against), the pings stop and
@@ -1913,6 +1917,21 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
                 /*withAdvertisedSet*/ false);
             tx_via(*a, payload, svc);
             reg->note_update_sent(now);
+            *lastKeepalive = now;     // the Update itself holds the NAT mapping
+        }
+
+        // NAT keepalive (apps/docs/keepalive note): a small CoAP ping (empty
+        // CON) holds the UDP mapping when the Update cadence (lifetime − margin)
+        // exceeds the link's NAT idle timeout. Only while cleanly Registered;
+        // the Update above resets the timer so a ping never trails it.
+        if (reg->keepalive_seconds() > 0 &&
+            reg->state() == ::lwm2m::RegistrationState::Registered &&
+            now - *lastKeepalive >=
+                std::chrono::seconds(reg->keepalive_seconds())) {
+            tx_via(*a,
+                   ::lwm2m::RegistrationClient::build_keepalive_ping(next_msgid()),
+                   svc);
+            *lastKeepalive = now;
         }
 
         // ── v2 Send telemetry (TDD §3b #1). Only while cleanly Registered —
@@ -1943,6 +1962,7 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
                 if (!wire.empty()) {
                     tx_via(*a, wire, svc);
                     sendst->inflight_since = now;
+                    *lastKeepalive = now;   // a Send also holds the NAT mapping
                 }
             }
         }

--- a/apps/test/coap_adapter_test.cpp
+++ b/apps/test/coap_adapter_test.cpp
@@ -97,6 +97,52 @@ TEST(CoAPAdapterTestSuite, CoAPSerialisation)
     
 }
 
+// ── CoAP ping / RST handling (NAT keepalive) ────────────────────────────────
+
+TEST(CoAPAdapterTestSuite, BuildResetIsFourByteRstEchoingMsgId) {
+    CoAPAdapter a;
+    CoAPAdapter::CoAPMessage m{};
+    m.coapheader.msgid = 0xBEEF;
+    auto rst = a.buildReset(m);
+    ASSERT_EQ(4u, rst.size());
+    EXPECT_EQ(0x70, static_cast<std::uint8_t>(rst[0]));   // ver1, type RST(3), TKL0
+    EXPECT_EQ(0x00, static_cast<std::uint8_t>(rst[1]));   // code 0.00
+    EXPECT_EQ(0xBE, static_cast<std::uint8_t>(rst[2]));   // msgid high
+    EXPECT_EQ(0xEF, static_cast<std::uint8_t>(rst[3]));   // msgid low
+}
+
+TEST(CoAPAdapterTestSuite, EmptyConPingAnsweredWithReset) {
+    CoAPAdapter a;
+    CoAPAdapter::CoAPMessage m{};
+    m.coapheader.type  = 0;        // Confirmable
+    m.coapheader.code  = 0;        // 0.00 (empty) → a CoAP ping
+    m.coapheader.msgid = 0x1234;
+    std::vector<std::string> out;
+    EXPECT_TRUE(a.handleEmptyMessage(m, out));            // consumed
+    ASSERT_EQ(1u, out.size());
+    EXPECT_EQ(0x70, static_cast<std::uint8_t>(out[0][0]));  // answered with RST
+}
+
+TEST(CoAPAdapterTestSuite, ResetIsConsumedAndDroppedNotEchoed) {
+    CoAPAdapter a;
+    CoAPAdapter::CoAPMessage m{};
+    m.coapheader.type = 3;         // Reset
+    m.coapheader.code = 0;
+    std::vector<std::string> out;
+    EXPECT_TRUE(a.handleEmptyMessage(m, out));            // consumed
+    EXPECT_TRUE(out.empty());                             // no echo back
+}
+
+TEST(CoAPAdapterTestSuite, NonEmptyRequestIsNotConsumed) {
+    CoAPAdapter a;
+    CoAPAdapter::CoAPMessage m{};
+    m.coapheader.type = 0;         // Confirmable
+    m.coapheader.code = 0x02;      // POST — a real request, must dispatch normally
+    std::vector<std::string> out;
+    EXPECT_FALSE(a.handleEmptyMessage(m, out));
+    EXPECT_TRUE(out.empty());
+}
+
 CoAPAdapterTest::CoAPAdapterTest(const std::string& jsonFileName) {
     fileName = jsonFileName;
 }

--- a/apps/test/registration_client_test.cpp
+++ b/apps/test/registration_client_test.cpp
@@ -469,3 +469,13 @@ TEST(RegistrationClient, deregister_send_is_stamped_against_instant_timeout) {
     EXPECT_EQ(AR::ReRegister, cli.check_ack_timeout(t + std::chrono::seconds(7)));
     EXPECT_EQ(RegistrationState::Unregistered, cli.state());
 }
+
+// NAT keepalive — the CoAP ping is an empty Confirmable (RFC 7252 §4.3).
+TEST(RegistrationClient, build_keepalive_ping_is_empty_con) {
+    auto ping = RegistrationClient::build_keepalive_ping(0xABCD);
+    ASSERT_EQ(4u, ping.size());
+    EXPECT_EQ(0x40, static_cast<std::uint8_t>(ping[0]));  // ver1, type CON, TKL0
+    EXPECT_EQ(0x00, static_cast<std::uint8_t>(ping[1]));  // code 0.00 (empty)
+    EXPECT_EQ(0xAB, static_cast<std::uint8_t>(ping[2]));  // message-id high
+    EXPECT_EQ(0xCD, static_cast<std::uint8_t>(ping[3]));  // message-id low
+}


### PR DESCRIPTION
## The bug (from cloud logs)
A device registered, then churned: every ~30 s the DM logged `got an alert for an unknown peer` from `<WAN-IP>:**18194**` while the working session was `<WAN-IP>:**52952**` (same IP, **different port**), and periodically `expired 1 registration`. Most visible once the VPN settled and the registration Update was the only LwM2M traffic.

## Root cause
The registration Update **doubles as the NAT keepalive**, but with `cloud.dm.lifetime=90` and `updateMarginSeconds=30` it only fires every **~60 s**. A NAT/CGNAT/cellular link with a **~30 s UDP idle timeout** drops the mapping between Updates → the device's DTLS source port rebinds → tinydtls (which keys peers by `ip:port`) sees an "unknown peer" → Updates can't refresh → `expired registration` → re-handshake. Same-IP/different-port rules out VPN-tunnel redirection (that would change the *IP*).

This is exactly the split-keepalive already specified in `lwm2m-design.md` §5.3.3 ("Timer 2 — an empty CoAP `CON` ping, idle-suppressed, to hold the NAT") — it just hadn't been built.

## The fix
- **`RegistrationClient::build_keepalive_ping`** — empty CoAP `CON` (RFC 7252 §4.3), 4 bytes. `ClientConfig.keepaliveSeconds` (default **20 s**, `0` disables) + accessor.
- **1 Hz client tick** (`main.cpp`): while `Registered`, send a ping once `keepaliveSeconds` elapse with no client→DM traffic. The timer **resets on every Update and every telemetry Send**, so it's genuinely idle-suppressed — a busy device emits no extra pings.
- **`CoAPAdapter::handleEmptyMessage` + `buildReset`**: both `processRequest` variants now intercept empty messages (code `0.00`) *before* the request dispatcher — a `CON` ping → `RST`; a `RST` → dropped. Keeps pings/RSTs out of the `buildResponse()` fallthrough (the Leshan-echo failure mode) on both the DM (gets the ping) and the device (gets the RST).
- **docs**: §5.3.3 marked implemented with the failure write-up.

`20 s` holds a ~30 s NAT; lower `keepaliveSeconds` for more aggressive links. (The quick no-rebuild mitigation remains `ds-cli set cloud.dm.lifetime 45`.)

## Verification (podman)
- Full `lwm2m` binary links clean.
- `lwm2m_test` **26/26**: new `build_keepalive_ping` byte test + 4 `handleEmptyMessage`/`buildReset` tests (ping→RST, RST→drop, real request not consumed) + existing reg/coap suites.

Live behind-NAT confirmation (churn stops) is the on-hardware check, like the other deferred integration items.

🤖 Generated with [Claude Code](https://claude.com/claude-code)