### PR TITLE
fix(client): reset_and_connect on DM switch so a cloud restart can't wedge dm-connecting

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1597,7 +1597,17 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
         if (dtls) {
             dtls->active_identity(dmIdentity);
             dtls->clientState("");            // drop the BS session state
-            dtls->connect(dmHost, dmPort);    // start the DM handshake now
+            // Force a FRESH DM handshake. A DM peer left CONNECTED from before a
+            // cloud restart (tinydtls has no liveness check, so the device never
+            // noticed the server lost its peer table) makes plain connect()
+            // attempt an ENCRYPTED renegotiation ClientHello. The restarted DM —
+            // peerless — rejects that as "no peer available / only ClientHello
+            // is allowed" and the device wedges at dm-connecting forever (only a
+            // manual iot-lwm2m-client restart recovered it). reset_and_connect()
+            // tears the stale peer down first so a PLAINTEXT ClientHello starts a
+            // clean handshake the restarted DM accepts — auto-recovery after any
+            // cloud bounce/upgrade.
+            dtls->reset_and_connect(dmHost, dmPort);
         }
         // Apply the bootstrap-delivered registration lifetime (Server Object
         // RID 1) — the client uses this, sourced by the BS from


### PR DESCRIPTION
## Problem (HW-confirmed 2026-06-28)

After upgrading cloud-iot to latest, **LwM2M went down while VPN stayed up** on two RPis (`192.168.1.{20,170}`, fw 1.3.6+git; cloud Vultr `65.20.74.23`). Both devices stuck at `iot.conn.state=dm-connecting`: Bootstrap (5684) succeeded every cycle, but the DM (5683) DTLS handshake never completed.

Cloud `lwm2m-dm` logged, on loop:
```
dtls: no peer available, send an alert
dtls: If there is no peer only ClientHello is allowed
dtls: error while handling handshake packet
```

## Root cause (transport layer, not credentials)

The cloud upgrade restarts `lwm2m-dm`, which loses its tinydtls peer table. tinydtls has no liveness check, so the **device's DM peer stays `CONNECTED`**. The post-bootstrap `on_done` called plain `connect()`, which on a still-CONNECTED peer attempts an **encrypted renegotiation ClientHello**. The peerless DM can't decrypt it → rejects as "no peer / only ClientHello allowed". The device's re-bootstrap loop keeps reusing the same stale peer, so it never sends a fresh plaintext ClientHello — wedged forever.

DM **credentials are not involved** — they're refreshed on every re-bootstrap (`add_credential` upserts; "DM credentials persisted" logged each cycle).

## Fix

In bootstrap `on_done`, use `dtls->reset_and_connect(dmHost, dmPort)` instead of `connect()` when switching to the DM. This force-tears the stale peer so a **plaintext** ClientHello starts a clean handshake the restarted DM accepts — auto-recovery after any cloud bounce/upgrade. No regression for fresh devices (no peer to reset).

## Validation

- Manual recovery confirmed: `systemctl restart iot-lwm2m-client` on both devices → `bootstrapped` → `registered` in ~6s.
- The cloud DM itself is healthy: a local registration-plane loadgen registered **500 devices at 100%** against the same `DeviceMgmtServer` code — this is purely the device-side stale-peer recovery gap.
- Fix compiles + links (podman ubuntu:22.04, incremental `lwm2m` target). **Not yet HW-validated** (needs image rebuild + OTA/reflash).

Related: cannot-add-peer (#463) and BS-identity (#472) re-bootstrap wedges — same family, DM-switch path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)