### PR TITLE
build: IOT_CLEAN=1 (bust stale fstab sstate) + build.sh copy from shell

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -59,10 +59,20 @@
 #   IOT_USE_CACHE=1 ./build.sh    # pull $CACHE_IMAGE and build — only the
 #                                 # meta-iot recipes recompile (minutes, not hours)
 #
+# Bust a stale base-files / image sstate that ships the self-bricking /etc/fstab
+# (/dev/sda4, mmcblk0p5/6 → boot hangs / emergency mode). cleansstates base-files
+# AND iot-image so the rootfs rebuilds from the clean base-files, then copies the
+# image out as usual. Reach for this when a freshly-flashed card hangs on
+# /dev/sda4 despite a clean base-files bbappend:
+#   IOT_CLEAN=1 ./build.sh        # (combine with IOT_AB=1 for the A/B image)
+#
 # Interactive build-container shell (ad-hoc bitbake / bitbake-layers, e.g. to
 # clear a stale cache or trace where a value comes from):
 #   ./build.sh shell              # default machine; then: bitbake -c cleansstate base-files
 #   IOT_AB=1 ./build.sh shell raspberrypi3-64   # with the A/B layers added
+# A manual bitbake inside `shell` does NOT auto-copy (and the shell is --rm), so
+# pull the fresh image out to the host from a second terminal:
+#   ./build.sh copy [machine]     # podman cp deploy/ → yocto/build/<machine>/
 
 set -euo pipefail
 
@@ -206,6 +216,7 @@ build_machine() {
     $CR run --name "$container" \
         -e "MACHINE=$machine" \
         -e "IOT_FRESH=${IOT_FRESH:-}" \
+        -e "IOT_CLEAN=${IOT_CLEAN:-}" \
         -e "IOT_AB=${IOT_AB:-}" \
         -e "IOT_BRANCH=${IOT_BRANCH:-}" \
         -e "IOT_HASH_LOCAL=1" \
@@ -280,6 +291,33 @@ EOF
     echo ""
 }
 
+# ── Copy artifacts out of a running shell container ───────────────────
+# `./build.sh shell` runs --rm with NO auto-copy, so a manual `bitbake` there
+# (e.g. `bitbake -c cleansstate base-files iot-image && bitbake iot-image` to
+# bust a stale fstab) leaves the fresh image stranded in the container — and the
+# container is --rm, so it's lost on exit. `./build.sh copy` pulls deploy/ out to
+# the host (same copy a normal build does), to be run from a SECOND terminal
+# while the shell is still open. (For an orchestrated clean rebuild that copies
+# automatically, prefer `IOT_CLEAN=1 ./build.sh` instead — no shell needed.)
+copy_from_shell() {
+    local machine="$1"
+    local container="iot-shell-${machine//./-}"
+    local out="$OUT_DIR/$machine"
+    if ! $CR inspect "$container" >/dev/null 2>&1; then
+        log_error "No running shell container '$container'."
+        log_info  "Start one with:  ./build.sh shell $machine   (then bitbake inside it)"
+        log_info  "or just run an auto-copying clean rebuild:  IOT_CLEAN=1 ./build.sh $machine"
+        exit 1
+    fi
+    mkdir -p "$out"
+    log_section "Copying artifacts from $container → $out"
+    $CR cp "$container:/home/builduser/yocto/build/tmp/deploy/." "$out/"
+    local img
+    img=$(ls -t "$out"/images/*/iot-image-*.rootfs-*.wic.bz2 2>/dev/null | head -1 || true)
+    log_info "Done: $out/"
+    [ -n "$img" ] && log_info "Newest image: $img"
+}
+
 # Interactive shell in the build container with the full bitbake env ready
 # (entrypoint does the layer + local.conf setup, then `exec bash` on IOT_SHELL=1).
 # For ad-hoc bitbake / bitbake-layers — e.g. `bitbake -c cleansstate base-files`,
@@ -317,6 +355,14 @@ main() {
     if [ "${1:-}" = "shell" ]; then
         prepare_image
         shell_into "${2:-$DEFAULT_MACHINE}"
+        return
+    fi
+
+    # Subcommand: copy artifacts from a running shell container to the host
+    # (no build) — for when a manual bitbake inside `./build.sh shell` produced
+    # an image that never auto-copied out.
+    if [ "${1:-}" = "copy" ]; then
+        copy_from_shell "${2:-$DEFAULT_MACHINE}"
         return
     fi
 

--- a/yocto/entrypoint.sh
+++ b/yocto/entrypoint.sh
@@ -270,6 +270,21 @@ if [ -n "${IOT_FRESH:-}" ]; then
     bitbake -c cleanall iot
 fi
 
+# ── 4c. Bust a stale base-files / image sstate (opt-in: IOT_CLEAN=1) ─
+# The fstab self-brick: a cached do_rootfs (or base-files) sstate can ship the
+# OLD self-bricking /etc/fstab (/dev/sda4, mmcblk0p5/6) even when the base-files
+# bbappend is clean — base-files is the same version (3.0.14-r0), so the image
+# task hash doesn't always flip on a content-only change, do_rootfs restores
+# stale, and the fstab precheck (baked into that sstate) never re-runs. Result:
+# the image boots to emergency mode on /dev/sda4. IOT_CLEAN=1 cleansstates BOTH
+# base-files and iot-image so the rootfs is rebuilt from the clean base-files.
+# Use when a flashed image hangs at boot on /dev/sda4. See iot-image.bb
+# fstab_sanity_check (now also wired to IMAGE_POSTPROCESS_COMMAND).
+if [ -n "${IOT_CLEAN:-}" ]; then
+    echo "→ IOT_CLEAN set: cleansstate base-files + iot-image (bust stale fstab) ..."
+    bitbake -c cleansstate base-files iot-image
+fi
+
 # ── 5. Run bitbake ─────────────────────────────────────────────────
 # For an A/B build also produce the signed .raucb (it DEPENDS on iot-image, so
 # this builds the rootfs too). Only when the default image target is in play —
@@ -294,6 +309,10 @@ if [ "${IOT_SHELL:-}" = "1" ]; then
     echo "    bitbake -c cleansstate base-files   # clear a recipe's stale sstate"
     echo "    bitbake-layers show-layers          # list configured layers + paths"
     echo "    bitbake -e base-files | grep fstab  # where a value comes from"
+    echo "  NOTE: images built here do NOT auto-copy to the host (and this shell"
+    echo "  is --rm). After 'bitbake iot-image', from a 2nd host terminal run:"
+    echo "    ./build.sh copy $MACHINE            # pull deploy/ out before you exit"
+    echo "  Or skip the shell: 'IOT_CLEAN=1 ./build.sh $MACHINE' rebuilds + copies."
     echo "  Exit with Ctrl-D / 'exit'."
     echo ""
     exec bash


### PR DESCRIPTION
Two ergonomics gaps that turned the fstab self-brick into a repeated "flash the wrong image" loop on a real bring-up:

## 1. `IOT_CLEAN=1` — automate the stale-sstate bust
Clearing the cached `do_rootfs`/`base-files` sstate that keeps shipping the self-bricking `/dev/sda4` fstab (even with a clean base-files bbappend — same pkg version, so the image task hash doesn't always flip) meant dropping into `./build.sh shell` and running `bitbake -c cleansstate base-files iot-image && bitbake iot-image` by hand.

Now `entrypoint.sh` cleansstates `base-files` + `iot-image` up front when `IOT_CLEAN=1`, and `build.sh` passes the env through — so a normal, **auto-copying** build does it:
```sh
IOT_CLEAN=1 ./build.sh                 # (combine with IOT_AB=1 for the A/B image)
```

## 2. `./build.sh copy` — pull artifacts from a `shell` build
A manual `bitbake` inside `./build.sh shell` does **not** auto-copy to the host (only the orchestrated `build_machine` path does), and the shell is `--rm` — so the fresh image is stranded in the container and lost on exit. The operator then re-flashes the **old** host-side image and keeps hitting the same `/dev/sda4` boot hang (exactly what happened during this bring-up).

```sh
./build.sh copy [machine]   # podman/docker cp deploy/ → yocto/build/<machine>/  (run from a 2nd terminal)
```
The interactive-shell banner now points at both `copy` and `IOT_CLEAN`.

## Notes
- No change to the default build path.
- `bash -n` clean on both scripts.
- Pairs with #462 (fstab precheck at `do_image`), which makes a stale image fail loudly instead of shipping.

🤖 Generated with [Claude Code](https://claude.com/claude-code)