### PR TITLE
fix(image): don't mount data partition at /var/lib/iot (breaks iot-ds, 238/STATE_DIRECTORY)

### DIFF
--- a/yocto/meta-iot/recipes-core/base-files/base-files_%.bbappend
+++ b/yocto/meta-iot/recipes-core/base-files/base-files_%.bbappend
@@ -10,7 +10,8 @@
 # Prepending our fstab makes it win over any stale/external one AND changes the
 # recipe signature, so the bad base-files sstate is invalidated (no cleansstate
 # needed). Based on the running A/B device (192.168.1.50): stock mounts + /boot
-# from mmcblk0p1. It additionally mounts the data partition (LABEL=data, nofail)
-# at /var/lib/iot so an A/B OTA bank swap preserves ds state — the wks data
-# partition carries `--no-fstab-update` so this entry is the sole authority.
+# from mmcblk0p1, and the data partition (p4) deliberately NOT mounted at
+# /var/lib/iot — that collides with iot-ds's DynamicUser+StateDirectory=iot and
+# crash-loops the whole stack (exit 238/STATE_DIRECTORY, HW-confirmed). The wks
+# data partition keeps `--no-fstab-update` so wic doesn't add a mount either.
 FILESEXTRAPATHS:prepend := "${THISDIR}/files:"

--- a/yocto/meta-iot/recipes-core/base-files/files/fstab
+++ b/yocto/meta-iot/recipes-core/base-files/files/fstab
@@ -11,10 +11,12 @@ tmpfs                /var/volatile        tmpfs      defaults              0  0
 
 /dev/mmcblk0p1  /boot   vfat    defaults         0       0
 
-# Persistent data partition (A/B layout: p4, label "data") → /var/lib/iot (ds
-# store, certs, /etc/iot overrides). Mounted by LABEL so it follows the data
-# partition across an A/B bank swap and any p-number change — this is what makes
-# A/B OTA preserve ds state instead of losing it with the swapped-out rootfs.
-# `nofail` so a single-rootfs image (no such partition) still boots; iot-ds's
-# StateDirectory=iot then fixes /var/lib/iot ownership/mode on the mounted fs.
-LABEL=data  /var/lib/iot  ext4  defaults,nofail  0  2
+# NOTE: the A/B data partition (p4, label "data") is intentionally NOT mounted
+# at /var/lib/iot. iot-ds runs DynamicUser=yes + StateDirectory=iot, so systemd
+# manages /var/lib/iot as a symlink into /var/lib/private/iot — a real mount
+# point there makes StateDirectory setup fail (exit 238/STATE_DIRECTORY), so
+# iot-ds crash-loops and the whole stack is dead (HW-confirmed 2025/2026). ds
+# state therefore lives on the rootfs. Persisting it across an A/B bank swap is
+# a separate task: mount LABEL=data at /var/lib/private (so DynamicUser's
+# /var/lib/private/iot lands on the partition) — deferred until validated on HW.
+# See apps/docs / the data-mount revert PR.

--- a/yocto/meta-iot/wic/iot-ab.wks.in
+++ b/yocto/meta-iot/wic/iot-ab.wks.in
@@ -15,11 +15,12 @@
 # fw_env, with headroom (the per-bank kernel/dtb live in each rootfs /boot,
 # loaded by u-boot from the active bank).
 #
-# The data partition's /etc/fstab entry is owned by the base-files bbappend
-# (meta-iot/recipes-core/base-files, LABEL=data -> /var/lib/iot, nofail), NOT by
-# wic — `--no-fstab-update` below keeps wic from adding a second, by-PARTUUID
-# entry. base-files owning it makes the mount deterministic and survives a
-# bank swap (state + certs untouched on an image/OTA swap).
+# The data partition (p4) is created but deliberately NOT auto-mounted:
+# `--no-fstab-update` keeps wic from adding an fstab entry, and the base-files
+# fstab does not mount it either. Mounting it at /var/lib/iot breaks iot-ds
+# (DynamicUser + StateDirectory=iot → exit 238/STATE_DIRECTORY, HW-confirmed),
+# so ds state lives on the rootfs for now. A/B state-persistence (mount
+# LABEL=data at /var/lib/private) is deferred until validated on HW.
 
 # Bank size (1024M) must exceed the standalone rootfs ext4 RAUC carries in the
 # .raucb — that image is inflated by IMAGE_ROOTFS_EXTRA_SPACE (512M of on-target


### PR DESCRIPTION
## HW-confirmed failure
A fresh A/B device was completely dead: `iot-dump` showed **every** ds key `<unreadable>`, `wlan0` stuck `state DOWN`. Tracing it:
- `ds-cli` → `connect(/run/iot/data_store.sock): No such file or directory` — no socket.
- `systemctl status iot-ds` → `failed … status=238/STATE_DIRECTORY`, crash-looping (3 rapid restarts → give up).
- `journalctl` → **"Failed to set up special execution directory in /var/lib"**.
- `/var/lib/iot` present as `drwx------ root root **1024**` → a **mount point** (the data partition), and `/var/lib/private` exists.

## Root cause
`iot-ds.service` runs `DynamicUser=yes` **+** `StateDirectory=iot`. systemd therefore manages `/var/lib/iot` as a **symlink into `/var/lib/private/iot`**. PR #457's `LABEL=data → /var/lib/iot` mount makes `/var/lib/iot` a real mount point, so systemd can't set up the StateDirectory → exit **238** → `iot-ds` never starts → no socket → the whole stack (config reads, wifi-client, lwm2m) is dead.

My earlier claim that "`StateDirectory=iot` fixes perms on the mounted fs" was wrong — `DynamicUser`+`StateDirectory` is incompatible with `/var/lib/iot` being a mount.

## Fix
- Remove the `/var/lib/iot` mount from the base-files fstab.
- Keep the wks `--no-fstab-update` so wic doesn't add one either.
- Data partition (p4) is still created, just unmounted → ds state on rootfs (matches the working device `.50`).
- The `IOT_AB` CI toggle from #457 is untouched.

## Deferred (separate task)
A/B OTA state-persistence: mount `LABEL=data` at **`/var/lib/private`** (so `DynamicUser`'s `/var/lib/private/iot` lands on the persistent partition and the symlink still works), validated on HW before shipping.

## Note
The in-flight A/B build (#10) is on a commit that still has the broken mount — its image would hit this same failure, so it should be discarded and re-dispatched after this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)