### PR TITLE
fix(image): ship a known-good /etc/fstab (base-files bbappend) for A/B

### DIFF
--- a/yocto/meta-iot/recipes-core/base-files/base-files_%.bbappend
+++ b/yocto/meta-iot/recipes-core/base-files/base-files_%.bbappend
@@ -1,0 +1,16 @@
+# Ship a known-good /etc/fstab so the image never bakes the self-bricking one.
+#
+# The field failure (apps/docs / fstab_sanity_check in iot-image.bb): a stale
+# base-files sstate — a leftover from an abandoned 6-partition layout — injected
+# `/dev/mmcblk0p5 -> /data` and `/dev/mmcblk0p6 -> /home`. Those partitions do
+# not exist in any current wks (the A/B layout iot-ab.wks.in is p1 boot, p2/p3
+# rootA/rootB, p4 data), so the device hangs at boot / drops to emergency mode,
+# and on A/B BOTH banks brick before rollback can help.
+#
+# Prepending our fstab makes it win over any stale/external one AND changes the
+# recipe signature, so the bad base-files sstate is invalidated (no cleansstate
+# needed). This fstab matches the running A/B device (192.168.1.50): stock
+# mounts + /boot from mmcblk0p1. NB the data partition (p4) is intentionally not
+# mounted here — same as the live device; see the bbappend note in git for the
+# A/B state-persistence follow-up (LABEL=data -> /var/lib/iot).
+FILESEXTRAPATHS:prepend := "${THISDIR}/files:"

--- a/yocto/meta-iot/recipes-core/base-files/files/fstab
+++ b/yocto/meta-iot/recipes-core/base-files/files/fstab
@@ -1,0 +1,12 @@
+# stock fstab - you probably want to override this with a machine specific one
+
+/dev/root            /                    auto       defaults              1  1
+proc                 /proc                proc       defaults              0  0
+devpts               /dev/pts             devpts     mode=0620,ptmxmode=0666,gid=5      0  0
+tmpfs                /run                 tmpfs      mode=0755,nodev,nosuid,strictatime 0  0
+tmpfs                /var/volatile        tmpfs      defaults              0  0
+
+# uncomment this if your device has a SD/MMC/Transflash slot
+#/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
+
+/dev/mmcblk0p1  /boot   vfat    defaults         0       0


### PR DESCRIPTION
## The break
`iot-image` `do_rootfs` failed the `fstab_sanity_check` precheck: a baked `/etc/fstab` mounted `/dev/mmcblk0p5 → /data` and `/dev/mmcblk0p6 → /home` — partitions that don't exist (the A/B wks is `p1 boot, p2/p3 rootA/B, p4 data`). That's a self-bricking image (`local-fs.target` times out → emergency mode; on A/B **both banks** brick before rollback). It's a leftover from an abandoned 6-partition layout carried in **stale `base-files` sstate** — **not in the repo** (git-confirmed: the only commit naming p5/p6 is the precheck itself).

The same fstab was deleted live on the running device during earlier A/B debugging; this caught it again at build time (the precheck doing its job).

## The fix
Ship `meta-iot/recipes-core/base-files/files/fstab` via a `base-files_%.bbappend` (`FILESEXTRAPATHS:prepend`). The content is **byte-identical to the running A/B device `192.168.1.50`** (`root=/dev/mmcblk0p2`, `rauc.slot=A`): stock mounts + `/boot` from `mmcblk0p1`, **no p5/p6**. Prepending makes it win over any stale/external fstab, and the new bbappend **changes the base-files signature so the bad sstate is invalidated** — no manual `cleansstate` needed. Layout-agnostic (only references `p1`), so it's valid for both the A/B and single-rootfs wks.

## Verified
- fstab **byte-identical** to `192.168.1.50` (diff clean).
- Passes the `iot-image.bb` precheck logic (no `/dev/sd*`, no `mmcblk0p>4`).

## Follow-up (not in this PR, per "match .50")
`p4`/data is **not** mounted — same as the live device. For A/B OTA to preserve ds state (`/var/lib/iot`) across a bank swap, it should mount `LABEL=data → /var/lib/iot`. Flagged for a decision; left as-is here to match what's running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)