### PR TITLE
fix(lwm2m): stable /rd/{location} per endpoint across reboot/expiry/restart

### DIFF
--- a/apps/docs/lwm2m-design.md
+++ b/apps/docs/lwm2m-design.md
@@ -449,6 +449,18 @@ LISTEN
 Today, the server replies 2.04 to `/rd` without recording the registration
 or generating a `Location-Path`. The new `ClientRegistry` owns this state.
 
+**Stable `/rd/{location}` per endpoint.** `ALLOCATE_LOCATION` mints a fresh id
+only for a genuinely new endpoint. A re-Register from a known `ep` (a device
+reboot) **reuses the location it had before** — even if the prior registration
+had already `expires_at`-lapsed or been deregistered. `ClientRegistry` keeps an
+`endpoint → location` index that outlives the registration record (not cleared
+on expire/remove) and is rebuilt by `load_from()`, so the mapping survives a
+long offline gap and a server restart alike. Without this, a reboot that
+outlasts the (now short, 90 s) lifetime would mint a new location every time,
+churning `/rd/{loc}` and leaving duplicate `cloud.lwm2m.registrations` rows
+where a stale row can win the last-writer reconcile (the recorded ISP IP stops
+tracking the live device).
+
 ### 5.5 Information Reporting
 
 ```

--- a/apps/inc/lwm2m_registration.hpp
+++ b/apps/inc/lwm2m_registration.hpp
@@ -51,16 +51,19 @@ class ClientRegistry {
 public:
     ClientRegistry() = default;
 
-    /// Insert a registration. If a registration for the **same endpoint**
-    /// already exists (e.g. the device rebooted / came back online and
-    /// re-registered before its prior lifetime expired), its existing
-    /// `location` is **reused** and the record replaced in place — so
-    /// `/rd/{location}` stays stable per endpoint and the registry never
-    /// accumulates duplicate entries for one device. Otherwise a fresh
-    /// identifier is generated. Either way `location` is populated on the
-    /// stored record; callers read the returned value to build the
-    /// Location-Path response. The current clock + `lifetime` define
-    /// `expiresAt`. Returns the (reused or generated) location.
+    /// Insert a registration, reusing a **stable `/rd/{location}` per endpoint**.
+    /// A device that re-registers (reboot) lands on the SAME location it had
+    /// before — even if its prior registration had already expired or been
+    /// deregistered — instead of minting a fresh one and orphaning the old. The
+    /// reuse is backed by an endpoint→location index that OUTLIVES the
+    /// registration record (it is not erased on expire/remove), so the mapping
+    /// survives a long offline gap; `load_from()` rebuilds it so it also
+    /// survives a server restart. Only a genuinely new endpoint mints a fresh
+    /// identifier. This prevents location churn and the duplicate
+    /// `cloud.lwm2m.registrations` rows where a stale row could win the
+    /// last-writer reconcile. `location` is populated on the stored record;
+    /// callers read the returned value to build the Location-Path response. The
+    /// current clock + `lifetime` define `expiresAt`. Returns the location.
     std::string add(ServerRegistration in,
                     std::chrono::steady_clock::time_point now =
                         std::chrono::steady_clock::now());
@@ -108,6 +111,10 @@ public:
 
 private:
     std::map<std::string, ServerRegistration> m_byLocation;
+    /// endpoint → its stable /rd/{location}. Persists across expire()/remove()
+    /// so a re-register after the record is gone reuses the same location.
+    /// Rebuilt by load_from(). Bounded by fleet size.
+    std::map<std::string, std::string>        m_locByEndpoint;
     std::uint64_t                             m_locCounter{0};
     IdGen                                     m_idGen{nullptr};
 };

--- a/apps/src/lwm2m_registration.cpp
+++ b/apps/src/lwm2m_registration.cpp
@@ -1,5 +1,7 @@
 #include "lwm2m_registration.hpp"
 
+#include <algorithm>
+
 namespace lwm2m {
 
 namespace {
@@ -10,36 +12,33 @@ std::string default_id(std::uint64_t counter) {
 
 std::string ClientRegistry::add(ServerRegistration in,
                                 std::chrono::steady_clock::time_point now) {
-    // Re-registration of a known endpoint (device rebooted / came back online
-    // and re-registered while the prior registration still lingers): reuse its
-    // existing location and replace the record in place, rather than minting a
-    // new /rd/{id} and leaving a stale duplicate behind until it expires.
-    // Keeps the location stable per endpoint and prevents duplicate registry
-    // entries — which otherwise surface as duplicate cloud.lwm2m.registrations
-    // rows whose lexicographic location order makes a STALE row win the
-    // last-writer reconcile (e.g. the device's recorded ISP IP stops tracking).
-    if (!in.endpoint.empty()) {
-        for (auto& [loc, reg] : m_byLocation) {
-            if (reg.endpoint == in.endpoint) {
-                in.location     = loc;
-                in.registeredAt = now;
-                in.expiresAt    = now + std::chrono::seconds(in.lifetime);
-                reg = std::move(in);
-                return loc;
-            }
-        }
-    }
-
-    auto gen = m_idGen ? m_idGen : default_id;
+    // Reuse a stable /rd/{location} per endpoint. A device that re-registers —
+    // reboot, even after its prior registration EXPIRED or was deregistered —
+    // lands on the SAME location instead of minting a new one and orphaning the
+    // old. The endpoint→location index outlives the registration record (it is
+    // not cleared on expire()/remove()), so the mapping survives a long offline
+    // gap; load_from() rebuilds it across a server restart. Only a genuinely new
+    // endpoint mints a fresh id. This kills the location churn that otherwise
+    // leaves duplicate cloud.lwm2m.registrations rows where a STALE row can win
+    // the last-writer reconcile (e.g. the device's recorded ISP IP stops
+    // tracking).
     std::string loc;
-    do {
-        loc = "/rd/" + gen(++m_locCounter);
-    } while (m_byLocation.find(loc) != m_byLocation.end());
+    if (!in.endpoint.empty()) {
+        auto it = m_locByEndpoint.find(in.endpoint);
+        if (it != m_locByEndpoint.end()) loc = it->second;
+    }
+    if (loc.empty()) {
+        auto gen = m_idGen ? m_idGen : default_id;
+        do {
+            loc = "/rd/" + gen(++m_locCounter);
+        } while (m_byLocation.find(loc) != m_byLocation.end());
+        if (!in.endpoint.empty()) m_locByEndpoint[in.endpoint] = loc;
+    }
 
     in.location     = loc;
     in.registeredAt = now;
     in.expiresAt    = now + std::chrono::seconds(in.lifetime);
-    m_byLocation[loc] = std::move(in);
+    m_byLocation[loc] = std::move(in);   // replace-or-insert (refreshes peer)
     return loc;
 }
 
@@ -100,10 +99,29 @@ std::vector<std::string> ClientRegistry::expire(
 
 void ClientRegistry::load_from(std::vector<ServerRegistration> persisted) {
     m_byLocation.clear();
+    m_locByEndpoint.clear();
+    std::uint64_t maxCounter = 0;
     for (auto& reg : persisted) {
-        std::string loc = reg.location;     // preserve persisted IDs
+        const std::string loc = reg.location;   // preserve persisted IDs
+        // Rebuild the endpoint→location index so a re-register after a server
+        // restart reuses the persisted location, not a fresh one.
+        if (!reg.endpoint.empty()) m_locByEndpoint[reg.endpoint] = loc;
+        // Advance the mint counter past any numeric "/rd/<n>" so a later mint
+        // for a NEW endpoint never reissues a remembered location whose record
+        // is currently absent (device offline at restore time).
+        if (loc.compare(0, 4, "/rd/") == 0) {
+            const std::string id = loc.substr(4);
+            if (!id.empty() &&
+                id.find_first_not_of("0123456789") == std::string::npos) {
+                try {
+                    maxCounter = std::max(maxCounter,
+                                          static_cast<std::uint64_t>(std::stoull(id)));
+                } catch (...) {}
+            }
+        }
         m_byLocation[loc] = std::move(reg);
     }
+    m_locCounter = std::max(m_locCounter, maxCounter);
 }
 
 } // namespace lwm2m

--- a/apps/test/registry_test.cpp
+++ b/apps/test/registry_test.cpp
@@ -198,3 +198,48 @@ TEST(Registry, D3_load_from_preserves_locations) {
     EXPECT_NE(nullptr, reg.find("/rd/def"));
     EXPECT_EQ("urn:a", reg.find("/rd/abc")->endpoint);
 }
+
+/* ── Stable /rd/{location} per endpoint across reboot/expiry/restart ───────── */
+
+TEST(Registry, reregister_after_expiry_reuses_same_location) {
+    ClientRegistry reg;
+    auto t0 = std::chrono::steady_clock::now();
+    auto first = reg.add(make_reg("urn:dev:1", /*lt*/ 100), t0);
+
+    // Device offline long enough that the registration expires and is reaped.
+    auto reaped = reg.expire(t0 + std::chrono::seconds(101));
+    ASSERT_EQ(1u, reaped.size());
+    EXPECT_EQ(0u, reg.size());
+
+    // It reboots and re-registers — same location, not a churned new one.
+    auto again = reg.add(make_reg("urn:dev:1", 100), t0 + std::chrono::seconds(300));
+    EXPECT_EQ(first, again);
+    EXPECT_EQ(1u, reg.size());
+}
+
+TEST(Registry, reregister_after_deregister_reuses_same_location) {
+    ClientRegistry reg;
+    auto first = reg.add(make_reg("urn:dev:1"));
+    ASSERT_TRUE(reg.remove(first));
+    EXPECT_EQ(0u, reg.size());
+
+    auto again = reg.add(make_reg("urn:dev:1"));
+    EXPECT_EQ(first, again);                  // deregister doesn't forget the loc
+    EXPECT_EQ(1u, reg.size());
+}
+
+TEST(Registry, load_from_rehydrates_endpoint_location_and_advances_counter) {
+    // Server restart: rehydrate from Mongo, then the device re-registers.
+    ClientRegistry reg;
+    ServerRegistration persisted = make_reg("urn:dev:7");
+    persisted.location = "/rd/42";            // counter-based id minted before restart
+    reg.load_from({persisted});
+
+    // Re-register of the rehydrated endpoint reuses its persisted location.
+    EXPECT_EQ("/rd/42", reg.add(make_reg("urn:dev:7")));
+
+    // A brand-new endpoint mints ABOVE the loaded max — never reissues /rd/42.
+    auto fresh = reg.add(make_reg("urn:dev:new"));
+    EXPECT_NE("/rd/42", fresh);
+    EXPECT_EQ(2u, reg.size());
+}


### PR DESCRIPTION
## The bug
On every device reboot the cloud LwM2M server minted a **new** `/rd/{location}` and left the previous registration to expire — churning the location and leaving **duplicate `cloud.lwm2m.registrations` rows** (a stale row could win the last-writer reconcile, so the recorded ISP IP stopped tracking the live device).

## Why the existing dedup missed it
`ClientRegistry::add()` already reused the location for a re-register — but only while the prior record was still in `m_byLocation`. With the **now-short 90 s lifetime** (from the NAT-keepalive fix), a reboot that outlasts the lifetime has its old registration **reaped first**, so the endpoint→location memory was gone and a fresh counter id was minted. Hence "new location every reboot."

## The fix
`ClientRegistry` now keeps an **`endpoint → location` index that outlives the registration record** — it is *not* cleared on `expire()`/`remove()`. So a re-register reuses the same location even after the prior one expired or was deregistered. `load_from()` rebuilds the index **and advances the mint counter past any numeric `/rd/<n>`**, so the mapping survives a server restart too (and a new endpoint never reissues a remembered-but-absent location). The location stays opaque to the client, so this is spec-clean (RFC: a Register for a known endpoint replaces the prior registration).

## Tests (podman, 43/43 in the filter; full `lwm2m` binary builds)
- `reregister_after_expiry_reuses_same_location`
- `reregister_after_deregister_reuses_same_location`
- `load_from_rehydrates_endpoint_location_and_advances_counter`
- Existing assertions unchanged: counter-based first location (`/rd/1`), uniqueness across distinct endpoints, the still-present dedup + peer refresh, and the non-numeric `load_from` snapshot.

Doc: `lwm2m-design.md` §5.4 gains a "Stable `/rd/{location}` per endpoint" note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)