### PR TITLE
fix(bs): accept formatted DM-style identity at the BS handshake

### DIFF
--- a/apps/cloud/CLAUDE.md
+++ b/apps/cloud/CLAUDE.md
@@ -238,7 +238,12 @@ deployed compose. Each server authenticates a handshake against the
 **live from `cloud.endpoint.credentials`** by a ds-backed PSK resolver
 (`DTLSAdapter::set_psk_resolver`, wired in `apps/src/main.cpp`):
 
-- **BS** matches `sha256(serial)[:32] == presented-identity` → `bs.psk.key`
+- **BS** matches `sha256(serial)[:32] == presented-identity` → `bs.psk.key`;
+  if that misses, falls back to matching the row's `identity` / `dm.psk.id`
+  (the formatted `rpi<serial>@cloud.local`) → the same `bs.psk.key`. The
+  fallback covers devices that present their DM-style identity at the BS
+  handshake (`iot.bs.psk.override=true`); without it, a cloud reboot's
+  re-bootstrap would wedge such a device offline (see `troubleshoot.md`).
 - **DM** matches `dm.psk.id == presented-identity` → `dm.psk.key`
 
 The resolver runs on the handshake/reactor thread (not the ds listener

--- a/apps/cloud/troubleshoot.md
+++ b/apps/cloud/troubleshoot.md
@@ -66,6 +66,39 @@ Notes:
 printf '%s' 'urn:dev:device-1' | sha256sum | cut -c1-32   # = the id_len:32 in the device log
 ```
 
+### Device sends its formatted identity at BS (`rpi<serial>@cloud.local`)
+
+Symptom (cloud `lwm2m-bs`):
+```
+PSK resolver: no key for BS identity 'rpi000000006556e041@cloud.local' — not in cloud.endpoint.credentials (HKDF tier off)
+dtls: PSK for unknown identity requested
+```
+i.e. the presented identity is the **DM-style** `rpi<serial>@cloud.local`, not
+the canonical `sha256(serial)[:32]`. That happens when the device has
+`iot.bs.psk.override=true` with `iot.bs.psk.identity=rpi<serial>@cloud.local`.
+
+**Why it often appears after a cloud reboot:** the DM registry is in-memory, so
+a reboot drops every registration. Registered devices then fall back to
+**re-bootstrap**, which exposes this latent identity mismatch — devices that
+were happily registered go offline and loop in `bootstrapping`.
+
+The BS resolver now **accepts both** forms: it tries `sha256(serial)[:32]`
+first, then falls back to matching a `cloud.endpoint.credentials` row's
+`identity` / `dm.psk.id`, returning the same `bs.psk.key`. So on an up-to-date
+cloud image this resolves itself. If you see it, the `lwm2m-bs` container is
+running an **older image** — rebuild + redeploy it.
+
+**Immediate field recovery (no cloud rebuild)** — drop the override on the
+device so it presents the canonical identity (the device's `iot.bs.psk.key`
+must equal the cloud row's `bs.psk.key`):
+```bash
+# on the device:
+ds-cli get iot.bs.psk.key                 # confirm == cloud row's bs.psk.key
+ds-cli set iot.bs.psk.override false
+systemctl restart iot-lwm2m-client
+# device now presents sha256(serial)[:32] → cloud matches → registers
+```
+
 ---
 
 ## Cloud advertises an unreachable DM (bootstrap OK, register fails)

--- a/apps/inc/provisioning_policy.hpp
+++ b/apps/inc/provisioning_policy.hpp
@@ -60,7 +60,10 @@ bool should_rebootstrap(bool dm_dtls_failed, bool dm_registration_rejected);
 /// PSK identity the peer sent; `master_hex` is the unwrapped HKDF master ("" if
 /// the zero-touch tier is unconfigured). Resolution order:
 ///   1. a commissioned row whose sha256(serial)[:32] == presented → its
-///      bs.psk.key (existing device-ui-provisioned tier, unchanged);
+///      bs.psk.key (the canonical device-ui-provisioned tier); else a row whose
+///      formatted identity / dm.psk.id == presented → its bs.psk.key (fallback
+///      for a device that presents its DM-style identity at the BS handshake,
+///      i.e. iot.bs.psk.override=true — both forms return the same bs.psk.key);
 ///   2. else, if a master is configured, HKDF-derive from the presented raw
 ///      serial (zero-touch tier — the device presents its serial verbatim);
 ///   3. else "" (no match → the handshake fails).

--- a/apps/src/provisioning_policy.cpp
+++ b/apps/src/provisioning_policy.cpp
@@ -49,7 +49,15 @@ std::string resolve_bs_psk(const std::string& credentials_json,
                            const std::string& master_hex) {
     if (presented.empty()) return {};
 
-    // 1) Commissioned tier: a row whose sha256(serial)[:32] == presented.
+    // 1) Commissioned tier: a row whose sha256(serial)[:32] == presented (the
+    //    canonical BS identity the device derives by default), OR — fallback —
+    //    a row whose formatted identity / dm.psk.id == presented. The fallback
+    //    covers devices that present their DM-style identity at the BS handshake
+    //    (iot.bs.psk.override=true with iot.bs.psk.identity=rpi<serial>@cloud.
+    //    local). Either form returns the same bs.psk.key, so a device whose
+    //    iot.bs.psk.key matches the commissioned row authenticates regardless of
+    //    which identity convention it sends. sha256 is tried first so the
+    //    canonical path is unchanged.
     const auto arr =
         nlohmann::json::parse(credentials_json, /*cb*/nullptr,
                               /*allow_exceptions*/false);
@@ -60,6 +68,14 @@ std::string resolve_bs_psk(const std::string& credentials_json,
             const std::string key    = e.value("bs.psk.key", std::string());
             if (!serial.empty() && !key.empty() &&
                 sha256_hex(serial).substr(0, 32) == presented)
+                return key;
+        }
+        for (const auto& e : arr) {
+            if (!e.is_object()) continue;
+            const std::string key = e.value("bs.psk.key", std::string());
+            if (key.empty()) continue;
+            if (e.value("identity", std::string())  == presented ||
+                e.value("dm.psk.id", std::string()) == presented)
                 return key;
         }
     }

--- a/apps/test/provisioning_policy_test.cpp
+++ b/apps/test/provisioning_policy_test.cpp
@@ -103,6 +103,30 @@ TEST(ResolveBsPsk, CommissionedRowWinsOverDerivation) {
     EXPECT_EQ("feedface", iot::resolve_bs_psk(creds, kSha256Id, kMaster));
 }
 
+TEST(ResolveBsPsk, FallsBackToFormattedIdentity) {
+    // A device with iot.bs.psk.override=true presents its DM-style identity at
+    // the BS handshake. With no sha256 match, fall back to the formatted
+    // identity / dm.psk.id and return the same bs.psk.key. No master needed.
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e",)"
+        R"("identity":"rpi100000003d1f9c2e@cloud.local",)"
+        R"("dm.psk.id":"rpi100000003d1f9c2e@cloud.local",)"
+        R"("bs.psk.key":"feedface"}])";
+    EXPECT_EQ("feedface",
+              iot::resolve_bs_psk(creds, "rpi100000003d1f9c2e@cloud.local", ""));
+    // The canonical sha256 path still resolves the same row.
+    EXPECT_EQ("feedface", iot::resolve_bs_psk(creds, kSha256Id, ""));
+}
+
+TEST(ResolveBsPsk, FormattedIdentityNoMatchYieldsEmpty) {
+    // A formatted identity for an unprovisioned serial, no master → no key.
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e",)"
+        R"("identity":"rpi100000003d1f9c2e@cloud.local",)"
+        R"("bs.psk.key":"feedface"}])";
+    EXPECT_EQ("", iot::resolve_bs_psk(creds, "rpiDEADBEEF@cloud.local", ""));
+}
+
 TEST(ResolveBsPsk, DerivesFromRawSerialWhenNoRow) {
     // Zero-touch: no row, master set, peer presented its raw serial verbatim.
     EXPECT_EQ(kDerivedPsk, iot::resolve_bs_psk("[]", kSerial, kMaster));


### PR DESCRIPTION
## Problem

After rebooting the cloud (Vultr), two commissioned RPi devices went **offline** and could not bootstrap. The cloud `iot-lwm2m-bs` logged:

```
PSK resolver: no key for BS identity 'rpi000000006556e041@cloud.local' — not in cloud.endpoint.credentials (HKDF tier off)
dtls: PSK for unknown identity requested  → handshake fails
```

The devices present `rpi<serial>@cloud.local` (their DM-style identity, via `iot.bs.psk.override=true`) at the **bootstrap** DTLS handshake, but `resolve_bs_psk` matched only the canonical `sha256(serial)[:32]` form (or HKDF-derived from the raw serial). HKDF is off here (`cloud.bs.master.key` empty) and the devices are commissioned (`cloud.endpoint.credentials` holds their `bs.psk.key`), so neither tier matched → stuck `bootstrapping`.

This is latent until a cloud reboot drops the in-memory DM registration and forces a re-bootstrap.

## Fix

`resolve_bs_psk` now, after the canonical `sha256(serial)[:32]` attempt, **falls back** to matching a row's `identity` / `dm.psk.id == presented` and returns the same `bs.psk.key`. Both conventions authenticate the same commissioned row. The canonical path and the HKDF zero-touch tier are unchanged. Mirrors how the DM resolver already matches `dm.psk.id`.

## Tests

Added `FallsBackToFormattedIdentity` and `FormattedIdentityNoMatchYieldsEmpty`. Built + ran the `ResolveBsPsk*`/`ResolveDmPsk*` suites via podman (ubuntu:22.04) — **10/10 pass**, no regression.

## Deploy note

Only affects `iot-lwm2m-bs`. After merge + image build, redeploy that container on the cloud host. (Immediate field recovery was done device-side: `iot.bs.psk.override false` + restart `iot-lwm2m-client`, which restored both devices to `registered/online`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)