### PR TITLE
fix(client): reset BS PSK identity before re-bootstrapping

### DIFF
--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -198,6 +198,12 @@ class DTLSAdapter {
             // credential after a re-bootstrap ("identity already registered" →
             // dtls: cannot send ClientHello → never registers → cloud shows the
             // device offline even with the VPN up). insert_or_assign replaces it.
+            // Remember the FIRST credential as the bootstrap (BS) identity. On
+            // the client the BS credential is installed at startup, before the
+            // bootstrap-delivered DM credential is ever added, so the first add
+            // pins the BS identity. reset_to_bootstrap_identity() restores it
+            // when the client falls back to bootstrap (see below).
+            if (m_bootstrapIdentity.empty()) m_bootstrapIdentity = identity;
             auto res = device_credentials.insert_or_assign(identity, secret);
             if(!res.second) {
                 ACE_DEBUG((LM_DEBUG,
@@ -388,6 +394,24 @@ class DTLSAdapter {
             m_activeIdentity = id;
         }
 
+        /// Restore the pinned identity to the bootstrap (BS) identity. After a
+        /// successful bootstrap the client pins the DM identity (active_identity)
+        /// for the DM session; when it later falls back to bootstrap (DM auth /
+        /// registration failed, or the BS DTLS is re-kicked) it MUST present the
+        /// BS identity again — otherwise it offers the DM identity+key to the BS
+        /// server, which has no DM key under the BS resolver, and the handshake
+        /// fails ("PSK for unknown identity"). Seen after a cloud restart forces
+        /// a re-bootstrap. No-op until a BS credential has been installed.
+        void reset_to_bootstrap_identity() {
+            if (!m_bootstrapIdentity.empty() &&
+                m_activeIdentity != m_bootstrapIdentity) {
+                m_activeIdentity = m_bootstrapIdentity;
+                ACE_DEBUG((LM_DEBUG,
+                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l reset PSK identity "
+                                    "to bootstrap for re-bootstrap handshake\n")));
+            }
+        }
+
         auto& clients() {
             return(m_clients);
         }
@@ -406,6 +430,7 @@ class DTLSAdapter {
         bool m_isClient;
         std::string m_clientState;
         std::string m_activeIdentity;
+        std::string m_bootstrapIdentity;   ///< BS identity (first credential added)
         std::vector<ClientDetails> m_clients;
 };
 

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -334,6 +334,11 @@ void DTLSAdapter::hard_reset() {
 }
 
 void DTLSAdapter::reset_and_connect(const std::string& ip, const std::uint16_t& port) {
+    // reset_and_connect is only ever used to (re)establish the BS bootstrap
+    // session. If a prior successful bootstrap pinned the DM identity, restore
+    // the BS identity so this fresh handshake presents BS creds, not the DM
+    // identity+key the BS server cannot resolve.
+    reset_to_bootstrap_identity();
     session(ip, port);
     m_peerSession = m_session;
     isClient(true);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1985,6 +1985,18 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
                            ACE_TEXT("%D lwm2m:thread:%t %M %N:%l DM rejected "
                                     "registration — re-bootstrapping for fresh "
                                     "DM credentials\n")));
+                // A prior successful bootstrap pinned the DM identity + pointed
+                // the data plane at the DM. Re-point to the BS and force a fresh
+                // BS DTLS handshake; reset_and_connect() restores the BS identity
+                // so the /bs handshake offers BS creds, not the DM identity+key
+                // the BS resolver can't match (else the device wedges in
+                // bootstrapping after a cloud restart).
+                for (auto& [type, ctx] : a->udpAdapter()->services()) {
+                    if (type != ::UDPAdapter::ServiceType_t::LwM2MClient) continue;
+                    ctx->peerHost(bsHost);
+                    ctx->peerPort(bsPort);
+                }
+                if (dtls) dtls->reset_and_connect(bsHost, bsPort);
                 auto payload = bs->build_bs_request(
                     next_msgid(), std::string{static_cast<char>(0x30)});
                 tx_via(*a, payload, svc);


### PR DESCRIPTION
## Problem

After a cloud restart, a device that had previously registered went **offline** and looped in `bootstrapping`. Cloud `lwm2m-bs`:

```
PSK resolver: no key for BS identity 'rpi000000006556e041@cloud.local' — not in cloud.endpoint.credentials (HKDF tier off)
dtls: PSK for unknown identity requested
```

**`iot.bs.psk.override` is OFF** — so the device's BS identity *should* be `sha256(serial)[:32]`. The real cause is a stale DTLS identity pin:

1. After the first successful bootstrap, the client calls `active_identity(dmIdentity)` to pin `rpi<serial>@cloud.local` for the DM session, and adds the DM credential (formatted identity → **DM key**).
2. When the cloud restarts and DM registration is rejected/fails, the client re-bootstraps **but never un-pins the DM identity** — so the `/bs` handshake offers `rpi<serial>@cloud.local` + the **DM key** to the BS server, which has no DM key under the BS resolver → wedge.

Only happens to a device that previously registered and is then forced to re-bootstrap — exactly the post-reboot scenario.

## Fix (device side)

- `DTLSAdapter` remembers the bootstrap (BS) identity (first credential installed, before any DM credential) and gains `reset_to_bootstrap_identity()`.
- `reset_and_connect()` (the BS re-handshake primitive) restores the BS identity, so any forced BS handshake presents BS creds.
- The DM-rejected re-bootstrap path (Task K) re-points the data plane to the BS and forces a fresh BS handshake instead of POSTing `/bs` over the stale DM-pinned session.

A re-bootstrap can no longer offer the DM identity/key to the BS server.

## Note on #470

The cloud-side formatted-identity fallback shipped in #470 does **not** fix this: the wedged device presents the DM *key*, so the cloud returning `bs.psk.key` would fail at MAC instead. This device-side change is the actual remedy. (#470 remains a harmless hardening.)

## Validation

- Full `lwm2m` binary **compiles + links clean** via podman (ubuntu:22.04) — `main.cpp`, `dtls_adapter.cpp`, `provisioning_policy.cpp` all built, `[100%] Built target lwm2m`.
- ⚠️ Needs **HW validation**: confirm a device that re-bootstraps after a cloud restart recovers without a manual client restart.

**Immediate field recovery without this build:** `systemctl restart iot-lwm2m-client` (a fresh start has no DM pin yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)