### PR TITLE
feat(cloud): console read-isolation by tenant (session tenant + scoped cloud API; gtest)

### DIFF
--- a/modules/http-server/CMakeLists.txt
+++ b/modules/http-server/CMakeLists.txt
@@ -153,6 +153,20 @@ if(BUILD_HTTP_SERVER_TESTS)
             http_server_lib
             GTest::gtest_main GTest::gtest)
         add_test(NAME http-handler-tests COMMAND http-handler-tests)
+
+        # Cloud API tests — exercise install_cloud_handlers (tenant read
+        # isolation). Needs the server-side registry/bootstrap/vpn sources the
+        # handler drives (http_server_lib drops handler_cloud.o for iot-httpd as
+        # unreferenced, so those symbols aren't otherwise linked).
+        add_executable(http-cloud-api-tests
+            test/cloud_api_test.cpp
+            ${HTTP_MODULE_DIR}/../server/lwm2m/src/endpoint_registry.cpp
+            ${HTTP_MODULE_DIR}/../server/lwm2m/src/bootstrap.cpp
+            ${HTTP_MODULE_DIR}/../server/openvpn/src/vpn_registry.cpp)
+        target_link_libraries(http-cloud-api-tests
+            http_server_lib
+            GTest::gtest_main GTest::gtest)
+        add_test(NAME http-cloud-api-tests COMMAND http-cloud-api-tests)
     endif()
 endif()
 

--- a/modules/http-server/inc/auth.hpp
+++ b/modules/http-server/inc/auth.hpp
@@ -39,6 +39,8 @@ public:
         std::string username;
         std::string role;          // "admin"
         std::string access;        // "Admin" or "Viewer"
+        std::string tenant;        // owning tenant; "*" = platform operator
+                                   // (sees all tenants). Default "default".
         std::chrono::steady_clock::time_point expires_at;
     };
 
@@ -48,7 +50,8 @@ public:
     /// The caller sets the token as a Set-Cookie header.
     std::string create_session(const std::string& username,
                                const std::string& role = "admin",
-                               const std::string& access = "Admin");
+                               const std::string& access = "Admin",
+                               const std::string& tenant = "default");
 
     /// Validate a token. Returns nullptr when expired or invalid.
     const Session* validate(const std::string& token);
@@ -104,6 +107,13 @@ public:
     /// Falls back to "Admin" when unset.
     static std::string load_user_access(data_store::Client& ds,
                                          const std::string& username);
+
+    /// Load the user's owning tenant from the data store.
+    /// Key: auth.users.<username>.tenant — a tenant slug, or "*" for a
+    /// platform operator (sees all tenants). Falls back to "default" when
+    /// unset, so existing single-tenant deployments are unaffected.
+    static std::string load_user_tenant(data_store::Client& ds,
+                                        const std::string& username);
 
     /// Default admin password hash: sha256("admin").
     static constexpr const char* kDefaultHash =

--- a/modules/http-server/inc/handler.hpp
+++ b/modules/http-server/inc/handler.hpp
@@ -23,9 +23,14 @@ void install_handlers(Router& router,
 
 /// Install /api/v1/cloud/* handlers (L21/D7).  Pointers must outlive
 /// the router.  Call after install_handlers().
+/// `auth` (optional) scopes reads to the caller's tenant: a session whose
+/// tenant is "*" (platform operator) sees all; otherwise only endpoints in the
+/// session's tenant. nullptr (or no session) → no filtering (legacy behaviour),
+/// so existing single-tenant deployments are unaffected.
 void install_cloud_handlers(Router& router,
                             server::lwm2m::EndpointRegistry* ep_reg,
-                            server::lwm2m::BootstrapProvisioner* provisioner);
+                            server::lwm2m::BootstrapProvisioner* provisioner,
+                            SessionStore* auth = nullptr);
 
 /// Install the per-device UI reverse proxy at /dev/<ep>/ (design:
 /// apps/docs/tdd-device-ui-path-proxy.md). Resolves <ep> -> dev_tun_ip from

--- a/modules/http-server/src/auth.cpp
+++ b/modules/http-server/src/auth.cpp
@@ -88,12 +88,14 @@ std::string SessionStore::make_token() {
 
 std::string SessionStore::create_session(const std::string& username,
                                           const std::string& role,
-                                          const std::string& access) {
+                                          const std::string& access,
+                                          const std::string& tenant) {
     std::string token = make_token();
     Session s;
     s.username   = username;
     s.role       = role;
     s.access     = access;
+    s.tenant     = tenant.empty() ? std::string("default") : tenant;
     s.expires_at = std::chrono::steady_clock::now() + std::chrono::hours(8);
 
     std::lock_guard<std::mutex> lk(m_mutex);
@@ -194,6 +196,19 @@ std::string CredentialStore::load_user_access(data_store::Client& ds,
         }
     }
     return "Admin";  // default: full access
+}
+
+std::string CredentialStore::load_user_tenant(data_store::Client& ds,
+                                              const std::string& username) {
+    std::string key = "auth.users." + username + ".tenant";
+    std::vector<data_store::Client::GetResult> got;
+    auto rs = ds.get({key}, got);
+    if (rs.ok && !got.empty() && got[0].has_value) {
+        if (auto s = data_store::to_string(got[0].value)) {
+            if (!s->empty()) return *s;   // a tenant slug, or "*" (operator)
+        }
+    }
+    return "default";  // unset → the implicit default tenant (legacy)
 }
 
 // ── Access control ─────────────────────────────────────────────────

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -339,10 +339,14 @@ void install_handlers(Router& router,
             std::string stored_hash;
             std::string access = "Admin";
             std::string role   = "admin";
+            std::string tenant = "default";   // multi-tenant: owning tenant
             if (id == "admin") {
                 stored_hash = ds ? CredentialStore::load_admin_password_hash(*ds)
                                  : CredentialStore::kDefaultHash;
-                if (ds) access = CredentialStore::load_user_access(*ds, id);
+                if (ds) {
+                    access = CredentialStore::load_user_access(*ds, id);
+                    tenant = CredentialStore::load_user_tenant(*ds, id);
+                }
             } else {
                 role = "user";
                 bool found = false;
@@ -351,6 +355,7 @@ void install_handlers(Router& router,
                         if (u.value("id", "") == id) {
                             stored_hash = u.value("hash", "");
                             access      = u.value("access", "Viewer");
+                            tenant      = u.value("tenant", "default");
                             found = true;
                             break;
                         }
@@ -368,7 +373,7 @@ void install_handlers(Router& router,
                 return r;
             }
             std::string token;
-            if (auth) token = auth->create_session(id, role, access);
+            if (auth) token = auth->create_session(id, role, access, tenant);
             json resp;
             resp["ok"]     = true;
             resp["role"]   = role;

--- a/modules/http-server/src/handler_cloud.cpp
+++ b/modules/http-server/src/handler_cloud.cpp
@@ -2,6 +2,7 @@
 
 #include "handler.hpp"
 
+#include "auth.hpp"
 #include "endpoint_registry.hpp"
 #include "bootstrap.hpp"
 
@@ -20,35 +21,57 @@ json parse_body(const std::string& body) {
     catch (const std::exception&) { return json::object(); }
 }
 
+/// The tenant this request acts as. No auth wired → "*" (no filtering, legacy).
+/// Authenticated → the session's tenant; no/invalid session → "default".
+std::string request_tenant(const HttpParser::Request& req, SessionStore* auth) {
+    if (!auth) return "*";
+    const std::string token =
+        extract_session_cookie(req.headers, auth->cookie_name());
+    const auto* s = token.empty() ? nullptr : auth->validate(token);
+    return s ? s->tenant : std::string("default");
+}
+
+/// An endpoint row (its tenant, "" == "default") is visible to a viewer whose
+/// tenant is `as` when `as` is "*" or the tenants match.
+bool visible_to(const std::string& row_tenant, const std::string& as) {
+    if (as == "*") return true;
+    const std::string rt = row_tenant.empty() ? std::string("default") : row_tenant;
+    return rt == as;
+}
+
 } // namespace
 
 void install_cloud_handlers(Router& router,
                             server::lwm2m::EndpointRegistry* ep_reg,
-                            server::lwm2m::BootstrapProvisioner* provisioner) {
+                            server::lwm2m::BootstrapProvisioner* provisioner,
+                            SessionStore* auth) {
 
     // ── GET /api/v1/cloud/endpoints ──────────────────────────────
     router.add("GET", "/api/v1/cloud/endpoints",
-        [ep_reg](const HttpParser::Request& /*req*/) -> HttpResponse {
+        [ep_reg, auth](const HttpParser::Request& req) -> HttpResponse {
             HttpResponse r;
             if (!ep_reg) {
                 r.status = 500;
                 r.body = R"({"ok":false,"err":"registry not connected"})";
                 return r;
             }
+            const std::string as = request_tenant(req, auth);
             auto eps = ep_reg->list_all();
             json arr = json::array();
             for (const auto& e : eps) {
+                if (!visible_to(e.tenant, as)) continue;   // tenant read-isolation
                 json item;
                 item["endpoint"]   = e.ep;
                 item["tun_ip"]     = e.tun_ip;
                 item["dev_tun_ip"] = e.dev_tun_ip;
                 item["proxy_port"] = e.proxy_port;
                 item["registered"] = e.registered;
+                item["tenant"]     = e.tenant.empty() ? "default" : e.tenant;
                 arr.push_back(item);
             }
             json resp;
             resp["ok"]        = true;
-            resp["count"]     = eps.size();
+            resp["count"]     = arr.size();   // visible (tenant-scoped) count
             resp["endpoints"] = arr;
             r.body = resp.dump();
             return r;
@@ -56,7 +79,7 @@ void install_cloud_handlers(Router& router,
 
     // ── GET /api/v1/cloud/endpoint?ep=<ep> ───────────────────────
     router.add("GET", "/api/v1/cloud/endpoint",
-        [ep_reg](const HttpParser::Request& req) -> HttpResponse {
+        [ep_reg, auth](const HttpParser::Request& req) -> HttpResponse {
             HttpResponse r;
             if (!ep_reg) {
                 r.status = 500;
@@ -71,7 +94,9 @@ void install_cloud_handlers(Router& router,
             }
             std::string ep = it->second;
             const auto* info = ep_reg->lookup_by_ep(ep);
-            if (!info) {
+            // Out-of-tenant endpoints are indistinguishable from missing ones
+            // (don't leak existence across tenants).
+            if (!info || !visible_to(info->tenant, request_tenant(req, auth))) {
                 r.status = 404;
                 r.body = R"({"ok":false,"err":"endpoint not found"})";
                 return r;

--- a/modules/http-server/test/cloud_api_test.cpp
+++ b/modules/http-server/test/cloud_api_test.cpp
@@ -7,6 +7,7 @@
 #include <gtest/gtest.h>
 
 #include "handler.hpp"
+#include "auth.hpp"
 #include "parser.hpp"
 #include "router.hpp"
 
@@ -77,12 +78,17 @@ TEST_F(CloudApiTest, ProvisionDevice) {
 
 // ── 3. Provision duplicate fails ───────────────────────────────────
 
-TEST_F(CloudApiTest, ProvisionDuplicateReturns400) {
-    post("/api/v1/cloud/endpoints", R"({"endpoint":"urn:dev:dup"})");
-    auto r = post("/api/v1/cloud/endpoints", R"({"endpoint":"urn:dev:dup"})");
-    EXPECT_EQ(r.status, 400);
-    auto j = json::parse(r.body);
-    EXPECT_FALSE(j["ok"].get<bool>());
+TEST_F(CloudApiTest, ProvisionDuplicateIsIdempotent) {
+    // Re-provisioning an existing endpoint is idempotent (it refreshes the
+    // credential) — it returns the SAME tunnel IP + proxy port, not a 400.
+    auto r1 = post("/api/v1/cloud/endpoints", R"({"endpoint":"urn:dev:dup"})");
+    auto r2 = post("/api/v1/cloud/endpoints", R"({"endpoint":"urn:dev:dup"})");
+    EXPECT_EQ(r2.status, 200);
+    auto j1 = json::parse(r1.body), j2 = json::parse(r2.body);
+    EXPECT_TRUE(j2["ok"].get<bool>());
+    EXPECT_EQ(j1["tun_ip"], j2["tun_ip"]);
+    EXPECT_EQ(j1["proxy_port"], j2["proxy_port"]);
+    EXPECT_EQ(ep_reg.count(), 1U);   // still one endpoint
 }
 
 // ── 4. Provision without endpoint returns 400 ──────────────────────
@@ -137,11 +143,96 @@ TEST_F(CloudApiTest, GetNonExistentEndpointReturns404) {
 
 TEST_F(CloudApiTest, DeprovisionEndpoint) {
     post("/api/v1/cloud/endpoints", R"({"endpoint":"urn:dev:to-remove"})");
-    auto r = post("/api/v1/cloud/endpoints",
-                  R"({"endpoint":"urn:dev:to-remove"})");
+    ASSERT_EQ(ep_reg.count(), 1U);
+    HttpParser::Request req;
+    req.method = "DELETE";
+    req.path   = "/api/v1/cloud/endpoints";
+    req.query["ep"] = "urn:dev:to-remove";
+    auto r = router.route(req);
     EXPECT_EQ(r.status, 200);
     EXPECT_TRUE(json::parse(r.body)["ok"].get<bool>());
     EXPECT_EQ(ep_reg.count(), 0U);
+}
+
+// ── Multi-tenant read isolation (tdd-multi-tenant-cloud.md) ──────────
+
+namespace {
+server::lwm2m::EndpointInfo mk(const std::string& ep, std::uint16_t port,
+                              const std::string& tenant) {
+    server::lwm2m::EndpointInfo e;
+    e.ep = ep; e.tun_ip = "10.9.0." + std::to_string(port - 5000);
+    e.proxy_port = port; e.registered = true; e.tenant = tenant;
+    return e;
+}
+
+// Build a router whose cloud handlers are tenant-scoped via `auth`, with three
+// endpoints across acme / default / globex.
+struct TenantFixture {
+    server::lwm2m::EndpointRegistry     reg;
+    server::openvpn::VpnRegistry        vpn{"10.9.0.0/24", 5001, 5100};
+    server::lwm2m::BootstrapProvisioner prov{reg, vpn};
+    http_server::SessionStore           auth;
+    Router                              router;
+    TenantFixture() {
+        reg.add(mk("dev-acme",   5001, "acme"));
+        reg.add(mk("dev-legacy", 5002, ""));        // untagged == default
+        reg.add(mk("dev-globex", 5003, "globex"));
+        http_server::install_cloud_handlers(router, &reg, &prov, &auth);
+    }
+    json list_as(const std::string& tenant) {
+        std::string tok = auth.create_session("u", "user", "Admin", tenant);
+        HttpParser::Request req;
+        req.method = "GET";
+        req.path   = "/api/v1/cloud/endpoints";
+        req.headers["cookie"] = "iot-session=" + tok;
+        return json::parse(router.route(req).body);
+    }
+};
+} // namespace
+
+TEST(CloudApiTenant, ListScopedToSessionTenant) {
+    TenantFixture f;
+    auto acme = f.list_as("acme");
+    EXPECT_EQ(acme["count"], 1U);
+    EXPECT_EQ(acme["endpoints"][0]["endpoint"], "dev-acme");
+
+    auto def = f.list_as("default");
+    EXPECT_EQ(def["count"], 1U);
+    EXPECT_EQ(def["endpoints"][0]["endpoint"], "dev-legacy");   // untagged
+}
+
+TEST(CloudApiTenant, PlatformOperatorSeesAll) {
+    TenantFixture f;
+    auto all = f.list_as("*");
+    EXPECT_EQ(all["count"], 3U);
+}
+
+TEST(CloudApiTenant, NoAuthIsLegacyUnfiltered) {
+    // auth=nullptr → no filtering, exactly as before tenants existed.
+    server::lwm2m::EndpointRegistry reg;
+    server::openvpn::VpnRegistry    vpn{"10.9.0.0/24", 5001, 5100};
+    server::lwm2m::BootstrapProvisioner prov{reg, vpn};
+    Router router;
+    reg.add(mk("dev-acme", 5001, "acme"));
+    reg.add(mk("dev-legacy", 5002, ""));
+    http_server::install_cloud_handlers(router, &reg, &prov, /*auth*/nullptr);
+    HttpParser::Request req;
+    req.method = "GET";
+    req.path   = "/api/v1/cloud/endpoints";
+    auto j = json::parse(router.route(req).body);
+    EXPECT_EQ(j["count"], 2U);
+}
+
+TEST(CloudApiTenant, SingleEndpointHiddenAcrossTenant) {
+    TenantFixture f;
+    std::string tok = f.auth.create_session("u", "user", "Admin", "acme");
+    HttpParser::Request req;
+    req.method = "GET";
+    req.path   = "/api/v1/cloud/endpoint";
+    req.query["ep"] = "dev-globex";                 // belongs to globex
+    req.headers["cookie"] = "iot-session=" + tok;
+    auto r = f.router.route(req);
+    EXPECT_EQ(r.status, 404);                        // not leaked to acme
 }
 
 } // namespace

--- a/modules/server/lwm2m/inc/endpoint_registry.hpp
+++ b/modules/server/lwm2m/inc/endpoint_registry.hpp
@@ -39,6 +39,9 @@ struct EndpointInfo {
                                       // heartbeat interval; next heartbeat is
                                       // due by last_seen_unix + lifetime
     std::string location;             // assigned /rd/<id> registration path
+    std::string tenant;               // owning tenant (multi-tenant cloud);
+                                      // empty == the implicit "default" tenant.
+                                      // See apps/docs/tdd-multi-tenant-cloud.md.
 
     EndpointInfo() = default;
     EndpointInfo(std::string ep_, std::string tun_ip_,


### PR DESCRIPTION
Fourth multi-tenant slice (`apps/docs/tdd-multi-tenant-cloud.md`). The console now carries a per-user tenant, and the cloud endpoint API is read-scoped to it. Builds on #484/#485/#486.

## Changes
- **auth** — `Session` gains `tenant` (`*` = platform operator → sees all; default `default`); `create_session` takes it. `CredentialStore::load_user_tenant` reads `auth.users.<u>.tenant` (unset → `default`). `/login` resolves the tenant (admin via `load_user_tenant`; other users via the accounts row's `tenant` field) and stamps the session.
- **handler_cloud** — `GET /api/v1/cloud/endpoints` filters to the session's tenant; `GET /api/v1/cloud/endpoint` 404s out-of-tenant endpoints (no existence leak). `install_cloud_handlers` gains an optional `SessionStore*` — **nullptr/no session ⇒ no filtering (legacy)**, so single-tenant deployments are unaffected.
- **EndpointInfo** — gains a `tenant` field (empty == `default`).

## Tests — 12/12 green (podman)
Wired the previously-**orphaned** `cloud_api_test.cpp` into a new `http-cloud-api-tests` target. Added 4 tenant cases:
- list scoped to session tenant (acme sees only acme; untagged row = default)
- platform operator (`*`) sees all
- no-auth ⇒ legacy unfiltered
- cross-tenant single-endpoint hidden (404)

Repaired 2 **stale** pre-existing cases the wiring surfaced: provision is now idempotent (was asserting a 400), and the deprovision test never actually issued `DELETE`.

## Scope note (honest)
This isolates the `/api/v1/cloud/*` handler path. The cloud-ui also reads `cloud.endpoints` via the generic `/api/v1/db/get`, and those rows aren't yet tenant-tagged by `iot-cloudd`. **Full UI isolation needs the next slice:** (a) `iot-cloudd` stamping `cloud.endpoints` rows with `tenant`, and (b) tenant-scoping the `db/get` of that key. Backward compatible throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)