### PR TITLE
fix(cloud): OTA push is one-shot — consume the job on delivery

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1019,6 +1019,29 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                         reg.endpoint.c_str(), ver.c_str(),
                                         reg.peerHost.c_str(),
                                         static_cast<unsigned>(reg.peerPort)));
+                                    // One-shot: consume the job. Remove it from
+                                    // cloud.update.pending so the cloud NEVER
+                                    // re-pushes on a later registration or after a
+                                    // cloud restart (otaSent is in-memory and was
+                                    // lost on restart → the old re-push "on its
+                                    // own"). The cloud only pushes as a direct
+                                    // result of an operator queueing a job;
+                                    // delivery consumes it. The operator re-pushes
+                                    // to retry a missed device.
+                                    {
+                                        nlohmann::json remaining =
+                                            nlohmann::json::array();
+                                        for (const auto& j : arr) {
+                                            if (j.value("endpoint", "") ==
+                                                    reg.endpoint &&
+                                                j.value("url", "") == url)
+                                                continue;   // drop the delivered one
+                                            remaining.push_back(j);
+                                        }
+                                        dsCertPush->set(
+                                            "cloud.update.pending",
+                                            data_store::Value{remaining.dump()});
+                                    }
                                     // Reflect "updating" in cloud.update.status.
                                     std::vector<data_store::Client::GetResult> sg;
                                     nlohmann::json st = nlohmann::json::array();


### PR DESCRIPTION
## Problem

The cloud delivered any job sitting in `cloud.update.pending` whenever a device **registered**, and re-delivered it after a **cloud restart** (the `otaSent` dedup is in-memory and lost on restart). So the cloud re-pushed an OTA **"on its own"** on every (re)registration / restart until the job was manually cleared.

Observed on HW: a redundant **1.3.3** bundle pushed to `6556e041` which was already on `1.3.3` — the manifest version `1.3.3` never exactly matches the device's `1.3.3+gitsha`, so the same-build guard didn't suppress it either.

## Fix

Policy: **the cloud only pushes as a direct result of an operator queueing a job.** A job is now **consumed on delivery** — right after the `Write(/5/0/1)` + `Execute(/5/0/2)` send, the cloud removes that endpoint's job from `cloud.update.pending` and persists it. So it is delivered **exactly once** and never re-pushed on a later registration or after a restart. The operator re-queues to retry a device that was offline/missed.

Trade-off (per the chosen policy): if the push goes out while the device's DTLS peer is momentarily gone, the job is still consumed → operator re-pushes. (Alternative "clear only after `cloud.update.status` confirms apply" is a small future variant if delivery-guarantee is wanted.)

## Scope / validation

- Cloud-side only (server-role `lwm2m`); ships in the cloud image — takes effect on cloud redeploy, no device OTA needed.
- Full `lwm2m` binary compiles + links via podman (ubuntu:22.04).

🤖 Generated with [Claude Code](https://claude.com/claude-code)