### PR TITLE
fix(image): --no-fstab-update on all A/B partitions (the real /dev/sda4 brick)

### DIFF
--- a/apps/docs/tdd-ab-image-ota.md
+++ b/apps/docs/tdd-ab-image-ota.md
@@ -186,18 +186,31 @@ orchestrated `build.sh` path auto-copies them out of the build container.
 A baked `/etc/fstab` that references a partition the target lacks makes systemd's
 `local-fs.target` time out (~90 s) and drop to **emergency mode** on first boot —
 `(1 of 2) A start job is running for /dev/sda4`. On A/B this bricks **both** banks
-before rollback can help. The offender is a **stale `do_rootfs` / `base-files`
-sstate**: even with a clean `base-files` bbappend (it ships a known-good fstab),
-`base-files` stays version `3.0.14-r0`, so the image task hash doesn't always flip
-on a content-only change → `do_rootfs` restores stale, and the fstab precheck
-(baked into that sstate) never re-runs. The build "succeeds" and ships the brick.
+before rollback can help.
 
-**Guard:** `iot-image.bb`'s `fstab_sanity_check` runs at BOTH
-`ROOTFS_POSTPROCESS_COMMAND` and `IMAGE_POSTPROCESS_COMMAND` (PR #462) — so a
-stale-rootfs image fails LOUDLY at `do_image` instead of shipping. It `bbfatal`s
-on `/dev/sd*` and `/dev/mmcblk0p<N>` for N>4.
+**TRUE root cause (HW-confirmed by extracting the wic's fstab): `wic`'s
+`--fstab-update`.** wic appends fstab entries for any partition lacking
+`--no-fstab-update`, using **`/dev/sdaN`** device names — which don't exist on an
+mmc-booted RPi. The A/B wks's boot partition (and, via a stale `do_image_wic`, the
+data partition) got `/dev/sda1 /boot` and `/dev/sda4 /var/lib/iot` appended *after*
+the clean base-files fstab. This is injected at `do_image_wic`, **after** do_rootfs
+and after the `iot-image.bb` fstab precheck (which only sees the *rootfs* fstab) —
+so it ships silently. The base-files ipk is clean the whole time; `cleansstate
+base-files` does NOT fix it. (A genuinely stale `do_rootfs` carrying an OLD
+base-files fstab is a *different*, rarer path — that one `cleansstate` does fix.)
 
-**Fix — bust the stale sstate and rebuild from clean:**
+**Fix (PR — `iot-ab.wks.in`):** `--no-fstab-update` on **every** partition, so
+base-files is the sole fstab authority and wic never writes `/dev/sda*`. Changing
+the wks also invalidates the stale `do_image_wic`.
+
+**Guard:** `iot-image.bb`'s `fstab_sanity_check` runs at `ROOTFS_POSTPROCESS_COMMAND`
+and `IMAGE_POSTPROCESS_COMMAND` (#462) — but note it scans the **rootfs** fstab, so
+it catches a stale base-files but NOT a wic `--fstab-update` injection; the wks
+`--no-fstab-update` is what closes that hole. To verify a built `.wic.bz2`, mount
+rootA and read its fstab: `file img.wic` for the p2 start sector, then
+`mount -o loop,ro,offset=<sector*512> img.wic /mnt && cat /mnt/etc/fstab`.
+
+**Fix a genuinely stale rootfs sstate (the other path) — rebuild from clean:**
 ```sh
 IOT_CLEAN=1 ./build.sh              # cleansstate base-files + iot-image, then build+copy
 # (equivalent manual form, inside `./build.sh shell`:)

--- a/yocto/meta-iot/wic/iot-ab.wks.in
+++ b/yocto/meta-iot/wic/iot-ab.wks.in
@@ -15,21 +15,30 @@
 # fw_env, with headroom (the per-bank kernel/dtb live in each rootfs /boot,
 # loaded by u-boot from the active bank).
 #
-# The data partition (p4) is created but deliberately NOT auto-mounted:
-# `--no-fstab-update` keeps wic from adding an fstab entry, and the base-files
-# fstab does not mount it either. Mounting it at /var/lib/iot breaks iot-ds
-# (DynamicUser + StateDirectory=iot → exit 238/STATE_DIRECTORY, HW-confirmed),
-# so ds state lives on the rootfs for now. A/B state-persistence (mount
-# LABEL=data at /var/lib/private) is deferred until validated on HW.
+# EVERY partition carries `--no-fstab-update` so wic NEVER writes /etc/fstab —
+# base-files (recipes-core/base-files bbappend) is the SOLE fstab authority.
+# Without it, wic's --fstab-update appends entries using /dev/sdaN device names
+# (e.g. `/dev/sda1 /boot`, `/dev/sda4 /var/lib/iot`) — devices that DON'T EXIST
+# on an mmc-booted RPi. The /dev/sda4 entry self-bricks the image: local-fs
+# waits ~90s then drops to emergency mode (and on A/B BOTH banks brick). This is
+# injected at do_image_wic, AFTER do_rootfs and after the iot-image.bb fstab
+# precheck (which only sees the rootfs fstab), so it ships silently — HW-hit
+# repeatedly during bring-up. The mmcblk0p1 /boot mount comes from base-files.
+#
+# The data partition (p4) in particular is created but deliberately NOT mounted:
+# mounting it at /var/lib/iot breaks iot-ds (DynamicUser + StateDirectory=iot →
+# exit 238/STATE_DIRECTORY, HW-confirmed), so ds state lives on the rootfs for
+# now. A/B state-persistence (mount LABEL=data at /var/lib/private) is deferred
+# until validated on HW.
 
 # Bank size (1024M) must exceed the standalone rootfs ext4 RAUC carries in the
 # .raucb — that image is inflated by IMAGE_ROOTFS_EXTRA_SPACE (512M of on-target
 # headroom for opkg/logs) to ~824M, and `rauc install` writes it raw to the
 # inactive slot. 768M banks flash fine (wic builds them from the rootfs dir,
 # ~300M used) but an OTA into a 768M slot would fail "image larger than slot".
-part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4096 --size 100M
-part /     --source rootfs --fstype=ext4 --label rootA --align 4096 --size 1024M
-part /     --source rootfs --fstype=ext4 --label rootB --align 4096 --size 1024M
+part /boot --source bootimg-partition --fstype=vfat --label boot --active --align 4096 --size 100M --no-fstab-update
+part /     --source rootfs --fstype=ext4 --label rootA --align 4096 --size 1024M --no-fstab-update
+part /     --source rootfs --fstype=ext4 --label rootB --align 4096 --size 1024M --no-fstab-update
 part /var/lib/iot --fstype=ext4 --label data --align 4096 --size 256M --no-fstab-update
 
 bootloader --ptable msdos


### PR DESCRIPTION
## The actual root cause (finally)
Extracting the built `.wic`'s rootA fstab settled it. The image fstab is the clean base-files content **plus two lines appended by `wic --fstab-update`**, in wic's tab style with **`/dev/sdaN`** naming:
```
/dev/sda1	/boot	vfat	defaults	0	0
/dev/sda4	/var/lib/iot	ext4	defaults	0	0     ← self-bricks the boot
```
`wic` writes an fstab entry for every partition **without** `--no-fstab-update`, using `/dev/sda*` device names that **don't exist on an mmc-booted RPi**. The A/B wks boot partition (p1) had no `--no-fstab-update` → `/dev/sda1 /boot`; and a **stale `do_image_wic`** (from before #459 added the flag to p4) also re-emitted `/dev/sda4 /var/lib/iot`.

This explains the entire saga:
- the `base-files` ipk was **always clean** (wic edits the fstab *inside the partition image*, after do_rootfs);
- `cleansstate base-files` never helped;
- **both** prechecks (#462 included) missed it — they scan the *rootfs* fstab, and wic's injection happens later, at `do_image_wic`.

## Fix
`--no-fstab-update` on **every** partition in `iot-ab.wks.in` → base-files is the sole fstab authority, wic never writes `/dev/sda*`. The wks edit also invalidates the stale `do_image_wic`, so p4's flag is finally honored.

## Verify a built image
```sh
file img.wic                                   # rootA = p2 start sector
mount -o loop,ro,offset=<sector*512> img.wic /mnt && cat /mnt/etc/fstab
# expect: NO /dev/sda* lines
```

Doc §10 (`tdd-ab-image-ota.md`) corrected to name `wic --fstab-update` as the cause (the prior "stale do_rootfs" note was a different, rarer path) and adds the wic-fstab verification recipe.

## Follow-up
Build needs a fresh `do_image_wic` (the wks change forces it). After merge: rebuild + reflash, confirm `grep sda /etc/fstab` is empty on-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)