### PR TITLE
docs(flash): note SD device is auto-detected / optional alongside --wifi

### DIFF
--- a/yocto/build.sh
+++ b/yocto/build.sh
@@ -270,8 +270,9 @@ print_summary() {
   ── Flash the SD card (Raspberry Pi 3B) ──────────────────────────────
     # Easiest: flash-sd.sh auto-detects the card, wipes it, writes the newest
     # image, and (optionally) seeds WiFi creds so a CI image joins your AP on
-    # first boot. Both --wifi flags are required together:
-    ./yocto/flash-sd.sh --wifi-ssid <SSID> --wifi-psk <WPA-PSK>
+    # first boot. The SD device is auto-detected, or pass it explicitly
+    # (e.g. /dev/disk4) — needed if 0 or several removable disks are present:
+    ./yocto/flash-sd.sh --wifi-ssid <SSID> --wifi-psk <WPA-PSK> [/dev/sdX|/dev/diskN]
     ./yocto/flash-sd.sh --list           # just list candidate SD cards
     # (see ./yocto/flash-sd.sh --help for --personalize / zero-touch BS seed)
 

--- a/yocto/flash-sd.sh
+++ b/yocto/flash-sd.sh
@@ -23,8 +23,9 @@
 #   ./flash-sd.sh --no-format /dev/sdX   # skip the wipe, just dd the image
 #
 #   # Seed WiFi creds onto the boot partition (so a CI image joins your AP on
-#   # first boot — see "WiFi seed" below). Both flags required together:
-#   ./flash-sd.sh --wifi-ssid <SSID> --wifi-psk <WPA-PSK>
+#   # first boot — see "WiFi seed" below). Both flags required together; the SD
+#   # device is auto-detected, or pass it explicitly (e.g. /dev/disk4):
+#   ./flash-sd.sh --wifi-ssid <SSID> --wifi-psk <WPA-PSK> [/dev/sdX|/dev/diskN]
 #
 #   MACHINE=qemuarm64 ./flash-sd.sh /dev/sdX     # pick another machine's image
 #   IMAGE=/path/to/custom.wic.bz2 ./flash-sd.sh /dev/sdX


### PR DESCRIPTION
Clarifies that `flash-sd.sh` auto-detects the SD card, so the device arg is optional — pass it explicitly (e.g. `/dev/disk4`) when 0 or several removable disks are present. Shows it composing with the `--wifi` flags. Follow-up to #467. Help-text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)