### PR TITLE
docs(flash): surface --wifi-ssid/--wifi-psk in flash-sd usage + build summary

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -268,8 +268,15 @@ print_summary() {
         cat <<EOF
 
   ── Flash the SD card (Raspberry Pi 3B) ──────────────────────────────
-    # Find the SD device first: lsblk (Linux, /dev/sdX) or
-    # diskutil list (macOS, /dev/diskN). Write the whole disk, not a partition.
+    # Easiest: flash-sd.sh auto-detects the card, wipes it, writes the newest
+    # image, and (optionally) seeds WiFi creds so a CI image joins your AP on
+    # first boot. Both --wifi flags are required together:
+    ./yocto/flash-sd.sh --wifi-ssid <SSID> --wifi-psk <WPA-PSK>
+    ./yocto/flash-sd.sh --list           # just list candidate SD cards
+    # (see ./yocto/flash-sd.sh --help for --personalize / zero-touch BS seed)
+
+    # Or flash manually with dd. Find the device first: lsblk (Linux, /dev/sdX)
+    # or diskutil list (macOS, /dev/diskN). Write the whole disk, not a partition.
     bzcat "$rpi_img" | sudo dd of=/dev/sdX bs=4M conv=fsync status=progress
     # macOS: target the raw node /dev/rdiskN instead of /dev/diskN — much faster.
 

--- a/yocto/flash-sd.sh
+++ b/yocto/flash-sd.sh
@@ -22,6 +22,10 @@
 #   ./flash-sd.sh --yes /dev/sdX         # skip the confirmation prompt
 #   ./flash-sd.sh --no-format /dev/sdX   # skip the wipe, just dd the image
 #
+#   # Seed WiFi creds onto the boot partition (so a CI image joins your AP on
+#   # first boot — see "WiFi seed" below). Both flags required together:
+#   ./flash-sd.sh --wifi-ssid <SSID> --wifi-psk <WPA-PSK>
+#
 #   MACHINE=qemuarm64 ./flash-sd.sh /dev/sdX     # pick another machine's image
 #   IMAGE=/path/to/custom.wic.bz2 ./flash-sd.sh /dev/sdX
 #


### PR DESCRIPTION
The WiFi-seed flags (`--wifi-ssid`/`--wifi-psk`) were only documented in a paragraph buried below the zero-touch personalize section of `flash-sd.sh`'s header — easy to miss when scanning `--help`.

- **`flash-sd.sh`**: add the WiFi flags to the top **Usage:** quick-reference block (the detailed "WiFi seed" explanation stays below).
- **`build.sh`**: the post-build "Flash the SD card" summary now recommends `flash-sd.sh` (with the `--wifi` flags) as the easy path — auto-detect + wipe + write + WiFi seed — keeping raw `dd` as the manual fallback.

Help-text/docs only. `bash -n` clean on both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)