### PR TITLE
feat(image): A/B CI toggle + mount data partition for OTA state persistence

### DIFF
--- a/.github/workflows/release-build.yml
+++ b/.github/workflows/release-build.yml
@@ -24,12 +24,22 @@ on:
         description: Target MACHINE
         default: raspberrypi3-64
         required: false
+      ab:
+        description: "RAUC A/B image (u-boot + 4-partition wic). Off = single-rootfs."
+        type: boolean
+        default: false
+        required: false
 
 env:
   MACHINE: ${{ github.event.inputs.machine || 'raspberrypi3-64' }}
   # The branch this run is on (the release branch). The iot recipe fetches its
   # source from here, so the artifacts carry release code, not main.
   IOT_BRANCH: ${{ github.ref_name }}
+  # A/B (RAUC) toggle. '1' → build.sh adds the RAUC layers + entrypoint writes the
+  # u-boot/4-partition local.conf (WKS_FILE=iot-ab.wks.in); empty → single-rootfs.
+  # Only the manual (workflow_dispatch) form can request A/B — release-branch
+  # pushes leave the input undefined, so they stay single-rootfs.
+  IOT_AB: ${{ github.event.inputs.ab == 'true' && '1' || '' }}
 
 jobs:
   full-image:

--- a/yocto/meta-iot/recipes-core/base-files/base-files_%.bbappend
+++ b/yocto/meta-iot/recipes-core/base-files/base-files_%.bbappend
@@ -9,8 +9,8 @@
 #
 # Prepending our fstab makes it win over any stale/external one AND changes the
 # recipe signature, so the bad base-files sstate is invalidated (no cleansstate
-# needed). This fstab matches the running A/B device (192.168.1.50): stock
-# mounts + /boot from mmcblk0p1. NB the data partition (p4) is intentionally not
-# mounted here — same as the live device; see the bbappend note in git for the
-# A/B state-persistence follow-up (LABEL=data -> /var/lib/iot).
+# needed). Based on the running A/B device (192.168.1.50): stock mounts + /boot
+# from mmcblk0p1. It additionally mounts the data partition (LABEL=data, nofail)
+# at /var/lib/iot so an A/B OTA bank swap preserves ds state — the wks data
+# partition carries `--no-fstab-update` so this entry is the sole authority.
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"

--- a/yocto/meta-iot/recipes-core/base-files/files/fstab
+++ b/yocto/meta-iot/recipes-core/base-files/files/fstab
@@ -10,3 +10,11 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 #/dev/mmcblk0p1       /media/card          auto       defaults,sync,noauto  0  0
 
 /dev/mmcblk0p1  /boot   vfat    defaults         0       0
+
+# Persistent data partition (A/B layout: p4, label "data") → /var/lib/iot (ds
+# store, certs, /etc/iot overrides). Mounted by LABEL so it follows the data
+# partition across an A/B bank swap and any p-number change — this is what makes
+# A/B OTA preserve ds state instead of losing it with the swapped-out rootfs.
+# `nofail` so a single-rootfs image (no such partition) still boots; iot-ds's
+# StateDirectory=iot then fixes /var/lib/iot ownership/mode on the mounted fs.
+LABEL=data  /var/lib/iot  ext4  defaults,nofail  0  2

--- a/yocto/meta-iot/wic/iot-ab.wks.in
+++ b/yocto/meta-iot/wic/iot-ab.wks.in
@@ -15,9 +15,11 @@
 # fw_env, with headroom (the per-bank kernel/dtb live in each rootfs /boot,
 # loaded by u-boot from the active bank).
 #
-# The data partition gets an automatic /etc/fstab entry from wic (non-root
-# mountpoints are added unless --no-fstab-update), so /var/lib/iot mounts the
-# `data` label at boot — an image/bank swap never touches ds state or certs.
+# The data partition's /etc/fstab entry is owned by the base-files bbappend
+# (meta-iot/recipes-core/base-files, LABEL=data -> /var/lib/iot, nofail), NOT by
+# wic — `--no-fstab-update` below keeps wic from adding a second, by-PARTUUID
+# entry. base-files owning it makes the mount deterministic and survives a
+# bank swap (state + certs untouched on an image/OTA swap).
 
 # Bank size (1024M) must exceed the standalone rootfs ext4 RAUC carries in the
 # .raucb — that image is inflated by IMAGE_ROOTFS_EXTRA_SPACE (512M of on-target
@@ -27,6 +29,6 @@
 part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4096 --size 100M
 part /     --source rootfs --fstype=ext4 --label rootA --align 4096 --size 1024M
 part /     --source rootfs --fstype=ext4 --label rootB --align 4096 --size 1024M
-part /var/lib/iot --fstype=ext4 --label data --align 4096 --size 256M
+part /var/lib/iot --fstype=ext4 --label data --align 4096 --size 256M --no-fstab-update
 
 bootloader --ptable msdos


### PR DESCRIPTION
Two A/B improvements (follow-ups to #456).

## 1. `IOT_AB` toggle in `release-build.yml`
New `workflow_dispatch` boolean input **`ab`** → sets `IOT_AB`. When on, `build.sh` adds the RAUC layers and `entrypoint.sh` writes the u-boot/4-partition `local.conf` (`WKS_FILE=iot-ab.wks.in`); off → single-rootfs. Release-branch **pushes** leave the input undefined, so they stay single-rootfs (unchanged). Lets the A/B image build from CI instead of only locally.

## 2. Mount the data partition → A/B OTA preserves ds state
Previously (and on the running device `192.168.1.50`) `p4`/data was **unmounted**, so all ds state lived on the active rootfs — an A/B bank swap would lose it, defeating the point of A/B. Now `base-files` fstab mounts it:
```
LABEL=data  /var/lib/iot  ext4  defaults,nofail  0  2
```
- **`LABEL=data`** follows the partition across a bank swap / p-number change.
- **`nofail`** keeps the fstab layout-agnostic — a single-rootfs image (no such partition) still boots.
- **`iot-ds` already has `StateDirectory=iot`**, so systemd fixes ownership/mode on the freshly-mounted (root:root) partition → group-`iot` writable. No tmpfiles change needed.

The wks data partition gains **`--no-fstab-update`** so base-files owns the entry (no duplicate by-PARTUUID line from wic).

## Verified
- fstab passes the `iot-image.bb` precheck (only `p1` + `LABEL=`; nothing `>p4` or `/dev/sd*`).
- Workflow YAML structure valid; build step inherits the workflow-level `IOT_AB`.
- `entrypoint.sh` already adds the RAUC A/B layers + local.conf on `IOT_AB`; `build.sh` forwards it.

## Caveats (need an actual A/B build/boot to confirm)
- The CI builder image must have the `meta-rauc*` / `meta-lts-mixins` layers present for `bitbake-layers add-layer` to succeed under `IOT_AB=1` (works on the local builder that produced `.50`).
- `StateDirectory=iot` over a real mount point at `/var/lib/iot` is expected-fine but worth eyeballing on first A/B boot (perms + that the data partition mounts before `iot-ds`).
- First flash: the data partition is empty → `iot-ds-seed` seeds it once; the `.seeded` flag now lives on the data partition, so it (correctly) persists across bank swaps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)