### PR TITLE
feat(cloud): P4b tenant-aware provision watcher + tenant-qualified cred minting

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -1087,6 +1087,17 @@ int main(int argc, char** argv) {
                                ACE_TEXT("%D cloudd:thread:%t %M %N:%l provision request '%C'\n"),
                                ep->c_str()));
 
+                    // Multi-tenant (P4b): a request may be tenant-qualified
+                    // ("<tenant>:<serial>"). Split it — the cred row is keyed by
+                    // the bare serial + a tenant tag, while the registry/DNAT use
+                    // the qualified endpoint (== what the device registers /rd
+                    // as). A colon-less request is the default tenant (legacy).
+                    std::string p_tenant = "default", p_serial = *ep;
+                    if (auto col = ep->find(':'); col != std::string::npos) {
+                        auto t = ep->substr(0, col), s = ep->substr(col + 1);
+                        if (!t.empty() && !s.empty()) { p_tenant = t; p_serial = s; }
+                    }
+
                     // PSK provisioning (task M-wire): the endpoint name IS
                     // the raw serial. Read the engineer-pasted BS PSK from
                     // the carrier, mint a DM PSK, and upsert a per-endpoint
@@ -1107,7 +1118,7 @@ int main(int argc, char** argv) {
                                 ds_str(ds, "cloud.endpoint.credentials", "[]");
                             const std::string next =
                                 server::lwm2m::upsert_credential(
-                                    cur, *ep, bs_psk, dm_psk);
+                                    cur, p_serial, bs_psk, dm_psk, p_tenant);
                             ds.set("cloud.endpoint.credentials",
                                    data_store::Value{next});
                             ds.set("cloud.provision.bs.psk",
@@ -1116,7 +1127,8 @@ int main(int argc, char** argv) {
                                        ACE_TEXT("%D cloudd:thread:%t %M %N:%l stored "
                                                 "credentials for %C (identity=%C)\n"),
                                        ep->c_str(),
-                                       server::lwm2m::format_identity(*ep).c_str()));
+                                       server::lwm2m::format_identity(
+                                           p_serial, p_tenant).c_str()));
                         } catch (const std::exception& e) {
                             ACE_ERROR((LM_ERROR,
                                        ACE_TEXT("%D cloudd:thread:%t %M %N:%l credential "
@@ -1131,14 +1143,14 @@ int main(int argc, char** argv) {
                     // formatted identity, for traceability.
                     if (cert_ca.have_ca()) {
                         const std::string cn =
-                            server::lwm2m::format_identity(*ep);
+                            server::lwm2m::format_identity(p_serial, p_tenant);
                         if (auto mc = cert_ca.mint_client(cn)) {
                             try {
                                 const std::string cur =
                                     ds_str(ds, "cloud.endpoint.credentials", "[]");
                                 const std::string next =
                                     server::lwm2m::upsert_vpn_cert(
-                                        cur, *ep, mc->ca_crt,
+                                        cur, p_serial, mc->ca_crt,
                                         mc->client_crt, mc->client_key);
                                 ds.set("cloud.endpoint.credentials",
                                        data_store::Value{next});
@@ -1159,23 +1171,14 @@ int main(int argc, char** argv) {
                         }
                     }
 
+                    // Provision keyed by the (possibly tenant-qualified)
+                    // endpoint so the registry key matches the device's /rd.
                     auto result = provisioner.provision(*ep);
                     if (result.has_value()) {
-                        // Multi-tenant: tag the endpoint with its tenant from
-                        // the cred row so cloud.endpoints carries it. The manual
-                        // provision flow has no tenant field → "" == default.
-                        try {
-                            auto cr = nlohmann::json::parse(
-                                ds_str(ds, "cloud.endpoint.credentials", "[]"));
-                            if (cr.is_array())
-                                for (const auto& c : cr)
-                                    if (c.is_object() &&
-                                        c.value("serial", std::string()) == *ep) {
-                                        ep_reg.update_tenant(
-                                            *ep, c.value("tenant", std::string()));
-                                        break;
-                                    }
-                        } catch (...) {}
+                        // Tag the registry row with the tenant so cloud.endpoints
+                        // carries it ("" == default).
+                        ep_reg.update_tenant(
+                            *ep, p_tenant == "default" ? std::string() : p_tenant);
                         ACE_DEBUG((LM_INFO,
                                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l provisioned %C"
                                             " tun=%C proxy=%d\n"),

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -21,7 +21,8 @@ instance).
 | P3b | Apply inter-tenant nft isolation table (compile-verified) | _this_ | 🔵 needs tun validation |
 | P3c | OpenVPN `/16` + per-client CCD static IP from tenant `/24` | — | ⏭️ needs tun validation |
 | P4a | Tenant registry: auto VPN-subnet assignment (`cloud.tenants` watch) | _this_ | 🔵 |
-| P4b | Operator console UI (tenant CRUD) + tenant-aware provision *watcher* | — | ⏭️ |
+| P4b | Tenant-aware provision *watcher* + tenant-qualified cred minting | _this_ | 🔵 |
+| P4c | Operator console UI (Angular tenant CRUD page) | — | ⏭️ needs node |
 | P5 | Per-tenant CA; quotas; audit log | — | ⏭️ |
 
 **P3b/P3c split:** P3b applies the inter-tenant **nft drop** table

--- a/modules/server/lwm2m/CMakeLists.txt
+++ b/modules/server/lwm2m/CMakeLists.txt
@@ -76,6 +76,6 @@ if(BUILD_SERVER_LWM2M_TESTS)
     target_include_directories(cloud-credentials-tests
         PRIVATE ${LWM2M_SERVER_DIR}/inc ${JSON_INCLUDE_DIR})
     target_link_libraries(cloud-credentials-tests
-        GTest::gtest_main GTest::gtest pthread)
+        GTest::gtest_main GTest::gtest pthread crypto)
     add_test(NAME cloud-credentials-tests COMMAND cloud-credentials-tests)
 endif()

--- a/modules/server/lwm2m/inc/cloud_credentials.hpp
+++ b/modules/server/lwm2m/inc/cloud_credentials.hpp
@@ -29,6 +29,12 @@ struct CredPair {
 /// Cloud canonical identity for a raw device serial: rpi<serial>@cloud.local.
 std::string format_identity(const std::string& serial);
 
+/// Tenant-qualified identity (multi-tenant cloud): the default/empty tenant
+/// gives the legacy rpi<serial>@cloud.local; any other tenant gives
+/// rpi<serial>@<tenant>.cloud.local. Matches tenant_policy::dm_identity.
+std::string format_identity(const std::string& serial,
+                            const std::string& tenant);
+
 /// Mint a cryptographically-random `nbytes` (default 32) DM PSK, lowercase
 /// hex-encoded (2*nbytes chars). Throws std::runtime_error if no entropy
 /// source is available. The BS PSK is device-generated; this is the cloud's
@@ -44,6 +50,16 @@ std::string upsert_credential(const std::string& array_json,
                               const std::string& serial,
                               const std::string& bs_psk_hex,
                               const std::string& dm_psk_hex);
+
+/// Tenant-aware upsert (multi-tenant cloud, P4b): the record's identity /
+/// dm.psk.id are tenant-qualified and a non-default tenant is recorded in a
+/// "tenant" field so the BS/DM resolvers + console scope correctly. The
+/// 4-arg overload is this with tenant = "default" (legacy, untagged).
+std::string upsert_credential(const std::string& array_json,
+                              const std::string& serial,
+                              const std::string& bs_psk_hex,
+                              const std::string& dm_psk_hex,
+                              const std::string& tenant);
 
 /// Remove the record matching `key` against any of its identity forms
 /// (serial / identity / dm.psk.id). No-op if absent. Returns the updated array.

--- a/modules/server/lwm2m/src/cloud_credentials.cpp
+++ b/modules/server/lwm2m/src/cloud_credentials.cpp
@@ -42,6 +42,12 @@ std::string format_identity(const std::string& serial) {
     return "rpi" + serial + "@cloud.local";
 }
 
+std::string format_identity(const std::string& serial,
+                            const std::string& tenant) {
+    if (tenant.empty() || tenant == "default") return format_identity(serial);
+    return "rpi" + serial + "@" + tenant + ".cloud.local";
+}
+
 std::string generate_psk_hex(std::size_t nbytes) {
     std::vector<unsigned char> buf(nbytes);
     std::ifstream urandom("/dev/urandom", std::ios::binary);
@@ -74,8 +80,17 @@ std::string upsert_credential(const std::string& array_json,
                               const std::string& serial,
                               const std::string& bs_psk_hex,
                               const std::string& dm_psk_hex) {
+    return upsert_credential(array_json, serial, bs_psk_hex, dm_psk_hex,
+                             "default");
+}
+
+std::string upsert_credential(const std::string& array_json,
+                              const std::string& serial,
+                              const std::string& bs_psk_hex,
+                              const std::string& dm_psk_hex,
+                              const std::string& tenant) {
     json arr = parse_array(array_json);
-    const std::string identity = format_identity(serial);
+    const std::string identity = format_identity(serial, tenant);
 
     // JSON field names follow the dotted convention (dm.psk.id, …).
     json rec = {
@@ -85,6 +100,8 @@ std::string upsert_credential(const std::string& array_json,
         {"dm.psk.id",  identity},
         {"dm.psk.key", dm_psk_hex},
     };
+    // Record a non-default tenant so the resolvers + console scope this row.
+    if (!tenant.empty() && tenant != "default") rec["tenant"] = tenant;
 
     // Replace an existing entry for this serial (idempotent provision).
     for (auto& e : arr) {

--- a/modules/server/lwm2m/test/cloud_credentials_test.cpp
+++ b/modules/server/lwm2m/test/cloud_credentials_test.cpp
@@ -18,6 +18,30 @@ TEST(CloudCredentials, FormatsIdentity) {
     EXPECT_EQ("rpi100000abcd@cloud.local", format_identity("100000abcd"));
 }
 
+TEST(CloudCredentials, TenantQualifiedUpsert) {
+    // Tenant row: identity/dm.psk.id are tenant-qualified + a "tenant" tag.
+    auto out = upsert_credential("[]", "SER1", "bbbb", "dddd", "acme");
+    auto j = json::parse(out);
+    ASSERT_EQ(j.size(), 1u);
+    EXPECT_EQ(j[0]["serial"],    "SER1");
+    EXPECT_EQ(j[0]["tenant"],    "acme");
+    EXPECT_EQ(j[0]["identity"],  "rpiSER1@acme.cloud.local");
+    EXPECT_EQ(j[0]["dm.psk.id"], "rpiSER1@acme.cloud.local");
+    EXPECT_EQ(format_identity("SER1", "acme"), "rpiSER1@acme.cloud.local");
+}
+
+TEST(CloudCredentials, DefaultTenantUpsertIsLegacyUntagged) {
+    // Default tenant reproduces the legacy untagged row, and the 4-arg overload
+    // == the 5-arg with tenant="default".
+    auto def5 = upsert_credential("[]", "SER1", "bbbb", "dddd", "default");
+    auto def4 = upsert_credential("[]", "SER1", "bbbb", "dddd");
+    EXPECT_EQ(def5, def4);
+    auto j = json::parse(def5);
+    EXPECT_EQ(j[0]["identity"], "rpiSER1@cloud.local");
+    EXPECT_FALSE(j[0].contains("tenant"));
+    EXPECT_EQ(format_identity("SER1", "default"), "rpiSER1@cloud.local");
+}
+
 TEST(CloudCredentials, UpsertAppendsNewRecord) {
     auto out = upsert_credential("[]", "SER1", "bbbb", "dddd");
     auto arr = json::parse(out);


### PR DESCRIPTION
Runtime tenant provisioning. An operator (or the future console) sets `cloud.provision.request` to a tenant-qualified `"<tenant>:<serial>"`; `iot-cloudd` splits it, mints a tenant-qualified credential, and keys the registry by the qualified endpoint so the device's `/rd` matches.

## Changes
- **`cloud_credentials`** — `format_identity(serial, tenant)` + a 5-arg `upsert_credential(..., tenant)` that writes tenant-qualified `identity`/`dm.psk.id` (`rpi<serial>@<tenant>.cloud.local`) and a `"tenant"` tag. The 4-arg overload delegates with `tenant="default"` — **byte-identical** to before.
- **`iot-cloudd` provision watcher** — split the request into `(tenant, serial)`; upsert the cred row with the tenant; mint the VPN client cert under the tenant-qualified CN; provision keyed by the qualified endpoint; tag the registry row. A colon-less request is the default tenant (unchanged).
- **`modules/server/lwm2m` CMake** — link `crypto` into `cloud-credentials-tests` (it was unbuildable — undefined OpenSSL EVP refs — since the suite defaults OFF and nothing exercised it).

## Tests
`cloud-credentials-tests` 6/6 green incl. 2 new (tenant-qualified upsert; default==legacy untagged + 4-arg==5-arg). `iot-cloudd` compiles + links (podman).

## Deferred
Operator console **UI** (Angular tenant CRUD page) → **P4c** (needs node). Default-tenant provisioning unchanged throughout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)