### PR TITLE
fix(image): run the fstab precheck at do_image too (catch stale do_rootfs)

### DIFF
--- a/yocto/meta-iot/recipes-iot/images/iot-image.bb
+++ b/yocto/meta-iot/recipes-iot/images/iot-image.bb
@@ -69,6 +69,14 @@ IMAGE_FSTYPES = "wic.bz2"
 # ships as an update / flash:
 #   * /dev/sd*               — these images boot from mmc, never a SATA/USB disk
 #   * /dev/mmcblk0p<N>, N>4  — no wks layout here has more than 4 partitions
+#
+# Wired to BOTH ROOTFS_POSTPROCESS_COMMAND (do_rootfs) and IMAGE_POSTPROCESS_COMMAND
+# (do_image). The do_rootfs hook is baked into the do_rootfs sstate, so a STALE
+# do_rootfs restored from cache (the exact failure we hit: clean base-files ipk
+# but a cached rootfs carrying the old fstab) SKIPS it and ships the bad fstab.
+# The do_image hook runs when the image is assembled — which happens even when
+# do_rootfs was sstate-restored — so it re-validates the materialised rootfs and
+# turns that silent ship into a loud build failure.
 fstab_sanity_check () {
     fstab="${IMAGE_ROOTFS}/etc/fstab"
     [ -f "$fstab" ] || return 0
@@ -93,3 +101,6 @@ $(cat "$fstab")"
     fi
 }
 ROOTFS_POSTPROCESS_COMMAND:append = " fstab_sanity_check;"
+# Also check at image-assembly time so a stale (sstate-restored) do_rootfs that
+# skipped the ROOTFS_POSTPROCESS hook can't silently ship a self-bricking fstab.
+IMAGE_POSTPROCESS_COMMAND:append = " fstab_sanity_check;"


### PR DESCRIPTION
## The gap (hit in the field today)
The fstab self-brick precheck (`fstab_sanity_check`) was wired only to `ROOTFS_POSTPROCESS_COMMAND`, so it's part of the **`do_rootfs` sstate**. A **stale `do_rootfs` restored from cache** — a clean `base-files` ipk but a cached rootfs still carrying the old `/dev/sda4` fstab — **skips** the postprocess and ships a self-bricking image **silently** (boots to emergency mode waiting on `/dev/sda4`, 90 s timeout). The build reports success.

That's exactly what happened: a freshly-assembled `.wic` (new timestamp) over a stale `do_rootfs`, so the per-flash `/etc/fstab` had `sda4` even though the `base-files` ipk was clean and `/dev/sda4` is nowhere in the source.

## Fix
Wire the same `fstab_sanity_check` to **`IMAGE_POSTPROCESS_COMMAND`** as well. `do_image` (which assembles the `.wic`) runs even when `do_rootfs` was sstate-restored — so it re-validates the materialised `/etc/fstab` and turns the silent ship into a loud `bbfatal` that points at `bitbake -c cleansstate base-files iot-image`.

No functional change to the check itself — same offenders (`/dev/sd*`, `mmcblk0p>4`), same recovery message — just a second, sstate-resilient trigger point.

## Note
This makes the failure **loud** (it can no longer ship). The immediate recovery for a current build is still `bitbake -c cleansstate base-files iot-image && bitbake iot-image`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)