### PR TITLE
feat(cloud): tenant-scope db/get cloud.endpoints (live UI isolation)

### DIFF
--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -17,9 +17,14 @@ instance).
 | P1c | Console read-isolation: session `tenant` + scoped `/api/v1/cloud/*` | #487 | ✅ merged |
 | P1d | `iot-cloudd` row-tagging: `cloud.endpoints` rows carry `tenant` | #488 | ✅ merged |
 | P3a | Per-tenant VPN **subnet math + nft isolation rules** (pure, gtest) | _this_ | 🔵 |
+| P1e | `db/get cloud.endpoints` tenant scoping (**live UI isolation**) | _this_ | 🔵 |
 | P3b | Wire P3a: OpenVPN `/16` + per-client CCD static IPs + apply nft | — | ⏭️ needs tun validation |
-| — | `db/get cloud.endpoints` tenant scoping (live UI isolation) | — | ⏭️ |
 | P4/P5 | Platform-operator console; per-tenant CA; quotas | — | ⏭️ |
+
+With P1e the **console is tenant-isolated end to end**: `iot-cloudd` tags
+`cloud.endpoints` rows (P1d), and both the cloud-API handler (P1c) and the
+generic `db/get` the cloud-ui actually uses (P1e) filter to the session's
+tenant. A platform operator (`tenant = "*"`) still sees all.
 
 P3 splits into **P3a** (the pure allocation/rule-generation core — landed here,
 fully unit-tested) and **P3b** (the live OpenVPN client-config-dir + nftables

--- a/modules/http-server/CMakeLists.txt
+++ b/modules/http-server/CMakeLists.txt
@@ -42,6 +42,7 @@ add_library(http_server_lib STATIC
     src/session.cpp
     src/handler.cpp
     src/handler_cloud.cpp
+    src/tenant_scope.cpp
     src/handler_proxy.cpp
     src/handler_shell.cpp
     src/shell.cpp

--- a/modules/http-server/inc/tenant_scope.hpp
+++ b/modules/http-server/inc/tenant_scope.hpp
@@ -1,0 +1,31 @@
+#ifndef __iot_http_tenant_scope_hpp__
+#define __iot_http_tenant_scope_hpp__
+
+/// Multi-tenant console scoping helpers (apps/docs/tdd-multi-tenant-cloud.md).
+/// Shared by the cloud-API and the generic db/get paths so the operator only
+/// ever sees endpoints in their own tenant.
+
+#include <map>
+#include <string>
+
+namespace http_server {
+
+class SessionStore;
+
+/// The tenant a request acts as: the validated session's tenant, or "default"
+/// when there is no/invalid session. Returns "*" (platform operator → no
+/// filtering) when `auth` is null, preserving legacy behaviour where auth isn't
+/// wired.
+std::string request_tenant(const std::map<std::string, std::string>& headers,
+                           SessionStore* auth);
+
+/// Filter a `cloud.endpoints` JSON-array *string* to rows whose tenant ==
+/// `tenant` (a row's absent/empty tenant counts as "default"). Returns the
+/// input unchanged when `tenant` is "*" or the value isn't a JSON array — so a
+/// platform operator and non-endpoint values pass through untouched.
+std::string scope_endpoints_json(const std::string& value,
+                                 const std::string& tenant);
+
+} // namespace http_server
+
+#endif /* __iot_http_tenant_scope_hpp__ */

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -1,5 +1,6 @@
 #include "auth.hpp"
 #include "handler.hpp"
+#include "tenant_scope.hpp"
 
 #include "data_store/client.hpp"
 #include "data_store/value.hpp"
@@ -104,7 +105,7 @@ void install_handlers(Router& router,
 
     // ─── POST /api/v1/db/get ─────────────────────────────────
     router.add("POST", "/api/v1/db/get",
-        [ds](const HttpParser::Request& req) -> HttpResponse {
+        [ds, auth](const HttpParser::Request& req) -> HttpResponse {
             HttpResponse r;
             if (!ds) {
                 r.status = 500;
@@ -132,6 +133,16 @@ void install_handlers(Router& router,
                 json resp;
                 resp["ok"] = true;
                 resp["data"] = get_result_to_json(got);
+                // Multi-tenant: scope cloud.endpoints to the caller's tenant so
+                // the operator only sees their own devices (the cloud-ui reads
+                // the endpoint list through this generic getter). No-op for the
+                // platform operator ("*") or when auth isn't wired.
+                if (resp["data"].contains("cloud.endpoints") &&
+                    resp["data"]["cloud.endpoints"].is_string()) {
+                    resp["data"]["cloud.endpoints"] = scope_endpoints_json(
+                        resp["data"]["cloud.endpoints"].get<std::string>(),
+                        request_tenant(req.headers, auth));
+                }
                 r.body = resp.dump();
             } catch (const std::exception& e) {
                 r.status = 400;
@@ -210,7 +221,7 @@ void install_handlers(Router& router,
 
     // ─── GET /api/v1/db/get?key=N&timeout=S (long-poll) ──────
     router.add("GET", "/api/v1/db/get",
-        [ds](const HttpParser::Request& req) -> HttpResponse {
+        [ds, auth](const HttpParser::Request& req) -> HttpResponse {
             HttpResponse r;
             if (!ds) {
                 r.status = 500;
@@ -248,6 +259,10 @@ void install_handlers(Router& router,
                 } else {
                     resp["value"] = nullptr;
                 }
+                if (key == "cloud.endpoints" && resp["value"].is_string())
+                    resp["value"] = scope_endpoints_json(
+                        resp["value"].get<std::string>(),
+                        request_tenant(req.headers, auth));
                 r.body = resp.dump();
                 return r;
             }
@@ -313,6 +328,10 @@ void install_handlers(Router& router,
                     resp["value"] = nullptr;
                 }
             }
+            if (key == "cloud.endpoints" && resp["value"].is_string())
+                resp["value"] = scope_endpoints_json(
+                    resp["value"].get<std::string>(),
+                    request_tenant(req.headers, auth));
             r.body = resp.dump();
             return r;
         });

--- a/modules/http-server/src/tenant_scope.cpp
+++ b/modules/http-server/src/tenant_scope.cpp
@@ -1,0 +1,35 @@
+/// Multi-tenant console scoping helpers. See tenant_scope.hpp.
+
+#include "tenant_scope.hpp"
+
+#include "auth.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace http_server {
+
+std::string request_tenant(const std::map<std::string, std::string>& headers,
+                           SessionStore* auth) {
+    if (!auth) return "*";                         // auth not wired → no filtering
+    const std::string token =
+        extract_session_cookie(headers, auth->cookie_name());
+    const auto* s = token.empty() ? nullptr : auth->validate(token);
+    return s ? s->tenant : std::string("default");
+}
+
+std::string scope_endpoints_json(const std::string& value,
+                                 const std::string& tenant) {
+    if (tenant == "*") return value;               // platform operator sees all
+    auto arr = nlohmann::json::parse(value, nullptr, /*allow_exceptions*/false);
+    if (!arr.is_array()) return value;             // not an endpoint array
+    nlohmann::json out = nlohmann::json::array();
+    for (const auto& e : arr) {
+        if (!e.is_object()) continue;
+        const std::string t = e.value("tenant", std::string());
+        const std::string et = t.empty() ? std::string("default") : t;
+        if (et == tenant) out.push_back(e);
+    }
+    return out.dump();
+}
+
+} // namespace http_server

--- a/modules/http-server/test/cloud_api_test.cpp
+++ b/modules/http-server/test/cloud_api_test.cpp
@@ -8,6 +8,7 @@
 
 #include "handler.hpp"
 #include "auth.hpp"
+#include "tenant_scope.hpp"
 #include "parser.hpp"
 #include "router.hpp"
 
@@ -233,6 +234,29 @@ TEST(CloudApiTenant, SingleEndpointHiddenAcrossTenant) {
     req.headers["cookie"] = "iot-session=" + tok;
     auto r = f.router.route(req);
     EXPECT_EQ(r.status, 404);                        // not leaked to acme
+}
+
+// ── db/get cloud.endpoints tenant scoping (tenant_scope.cpp) ────────
+
+TEST(ScopeEndpointsJson, FiltersByTenantWithLegacyDefault) {
+    const std::string v = R"([
+        {"endpoint":"a","tenant":"acme"},
+        {"endpoint":"b"},
+        {"endpoint":"c","tenant":"globex"}
+    ])";
+    auto acme = json::parse(http_server::scope_endpoints_json(v, "acme"));
+    ASSERT_EQ(acme.size(), 1U);
+    EXPECT_EQ(acme[0]["endpoint"], "a");
+
+    auto def = json::parse(http_server::scope_endpoints_json(v, "default"));
+    ASSERT_EQ(def.size(), 1U);
+    EXPECT_EQ(def[0]["endpoint"], "b");           // untagged == default
+}
+
+TEST(ScopeEndpointsJson, OperatorAndNonArrayPassThrough) {
+    const std::string v = R"([{"endpoint":"a","tenant":"acme"}])";
+    EXPECT_EQ(http_server::scope_endpoints_json(v, "*"), v);   // operator: unchanged
+    EXPECT_EQ(http_server::scope_endpoints_json("not json", "acme"), "not json");
 }
 
 } // namespace


### PR DESCRIPTION
Completes console read-isolation (`apps/docs/tdd-multi-tenant-cloud.md`, **P1e**). The cloud-ui reads the endpoint list via the **generic** `POST /api/v1/db/get` (and the GET long-poll), not the `/api/v1/cloud/*` handler — so that path must scope to the caller's tenant too, now that `iot-cloudd` tags `cloud.endpoints` rows (#488).

## Changes
- **`tenant_scope.{hpp,cpp}`** (new, in `http_server_lib`):
  - `request_tenant(headers, auth)` — the session's tenant (`"default"` if no session; `"*"` = platform operator / no filtering when auth unwired).
  - `scope_endpoints_json(value, tenant)` — filter a `cloud.endpoints` JSON-array string to rows in the tenant (absent row tenant == default); `"*"` or a non-array value passes through unchanged.
- **`handler.cpp`** — both `db/get` paths (POST batch + GET long-poll) post-filter the `cloud.endpoints` value by the caller's tenant. Other keys untouched.

## Tests — 14/14 `http-cloud-api-tests` green (podman)
2 new `scope_endpoints_json` cases (filter-by-tenant incl. legacy default; operator + non-array pass-through) + the existing tenant API-filter suite.

## End to end
`iot-cloudd` tags rows (P1d) → **both** the cloud-API handler (P1c) and `db/get` (P1e) filter by session tenant. A platform operator (`"*"`) sees all. Backward compatible: a default-tenant operator sees default/untagged rows (= every row in a single-tenant deployment); auth-unwired ⇒ no filtering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)