### PR TITLE
feat(cloud): tenant-aware BS/DM PSK resolvers (default == legacy; gtest)

### DIFF
--- a/apps/src/provisioning_policy.cpp
+++ b/apps/src/provisioning_policy.cpp
@@ -3,6 +3,7 @@
 #include <nlohmann/json.hpp>
 
 #include "psk_gen.hpp"
+#include "tenant_policy.hpp"   // multi-tenant: bs_identity / parse_dm_identity
 
 namespace iot {
 
@@ -66,8 +67,14 @@ std::string resolve_bs_psk(const std::string& credentials_json,
             if (!e.is_object()) continue;
             const std::string serial = e.value("serial", std::string());
             const std::string key    = e.value("bs.psk.key", std::string());
+            // Tenant-aware canonical BS identity. For an untagged row this is
+            // bs_identity("default", serial) == sha256(serial)[:32] — byte-for-
+            // byte the legacy match, so fielded devices are unaffected. A
+            // tenant-tagged row matches only its tenant's identity, so two
+            // tenants sharing a serial never cross-authenticate.
+            const std::string tenant = e.value("tenant", std::string());
             if (!serial.empty() && !key.empty() &&
-                sha256_hex(serial).substr(0, 32) == presented)
+                bs_identity(tenant, serial) == presented)
                 return key;
         }
         for (const auto& e : arr) {
@@ -142,8 +149,11 @@ std::string resolve_dm_psk(const std::string& credentials_json,
     }
 
     // 2) Zero-touch tier: derive from the serial embedded in the DM identity.
+    // parse_dm_identity handles BOTH the legacy "rpi<serial>@cloud.local" and
+    // the tenant "rpi<serial>@<tenant>.cloud.local" forms, so a default-tenant
+    // device derives exactly as before.
     if (!master_hex.empty()) {
-        const std::string serial = serial_from_dm_identity(presented);
+        const std::string serial = parse_dm_identity(presented).serial;
         if (!serial.empty()) return derive_dm_psk_hex(master_hex, serial);
     }
 

--- a/apps/test/provisioning_policy_test.cpp
+++ b/apps/test/provisioning_policy_test.cpp
@@ -4,6 +4,7 @@
 
 #include "provisioning_policy.hpp"
 #include "psk_gen.hpp"
+#include "tenant_policy.hpp"
 
 using iot::resolve_endpoint;
 
@@ -207,4 +208,48 @@ TEST(ResolveDmPsk, NoMasterOrUnparseableYieldsEmpty) {
     EXPECT_EQ("", iot::resolve_dm_psk("[]", iot::format_dm_identity(kSerial), ""));
     EXPECT_EQ("", iot::resolve_dm_psk("[]", "not-a-dm-id", kMaster));
     EXPECT_EQ("", iot::resolve_dm_psk("[]", "", kMaster));
+}
+
+// ── Multi-tenant resolution (tdd-multi-tenant-cloud.md) ──────────────────────
+
+TEST(ResolveBsPskTenant, UntaggedRowIsByteIdenticalToLegacy) {
+    // The whole backward-compat guarantee: an untagged row resolves under the
+    // device's legacy sha256(serial)[:32] identity exactly as before — a fielded
+    // device stays online after the cloud gains tenant awareness.
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","bs.psk.key":"feedface"}])";
+    EXPECT_EQ(iot::bs_identity("default", kSerial), std::string(kSha256Id));
+    EXPECT_EQ("feedface", iot::resolve_bs_psk(creds, kSha256Id, kMaster));
+}
+
+TEST(ResolveBsPskTenant, TenantRowMatchesTenantIdentityOnly) {
+    // A tenant-tagged row authenticates only against its tenant-qualified
+    // identity, never the bare-serial (default) one.
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"acmekey"}])";
+    EXPECT_EQ("acmekey",
+              iot::resolve_bs_psk(creds, iot::bs_identity("acme", kSerial), ""));
+    // The default identity for the same serial must NOT resolve the acme row.
+    EXPECT_EQ("", iot::resolve_bs_psk(creds, kSha256Id, ""));
+}
+
+TEST(ResolveBsPskTenant, NoCrossTenantAuthOnDuplicateSerial) {
+    // Two tenants, same serial, different keys. Each identity resolves only its
+    // own tenant's key.
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"acmekey"},)"
+        R"({"serial":"100000003d1f9c2e","tenant":"globex","bs.psk.key":"globexkey"}])";
+    EXPECT_EQ("acmekey",
+              iot::resolve_bs_psk(creds, iot::bs_identity("acme", kSerial), ""));
+    EXPECT_EQ("globexkey",
+              iot::resolve_bs_psk(creds, iot::bs_identity("globex", kSerial), ""));
+}
+
+TEST(ResolveDmPskTenant, DerivesFromTenantQualifiedDmIdentity) {
+    // The derive path parses both legacy and tenant DM identities to the same
+    // serial, so the derived DM key is identical regardless of tenant suffix.
+    EXPECT_EQ(kDerivedDm,
+              iot::resolve_dm_psk("[]", iot::dm_identity("default", kSerial), kMaster));
+    EXPECT_EQ(kDerivedDm,
+              iot::resolve_dm_psk("[]", iot::dm_identity("acme", kSerial), kMaster));
 }


### PR DESCRIPTION
Second multi-tenant slice (`apps/docs/tdd-multi-tenant-cloud.md`). Wires the P1 tenant primitives (#484) into the cloud's credential resolvers so devices authenticate **within their tenant** — with **zero behaviour change for existing default-tenant devices**.

## Changes (`provisioning_policy.cpp`)
- **`resolve_bs_psk`** — the canonical identity match is now per-row `bs_identity(row.tenant, serial)` instead of a hardcoded `sha256(serial)[:32]`. For an untagged row, `bs_identity("default", serial) == sha256(serial)[:32]` **byte-for-byte**; a tenant-tagged row authenticates only against its own tenant identity.
- **`resolve_dm_psk`** derive path — `parse_dm_identity` (handles both legacy `rpi<serial>@cloud.local` and tenant `rpi<serial>@<tenant>.cloud.local`) replaces the legacy-only parser.

## "Will it break existing online devices?" — No (proven two ways)
1. **Unit:** `ResolveBsPskTenant.UntaggedRowIsByteIdenticalToLegacy` asserts the default path is byte-identical; the existing `ResolveBsPsk.*`/`ResolveDmPsk.*` suite passes unchanged. New cases prove tenant scoping + **no cross-tenant auth on duplicate serials**. **30/30 gtest green** (podman, ubuntu 22.04).
2. **Empirical:** rebuilt the cloud image with this change and ran the load benchmark — **300/300 default-tenant devices registered (100%)**. Default-tenant = exactly how fielded RPis present themselves.

## Scope / safety
No device-facing change yet: the BS `provisioning_resolver` in `main.cpp` still pushes default DM accounts; tenant-qualified onboarding + console read-scoping are the next slices. Ships only in the cloud image — device firmware untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)