### PR TITLE
feat(cloud): P3a per-tenant VPN subnet math + nft isolation rules (gtest)

### DIFF
--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -15,10 +15,17 @@ instance).
 | P1b | Tenant-aware BS/DM PSK resolvers (default == legacy) | #485 | ✅ merged |
 | P2a | BS `provisioning_resolver` (device→tenant onboarding); e2e 200/200 | #486 | ✅ merged |
 | P1c | Console read-isolation: session `tenant` + scoped `/api/v1/cloud/*` | #487 | ✅ merged |
-| P1d | `iot-cloudd` row-tagging: `cloud.endpoints` rows carry `tenant` | _this_ | 🔵 |
-| — | `db/get cloud.endpoints` tenant scoping (live UI isolation) | — | ⏭️ next |
-| P3 | Per-tenant VPN subnet + nftables isolation | — | ⏭️ |
+| P1d | `iot-cloudd` row-tagging: `cloud.endpoints` rows carry `tenant` | #488 | ✅ merged |
+| P3a | Per-tenant VPN **subnet math + nft isolation rules** (pure, gtest) | _this_ | 🔵 |
+| P3b | Wire P3a: OpenVPN `/16` + per-client CCD static IPs + apply nft | — | ⏭️ needs tun validation |
+| — | `db/get cloud.endpoints` tenant scoping (live UI isolation) | — | ⏭️ |
 | P4/P5 | Platform-operator console; per-tenant CA; quotas | — | ⏭️ |
+
+P3 splits into **P3a** (the pure allocation/rule-generation core — landed here,
+fully unit-tested) and **P3b** (the live OpenVPN client-config-dir + nftables
+*application*, which can only be validated against a real `tun`/OpenVPN
+environment, so it is deferred to HW/integration validation rather than merged
+blind — same discipline as the device-side fixes marked "needs HW validation").
 
 Every slice keeps the **default tenant byte-identical to today**, so existing
 single-tenant deployments and fielded devices are unaffected (verified by gtest

--- a/modules/server/openvpn/CMakeLists.txt
+++ b/modules/server/openvpn/CMakeLists.txt
@@ -59,4 +59,14 @@ if(BUILD_SERVER_OPENVPN_TESTS)
     target_link_libraries(cert-authority-tests
         GTest::gtest_main GTest::gtest ACE pthread)
     add_test(NAME cert-authority-tests COMMAND cert-authority-tests)
+
+    # Multi-tenant subnet math + nft isolation rules (pure; no ACE/tun).
+    add_executable(tenant-subnet-tests
+        test/tenant_subnet_test.cpp
+        src/tenant_subnet.cpp)
+    target_include_directories(tenant-subnet-tests
+        PRIVATE ${OVPN_SERVER_DIR}/inc)
+    target_link_libraries(tenant-subnet-tests
+        GTest::gtest_main GTest::gtest pthread)
+    add_test(NAME tenant-subnet-tests COMMAND tenant-subnet-tests)
 endif()

--- a/modules/server/openvpn/inc/tenant_subnet.hpp
+++ b/modules/server/openvpn/inc/tenant_subnet.hpp
@@ -1,0 +1,39 @@
+#ifndef __iot_tenant_subnet_hpp__
+#define __iot_tenant_subnet_hpp__
+
+/// Multi-tenant VPN — pure subnet math + nftables isolation-rule generation
+/// (apps/docs/tdd-multi-tenant-cloud.md, P3). No I/O, no nft/openvpn calls —
+/// just the allocation + ruleset-text logic so it's unit-testable. The live
+/// wiring (per-client CCD static IPs, applying the ruleset) is the caller's job
+/// and needs a real tun/OpenVPN environment to validate.
+
+#include <string>
+#include <vector>
+
+namespace server { namespace openvpn {
+
+/// True if the two CIDRs (e.g. "10.9.16.0/24") share any address. Invalid
+/// inputs never overlap (return false).
+bool subnets_overlap(const std::string& a, const std::string& b);
+
+/// Carve the next free /`tenant_prefix` block out of `pool_cidr` (e.g. the
+/// "10.9.0.0/16" tenant pool), skipping any block that overlaps an entry in
+/// `used`. Returns the CIDR of the first free block, or "" when the pool is
+/// exhausted or an input is malformed. `tenant_prefix` must be >= the pool
+/// prefix and <= 30.
+std::string allocate_tenant_subnet(const std::string& pool_cidr,
+                                   const std::vector<std::string>& used,
+                                   int tenant_prefix = 24);
+
+/// Build an nftables ruleset (table `ip iot_tenant_isol`) that DROPS forwarded
+/// traffic between *different* tenant subnets while leaving each tenant's
+/// traffic to the cloud/services untouched (default-accept; we only add the
+/// cross-tenant drops). Pairwise drops — explicit and order-independent.
+/// Returns a full `table { ... }` block ready for `nft -f -`. Empty/one-tenant
+/// input yields an empty table (nothing to isolate).
+std::string build_tenant_isolation_rules(
+    const std::vector<std::string>& tenant_subnets);
+
+}} // namespace server::openvpn
+
+#endif /* __iot_tenant_subnet_hpp__ */

--- a/modules/server/openvpn/src/tenant_subnet.cpp
+++ b/modules/server/openvpn/src/tenant_subnet.cpp
@@ -1,0 +1,104 @@
+/// Multi-tenant VPN — pure subnet math + nft isolation rules.
+/// See tenant_subnet.hpp + apps/docs/tdd-multi-tenant-cloud.md (P3).
+
+#include "tenant_subnet.hpp"
+
+#include <arpa/inet.h>
+
+#include <cstdint>
+#include <sstream>
+#include <utility>
+
+namespace server { namespace openvpn {
+
+namespace {
+
+// Parse "a.b.c.d/n" → (host-order base, prefix). Returns prefix = -1 on error.
+std::pair<std::uint32_t, int> parse_cidr(const std::string& cidr) {
+    const auto slash = cidr.find('/');
+    if (slash == std::string::npos) return {0, -1};
+    const std::string ip = cidr.substr(0, slash);
+    int prefix = -1;
+    try { prefix = std::stoi(cidr.substr(slash + 1)); }
+    catch (...) { return {0, -1}; }
+    if (prefix < 0 || prefix > 32) return {0, -1};
+    in_addr a{};
+    if (::inet_pton(AF_INET, ip.c_str(), &a) != 1) return {0, -1};
+    return {ntohl(a.s_addr), prefix};
+}
+
+std::string u32_to_ip(std::uint32_t v) {
+    in_addr a{};
+    a.s_addr = htonl(v);
+    char buf[INET_ADDRSTRLEN] = {0};
+    ::inet_ntop(AF_INET, &a, buf, sizeof(buf));
+    return buf;
+}
+
+std::uint32_t mask_of(int prefix) {
+    return prefix == 0 ? 0U : (~0U << (32 - prefix));
+}
+
+} // namespace
+
+bool subnets_overlap(const std::string& a, const std::string& b) {
+    auto [ba, pa] = parse_cidr(a);
+    auto [bb, pb] = parse_cidr(b);
+    if (pa < 0 || pb < 0) return false;
+    const std::uint32_t na = ba & mask_of(pa), bca = na | ~mask_of(pa);
+    const std::uint32_t nb = bb & mask_of(pb), bcb = nb | ~mask_of(pb);
+    return na <= bcb && nb <= bca;            // ranges [na,bca] and [nb,bcb] intersect
+}
+
+std::string allocate_tenant_subnet(const std::string& pool_cidr,
+                                   const std::vector<std::string>& used,
+                                   int tenant_prefix) {
+    auto [pbase, pprefix] = parse_cidr(pool_cidr);
+    if (pprefix < 0 || tenant_prefix < pprefix || tenant_prefix > 30)
+        return {};
+
+    const std::uint32_t pnet  = pbase & mask_of(pprefix);
+    const std::uint32_t pbcast = pnet | ~mask_of(pprefix);
+    const std::uint32_t step  = 1U << (32 - tenant_prefix);   // block size
+
+    for (std::uint64_t net = pnet; net + step - 1 <= pbcast; net += step) {
+        const std::string cand =
+            u32_to_ip(static_cast<std::uint32_t>(net)) + "/" +
+            std::to_string(tenant_prefix);
+        bool clash = false;
+        for (const auto& u : used) {
+            if (subnets_overlap(cand, u)) { clash = true; break; }
+        }
+        if (!clash) return cand;
+    }
+    return {};   // pool exhausted
+}
+
+std::string build_tenant_isolation_rules(
+    const std::vector<std::string>& tenant_subnets) {
+    // Keep only well-formed, distinct subnets.
+    std::vector<std::string> nets;
+    for (const auto& s : tenant_subnets) {
+        if (parse_cidr(s).second < 0) continue;
+        bool dup = false;
+        for (const auto& n : nets) if (n == s) { dup = true; break; }
+        if (!dup) nets.push_back(s);
+    }
+
+    std::ostringstream os;
+    os << "table ip iot_tenant_isol {\n";
+    os << "  chain forward {\n";
+    os << "    type filter hook forward priority -10; policy accept;\n";
+    // Pairwise cross-tenant drops (A->B for every A != B). Same-tenant and
+    // tenant<->cloud traffic falls through to the accept policy.
+    for (std::size_t i = 0; i < nets.size(); ++i)
+        for (std::size_t j = 0; j < nets.size(); ++j)
+            if (i != j)
+                os << "    ip saddr " << nets[i]
+                   << " ip daddr " << nets[j] << " drop\n";
+    os << "  }\n";
+    os << "}\n";
+    return os.str();
+}
+
+}} // namespace server::openvpn

--- a/modules/server/openvpn/test/tenant_subnet_test.cpp
+++ b/modules/server/openvpn/test/tenant_subnet_test.cpp
@@ -1,0 +1,79 @@
+/// Unit tests for the multi-tenant VPN subnet math + nft isolation rules
+/// (tenant_subnet.{hpp,cpp}). Pure logic — no tun/openvpn/nft needed.
+
+#include <gtest/gtest.h>
+
+#include "tenant_subnet.hpp"
+
+using namespace server::openvpn;
+
+// ── subnets_overlap ─────────────────────────────────────────────────────────
+
+TEST(SubnetsOverlap, DisjointAndOverlapping) {
+    EXPECT_FALSE(subnets_overlap("10.9.16.0/24", "10.9.17.0/24"));
+    EXPECT_TRUE(subnets_overlap("10.9.16.0/24", "10.9.16.128/25"));   // contained
+    EXPECT_TRUE(subnets_overlap("10.9.0.0/16", "10.9.16.0/24"));      // pool ⊃ block
+    EXPECT_TRUE(subnets_overlap("10.9.16.0/24", "10.9.16.0/24"));     // identical
+    EXPECT_FALSE(subnets_overlap("10.9.16.0/24", "garbage"));         // malformed
+}
+
+// ── allocate_tenant_subnet ──────────────────────────────────────────────────
+
+TEST(AllocTenantSubnet, FirstFreeBlockSkipsUsed) {
+    // Empty pool → first /24 is the pool base.
+    EXPECT_EQ(allocate_tenant_subnet("10.9.0.0/16", {}), "10.9.0.0/24");
+    // Skips used blocks, returns the next free one.
+    EXPECT_EQ(allocate_tenant_subnet("10.9.0.0/16",
+                                     {"10.9.0.0/24", "10.9.1.0/24"}),
+              "10.9.2.0/24");
+    // Skips a non-contiguous used block.
+    EXPECT_EQ(allocate_tenant_subnet("10.9.0.0/16", {"10.9.0.0/24"}),
+              "10.9.1.0/24");
+}
+
+TEST(AllocTenantSubnet, NonOverlapWithExisting) {
+    auto s = allocate_tenant_subnet("10.9.0.0/16",
+                                    {"10.9.0.0/24", "10.9.2.0/24"});
+    EXPECT_EQ(s, "10.9.1.0/24");
+    EXPECT_FALSE(subnets_overlap(s, "10.9.0.0/24"));
+    EXPECT_FALSE(subnets_overlap(s, "10.9.2.0/24"));
+}
+
+TEST(AllocTenantSubnet, ExhaustionAndBadInput) {
+    // A /24 pool yields exactly one /24 block; once used, exhausted.
+    EXPECT_EQ(allocate_tenant_subnet("10.9.5.0/24", {}), "10.9.5.0/24");
+    EXPECT_EQ(allocate_tenant_subnet("10.9.5.0/24", {"10.9.5.0/24"}), "");
+    // tenant_prefix smaller than the pool prefix is invalid.
+    EXPECT_EQ(allocate_tenant_subnet("10.9.0.0/24", {}, /*prefix*/16), "");
+    EXPECT_EQ(allocate_tenant_subnet("garbage", {}), "");
+}
+
+// ── build_tenant_isolation_rules ────────────────────────────────────────────
+
+TEST(IsolationRules, PairwiseCrossTenantDrops) {
+    auto r = build_tenant_isolation_rules({"10.9.16.0/24", "10.9.17.0/24"});
+    EXPECT_NE(r.find("table ip iot_tenant_isol"), std::string::npos);
+    // both cross directions dropped
+    EXPECT_NE(r.find("ip saddr 10.9.16.0/24 ip daddr 10.9.17.0/24 drop"),
+              std::string::npos);
+    EXPECT_NE(r.find("ip saddr 10.9.17.0/24 ip daddr 10.9.16.0/24 drop"),
+              std::string::npos);
+    // no same-tenant self-drop
+    EXPECT_EQ(r.find("ip saddr 10.9.16.0/24 ip daddr 10.9.16.0/24"),
+              std::string::npos);
+}
+
+TEST(IsolationRules, SingleOrEmptyTenantHasNoDrops) {
+    EXPECT_EQ(build_tenant_isolation_rules({}).find(" drop"),
+              std::string::npos);
+    EXPECT_EQ(build_tenant_isolation_rules({"10.9.16.0/24"}).find(" drop"),
+              std::string::npos);
+}
+
+TEST(IsolationRules, ThreeTenantsSixDirectedDrops) {
+    auto r = build_tenant_isolation_rules(
+        {"10.9.16.0/24", "10.9.17.0/24", "10.9.18.0/24"});
+    std::size_t n = 0, pos = 0;
+    while ((pos = r.find(" drop\n", pos)) != std::string::npos) { ++n; pos += 6; }
+    EXPECT_EQ(n, 6U);   // 3 tenants → 3*2 directed pairs
+}


### PR DESCRIPTION
First **P3** slice (`apps/docs/tdd-multi-tenant-cloud.md`) — the pure, unit-tested core for per-tenant VPN isolation. No `tun`/openvpn/nft side effects, so it lands and reviews independently of the live wiring.

## `modules/server/openvpn/tenant_subnet.{hpp,cpp}`
- `subnets_overlap(a,b)` — CIDR range-intersection test.
- `allocate_tenant_subnet(pool, used, prefix=24)` — carve the next free `/24` out of a tenant pool (e.g. `10.9.0.0/16`), skipping used/overlapping blocks; `""` on exhaustion/bad input.
- `build_tenant_isolation_rules(subnets)` — emit an `nft` table that pairwise-**DROPs** forwarded traffic between *different* tenant subnets (same-tenant + tenant↔cloud fall through to accept); ready for `nft -f -`.

## Tests — 7/7 gtest (podman)
overlap; first-free + skip-used allocation; exhaustion + bad input; pairwise cross-tenant drops; no self-drop; N-tenant directed-drop count.

## Scope — P3b deferred (needs tun validation)
The live wiring — OpenVPN on a `/16`, per-client client-config-dir static IPs from each tenant's `/24`, and *applying* this ruleset via `nft` — can only be validated against a real `tun`/OpenVPN environment, so it's deferred to HW/integration rather than merged blind (same discipline as device fixes marked "needs HW validation"). The progress table in the TDD is updated (P3a ✅ / P3b ⏭️).

🤖 Generated with [Claude Code](https://claude.com/claude-code)