### PR TITLE
feat(cloud): P3b apply inter-tenant nft isolation table

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -145,6 +145,38 @@ void reconcile_tenants(data_store::Client& ds) {
     }
 }
 
+// Multi-tenant (P3b): apply the inter-tenant nftables isolation table — DROP
+// forwarded traffic between different tenant /24s (same-tenant + tenant<->cloud
+// still flow). Rebuilt from cloud.tenants' subnets and applied with nft -f -
+// (atomic, own table `iot_tenant_isol`), mirroring rebuild_device_dnat. The
+// pure ruleset text is server::openvpn::build_tenant_isolation_rules
+// (unit-tested); this is the privileged apply.
+// NOTE: the nft apply itself needs NET_ADMIN + a real netfilter stack — it is
+// compile-verified here but its live effect must be validated on a tun/OpenVPN
+// host (see apps/docs/tdd-multi-tenant-cloud.md P3b).
+void rebuild_tenant_isolation(data_store::Client& ds) {
+    std::vector<std::string> subnets;
+    try {
+        auto arr = nlohmann::json::parse(ds_str(ds, "cloud.tenants", "[]"));
+        if (arr.is_array()) for (const auto& t : arr) {
+            if (!t.is_object()) continue;
+            const std::string s = t.value("vpn.subnet", std::string());
+            if (!s.empty()) subnets.push_back(s);
+        }
+    } catch (const std::exception& ex) {
+        ACE_ERROR((LM_ERROR, ACE_TEXT("%D cloudd:thread:%t %M %N:%l tenant "
+                  "isolation: cloud.tenants parse: %C\n"), ex.what()));
+        return;
+    }
+    const std::string script =
+        server::openvpn::build_tenant_isolation_rules(subnets);
+    if (server::dnat::apply_ruleset(script)) {
+        ACE_DEBUG((LM_INFO, ACE_TEXT("%D cloudd:thread:%t %M %N:%l tenant "
+                  "isolation nft applied (%u tenant subnet(s))\n"),
+                  static_cast<unsigned>(subnets.size())));
+    }
+}
+
 // Rebuild + apply the per-device "device UI over VPN" DNAT ruleset.
 //
 // The device list is read from the *persisted* cloud.endpoints ds JSON (not
@@ -524,8 +556,10 @@ int main(int argc, char** argv) {
     rehydrate_registry(ds, ep_reg, vpn_reg, provisioner);
 
     // Multi-tenant (P4): assign VPN subnets to any tenants already in
-    // cloud.tenants at startup (operator may have added them while we were down).
+    // cloud.tenants at startup (operator may have added them while we were down),
+    // then (P3b) apply the inter-tenant nft isolation.
     reconcile_tenants(ds);
+    rebuild_tenant_isolation(ds);
 
     ::signal(SIGINT, on_signal);
     ::signal(SIGTERM, on_signal);
@@ -1170,7 +1204,8 @@ int main(int argc, char** argv) {
                 ACE_DEBUG((LM_INFO,
                            ACE_TEXT("%D cloudd:thread:%t %M %N:%l log level changed\n")));
             } else if (ev.key == "cloud.tenants") {
-                reconcile_tenants(ds);   // assign VPN subnet(s) to new tenants
+                reconcile_tenants(ds);        // assign VPN subnet(s) to new tenants
+                rebuild_tenant_isolation(ds); // re-apply inter-tenant nft isolation
             } else if (ev.key == "cloud.lwm2m.registrations") {
                 // lwm2m-dm published a registration change — fold online/
                 // offline into the endpoint registry before the sync below.

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -18,10 +18,19 @@ instance).
 | P1d | `iot-cloudd` row-tagging: `cloud.endpoints` rows carry `tenant` | #488 | ✅ merged |
 | P3a | Per-tenant VPN **subnet math + nft isolation rules** (pure, gtest) | _this_ | 🔵 |
 | P1e | `db/get cloud.endpoints` tenant scoping (**live UI isolation**) | _this_ | 🔵 |
-| P3b | Wire P3a: OpenVPN `/16` + per-client CCD static IPs + apply nft | — | ⏭️ needs tun validation |
+| P3b | Apply inter-tenant nft isolation table (compile-verified) | _this_ | 🔵 needs tun validation |
+| P3c | OpenVPN `/16` + per-client CCD static IP from tenant `/24` | — | ⏭️ needs tun validation |
 | P4a | Tenant registry: auto VPN-subnet assignment (`cloud.tenants` watch) | _this_ | 🔵 |
 | P4b | Operator console UI (tenant CRUD) + tenant-aware provision *watcher* | — | ⏭️ |
 | P5 | Per-tenant CA; quotas; audit log | — | ⏭️ |
+
+**P3b/P3c split:** P3b applies the inter-tenant **nft drop** table
+(`build_tenant_isolation_rules` over the tenant subnets) via the same
+`apply_ruleset` path as the device DNAT — compile-verified, but the live nft
+effect needs a NET_ADMIN/netfilter host. The rules only *bite* once each
+device's tunnel IP comes from its tenant's `/24`, which is **P3c**: per-client
+OpenVPN client-config-dir static IPs + `VpnRegistry` allocating from the
+tenant subnet. P3c is the larger, tun-validated piece.
 
 **P4a:** an operator creates a tenant by `db/set`-ing `{id, name}` into
 `cloud.tenants`; `iot-cloudd` watches the key and carves a non-overlapping `/24`


### PR DESCRIPTION
`iot-cloudd` applies the inter-tenant **nftables isolation** table — DROP forwarded traffic between different tenant `/24`s (same-tenant + tenant↔cloud still flow) — rebuilt from `cloud.tenants`' subnets via the same `server::dnat::apply_ruleset` path as the device DNAT (own table `iot_tenant_isol`, atomic `nft -f -`). Runs at startup + on the `cloud.tenants` watch.

Ruleset text is `build_tenant_isolation_rules` (pure, unit-tested in #489). Compiles + links clean (podman).

## ⚠️ Needs HW validation
The nft apply needs `NET_ADMIN` + a real netfilter stack; the live effect is unvalidated in CI (same bar as device fixes #463/#472). The rules only *bite* once each device's tunnel IP is from its tenant `/24` — that's **P3c** (per-client OpenVPN client-config-dir static IPs + `VpnRegistry` per-tenant allocation), the larger tun-validated piece (tracked in the TDD).

🤖 Generated with [Claude Code](https://claude.com/claude-code)