### PR TITLE
fix(ota): bundle libcrypto3 + libssl3 so OTA installs across the OpenSSL bump

### DIFF
--- a/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
+++ b/yocto/meta-iot/recipes-iot/lwm2m/iot-bundle.bb
@@ -31,11 +31,14 @@ do_deploy[depends] += "iot:do_package_write_ipk"
 # NEW or version-bumped lib dep makes `opkg install` fail on a stale device with
 # "nothing provides <lib> >= <ver>" — observed 1.3.0→1.3.2: iot-lwm2m needs
 # libsqlite3-0>=3.45.3 (the SQLite DurableSampleBuffer) and iot-mqtt needs
-# libmosquitto1>=2.0.22, neither on the 1.3.0 image. Bundle them so the OTA is
-# self-contained. Bare package basenames; the newest matching .ipk is included.
+# libmosquitto1>=2.0.22, neither on the 1.3.0 image; and 1.3.3→1.3.5: an OpenSSL
+# bump made every iot-* (and libmosquitto1) need libcrypto3>=3.5.7 / libssl3,
+# which the older image lacks. Bundle these runtime libs so the OTA is
+# self-contained across a dependency/version bump. Bare package basenames; the
+# newest matching .ipk is included.
 # Build-deps that drag these in so their .ipk is written to the feed before bundling.
-IOT_BUNDLE_EXTRA_PKGS ?= "libsqlite3-0 libmosquitto1"
-do_deploy[depends] += "sqlite3:do_package_write_ipk mosquitto:do_package_write_ipk"
+IOT_BUNDLE_EXTRA_PKGS ?= "libsqlite3-0 libmosquitto1 libcrypto3 libssl3"
+do_deploy[depends] += "sqlite3:do_package_write_ipk mosquitto:do_package_write_ipk openssl:do_package_write_ipk"
 
 do_deploy() {
     feed="${DEPLOY_DIR_IPK}"


### PR DESCRIPTION
## Problem (HW)

OTA of 1.3.5 onto a 1.3.3 device failed at `opkg install` (`Result: install error`). `/run/iot/update/last.log`:

```
nothing provides libcrypto3 >= 3.5.7 needed by iot-httpd / iot-lwm2m / iot-containerd / libmosquitto1
```

The 1.3.5 build bumped **OpenSSL to 3.5.7**, so every `iot-*` binary (and the bundled `libmosquitto1`) needs `libcrypto3>=3.5.7` / `libssl3`. Incremental `.ipk` OTA installs only what's in the bundle; the older on-device image has an older `libcrypto3` → unsatisfiable → install aborts. Staging (download + sha + extract) was fine; this is the install step.

Same failure family as 1.3.0→1.3.2 (libsqlite3/libmosquitto), which is exactly why those are already in `IOT_BUNDLE_EXTRA_PKGS` — OpenSSL just wasn't listed.

## Fix

Add `libcrypto3` + `libssl3` to `IOT_BUNDLE_EXTRA_PKGS` and `openssl` to the `do_package_write_ipk` deps, so the bundle ships the OpenSSL runtime libs and is self-contained across the bump.

## Impact

⚠️ The existing **1.3.5 and 1.3.6 bundles lack these libs and will fail the same way** — a rebuilt bundle from a release carrying this fix is required.

Follow-up worth considering: derive the bundled runtime libs from the `iot-*` RDEPENDS closure instead of a manual list, so the next lib bump doesn't silently break OTA again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)