### PR TITLE
feat(cloud): tenant-aware BS provisioning_resolver + loadgen tenant mode (gtest)

### DIFF
--- a/apps/bench/CMakeLists.txt
+++ b/apps/bench/CMakeLists.txt
@@ -90,6 +90,7 @@ set(APP_SRC
     ../src/rpi_serial.cpp
     ../src/psk_gen.cpp
     ../src/provisioning_policy.cpp
+    ../src/tenant_policy.cpp
 )
 
 add_executable(cloud_loadgen cloud_loadgen.cpp ${APP_SRC})

--- a/apps/bench/cloud_loadgen.cpp
+++ b/apps/bench/cloud_loadgen.cpp
@@ -57,6 +57,7 @@
 #include "lwm2m_object_store.hpp"
 #include "lwm2m_registration_client.hpp"
 #include "psk_gen.hpp"
+#include "tenant_policy.hpp"
 
 // tinydtls' numeric.h (pulled in transitively via dtls.h) #defines min()/max()
 // as function-like macros, which clobber std::min/std::max. Undo them so the
@@ -85,6 +86,7 @@ struct Config {
     std::uint32_t bootTimeoutSecs = 30;    ///< per-device give-up → Failed
     std::string csvPath;                   ///< optional per-device CSV dump
     bool emitCreds = false;                ///< print cloud.endpoint.credentials + exit
+    std::string tenant;                    ///< tenant slug ("" = default tenant)
     log_t logLevel = DTLS_LOG_EMERG;       ///< keep tinydtls quiet at scale
 };
 
@@ -98,9 +100,6 @@ static std::string bs_key16(const std::string& seed, const std::string& serial) 
 }
 static std::string dm_key16(const std::string& seed, const std::string& serial) {
     return iot::derive_dm_psk_hex(seed, serial).substr(0, 32);
-}
-static std::string dm_identity(const std::string& serial) {
-    return "rpi" + serial + "@cloud.local";
 }
 
 // ─────────────────────────── per-device milestones ─────────────────────────
@@ -159,13 +158,18 @@ public:
         }
         m_fd = m_sock.get_handle();
 
+        // Tenant-qualified bootstrap endpoint: "tenant:serial" (default tenant
+        // ⇒ bare serial, legacy on the wire). The serial stays bare for key
+        // derivation + credential-row matching.
+        const std::string ep = iot::join_endpoint(m_cfg.tenant, m_serial);
+
         m_dtls  = std::make_shared<DTLSAdapter>(m_fd, m_cfg.logLevel);
         m_store = std::make_shared<lwm2m::ObjectStore>();
         m_bs    = std::make_shared<lwm2m::bootstrap::Client>(
-                      m_serial, m_store, m_dtls);
+                      ep, m_store, m_dtls);
 
         lwm2m::ClientConfig rc;
-        rc.endpoint     = m_serial;
+        rc.endpoint     = ep;
         rc.lifetime     = m_cfg.lifetime;   // BS Server Object RID 1 overrides
         rc.binding      = "U";
         rc.lwm2mVersion = "1.1";
@@ -182,7 +186,7 @@ public:
         // the 128 KB ds-cli arg cap at high N). Secret = 128-bit key derived
         // from seed + serial. add_credential stores hex; the PSK callback
         // hex-decodes it to 16 bytes (fits DTLS_PSK_MAX_KEY_LEN).
-        const std::string bsId     = iot::sha256_hex(m_serial).substr(0, 32);
+        const std::string bsId     = iot::bs_identity(m_cfg.tenant, m_serial);
         const std::string bsPskHex = bs_key16(m_cfg.masterHex, m_serial);
         if (bsPskHex.empty()) {
             ACE_ERROR_RETURN((LM_ERROR,
@@ -537,15 +541,20 @@ static void emit_creds(const Config& cfg) {
     std::printf("[");
     for (std::uint32_t i = 0; i < cfg.count; ++i) {
         const std::string s = cfg.serialPrefix + std::to_string(i);
-        // No "identity" field: the device presents sha256(serial)[:32], which
-        // resolve_bs_psk matches via serial (step 1). Omitting it keeps the
-        // array under ds-cli's 128 KB single-arg cap at high device counts.
-        std::printf("%s{\"serial\":\"%s\","
+        // No "identity" field: the device presents bs_identity(tenant,serial),
+        // which the cloud recomputes per row. Omitting it keeps the array under
+        // ds-cli's 128 KB single-arg cap at high device counts. The "tenant"
+        // tag is emitted only for a non-default tenant (default rows stay
+        // untagged = legacy).
+        const std::string tenantField =
+            cfg.tenant.empty() ? std::string()
+                               : ("\"tenant\":\"" + cfg.tenant + "\",");
+        std::printf("%s{\"serial\":\"%s\",%s"
                     "\"bs.psk.key\":\"%s\",\"dm.psk.id\":\"%s\","
                     "\"dm.psk.key\":\"%s\"}",
-                    i ? "," : "", s.c_str(),
+                    i ? "," : "", s.c_str(), tenantField.c_str(),
                     bs_key16(cfg.masterHex, s).c_str(),
-                    dm_identity(s).c_str(),
+                    iot::dm_identity(cfg.tenant, s).c_str(),
                     dm_key16(cfg.masterHex, s).c_str());
     }
     std::printf("]\n");
@@ -567,6 +576,7 @@ int main(int argc, char* argv[]) {
             cfg.bootTimeoutSecs = (std::uint32_t)std::stoul(v);
         else if (arg(a, "prefix", v))  cfg.serialPrefix = v;
         else if (arg(a, "csv", v))     cfg.csvPath = v;
+        else if (arg(a, "tenant", v))  cfg.tenant = v;
         else if (arg(a, "emit-creds", v)) cfg.emitCreds = (v != "0");
         else if (a == "-h" || a == "--help") {
             std::printf(

--- a/apps/bench/run-bench.sh
+++ b/apps/bench/run-bench.sh
@@ -94,9 +94,21 @@ log "compose network: $NET"
 # buffer and never completes a handshake). MASTER is just a derivation seed so
 # the loadgen and the provisioned rows agree byte-for-byte.
 MASTER="$(openssl rand -hex 32)"
-log "generating $COUNT device credentials…"
+# TENANT=<slug> exercises the multi-tenant path: devices bootstrap as
+# "<slug>:<serial>", creds are tenant-tagged, and the tenant is registered in
+# cloud.tenants. Empty = the default tenant (legacy single-tenant behaviour).
+TENANT="${TENANT:-}"
+TARG=""
+if [ -n "$TENANT" ]; then
+  TARG="tenant=$TENANT"
+  log "registering tenant '$TENANT' in cloud.tenants…"
+  dscli set cloud.tenants \
+    "[{\"id\":\"$TENANT\",\"name\":\"$TENANT\",\"dm.uri\":\"coaps://iot-lwm2m-dm:5683\",\"status\":\"active\"}]"
+fi
+
+log "generating $COUNT device credentials${TENANT:+ for tenant $TENANT}…"
 CREDS="$($ENGINE run --rm "$BENCH_TAG" \
-          emit-creds=1 master="$MASTER" count="$COUNT" prefix=bench)"
+          emit-creds=1 master="$MASTER" count="$COUNT" prefix=bench $TARG)"
 [ "${CREDS:0:1}" = "[" ] || { echo "emit-creds produced no JSON" >&2; exit 1; }
 
 log "writing cloud.endpoint.credentials + DM URI to data-store…"
@@ -125,7 +137,7 @@ CSV="$SAMPLES_DIR/devices-$STAMP.csv"
 log "running loadgen: count=$COUNT ramp=$RAMP/s soak=${SOAK}s → $NET"
 set +e
 $ENGINE run --rm --network "$NET" -v "$SAMPLES_DIR:/out" "$BENCH_TAG" \
-    master="$MASTER" \
+    master="$MASTER" $TARG \
     bs-host=iot-lwm2m-bs bs-port=5684 \
     count="$COUNT" ramp="$RAMP" soak="$SOAK" \
     lifetime="$LIFETIME" boot-timeout="$BOOT_TIMEOUT" \

--- a/apps/inc/provisioning_policy.hpp
+++ b/apps/inc/provisioning_policy.hpp
@@ -101,6 +101,38 @@ std::string resolve_dm_psk(const std::string& credentials_json,
                            const std::string& presented,
                            const std::string& master_hex);
 
+/// Multi-tenant BS account plan (apps/docs/tdd-multi-tenant-cloud.md). The pure
+/// core of the BS provisioning_resolver: given the bootstrap endpoint and the ds
+/// state, decide which tenant the device belongs to and what BS/DM account to
+/// hand back. Keeps the tenant logic out of the integration-heavy main.cpp
+/// lambda so it can be unit-tested.
+struct BsAccountPlan {
+    bool        ok{false};        ///< false → reject the /bs (caller returns nullopt)
+    std::string tenant;           ///< resolved tenant ("default" for legacy)
+    std::string serial;           ///< serial (endpoint minus any "tenant:" prefix)
+    std::string bs_identity;      ///< BS DTLS identity to write to Security /0/0
+    std::string bs_key;           ///< BS PSK (hex)
+    std::string dm_identity;      ///< DM identity for Security /0/1
+    std::string dm_key;           ///< DM PSK (hex)
+    std::string dm_uri;           ///< per-tenant dm.uri if set, else the global one
+    bool        zero_touch{false};///< true → HKDF-derived (no stored row)
+};
+
+/// Plan the account for a `POST /bs?ep=<endpoint>`:
+///   - split the endpoint into (tenant, serial) — colon-less ⇒ "default";
+///   - a non-default tenant must exist and be active in `tenants_json`, else
+///     ok=false (reject unknown/suspended tenant);
+///   - look up the commissioned row scoped to that tenant (by serial), else
+///     HKDF-derive when `master_hex` is set;
+///   - identities are tenant-qualified (default ⇒ byte-identical to legacy);
+///   - dm_uri = the tenant's dm.uri if present, else `global_dm_uri`.
+/// ok requires a usable DM identity + key + dm_uri.
+BsAccountPlan plan_bs_account(const std::string& ep,
+                              const std::string& credentials_json,
+                              const std::string& tenants_json,
+                              const std::string& global_dm_uri,
+                              const std::string& master_hex);
+
 } // namespace iot
 
 #endif /* __iot_provisioning_policy_hpp__ */

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -291,7 +291,8 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                                 std::string("cloud.dm.lifetime"),
                                 std::string("cloud.dm.binding"),
                                 std::string("cloud.bs.uri"),
-                                std::string("cloud.bs.master.key")}, got);
+                                std::string("cloud.bs.master.key"),
+                                std::string("cloud.tenants")}, got);
             if (!rs.ok || got.size() < 5) return std::nullopt;
 
             auto str_at = [&](std::size_t i) -> std::string {
@@ -322,14 +323,6 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
             if (binding.empty()) binding = "U";
             const std::string bsUri = str_at(4);
 
-            if (dmUri.empty()) {
-                ACE_ERROR((LM_WARNING,
-                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: "
-                                    "cloud.dm.uri unset — cannot provision DM "
-                                    "account\n"),
-                           ep.c_str()));
-                return std::nullopt;
-            }
             // Unwrap the HKDF master (zero-touch tier) if a KEK is configured.
             // str_at(5) is the AES-256-GCM-wrapped cloud.bs.master.key blob; a
             // missing KEK or a bad/tampered blob → "" → tier disabled, fail
@@ -338,58 +331,33 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                 bsKekHex.empty()
                     ? std::string()
                     : iot::unwrap_bs_master_hex(bsKekHex, str_at(5)).value_or("");
+            const std::string tenantsJson = str_at(6);   // cloud.tenants ("[]" ok)
 
-            std::string dmId, dmKey, bsKey;
-            bool zeroTouch = false;
-            if (!credsJson.empty()) {
-                try {
-                    auto arr = nlohmann::json::parse(credsJson);
-                    if (arr.is_array()) {
-                        for (auto& e : arr) {
-                            if (!e.is_object()) continue;
-                            const std::string serial   = e.value("serial",   std::string());
-                            const std::string identity = e.value("identity", std::string());
-                            if (serial == ep || identity == ep) {
-                                dmId  = e.value("dm.psk.id",  std::string());
-                                dmKey = e.value("dm.psk.key", std::string());
-                                bsKey = e.value("bs.psk.key", std::string());
-                                break;
-                            }
-                        }
-                    }
-                } catch (const std::exception& ex) {
-                    // Don't fail outright — a master can still serve zero-touch.
-                    ACE_ERROR((LM_ERROR,
-                               ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: "
-                                        "cloud.endpoint.credentials parse: %C\n"),
-                               ep.c_str(), ex.what()));
-                }
-            }
-
-            // Zero-touch (HKDF) tier: no stored row, but a master is available →
-            // derive per-device BS+DM creds statelessly (nothing minted/stored).
-            // The device presents its RAW serial as the BS PSK identity (the
-            // override path), so the BS account handed back uses the raw serial
-            // verbatim — NOT sha256(ep) as in the commissioned tier.
-            if ((dmId.empty() || dmKey.empty()) && !masterHex.empty()) {
-                bsKey     = iot::derive_bs_psk_hex(masterHex, ep);
-                dmId      = iot::format_dm_identity(ep);
-                dmKey     = iot::derive_dm_psk_hex(masterHex, ep);
-                zeroTouch = true;
-                ACE_DEBUG((LM_INFO,
-                           ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: "
-                                    "zero-touch HKDF-derived BS+DM creds (no "
-                                    "stored row)\n"),
-                           ep.c_str()));
-            }
-
-            if (dmId.empty() || dmKey.empty()) {
+            // Tenant-aware account planning (pure; unit-tested in
+            // provisioning_policy_test.cpp). Splits ep into (tenant, serial),
+            // validates a non-default tenant against cloud.tenants, scopes the
+            // credential lookup to that tenant, derives identities (default ⇒
+            // byte-identical to legacy), and picks the per-tenant or global
+            // dm.uri. ok=false ⇒ reject the /bs.
+            const iot::BsAccountPlan plan = iot::plan_bs_account(
+                ep, credsJson, tenantsJson, dmUri, masterHex);
+            if (!plan.ok) {
                 ACE_ERROR((LM_WARNING,
                            ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: no "
-                                    "provisioned DM credential found\n"),
-                           ep.c_str()));
+                                    "provisionable account (tenant=%C)\n"),
+                           ep.c_str(), plan.tenant.c_str()));
                 return std::nullopt;
             }
+            const std::string& dmId  = plan.dm_identity;
+            const std::string& dmKey = plan.dm_key;
+            const std::string& bsKey = plan.bs_key;
+            const bool         zeroTouch = plan.zero_touch;
+            const std::string& dmUriEff = plan.dm_uri;   // per-tenant or global
+            ACE_DEBUG((LM_INFO,
+                       ACE_TEXT("%D lwm2m:thread:%t %M %N:%l /bs for %C: "
+                                "tenant=%C serial=%C %C\n"),
+                       ep.c_str(), plan.tenant.c_str(), plan.serial.c_str(),
+                       zeroTouch ? "(zero-touch)" : "(commissioned)"));
 
             ::lwm2m::bootstrap::AccountProvisioning a;
             a.endpoint = ep;
@@ -406,10 +374,10 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                 bs.serverUri         = bsUri;
                 bs.isBootstrapServer = true;
                 bs.securityMode      = 0;       // PSK
-                // Commissioned tier: derived identity sha256(ep)[:32].
-                // Zero-touch tier: the device presents its RAW serial verbatim.
-                bs.identity          = zeroTouch ? ep
-                                                 : iot::sha256_hex(ep).substr(0, 32);
+                // Tenant-qualified canonical BS identity (default tenant ⇒
+                // sha256(serial)[:32], byte-identical to legacy); zero-touch ⇒
+                // the raw serial the device presents. Computed by plan_bs_account.
+                bs.identity          = plan.bs_identity;
                 bs.secretKey         = bsKey;   // hex (omitted by encoder if empty)
                 bs.shortServerId     = 0;       // ignored for a BS account
                 a.security.push_back(std::move(bs));
@@ -423,7 +391,7 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
             // Security /0/1 — the DM-Server account (Is Bootstrap=false).
             ::lwm2m::bootstrap::SecurityInstance dm;
             dm.iid               = 1;
-            dm.serverUri         = dmUri;
+            dm.serverUri         = dmUriEff;
             dm.isBootstrapServer = false;
             dm.securityMode      = 0;           // PSK
             dm.identity          = dmId;        // distinct DM identity

--- a/apps/src/provisioning_policy.cpp
+++ b/apps/src/provisioning_policy.cpp
@@ -161,4 +161,72 @@ std::string resolve_dm_psk(const std::string& credentials_json,
     return {};
 }
 
+BsAccountPlan plan_bs_account(const std::string& ep,
+                              const std::string& credentials_json,
+                              const std::string& tenants_json,
+                              const std::string& global_dm_uri,
+                              const std::string& master_hex) {
+    BsAccountPlan p;
+    const EndpointId eid = split_endpoint(ep);
+    p.tenant = eid.tenant;
+    p.serial = eid.serial;
+
+    // A non-default tenant must be a known, active tenant. The default tenant is
+    // always allowed (legacy single-tenant deployments have no cloud.tenants).
+    p.dm_uri = global_dm_uri;
+    if (p.tenant != kDefaultTenant) {
+        auto t = find_tenant(tenants_json, p.tenant);
+        if (!t.has_value() || !t->active) return p;          // ok stays false
+        if (!t->dm_uri.empty()) p.dm_uri = t->dm_uri;        // per-tenant override
+    } else {
+        // The default tenant may still carry a registry override.
+        auto t = find_tenant(tenants_json, p.tenant);
+        if (t.has_value() && !t->dm_uri.empty()) p.dm_uri = t->dm_uri;
+    }
+
+    // Commissioned row, scoped to this tenant.
+    auto arr = nlohmann::json::parse(credentials_json, nullptr, false);
+    if (arr.is_array()) {
+        for (const auto& e : arr) {
+            if (!e.is_object()) continue;
+            const std::string rt = e.value("tenant", std::string());
+            const std::string rtenant = rt.empty() ? std::string(kDefaultTenant) : rt;
+            if (rtenant != p.tenant) continue;
+            const std::string rserial = e.value("serial", std::string());
+            // Match by serial within the tenant; for the default tenant also
+            // honour the legacy identity==ep override path.
+            const bool match =
+                (rserial == p.serial) ||
+                (p.tenant == kDefaultTenant &&
+                 e.value("identity", std::string()) == ep);
+            if (!match) continue;
+            p.bs_key      = e.value("bs.psk.key", std::string());
+            p.dm_key      = e.value("dm.psk.key", std::string());
+            p.dm_identity = e.value("dm.psk.id",  std::string());
+            break;
+        }
+    }
+
+    // Zero-touch (HKDF) tier: no stored row but a master is available → derive
+    // statelessly. The device presents its raw serial as the BS identity here
+    // (override path), matching the legacy zero-touch behaviour.
+    if ((p.dm_key.empty() || p.dm_identity.empty()) && !master_hex.empty()) {
+        p.bs_key      = derive_bs_psk_hex(master_hex, p.serial);
+        p.dm_key      = derive_dm_psk_hex(master_hex, p.serial);
+        p.dm_identity = dm_identity(p.tenant, p.serial);
+        p.zero_touch  = true;
+    }
+
+    if (p.dm_identity.empty())
+        p.dm_identity = dm_identity(p.tenant, p.serial);
+
+    // BS DTLS identity written to the device's Security /0/0. Commissioned tier
+    // uses the tenant-qualified canonical identity (default ⇒ sha256(serial)[:32]
+    // byte-for-byte); zero-touch keeps the raw serial the device presents.
+    p.bs_identity = p.zero_touch ? p.serial : bs_identity(p.tenant, p.serial);
+
+    p.ok = !p.dm_identity.empty() && !p.dm_key.empty() && !p.dm_uri.empty();
+    return p;
+}
+
 } // namespace iot

--- a/apps/test/provisioning_policy_test.cpp
+++ b/apps/test/provisioning_policy_test.cpp
@@ -253,3 +253,86 @@ TEST(ResolveDmPskTenant, DerivesFromTenantQualifiedDmIdentity) {
     EXPECT_EQ(kDerivedDm,
               iot::resolve_dm_psk("[]", iot::dm_identity("acme", kSerial), kMaster));
 }
+
+// ── plan_bs_account ─────────────────────────────────────────────────────────
+
+TEST(PlanBsAccount, DefaultCommissionedIsLegacy) {
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","bs.psk.key":"bs","dm.psk.id":)"
+        R"("rpi100000003d1f9c2e@cloud.local","dm.psk.key":"dm"}])";
+    auto p = iot::plan_bs_account(/*ep*/kSerial, creds, /*tenants*/"[]",
+                                  /*global dm.uri*/"coaps://h:5683", /*master*/"");
+    EXPECT_TRUE(p.ok);
+    EXPECT_EQ(p.tenant, "default");
+    EXPECT_EQ(p.serial, kSerial);
+    EXPECT_EQ(p.bs_identity, std::string(kSha256Id));           // legacy
+    EXPECT_EQ(p.dm_identity, "rpi100000003d1f9c2e@cloud.local"); // legacy
+    EXPECT_EQ(p.dm_uri, "coaps://h:5683");
+    EXPECT_FALSE(p.zero_touch);
+}
+
+TEST(PlanBsAccount, DefaultZeroTouchWhenNoRow) {
+    auto p = iot::plan_bs_account(kSerial, "[]", "[]", "coaps://h:5683", kMaster);
+    EXPECT_TRUE(p.ok);
+    EXPECT_TRUE(p.zero_touch);
+    EXPECT_EQ(p.bs_identity, std::string(kSerial));   // raw serial (override path)
+    EXPECT_EQ(p.dm_identity, "rpi100000003d1f9c2e@cloud.local");
+    EXPECT_EQ(p.dm_key, kDerivedDm);
+}
+
+TEST(PlanBsAccount, RejectsWhenNoRowNoMasterOrNoDmUri) {
+    EXPECT_FALSE(iot::plan_bs_account(kSerial, "[]", "[]", "coaps://h:5683", "").ok);
+    EXPECT_FALSE(iot::plan_bs_account(kSerial, "[]", "[]", /*no dm.uri*/"", kMaster).ok);
+}
+
+TEST(PlanBsAccount, TenantCommissionedScopedAndQualified) {
+    const std::string tenants =
+        R"([{"id":"acme","vpn.subnet":"10.9.16.0/24","status":"active"}])";
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
+        R"("dm.psk.id":"rpi100000003d1f9c2e@acme.cloud.local","dm.psk.key":"adm"}])";
+    auto p = iot::plan_bs_account("acme:100000003d1f9c2e", creds, tenants,
+                                  "coaps://h:5683", "");
+    EXPECT_TRUE(p.ok);
+    EXPECT_EQ(p.tenant, "acme");
+    EXPECT_EQ(p.serial, kSerial);
+    EXPECT_EQ(p.bs_identity, iot::bs_identity("acme", kSerial));   // tenant-qualified
+    EXPECT_EQ(p.dm_identity, "rpi100000003d1f9c2e@acme.cloud.local");
+    EXPECT_EQ(p.dm_key, "adm");
+    EXPECT_EQ(p.dm_uri, "coaps://h:5683");                          // global fallback
+}
+
+TEST(PlanBsAccount, TenantDmUriOverride) {
+    const std::string tenants =
+        R"([{"id":"acme","dm.uri":"coaps://acme.example:5683","status":"active"}])";
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
+        R"("dm.psk.id":"rpi100000003d1f9c2e@acme.cloud.local","dm.psk.key":"adm"}])";
+    auto p = iot::plan_bs_account("acme:100000003d1f9c2e", creds, tenants,
+                                  "coaps://global:5683", "");
+    ASSERT_TRUE(p.ok);
+    EXPECT_EQ(p.dm_uri, "coaps://acme.example:5683");
+}
+
+TEST(PlanBsAccount, RejectsUnknownOrSuspendedTenant) {
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
+        R"("dm.psk.id":"x","dm.psk.key":"adm"}])";
+    // Unknown tenant (empty registry).
+    EXPECT_FALSE(iot::plan_bs_account("acme:100000003d1f9c2e", creds, "[]",
+                                      "coaps://h:5683", "").ok);
+    // Suspended tenant.
+    const std::string suspended =
+        R"([{"id":"acme","status":"suspended"}])";
+    EXPECT_FALSE(iot::plan_bs_account("acme:100000003d1f9c2e", creds, suspended,
+                                      "coaps://h:5683", "").ok);
+}
+
+TEST(PlanBsAccount, TenantRowNotVisibleToDefault) {
+    // A tenant-tagged row must not satisfy a default-tenant (legacy) bootstrap.
+    const std::string creds =
+        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
+        R"("dm.psk.id":"x","dm.psk.key":"adm"}])";
+    auto p = iot::plan_bs_account(kSerial, creds, "[]", "coaps://h:5683", "");
+    EXPECT_FALSE(p.ok);   // no default row, no master
+}


### PR DESCRIPTION
Third multi-tenant slice (`apps/docs/tdd-multi-tenant-cloud.md`). The BS server now provisions each device **into its tenant**, completing the device-onboarding path. Builds on #484 (primitives) and #485 (resolvers).

## Changes
- **`provisioning_policy.cpp` — new pure `plan_bs_account()`**: splits `/bs?ep=` into `(tenant, serial)`, validates a non-default tenant against `cloud.tenants` (rejects unknown/suspended), scopes the credential lookup to that tenant, derives tenant-qualified BS/DM identities (**default == legacy byte-for-byte**), and picks the per-tenant or global `dm.uri`.
- **`main.cpp`** — the BS `provisioning_resolver` reads `cloud.tenants` and delegates the tenant/identity/key/uri decision to `plan_bs_account`, then builds the same Security/Server objects. Thin glue over a unit-tested core.
- **bench** — `cloud_loadgen` gains `tenant=` (`ep=<tenant>:<serial>`, tenant-qualified BS identity, tenant-tagged `emit-creds`); `run-bench.sh TENANT=` registers the tenant + provisions scoped rows, so the multi-tenant path is **load-testable end to end**.

## Tests — 35/35 gtest green (podman)
7 new `PlanBsAccount` cases: default==legacy, zero-touch, tenant scoping + qualified identities, per-tenant `dm.uri` override, unknown/suspended-tenant reject, and **tenant-row-not-visible-to-default**.

## End-to-end validation (rebuilt cloud image)
- **Default tenant: 200/200 (100%)** — legacy path unaffected (answers "won't break existing online devices" again, now with `main.cpp` wired).
- **`TENANT=acme`: 200/200 (100%)** — devices onboard as `acme:serial`, receive `rpi<serial>@acme.cloud.local`, and register against the tenant-scoped DM credential. 100% success confirms the tenant DM identity resolves correctly.

## Scope
Cloud-image only; device firmware untouched. Console read-isolation (`tenant_id` on `auth.users.accounts` + `handler_cloud.cpp` filtering) and per-tenant VPN (P3) are the remaining slices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)