### PR TITLE
feat(cloud): P5a per-tenant device quota (max.devices), enforced at provision

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -1098,6 +1098,22 @@ int main(int argc, char** argv) {
                         if (!t.empty() && !s.empty()) { p_tenant = t; p_serial = s; }
                     }
 
+                    // Multi-tenant (P5): enforce the per-tenant device quota
+                    // (cloud.tenants "max.devices"). A new serial over the cap is
+                    // rejected; a re-provision of an existing one is allowed.
+                    if (server::openvpn::tenant_at_capacity(
+                            ds_str(ds, "cloud.tenants", "[]"),
+                            ds_str(ds, "cloud.endpoint.credentials", "[]"),
+                            p_tenant, p_serial)) {
+                        ACE_ERROR((LM_WARNING,
+                                   ACE_TEXT("%D cloudd:thread:%t %M %N:%l provision "
+                                            "rejected: tenant '%C' at capacity (%C)\n"),
+                                   p_tenant.c_str(), p_serial.c_str()));
+                        ds.set("cloud.provision.request",
+                               data_store::Value{std::string("")});
+                        continue;
+                    }
+
                     // PSK provisioning (task M-wire): the endpoint name IS
                     // the raw serial. Read the engineer-pasted BS PSK from
                     // the carrier, mint a DM PSK, and upsert a per-endpoint

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -23,7 +23,9 @@ instance).
 | P4a | Tenant registry: auto VPN-subnet assignment (`cloud.tenants` watch) | _this_ | 🔵 |
 | P4b | Tenant-aware provision *watcher* + tenant-qualified cred minting | _this_ | 🔵 |
 | P4c | Operator console UI (Angular tenant CRUD page) | — | ⏭️ needs node |
-| P5 | Per-tenant CA; quotas; audit log | — | ⏭️ |
+| P5a | Per-tenant device **quota** (`max.devices`), enforced at provision | _this_ | 🔵 |
+| P5b | Per-tenant CA / cert namespace | — | ⏭️ needs tun validation |
+| P5c | Audit log of platform-operator + provisioning actions | — | ⏭️ |
 
 **P3b/P3c split:** P3b applies the inter-tenant **nft drop** table
 (`build_tenant_isolation_rules` over the tenant subnets) via the same

--- a/modules/server/openvpn/inc/tenant_subnet.hpp
+++ b/modules/server/openvpn/inc/tenant_subnet.hpp
@@ -46,6 +46,16 @@ std::pair<std::string, bool> assign_missing_subnets(
     const std::string& pool_cidr,
     int tenant_prefix = 24);
 
+/// Per-tenant device quota (P5). True if provisioning `candidate_serial` into
+/// `tenant` would exceed that tenant's "max.devices" (from `tenants_json`),
+/// where the current count is the number of `creds_json` rows in the tenant.
+/// A missing / <=0 max.devices is unlimited → false. Re-provisioning a serial
+/// already in the tenant is always allowed → false (it doesn't grow the count).
+bool tenant_at_capacity(const std::string& tenants_json,
+                        const std::string& creds_json,
+                        const std::string& tenant,
+                        const std::string& candidate_serial);
+
 }} // namespace server::openvpn
 
 #endif /* __iot_tenant_subnet_hpp__ */

--- a/modules/server/openvpn/src/tenant_subnet.cpp
+++ b/modules/server/openvpn/src/tenant_subnet.cpp
@@ -132,4 +132,38 @@ std::pair<std::string, bool> assign_missing_subnets(
     return {arr.dump(), changed};
 }
 
+bool tenant_at_capacity(const std::string& tenants_json,
+                        const std::string& creds_json,
+                        const std::string& tenant,
+                        const std::string& candidate_serial) {
+    // The tenant's cap (0 / absent ⇒ unlimited).
+    long max_devices = 0;
+    {
+        auto ts = nlohmann::json::parse(tenants_json, nullptr, false);
+        if (ts.is_array())
+            for (const auto& t : ts)
+                if (t.is_object() && t.value("id", std::string()) == tenant) {
+                    max_devices = t.value("max.devices", 0);
+                    break;
+                }
+    }
+    if (max_devices <= 0) return false;
+
+    // Current count of this tenant's credential rows; a re-provision of an
+    // already-present serial doesn't grow it, so it's never blocked.
+    long count = 0;
+    auto cr = nlohmann::json::parse(creds_json, nullptr, false);
+    if (cr.is_array())
+        for (const auto& c : cr) {
+            if (!c.is_object()) continue;
+            const std::string ct = c.value("tenant", std::string());
+            const std::string et = ct.empty() ? std::string("default") : ct;
+            if (et != tenant) continue;
+            if (c.value("serial", std::string()) == candidate_serial)
+                return false;            // already provisioned → allowed
+            ++count;
+        }
+    return count >= max_devices;
+}
+
 }} // namespace server::openvpn

--- a/modules/server/openvpn/test/tenant_subnet_test.cpp
+++ b/modules/server/openvpn/test/tenant_subnet_test.cpp
@@ -117,3 +117,37 @@ TEST(AssignMissingSubnets, BadInputUnchanged) {
     EXPECT_FALSE(changed);
     EXPECT_EQ(out, "not json");
 }
+
+// ── tenant_at_capacity ──────────────────────────────────────────────────────
+
+TEST(TenantAtCapacity, EnforcesMaxDevices) {
+    const std::string tenants = R"([{"id":"acme","max.devices":2}])";
+    const std::string two = R"([
+        {"serial":"a","tenant":"acme"},
+        {"serial":"b","tenant":"acme"}
+    ])";
+    // full → a NEW serial is blocked
+    EXPECT_TRUE(tenant_at_capacity(tenants, two, "acme", "c"));
+    // full → re-provisioning an EXISTING serial is allowed
+    EXPECT_FALSE(tenant_at_capacity(tenants, two, "acme", "a"));
+    // under cap → allowed
+    const std::string one = R"([{"serial":"a","tenant":"acme"}])";
+    EXPECT_FALSE(tenant_at_capacity(tenants, one, "acme", "c"));
+}
+
+TEST(TenantAtCapacity, UnlimitedWhenNoMax) {
+    const std::string tenants = R"([{"id":"acme"}])";          // no max.devices
+    const std::string many = R"([
+        {"serial":"a","tenant":"acme"},{"serial":"b","tenant":"acme"}
+    ])";
+    EXPECT_FALSE(tenant_at_capacity(tenants, many, "acme", "c"));
+    // Unknown tenant → no cap.
+    EXPECT_FALSE(tenant_at_capacity("[]", many, "acme", "c"));
+}
+
+TEST(TenantAtCapacity, CountsDefaultTenantUntagged) {
+    const std::string tenants = R"([{"id":"default","max.devices":1}])";
+    const std::string one = R"([{"serial":"a"}])";            // untagged == default
+    EXPECT_TRUE(tenant_at_capacity(tenants, one, "default", "b"));
+    EXPECT_FALSE(tenant_at_capacity(tenants, one, "default", "a"));
+}


### PR DESCRIPTION
A tenant in `cloud.tenants` may carry `"max.devices"`; `iot-cloudd` rejects a provision that would push the tenant past it. Unlimited when unset/0; re-provisioning an already-present serial is always allowed (it doesn't grow the count).

## Changes
- **`tenant_subnet`** — new pure `tenant_at_capacity(tenants_json, creds_json, tenant, candidate_serial)`: counts the tenant's credential rows (untagged == default) vs its `max.devices`.
- **`iot-cloudd` provision watcher** — guard before minting/provisioning; on over-cap, log + clear the request.

## Tests — `tenant-subnet-tests` +3 (now 13 total)
enforce cap on a new serial; allow re-provision of an existing one; default-tenant counts untagged rows; unlimited when no max. `iot-cloudd` compiles + links (podman).

## Deferred
Per-tenant CA / cert namespace → **P5b** (needs tun); audit log → **P5c**. Default tenant unaffected (no `max.devices` ⇒ unlimited).

🤖 Generated with [Claude Code](https://claude.com/claude-code)