### PR TITLE
feat(cloud): P3c building blocks — per-tenant IP alloc + OpenVPN CCD (inert; gtest)

### DIFF
--- a/modules/server/openvpn/inc/openvpn_server.hpp
+++ b/modules/server/openvpn/inc/openvpn_server.hpp
@@ -38,6 +38,12 @@ struct OpenVpnServerConfig {
                                                 // `crl-verify <path>` (revocation)
     std::uint16_t mgmt_port  = 7506;            // management 127.0.0.1 <port>
     int           verb       = 3;
+    std::string   ccd_dir;                       // empty → no client-config-dir;
+                                                 // else `client-config-dir <dir>`
+                                                 // for per-client static IPs
+                                                 // (multi-tenant P3c): each
+                                                 // device's CCD file pins it into
+                                                 // its tenant /24 via ifconfig-push.
 };
 
 /// Render a server-mode OpenVPN config. Pure. Uses `dh none` (ECDH), so

--- a/modules/server/openvpn/inc/tenant_subnet.hpp
+++ b/modules/server/openvpn/inc/tenant_subnet.hpp
@@ -56,6 +56,24 @@ bool tenant_at_capacity(const std::string& tenants_json,
                         const std::string& tenant,
                         const std::string& candidate_serial);
 
+// ── P3c: per-client static IPs in the tenant /24 (OpenVPN CCD) ───────────────
+
+/// Allocate the next free host IP from `subnet_cidr` (e.g. a tenant's
+/// "10.9.16.0/24"), skipping the network/gateway/broadcast addresses and any IP
+/// in `used`. Gateway is `network+1`, so the first assignable host is
+/// `network+2`. Returns the dotted IP, or "" when the subnet is full / invalid.
+std::string allocate_ip_in_subnet(const std::string& subnet_cidr,
+                                  const std::vector<std::string>& used);
+
+/// Build an OpenVPN client-config-dir line pinning a client to `ip`:
+///   "ifconfig-push <ip> <netmask>\n"
+/// With `topology subnet`, the netmask is the *server* pool's mask (from
+/// `server_cidr`, e.g. the "/16"), not the tenant /24 — the per-tenant boundary
+/// is enforced by nftables (build_tenant_isolation_rules), not the mask.
+/// Returns "" on invalid input.
+std::string build_ccd_entry(const std::string& ip,
+                            const std::string& server_cidr);
+
 }} // namespace server::openvpn
 
 #endif /* __iot_tenant_subnet_hpp__ */

--- a/modules/server/openvpn/src/openvpn_server.cpp
+++ b/modules/server/openvpn/src/openvpn_server.cpp
@@ -132,6 +132,11 @@ std::string build_server_config(const OpenVpnServerConfig& c) {
     ss << "port "  << c.port  << "\n";
     ss << "topology subnet\n";
     ss << "server " << net << " " << mask << "\n";
+    // Multi-tenant (P3c): per-client static IPs via client-config-dir. Each
+    // device's CCD file (named by its cert CN) does ifconfig-push to an address
+    // in its tenant's /24, so the inter-tenant nft drops (P3b) match. Emitted
+    // only when configured — a single-tenant deployment is unchanged.
+    if (!c.ccd_dir.empty()) ss << "client-config-dir " << c.ccd_dir << "\n";
     // Push a DNS resolver to clients (when configured) so the device learns
     // it in the PUSH_REPLY and surfaces vpn.assigned.dns. topology subnet
     // already auto-pushes route-gateway + ifconfig (ip+netmask).

--- a/modules/server/openvpn/src/tenant_subnet.cpp
+++ b/modules/server/openvpn/src/tenant_subnet.cpp
@@ -6,6 +6,7 @@
 #include <arpa/inet.h>
 
 #include <cstdint>
+#include <set>
 #include <sstream>
 #include <utility>
 
@@ -164,6 +165,32 @@ bool tenant_at_capacity(const std::string& tenants_json,
             ++count;
         }
     return count >= max_devices;
+}
+
+std::string allocate_ip_in_subnet(const std::string& subnet_cidr,
+                                  const std::vector<std::string>& used) {
+    auto [base, prefix] = parse_cidr(subnet_cidr);
+    if (prefix < 0 || prefix > 30) return {};   // need room for >=2 hosts
+    const std::uint32_t net   = base & mask_of(prefix);
+    const std::uint32_t bcast = net | ~mask_of(prefix);
+    // .0 = network, .1 = gateway (the cloud end of the tunnel), so the first
+    // assignable device host is network+2; last is broadcast-1.
+    std::set<std::string> taken(used.begin(), used.end());
+    for (std::uint64_t h = net + 2; h + 1 <= bcast; ++h) {
+        const std::string ip = u32_to_ip(static_cast<std::uint32_t>(h));
+        if (!taken.count(ip)) return ip;
+    }
+    return {};   // subnet full
+}
+
+std::string build_ccd_entry(const std::string& ip,
+                            const std::string& server_cidr) {
+    auto [sbase, sprefix] = parse_cidr(server_cidr);
+    (void)sbase;
+    if (sprefix < 0) return {};
+    in_addr a{};
+    if (::inet_pton(AF_INET, ip.c_str(), &a) != 1) return {};   // bad ip
+    return "ifconfig-push " + ip + " " + u32_to_ip(mask_of(sprefix)) + "\n";
 }
 
 }} // namespace server::openvpn

--- a/modules/server/openvpn/test/openvpn_server_test.cpp
+++ b/modules/server/openvpn/test/openvpn_server_test.cpp
@@ -80,6 +80,18 @@ TEST(BuildServerConfig, badSubnetReturnsEmpty) {
     EXPECT_TRUE(build_server_config(c).empty());
 }
 
+TEST(BuildServerConfig, clientConfigDirEmittedOnlyWhenSet) {
+    OpenVpnServerConfig c;
+    c.subnet = "10.9.0.0/16";
+    // Default (no ccd_dir): no client-config-dir line — single-tenant unchanged.
+    EXPECT_EQ(build_server_config(c).find("client-config-dir"),
+              std::string::npos);
+    // Multi-tenant (P3c): the directive appears when configured.
+    c.ccd_dir = "/etc/iot/vpn/ccd";
+    EXPECT_NE(build_server_config(c).find("client-config-dir /etc/iot/vpn/ccd"),
+              std::string::npos);
+}
+
 TEST(BuildServerConfig, tcpProtoGetsServerSuffix) {
     // Operator-facing proto is the base form "tcp"; the server *socket* must
     // LISTEN, so the config must render "proto tcp-server" (not bare "proto tcp",

--- a/modules/server/openvpn/test/tenant_subnet_test.cpp
+++ b/modules/server/openvpn/test/tenant_subnet_test.cpp
@@ -151,3 +151,38 @@ TEST(TenantAtCapacity, CountsDefaultTenantUntagged) {
     EXPECT_TRUE(tenant_at_capacity(tenants, one, "default", "b"));
     EXPECT_FALSE(tenant_at_capacity(tenants, one, "default", "a"));
 }
+
+// ── allocate_ip_in_subnet ───────────────────────────────────────────────────
+
+TEST(AllocateIpInSubnet, FirstHostIsNetworkPlus2) {
+    // .0 network, .1 gateway → first device host is .2
+    EXPECT_EQ(allocate_ip_in_subnet("10.9.16.0/24", {}), "10.9.16.2");
+}
+
+TEST(AllocateIpInSubnet, SkipsUsed) {
+    EXPECT_EQ(allocate_ip_in_subnet("10.9.16.0/24",
+              {"10.9.16.2", "10.9.16.3"}), "10.9.16.4");
+}
+
+TEST(AllocateIpInSubnet, ExhaustionAndBadInput) {
+    // /30 = .0 net, .1 gw, .2 host, .3 bcast → exactly one assignable (.2)
+    EXPECT_EQ(allocate_ip_in_subnet("10.9.16.0/30", {}), "10.9.16.2");
+    EXPECT_EQ(allocate_ip_in_subnet("10.9.16.0/30", {"10.9.16.2"}), "");
+    EXPECT_EQ(allocate_ip_in_subnet("10.9.16.0/31", {}), "");   // no room
+    EXPECT_EQ(allocate_ip_in_subnet("garbage", {}), "");
+}
+
+// ── build_ccd_entry ─────────────────────────────────────────────────────────
+
+TEST(BuildCcdEntry, UsesServerMaskNotTenantMask) {
+    // server pool /16 → netmask 255.255.0.0 even though the IP is in a /24
+    EXPECT_EQ(build_ccd_entry("10.9.16.2", "10.9.0.0/16"),
+              "ifconfig-push 10.9.16.2 255.255.0.0\n");
+    EXPECT_EQ(build_ccd_entry("10.9.0.5", "10.9.0.0/24"),
+              "ifconfig-push 10.9.0.5 255.255.255.0\n");
+}
+
+TEST(BuildCcdEntry, BadInput) {
+    EXPECT_EQ(build_ccd_entry("not-an-ip", "10.9.0.0/16"), "");
+    EXPECT_EQ(build_ccd_entry("10.9.16.2", "garbage"), "");
+}


### PR DESCRIPTION
The **inert, testable building blocks** for P3c (per-client static IPs so P3b's nft isolation bites). No runtime behaviour change — the helpers are unused until wired, and the OpenVPN `client-config-dir` is opt-in (empty `ccd_dir` ⇒ config byte-identical). Safe to land ahead of the tun-validated integration.

## Changes
- `tenant_subnet`: `allocate_ip_in_subnet(tenant /24, used)` (next free host, skips network/gw/broadcast/used) + `build_ccd_entry(ip, server_cidr)` (`ifconfig-push <ip> <server-mask>` — mask is the `/16` pool's; the tenant boundary is nft, not the mask).
- `openvpn_server`: `OpenVpnServerConfig.ccd_dir` → emits `client-config-dir <dir>` only when set.

## Tests (podman)
`tenant-subnet-tests` 18/18 (+5 new); `openvpn-server-tests` +1 (`client-config-dir` absent by default / present when set).

## Remaining P3c (needs tun — separate PR after HW validation)
`iot-cloudd`: server on the `/16` pool + `ccd_dir`; on provision/rehydrate of a tenant device, allocate its `tun_ip` from the tenant `/24` and write the per-device CCD file. Tracked in `tdd-multi-tenant-cloud.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)