### PR TITLE
fix(lwm2m): self-recover from a wedged DTLS peer (cannot add peer)

### DIFF
--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -175,6 +175,14 @@ class DTLSAdapter {
         /// stale "connected" peer) gets a fresh ClientHello instead of a doomed
         /// renegotiation. Use when the session must be assumed dead.
         void reset_and_connect(const std::string& ip, const std::uint16_t& port);
+        /// Nuke and recreate the whole tinydtls context (empty peer table), the
+        /// in-process equivalent of restarting iot-lwm2m-client. connect()/
+        /// reset_and_connect() reset the peer matched by dtls_get_peer(&m_session),
+        /// but a stuck peer whose session key has drifted (different size/ifindex/
+        /// sockaddr rep) is NOT matched — it lingers, fills the DTLS_PEER_MAX slot,
+        /// and dtls_connect() then loops forever on "cannot add peer". A fresh
+        /// context is the only sure recovery; used as the fallback on connect error.
+        void hard_reset();
 
         /**
          * @brief 

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -307,9 +307,30 @@ void DTLSAdapter::connect(const std::string& ip, const std::uint16_t& port) {
         /// Establishes new Channel
         dtls_debug("DTLSAdapter::connect Establises new channel for Client Hello\n");
     } else {
-        /// Error in establishes channel
-        dtls_debug("DTLSAdapter::connect Error in establishes Channel\n");
+        /// Error establishing the channel. The targeted reset above missed a
+        /// stuck peer whose session key drifted, so the peer table is full and
+        /// dtls_connect() returned "cannot add peer" (a forever wedge — observed
+        /// on HW: a device looping "cannot add peer" until a manual restart).
+        /// Recreate the context (empty peer table) and retry once.
+        dtls_debug("DTLSAdapter::connect dtls_connect error (%d) — hard-resetting context\n", ret);
+        hard_reset();
+        if (dtls_connect(dtls_ctx(), &m_session) > 0)
+            dtls_debug("DTLSAdapter::connect fresh context: new channel for Client Hello\n");
     }
+}
+
+void DTLSAdapter::hard_reset() {
+    // In-process equivalent of restarting iot-lwm2m-client: free the context
+    // (drops ALL peers, busting a stuck/drifted one that targeted resets miss)
+    // and rebuild it exactly as the ctor does. The fd, credentials and handler
+    // table (cb, keyed off `this`) persist, so the next dtls_connect() opens a
+    // clean handshake. Safe here because we only reach this on a connect error
+    // (BS/DM DTLS already not up), so no healthy session is being torn down.
+    if (m_dtls_ctx) dtls_free_context(m_dtls_ctx);
+    m_dtls_ctx = dtls_new_context(this);
+    dtls_set_handler(m_dtls_ctx, &cb);
+    clientState("");
+    dtls_debug("DTLSAdapter::hard_reset recreated dtls context (peer table cleared)\n");
 }
 
 void DTLSAdapter::reset_and_connect(const std::string& ip, const std::uint16_t& port) {
@@ -328,10 +349,16 @@ void DTLSAdapter::reset_and_connect(const std::string& ip, const std::uint16_t& 
     }
     clientState("");                       // drop the stale app-level state too
     auto ret = dtls_connect(dtls_ctx(), &m_session);
-    if (ret > 0)
+    if (ret > 0) {
         dtls_debug("DTLSAdapter::reset_and_connect new channel for Client Hello\n");
-    else if (ret < 0)
-        dtls_debug("DTLSAdapter::reset_and_connect error establishing channel\n");
+    } else if (ret < 0) {
+        // Same wedge guard as connect(): a drifted stuck peer the targeted reset
+        // didn't match leaves the table full ("cannot add peer"). Rebuild clean.
+        dtls_debug("DTLSAdapter::reset_and_connect error (%d) — hard-resetting context\n", ret);
+        hard_reset();
+        if (dtls_connect(dtls_ctx(), &m_session) > 0)
+            dtls_debug("DTLSAdapter::reset_and_connect fresh context: new channel\n");
+    }
 }
 
 std::int32_t DTLSAdapter::rx(std::int32_t fd) {


### PR DESCRIPTION
## HW-observed bug
Device `192.168.1.20` stuck in `iot.conn.state=bootstrapping` **indefinitely**, the BS re-kick loop logging:
```
ALRT cannot add peer
BS DTLS not up — re-kicking handshake, next retry in 30 s
```
Cloud credential + reachability were **fine** (VPN gateway pings 10 ms; the cloud just drops ICMP). **Restarting `iot-lwm2m-client` recovered it in ~2 s** → `bootstrap → DM → registered`.

## Root cause
An early failed BS handshake leaves a peer in tinydtls' table whose **session key has drifted** (different `size`/`ifindex`/sockaddr representation than a freshly built `session(host,port)`). `connect()`/`reset_and_connect()` already reset the peer matched by `dtls_get_peer(&m_session)` — but that lookup **misses the drifted peer**, so it lingers, fills the single `DTLS_PEER_MAX` slot, and every subsequent `dtls_connect()` returns **"cannot add peer"**. The 30 s re-kick can never clear it; only a fresh dtls context (process restart) does.

## Fix
`DTLSAdapter::hard_reset()` — `dtls_free_context` + `dtls_new_context` + `dtls_set_handler` (empty peer table), the in-process equivalent of the restart that recovered the device. Invoked as the fallback when `dtls_connect()` returns an error, in **both** `connect()` and `reset_and_connect()`, then retry once. The fd, credentials and handler table (keyed off `this`) persist, so the retry opens a clean handshake. Safe: only reached on a connect error (DTLS already down), so no healthy session is torn down.

## Why it matters
Without this, **any** transient BS failure (cloud redeploy, NAT drop, dropped HelloVerify) wedges an unattended device in `bootstrapping` permanently until someone SSHes in and restarts the client — a real fleet-robustness hole.

## Verification
- ✅ Compile-verified (podman, `lwm2m` target).
- ⚠️ **NEEDS ON-DEVICE VALIDATION**: reproduce the wedge (force a transient BS failure) and confirm the client self-recovers without a manual restart. Easy to A/B now that `.20` registers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)