### PR TITLE
fix(containers): dedupe overlay lowerdir paths (Linux 6.6 mount)

### DIFF
--- a/modules/containers/src/oci_layer.cpp
+++ b/modules/containers/src/oci_layer.cpp
@@ -1,6 +1,7 @@
 #include "oci_layer.hpp"
 
 #include <sstream>
+#include <unordered_set>
 
 namespace containers {
 
@@ -115,7 +116,18 @@ std::string safe_rel_path(const std::string& name) {
 std::string overlay_lowerdir(const std::vector<std::string>& layer_dirs_base_to_top) {
     std::string out;
     // overlayfs wants the highest-priority (topmost) layer first.
+    //
+    // Dedupe repeated paths. An OCI image can list the same layer digest more
+    // than once (e.g. the shared empty layer, or genuinely identical layers);
+    // each maps to the SAME extracted dir, so a naive join yields
+    // `lowerdir=/x/fs:/x/fs`. Linux 6.6's rewritten overlay mount parser
+    // REJECTS a duplicate lowerdir with "overlayfs: conflicting lowerdir path"
+    // (older kernels silently tolerated it — why this only bit on HW). Identical
+    // digest == identical content, so keeping the topmost occurrence preserves
+    // the merged view.
+    std::unordered_set<std::string> seen;
     for (auto it = layer_dirs_base_to_top.rbegin(); it != layer_dirs_base_to_top.rend(); ++it) {
+        if (!seen.insert(*it).second) continue;   // already emitted this path
         if (!out.empty()) out += ':';
         out += *it;
     }

--- a/modules/containers/test/oci_layer_test.cpp
+++ b/modules/containers/test/oci_layer_test.cpp
@@ -132,3 +132,13 @@ TEST(Overlay, TopLayerFirst) {
 TEST(Overlay, SingleLayer) {
     EXPECT_EQ(overlay_lowerdir({"/l/only"}), "/l/only");
 }
+TEST(Overlay, DedupesRepeatedLayerPaths) {
+    // An image can list the same layer digest twice → same extracted dir.
+    // Linux 6.6 overlay rejects a duplicate lowerdir ("conflicting lowerdir
+    // path"), so we keep the topmost occurrence only.
+    std::vector<std::string> dirs = {"/l/base", "/l/dup", "/l/mid", "/l/dup"};
+    EXPECT_EQ(overlay_lowerdir(dirs), "/l/dup:/l/mid:/l/base");
+}
+TEST(Overlay, AllIdenticalCollapseToOne) {
+    EXPECT_EQ(overlay_lowerdir({"/l/x", "/l/x", "/l/x"}), "/l/x");
+}


### PR DESCRIPTION
## Problem

First on-HW test of the container runtime (RPi3B, kernel `6.6.63-v8`): `container run` failed, `container.state=error`. Kernel log:

```
overlayfs: conflicting lowerdir path
```

(`/` is plain ext4 — not nesting; daemon runs root with `cap_sys_admin`, no sandbox — not EPERM.)

## Cause

An OCI image can list the **same layer digest more than once** (the shared empty layer, or genuinely identical layers). `ensure_layers_extracted` maps each digest to the same `root/layers/<hex>/fs` dir, so `overlay_lowerdir()` produced a `lowerdir=…/fs:…/fs` string with a **duplicate path**. Linux **6.6's rewritten overlay mount parser rejects duplicate lowerdirs**; older kernels silently tolerated it — which is why CI and earlier tests passed and this only bit on hardware (containers Phase 7).

## Fix

Dedupe paths in `overlay_lowerdir()`, keeping the topmost occurrence. Identical digest == identical content, so dropping the repeat preserves the merged view.

## Tests

Added `Overlay.DedupesRepeatedLayerPaths` and `Overlay.AllIdenticalCollapseToOne`. Built + ran via podman — `Overlay.*` 4/4 pass.

⚠️ Needs HW re-test: `container run` of the image that previously failed should now mount + start.

🤖 Generated with [Claude Code](https://claude.com/claude-code)