### PR TITLE
fix(cloud): key healed endpoints by tenant-qualified endpoint

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -403,11 +403,21 @@ std::size_t rehydrate_registry(data_store::Client& ds,
             for (const auto& c : creds) {
                 if (!c.is_object()) continue;
                 auto serial = c.value("serial", std::string());
-                if (serial.empty() || reg.lookup_by_ep(serial)) continue;
-                if (prov.provision(serial)) {
-                    // Tag the healed endpoint with its tenant from the cred row
-                    // so cloud.endpoints carries it (multi-tenant scoping).
-                    reg.update_tenant(serial, c.value("tenant", std::string()));
+                if (serial.empty()) continue;
+                const auto tenant = c.value("tenant", std::string());
+                // Registry key = the tenant-qualified endpoint
+                // ("<tenant>:<serial>" for a tenant row, bare serial for the
+                // default tenant) so it MATCHES what a tenant device registers
+                // /rd as — otherwise the cloud.lwm2m.registrations → registry
+                // online/offline merge (keyed by endpoint) never matches a
+                // tenant device. Default rows are unchanged (key == serial);
+                // duplicate serials across tenants stay distinct.
+                const std::string key =
+                    (tenant.empty() || tenant == "default")
+                        ? serial : (tenant + ":" + serial);
+                if (reg.lookup_by_ep(key)) continue;
+                if (prov.provision(key)) {
+                    reg.update_tenant(key, tenant);
                     ++healed;
                 }
             }

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -31,12 +31,16 @@ Every slice keeps the **default tenant byte-identical to today**, so existing
 single-tenant deployments and fielded devices are unaffected (verified by gtest
 + a 200/200 default-tenant load run per slice).
 
-**Known follow-up — tenant endpoint keying:** `iot-cloudd`'s `EndpointRegistry`
-keys by serial, but a tenant device registers `/rd` as `<tenant>:<serial>`, so
-the `cloud.lwm2m.registrations` → registry online/offline merge won't match a
-tenant device until the registry keys by the full endpoint. Default devices
-(ep == serial) are unaffected. Tracked for the keying slice before tenant
-devices can show "online" + receive a per-device DNAT.
+**Tenant endpoint keying (addressed for the heal path).** `iot-cloudd` now keys
+the registry by the **tenant-qualified endpoint** (`<tenant>:<serial>`; bare
+serial for the default tenant) when healing endpoints from
+`cloud.endpoint.credentials`, so it matches what a tenant device registers `/rd`
+as and the `cloud.lwm2m.registrations` → registry online/offline merge resolves
+it. Default devices (key == serial) are unchanged; duplicate serials across
+tenants stay distinct. **Remaining:** the runtime provision *watcher*
+(`cloud.provision.request`) still takes a bare serial — tenant provisioning via
+the operator console (P4) will pass the qualified endpoint; until then tenant
+devices enter the registry via the startup heal.
 
 ## 1. Problem
 


### PR DESCRIPTION
The `EndpointRegistry` keyed healed endpoints by bare serial, but a tenant device registers `/rd` as `<tenant>:<serial>`, so the `cloud.lwm2m.registrations` → registry online/offline merge (keyed by endpoint) **never matched a tenant device** — it would register fine yet show offline in `cloud.endpoints` and get no per-device DNAT.

## Fix
`rehydrate_registry`'s heal path now keys the registry by the **tenant-qualified endpoint** (`<tenant>:<serial>` for a tenant cred row, bare serial for the default tenant), matching the device's `/rd` endpoint. Default devices are unchanged (key == serial); duplicate serials across tenants stay distinct.

## Validation
Compile + link verified (podman). Default-tenant behaviour unchanged. Tenant online-state e2e needs `iot-cloudd` + a `tun`/OpenVPN environment to validate (deferred, same bar as P3b). The runtime provision watcher (bare serial) gets the tenant field under the P4 operator console. TDD note updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)