### PR TITLE
feat(image): ship vim + on-device debug toolset in the RPi image

### DIFF
--- a/yocto/meta-iot/recipes-iot/images/iot-image.bb
+++ b/yocto/meta-iot/recipes-iot/images/iot-image.bb
@@ -32,8 +32,12 @@ EXTRA_IMAGE_FEATURES ?= "debug-tweaks"
 # nvram). It's gated by the synaptics-killswitch LICENSE_FLAG, accepted in
 # entrypoint.sh / kas-iot.yml. If your meta-raspberrypi revision names it
 # differently, swap to linux-firmware-bcm43430.
+# packagegroup-iot-debug pulls packagegroup-iot-full (the whole gateway
+# daemon set + runtime deps) PLUS the on-device debugging toolset (vim,
+# strace, gdb, lsof, tcpdump, i2c-tools, …). For a slimmer production
+# image swap this to packagegroup-iot-full and drop debug-tweaks above.
 IMAGE_INSTALL:append = " \
-    packagegroup-iot-full \
+    packagegroup-iot-debug \
     kernel-modules \
     linux-firmware-rpidistro-bcm43430 \
     pi-bluetooth \
@@ -41,8 +45,6 @@ IMAGE_INSTALL:append = " \
     openssh \
     opkg \
     kernel-module-tun \
-    htop \
-    nano \
 "
 
 # Headroom on the rootfs for opkg-installed .ipk updates + logs (512 MB).

--- a/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
+++ b/yocto/meta-iot/recipes-iot/packagegroups/packagegroup-iot.bb
@@ -59,10 +59,32 @@ RDEPENDS:${PN}-full = "\
 # wpa_cli. The DHCP client comes from the recipe's
 # RRECOMMENDS:iot-wifi-client = busybox-udhcpc.
 
-# ── Debug: includes test binaries ─────────────────────────────────
-# For CI and developer images.
+# ── Debug: full stack + on-device debugging toolset ───────────────
+# For CI and developer/field-debug images. Adds editors and the tools you
+# reach for when ssh'd into a misbehaving RPi (process/syscall tracing,
+# open-fd/socket inspection, packet capture, USB/I2C/MMC bus probing).
 RDEPENDS:${PN}-debug = "\
     ${PN}-full \
+    vim \
+    nano \
+    less \
+    htop \
+    procps \
+    strace \
+    ltrace \
+    gdb \
+    lsof \
+    file \
+    tree \
+    curl \
+    wget \
+    socat \
+    tcpdump \
+    bind-utils \
+    ethtool \
+    usbutils \
+    i2c-tools \
+    mmc-utils \
 "
 # Note: test binaries (lwm2m_test, ds-tests, etc.) are not yet split
 # into a separate iot-test package. Add them here when PACKAGECONFIG[gtest]


### PR DESCRIPTION
## What

Adds vim and a field-debug toolset to the RPi image so you can effectively debug a misbehaving device over ssh without a reflash.

- **`packagegroup-iot.bb`** — populated the previously-empty `packagegroup-iot-debug` (it RDEPENDed only on `-full`) with:
  - Editors/pagers: `vim`, `nano`, `less`
  - Tracing: `htop`, `procps`, `strace`, `ltrace`, `gdb`
  - FD/socket/file inspection: `lsof`, `file`, `tree`
  - Networking: `curl`, `wget`, `socat`, `tcpdump`, `bind-utils` (dig/nslookup), `ethtool`
  - Bus probing (mangOH/RPi I²C + cellular work): `usbutils`, `i2c-tools`, `mmc-utils`
- **`iot-image.bb`** — switched `IMAGE_INSTALL` from `packagegroup-iot-full` → `packagegroup-iot-debug` (pulls `-full` transitively, so no daemons lost) and dropped the now-redundant inline `htop`/`nano`. Documented how to revert to `-full` for a slim production image.

## Why packagegroup, not a systemd unit

`.service` units don't install packages — package selection is Yocto image/packagegroup wiring. The `-debug` group already existed for exactly this ("For CI and developer images") and was empty.

## Layer safety

All packages resolve against the already-enabled `meta-oe` / `meta-python` / `meta-networking` layers (verified in `kas-iot.yml` + `entrypoint.sh`), so the on-main image build stays green.

## Testing

Config-only change. No local Yocto build on the dev Mac; image CI runs on push to main, so on-HW confirmation comes post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)