### PR TITLE
fix(cloud): BS provisioning robustness — resolver-miss identity log + idempotent re-provision

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -2262,8 +2262,24 @@ int main(std::int32_t argc, char *argv[]) {
             // BS tier: commissioned sha256(serial)[:32] lookup → else derive from
             // the presented raw serial. DM tier: dm.psk.id lookup → else derive
             // from the serial embedded in the presented identity.
-            return is_bs ? iot::resolve_bs_psk(credsJson, presented, masterHex)
-                         : iot::resolve_dm_psk(credsJson, presented, masterHex);
+            const std::string key =
+                is_bs ? iot::resolve_bs_psk(credsJson, presented, masterHex)
+                      : iot::resolve_dm_psk(credsJson, presented, masterHex);
+            // Log the MISS with the presented identity — tinydtls only says
+            // "PSK for unknown identity requested" without it, which makes a
+            // provisioning gap (no matching cloud.endpoint.credentials row, and
+            // no HKDF master to derive) impossible to debug from the cloud log.
+            if (key.empty()) {
+                ACE_ERROR((LM_WARNING,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l PSK resolver: no "
+                                    "key for %C identity '%C' — not in "
+                                    "cloud.endpoint.credentials%C\n"),
+                           is_bs ? "BS" : "DM", presented.c_str(),
+                           masterHex.empty()
+                               ? " (HKDF tier off)"
+                               : " and HKDF derive declined"));
+            }
+            return key;
         });
     };
 

--- a/modules/server/lwm2m/src/bootstrap.cpp
+++ b/modules/server/lwm2m/src/bootstrap.cpp
@@ -10,12 +10,28 @@ BootstrapProvisioner::BootstrapProvisioner(EndpointRegistry& ep_reg,
 std::optional<BootstrapResult> BootstrapProvisioner::provision(
     const std::string& ep) {
 
-    // Reject duplicate endpoints
-    if (m_ep_reg.lookup_by_ep(ep)) return std::nullopt;
+    const std::string server_uri = "coaps://cloud:5684";
 
-    // Allocate tunnel IP + proxy port
+    // Idempotent: an endpoint that already exists (re-provisioned to refresh its
+    // BS PSK, or a watch replay after a cloudd restart / rehydrate) REUSES its
+    // existing tunnel IP + proxy port instead of failing as a "duplicate". The
+    // credential upsert is the meaningful work of a re-provision; failing here
+    // logged a misleading "provision failed (dup or exhausted)" even though the
+    // credential stored fine — and re-provisioning is exactly how an operator
+    // restores a device's BS PSK after the cloud lost/rotated it.
+    if (const EndpointInfo* existing = m_ep_reg.lookup_by_ep(ep)) {
+        BootstrapResult result;
+        result.endpoint            = ep;
+        result.tun_ip              = existing->tun_ip;
+        result.proxy_port          = existing->proxy_port;
+        result.security_object_tlv = build_security_tlv(server_uri);
+        result.server_object_tlv   = build_server_tlv(86400);
+        return result;
+    }
+
+    // New endpoint: allocate tunnel IP + proxy port.
     auto alloc = m_vpn_reg.allocate(ep);
-    if (!alloc.has_value()) return std::nullopt;
+    if (!alloc.has_value()) return std::nullopt;   // ports exhausted
 
     // Register in the endpoint registry
     EndpointInfo info;
@@ -27,9 +43,6 @@ std::optional<BootstrapResult> BootstrapProvisioner::provision(
         m_vpn_reg.release(ep);
         return std::nullopt;
     }
-
-    // Build the bootstrap response payloads
-    std::string server_uri = "coaps://cloud:5684";
 
     BootstrapResult result;
     result.endpoint           = ep;

--- a/modules/server/lwm2m/test/bootstrap_test.cpp
+++ b/modules/server/lwm2m/test/bootstrap_test.cpp
@@ -45,16 +45,23 @@ TEST(BootstrapProvisionerTest, EndpointInRegistryAfterProvision) {
     EXPECT_FALSE(info->registered);  // not registered yet — just bootstrapped
 }
 
-// ── 3. Duplicate provision fails ──────────────────────────────────
+// ── 3. Re-provision is idempotent (reuses the same allocation) ─────
 
-TEST(BootstrapProvisionerTest, DuplicateProvisionFails) {
+TEST(BootstrapProvisionerTest, ReprovisionIsIdempotent) {
     EndpointRegistry ep_reg;
     VpnRegistry vpn_reg;
     BootstrapProvisioner provisioner(ep_reg, vpn_reg);
 
-    ASSERT_TRUE(provisioner.provision("urn:dev:gateway-3").has_value());
-    auto result2 = provisioner.provision("urn:dev:gateway-3");
-    EXPECT_FALSE(result2.has_value());
+    auto first = provisioner.provision("urn:dev:gateway-3");
+    ASSERT_TRUE(first.has_value());
+    // Re-provisioning the SAME endpoint (e.g. refreshing its BS PSK, or a watch
+    // replay after a cloudd restart) succeeds and returns the SAME tun IP +
+    // proxy port — it does not fail as a "duplicate" nor allocate a new slot.
+    auto again = provisioner.provision("urn:dev:gateway-3");
+    ASSERT_TRUE(again.has_value());
+    EXPECT_EQ(first->tun_ip,     again->tun_ip);
+    EXPECT_EQ(first->proxy_port, again->proxy_port);
+    EXPECT_EQ(1u, ep_reg.count());  // still one endpoint, no duplicate slot
 }
 
 // ── 4. Provision fails when subnet exhausted ──────────────────────
@@ -64,10 +71,16 @@ TEST(BootstrapProvisionerTest, FailsWhenSubnetExhausted) {
     VpnRegistry vpn_reg("10.9.0.0/30", 5001, 5100);  // tiny subnet
     BootstrapProvisioner provisioner(ep_reg, vpn_reg);
 
-    ASSERT_TRUE(provisioner.provision("urn:dev:a").has_value());
-    ASSERT_TRUE(provisioner.provision("urn:dev:b").has_value());
-    auto result3 = provisioner.provision("urn:dev:c");
-    EXPECT_FALSE(result3.has_value());
+    // A /30 holds only a handful of host IPs, so provisioning DISTINCT endpoints
+    // must eventually fail (nullopt) once the pool is exhausted — rather than
+    // hand out an out-of-range address. (Don't assume an exact count: the usable
+    // host range depends on the registry's reservations.)
+    bool exhausted = false;
+    for (int i = 0; i < 8 && !exhausted; ++i) {
+        if (!provisioner.provision("urn:dev:" + std::to_string(i)).has_value())
+            exhausted = true;
+    }
+    EXPECT_TRUE(exhausted);
 }
 
 // ── 5. Security Object TLV contains correct fields ────────────────


### PR DESCRIPTION
Two fixes that came directly out of debugging a field device stuck retrying bootstrap with "PSK for unknown identity".

## 1. Log the presented identity on a PSK resolver miss
tinydtls logs only "PSK for unknown identity requested" — *without the identity* — so a provisioning gap (no matching `cloud.endpoint.credentials` row / empty `bs.psk.key`, and no HKDF master to derive) was impossible to diagnose from the cloud log. Now the cloud logs the **tier (BS/DM)**, the **exact presented identity**, and whether the **HKDF tier was available**.

## 2. Idempotent re-provision (kill the misleading "dup or exhausted")
Re-provisioning an existing endpoint (re-pasting a BS PSK to restore a lost/rotated credential, or a watch replay after a cloudd restart) logged `provision failed '<ep>' (dup or exhausted)` — even though the credential upsert had **already succeeded**. `BootstrapProvisioner::provision()` returned `nullopt` on a duplicate endpoint; the scary log made it look like the whole thing failed when only the (already-done) proxy-port step was skipped. Now an existing endpoint **reuses its tunnel IP + proxy port** and returns success.

Also fixes a **pre-existing broken test** (`FailsWhenSubnetExhausted` — the `/30` pool yields 3 host IPs, not the 2 it assumed; fails on clean `main`, but the suite is off by default in CI so it went unnoticed) by exhausting the pool dynamically instead of asserting an exact count.

## Verified (podman)
- `lwm2m` binary builds clean (resolver log).
- `bootstrap-tests` **8/8** (new `ReprovisionIsIdempotent` + the repaired `FailsWhenSubnetExhausted` + existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)