### PR TITLE
feat(cloud): adopt Option B — device-agnostic multi-tenancy

### DIFF
--- a/apps/bench/cloud_loadgen.cpp
+++ b/apps/bench/cloud_loadgen.cpp
@@ -158,10 +158,10 @@ public:
         }
         m_fd = m_sock.get_handle();
 
-        // Tenant-qualified bootstrap endpoint: "tenant:serial" (default tenant
-        // ⇒ bare serial, legacy on the wire). The serial stays bare for key
-        // derivation + credential-row matching.
-        const std::string ep = iot::join_endpoint(m_cfg.tenant, m_serial);
+        // Device-agnostic tenancy (Option B): the device bootstraps with its
+        // BARE serial regardless of tenant — the tenant lives only in the cred
+        // row's tag (emitted by emit-creds), never on the wire.
+        const std::string ep = m_serial;
 
         m_dtls  = std::make_shared<DTLSAdapter>(m_fd, m_cfg.logLevel);
         m_store = std::make_shared<lwm2m::ObjectStore>();
@@ -186,7 +186,7 @@ public:
         // the 128 KB ds-cli arg cap at high N). Secret = 128-bit key derived
         // from seed + serial. add_credential stores hex; the PSK callback
         // hex-decodes it to 16 bytes (fits DTLS_PSK_MAX_KEY_LEN).
-        const std::string bsId     = iot::bs_identity(m_cfg.tenant, m_serial);
+        const std::string bsId     = iot::bs_identity(std::string(), m_serial);
         const std::string bsPskHex = bs_key16(m_cfg.masterHex, m_serial);
         if (bsPskHex.empty()) {
             ACE_ERROR_RETURN((LM_ERROR,
@@ -541,11 +541,11 @@ static void emit_creds(const Config& cfg) {
     std::printf("[");
     for (std::uint32_t i = 0; i < cfg.count; ++i) {
         const std::string s = cfg.serialPrefix + std::to_string(i);
-        // No "identity" field: the device presents bs_identity(tenant,serial),
-        // which the cloud recomputes per row. Omitting it keeps the array under
-        // ds-cli's 128 KB single-arg cap at high device counts. The "tenant"
-        // tag is emitted only for a non-default tenant (default rows stay
-        // untagged = legacy).
+        // No "identity" field: the device presents the bare sha256(serial)[:32]
+        // (Option B — tenant-agnostic), which the cloud recomputes per row.
+        // Omitting it keeps the array under ds-cli's 128 KB single-arg cap at
+        // high N. The "tenant" tag is emitted for a non-default tenant (default
+        // rows stay untagged = legacy); identities stay BARE either way.
         const std::string tenantField =
             cfg.tenant.empty() ? std::string()
                                : ("\"tenant\":\"" + cfg.tenant + "\",");
@@ -554,7 +554,7 @@ static void emit_creds(const Config& cfg) {
                     "\"dm.psk.key\":\"%s\"}",
                     i ? "," : "", s.c_str(), tenantField.c_str(),
                     bs_key16(cfg.masterHex, s).c_str(),
-                    iot::dm_identity(cfg.tenant, s).c_str(),
+                    iot::dm_identity(std::string(), s).c_str(),
                     dm_key16(cfg.masterHex, s).c_str());
     }
     std::printf("]\n");

--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -456,19 +456,13 @@ std::size_t rehydrate_registry(data_store::Client& ds,
                 auto serial = c.value("serial", std::string());
                 if (serial.empty()) continue;
                 const auto tenant = c.value("tenant", std::string());
-                // Registry key = the tenant-qualified endpoint
-                // ("<tenant>:<serial>" for a tenant row, bare serial for the
-                // default tenant) so it MATCHES what a tenant device registers
-                // /rd as — otherwise the cloud.lwm2m.registrations → registry
-                // online/offline merge (keyed by endpoint) never matches a
-                // tenant device. Default rows are unchanged (key == serial);
-                // duplicate serials across tenants stay distinct.
-                const std::string key =
-                    (tenant.empty() || tenant == "default")
-                        ? serial : (tenant + ":" + serial);
-                if (reg.lookup_by_ep(key)) continue;
-                if (prov.provision(key)) {
-                    reg.update_tenant(key, tenant);
+                // Device-agnostic tenancy (Option B): the registry key is the
+                // BARE serial (globally unique) == what every device registers
+                // /rd as, regardless of tenant. The tenant is only a row tag,
+                // carried into cloud.endpoints for the console.
+                if (reg.lookup_by_ep(serial)) continue;
+                if (prov.provision(serial)) {
+                    reg.update_tenant(serial, tenant);
                     ++healed;
                 }
             }
@@ -1087,16 +1081,15 @@ int main(int argc, char** argv) {
                                ACE_TEXT("%D cloudd:thread:%t %M %N:%l provision request '%C'\n"),
                                ep->c_str()));
 
-                    // Multi-tenant (P4b): a request may be tenant-qualified
-                    // ("<tenant>:<serial>"). Split it — the cred row is keyed by
-                    // the bare serial + a tenant tag, while the registry/DNAT use
-                    // the qualified endpoint (== what the device registers /rd
-                    // as). A colon-less request is the default tenant (legacy).
-                    std::string p_tenant = "default", p_serial = *ep;
-                    if (auto col = ep->find(':'); col != std::string::npos) {
-                        auto t = ep->substr(0, col), s = ep->substr(col + 1);
-                        if (!t.empty() && !s.empty()) { p_tenant = t; p_serial = s; }
-                    }
+                    // Multi-tenant (Option B): the device is tenant-agnostic, so
+                    // the request IS the bare serial. The target tenant comes from
+                    // the cloud.provision.tenant carrier (set by the operator
+                    // console alongside the request); empty ⇒ default. The cred
+                    // row is tagged with it; the registry/DNAT key by the bare
+                    // serial (globally unique) == what the device registers /rd as.
+                    const std::string p_serial = *ep;
+                    std::string p_tenant = ds_str(ds, "cloud.provision.tenant", "");
+                    if (p_tenant.empty()) p_tenant = "default";
 
                     // Multi-tenant (P5): enforce the per-tenant device quota
                     // (cloud.tenants "max.devices"). A new serial over the cap is
@@ -1144,7 +1137,7 @@ int main(int argc, char** argv) {
                                                 "credentials for %C (identity=%C)\n"),
                                        ep->c_str(),
                                        server::lwm2m::format_identity(
-                                           p_serial, p_tenant).c_str()));
+                                           p_serial).c_str()));
                         } catch (const std::exception& e) {
                             ACE_ERROR((LM_ERROR,
                                        ACE_TEXT("%D cloudd:thread:%t %M %N:%l credential "
@@ -1159,7 +1152,7 @@ int main(int argc, char** argv) {
                     // formatted identity, for traceability.
                     if (cert_ca.have_ca()) {
                         const std::string cn =
-                            server::lwm2m::format_identity(p_serial, p_tenant);
+                            server::lwm2m::format_identity(p_serial);
                         if (auto mc = cert_ca.mint_client(cn)) {
                             try {
                                 const std::string cur =
@@ -1188,13 +1181,13 @@ int main(int argc, char** argv) {
                     }
 
                     // Provision keyed by the (possibly tenant-qualified)
-                    // endpoint so the registry key matches the device's /rd.
-                    auto result = provisioner.provision(*ep);
+                    // bare serial — globally unique, == the device's /rd ep.
+                    auto result = provisioner.provision(p_serial);
                     if (result.has_value()) {
                         // Tag the registry row with the tenant so cloud.endpoints
                         // carries it ("" == default).
                         ep_reg.update_tenant(
-                            *ep, p_tenant == "default" ? std::string() : p_tenant);
+                            p_serial, p_tenant == "default" ? std::string() : p_tenant);
                         ACE_DEBUG((LM_INFO,
                                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l provisioned %C"
                                             " tun=%C proxy=%d\n"),
@@ -1206,10 +1199,12 @@ int main(int argc, char** argv) {
                                             " '%C' (dup or exhausted)\n"),
                                    ep->c_str()));
                     }
-                    // One-shot: clear the request so a watch replay on cloudd
-                    // restart doesn't re-provision (and resurrect) a since-
-                    // deprovisioned endpoint. The "" re-fire is ignored above.
+                    // One-shot: clear the request + tenant carrier so a watch
+                    // replay on cloudd restart doesn't re-provision (and
+                    // resurrect) a since-deprovisioned endpoint.
                     ds.set("cloud.provision.request",
+                           data_store::Value{std::string("")});
+                    ds.set("cloud.provision.tenant",
                            data_store::Value{std::string("")});
                 }
             } else if (ev.key == "cloud.deprovision.request") {

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -21,9 +21,11 @@ instance).
 | P3b | Apply inter-tenant nft isolation table (compile-verified) | _this_ | 🔵 needs tun validation |
 | P3c | OpenVPN `/16` + per-client CCD static IP from tenant `/24` | — | ⏭️ needs tun validation |
 | P4a | Tenant registry: auto VPN-subnet assignment (`cloud.tenants` watch) | _this_ | 🔵 |
-| P4b | Tenant-aware provision *watcher* + tenant-qualified cred minting | _this_ | 🔵 |
-| P4c | Operator console UI (Angular tenant CRUD page) | — | ⏭️ needs node |
-| P5a | Per-tenant device **quota** (`max.devices`), enforced at provision | _this_ | 🔵 |
+| P4b | Tenant-aware provision *watcher* + cred minting | #494 | ✅ merged |
+| P5a | Per-tenant device **quota** (`max.devices`), enforced at provision | #495 | ✅ merged |
+| P3c-bb | P3c building blocks: per-tenant IP alloc + OpenVPN CCD (inert) | #496 | ✅ merged |
+| **PB** | **Adopt Option B (device-agnostic tenancy): bare identities, tenant from cred-row tag, `cloud.provision.tenant` carrier; revert qualified `ep`/identity** | _this_ | 🔵 gtest |
+| P4c | Operator console UI (tenant CRUD + `provision.tenant` selector) | — | ⏭️ needs node |
 | P5b | Per-tenant CA / cert namespace | — | ⏭️ needs tun validation |
 | P5c | Audit log of platform-operator + provisioning actions | — | ⏭️ |
 
@@ -58,16 +60,25 @@ Every slice keeps the **default tenant byte-identical to today**, so existing
 single-tenant deployments and fielded devices are unaffected (verified by gtest
 + a 200/200 default-tenant load run per slice).
 
-**Tenant endpoint keying (addressed for the heal path).** `iot-cloudd` now keys
-the registry by the **tenant-qualified endpoint** (`<tenant>:<serial>`; bare
-serial for the default tenant) when healing endpoints from
-`cloud.endpoint.credentials`, so it matches what a tenant device registers `/rd`
-as and the `cloud.lwm2m.registrations` → registry online/offline merge resolves
-it. Default devices (key == serial) are unchanged; duplicate serials across
-tenants stay distinct. **Remaining:** the runtime provision *watcher*
-(`cloud.provision.request`) still takes a bare serial — tenant provisioning via
-the operator console (P4) will pass the qualified endpoint; until then tenant
-devices enter the registry via the startup heal.
+> **Design change — Option B (device-agnostic), adopted 2026-06-29.** The
+> original design encoded the tenant into the device's identity
+> (`ep=<tenant>:<serial>`, `sha256("tenant:serial")[:32]`). On review that
+> over-coupled the device to cloud org structure: it only existed to keep the
+> DTLS-PSK identity unique when two tenants share a serial. We instead **require
+> globally-unique device serials** and keep the device **fully tenant-agnostic**
+> — it bootstraps with its bare serial exactly as single-tenant. The tenant
+> lives **only in the matched `cloud.endpoint.credentials` row's `tenant` tag**;
+> the cloud derives it from there. This decouples the device, makes tenant
+> transfer a pure cloud-side row edit, and keeps the default tenant automatically
+> byte-identical. The sections below reflect Option B; D3 records the switch.
+
+**Endpoint keying (Option B).** Identities are **bare** everywhere
+(`sha256(serial)[:32]`, `rpi<serial>@cloud.local`) and the registry/DNAT key by
+the **bare serial** — globally unique, so it matches what every device registers
+`/rd` as, regardless of tenant. The provision *watcher* reads the target tenant
+from a `cloud.provision.tenant` carrier (set by the operator console alongside
+`cloud.provision.request`) and tags the cred + registry rows; the startup heal
+tags from the existing row's `tenant`.
 
 ## 1. Problem
 
@@ -106,7 +117,7 @@ cloud-iot to host **multiple organizations** with strong isolation.
 |---|---|---|---|
 | D1 | Tenant identifier | UUID / operator slug | **short slug** (`acme`), 3–32 `[a-z0-9-]`; human-readable in keys, URLs, CNs |
 | D2 | Credential store shape | per-tenant arrays / one array + `tenant` field | **one `cloud.endpoint.credentials` array, each row tagged `tenant`** — reuses the existing resolver path; tenant is *derived* from the matched row. Minimal blast radius. |
-| D3 | Device→tenant resolution at DTLS handshake | encode tenant in identity / global identity→tenant index / lookup by matched cred row | **tenant-qualified PSK identity** (below) → unambiguous even with duplicate serials; the matched row confirms it |
+| D3 | Device→tenant resolution at DTLS handshake | encode tenant in identity / global identity→tenant index / lookup by matched cred row | **lookup by matched cred row (Option B, device-agnostic)** — device presents its bare serial; the tenant is the matched row's `tenant` tag. Requires globally-unique serials (documented constraint). Decouples the device from org structure; transfer = a cloud-side row edit. *(Superseded the original "tenant-qualified PSK identity" choice on 2026-06-29 — that only bought duplicate-serial support, at the cost of coupling the device.)* |
 | D4 | VPN isolation | N OpenVPN servers / one server + per-tenant subnet via CCD | **one OpenVPN server on a `/16`, per-tenant `/24` carved via client-config-dir static IPs + per-tenant nftables** — avoids N daemons; isolation enforced by nft |
 | D5 | VPN PKI | per-tenant CA / one CA, tenant in cert CN | **one runtime CA, tenant in the client-cert CN/OU**; network isolation is the nft subnet boundary, not the CA. (Per-tenant CA is a later hardening option.) |
 | D6 | Console authz | per-tenant user arrays / `tenant_id` on each account + role | **`tenant_id` + role on each `auth.users.accounts` entry**; a reserved `*` tenant = platform-operator (cross-tenant) |
@@ -146,28 +157,31 @@ secondary index `by_tenant`. No new top-level keys for device data — keeps the
 sync/rehydrate paths (`sync_endpoints_to_ds`, the startup rehydrate) intact, just
 tenant-aware.
 
-### 4.3 Device → tenant resolution (D3) — the crux
+### 4.3 Device → tenant resolution (D3) — the crux (Option B, device-agnostic)
 
-A device must prove which tenant it is, and duplicate serials across tenants must
-not collide. **Tenant-qualified identity:**
+The device is **tenant-agnostic** — it bootstraps with its **bare serial**,
+exactly as single-tenant. Globally-unique serials make this unambiguous; the
+tenant is the matched credential row's tag.
 
-- Onboarding provisions the device's bootstrap `ep` as **`<tenant>:<serial>`**
-  (e.g. `acme:000000fe26a4ff`) and its BS PSK identity as
-  `sha256("<tenant>:<serial>")[:32]`.
-- `POST /bs?ep=acme:<serial>` → the BS splits off the tenant, validates it
-  against `cloud.tenants`, and provisions the DM account with a tenant-scoped DM
-  identity `rpi<serial>@acme.cloud.local` (extends today's
-  `rpi<serial>@cloud.local`; `format_dm_identity` /`serial_from_dm_identity` in
-  `provisioning_policy.cpp` gain a tenant arg).
-- `resolve_bs_psk` / `resolve_dm_psk` match the tenant-qualified identity against
-  the (tenant-tagged) credential rows, so a row only authenticates within its
-  tenant. Duplicate serials in different tenants → different identities → no
-  collision.
+- Onboarding provisions a `cloud.endpoint.credentials` row keyed by the bare
+  serial, **tagged `"tenant":"acme"`**, with **bare** identities (BS
+  `sha256(serial)[:32]`, DM `rpi<serial>@cloud.local`). The operator console
+  selects the tenant via the `cloud.provision.tenant` carrier — the device never
+  learns it.
+- `POST /bs?ep=<serial>` → `plan_bs_account` matches the row by serial, reads its
+  `tenant` tag, validates it against `cloud.tenants`, and provisions the DM
+  account with the **bare** DM identity + the **per-tenant `dm.uri`**.
+- `resolve_bs_psk` / `resolve_dm_psk` match the **bare** identity against the
+  credential rows and return the key; the tenant isn't needed for key selection
+  (it's read from the matched row downstream). Globally-unique serials guarantee
+  a single match.
 - The matched row's `tenant` then drives everything downstream: which VPN subnet
-  the device gets, which registry bucket it lands in, which `dm.uri` it’s told.
+  the device gets, which registry bucket it lands in, which `dm.uri` it's told.
 
-Backward compatibility: an `ep` with no `:` ⇒ `default` tenant + today's
-identity scheme. Fielded devices keep working untouched.
+**Duplicate serials across tenants are disallowed** (the documented constraint
+that buys this simplicity). The quota/provision path can reject a serial already
+present under another tenant. Backward compatibility is automatic: an untagged
+row ⇒ `default` tenant + today's exact bytes; fielded devices are untouched.
 
 ### 4.4 VPN isolation (D4/D5)
 

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -374,9 +374,9 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
                 bs.serverUri         = bsUri;
                 bs.isBootstrapServer = true;
                 bs.securityMode      = 0;       // PSK
-                // Tenant-qualified canonical BS identity (default tenant ⇒
-                // sha256(serial)[:32], byte-identical to legacy); zero-touch ⇒
-                // the raw serial the device presents. Computed by plan_bs_account.
+                // Bare canonical BS identity sha256(serial)[:32] (Option B —
+                // device-agnostic, byte-identical to single-tenant); zero-touch
+                // ⇒ the raw serial the device presents. From plan_bs_account.
                 bs.identity          = plan.bs_identity;
                 bs.secretKey         = bsKey;   // hex (omitted by encoder if empty)
                 bs.shortServerId     = 0;       // ignored for a BS account

--- a/apps/src/provisioning_policy.cpp
+++ b/apps/src/provisioning_policy.cpp
@@ -67,14 +67,14 @@ std::string resolve_bs_psk(const std::string& credentials_json,
             if (!e.is_object()) continue;
             const std::string serial = e.value("serial", std::string());
             const std::string key    = e.value("bs.psk.key", std::string());
-            // Tenant-aware canonical BS identity. For an untagged row this is
-            // bs_identity("default", serial) == sha256(serial)[:32] — byte-for-
-            // byte the legacy match, so fielded devices are unaffected. A
-            // tenant-tagged row matches only its tenant's identity, so two
-            // tenants sharing a serial never cross-authenticate.
-            const std::string tenant = e.value("tenant", std::string());
+            // Device-agnostic tenancy (Option B): the device presents the SAME
+            // bare canonical identity regardless of tenant — sha256(serial)[:32].
+            // Serials are globally unique across tenants, so this is unambiguous;
+            // the tenant lives only in the matched row's "tenant" tag (read
+            // downstream, not needed for key selection). Identical to the
+            // single-tenant behaviour, so fielded devices are unaffected.
             if (!serial.empty() && !key.empty() &&
-                bs_identity(tenant, serial) == presented)
+                sha256_hex(serial).substr(0, 32) == presented)
                 return key;
         }
         for (const auto& e : arr) {
@@ -166,40 +166,27 @@ BsAccountPlan plan_bs_account(const std::string& ep,
                               const std::string& tenants_json,
                               const std::string& global_dm_uri,
                               const std::string& master_hex) {
+    // Device-agnostic tenancy (Option B): the device bootstraps with its bare
+    // serial — it never sends its tenant. The endpoint IS the serial; the tenant
+    // is the matched credential row's "tenant" tag (serials are globally unique,
+    // so the match is unambiguous). Identities are bare (rpi<serial>@cloud.local,
+    // sha256(serial)[:32]), exactly as single-tenant. The tenant only selects the
+    // per-tenant dm.uri + tags the endpoint downstream.
     BsAccountPlan p;
-    const EndpointId eid = split_endpoint(ep);
-    p.tenant = eid.tenant;
-    p.serial = eid.serial;
-
-    // A non-default tenant must be a known, active tenant. The default tenant is
-    // always allowed (legacy single-tenant deployments have no cloud.tenants).
+    p.serial = ep;
+    p.tenant = kDefaultTenant;
     p.dm_uri = global_dm_uri;
-    if (p.tenant != kDefaultTenant) {
-        auto t = find_tenant(tenants_json, p.tenant);
-        if (!t.has_value() || !t->active) return p;          // ok stays false
-        if (!t->dm_uri.empty()) p.dm_uri = t->dm_uri;        // per-tenant override
-    } else {
-        // The default tenant may still carry a registry override.
-        auto t = find_tenant(tenants_json, p.tenant);
-        if (t.has_value() && !t->dm_uri.empty()) p.dm_uri = t->dm_uri;
-    }
 
-    // Commissioned row, scoped to this tenant.
+    // Commissioned row matched by serial (or the legacy identity==ep override).
     auto arr = nlohmann::json::parse(credentials_json, nullptr, false);
     if (arr.is_array()) {
         for (const auto& e : arr) {
             if (!e.is_object()) continue;
+            if (e.value("serial", std::string()) != ep &&
+                e.value("identity", std::string()) != ep)
+                continue;
             const std::string rt = e.value("tenant", std::string());
-            const std::string rtenant = rt.empty() ? std::string(kDefaultTenant) : rt;
-            if (rtenant != p.tenant) continue;
-            const std::string rserial = e.value("serial", std::string());
-            // Match by serial within the tenant; for the default tenant also
-            // honour the legacy identity==ep override path.
-            const bool match =
-                (rserial == p.serial) ||
-                (p.tenant == kDefaultTenant &&
-                 e.value("identity", std::string()) == ep);
-            if (!match) continue;
+            p.tenant      = rt.empty() ? std::string(kDefaultTenant) : rt;
             p.bs_key      = e.value("bs.psk.key", std::string());
             p.dm_key      = e.value("dm.psk.key", std::string());
             p.dm_identity = e.value("dm.psk.id",  std::string());
@@ -207,23 +194,30 @@ BsAccountPlan plan_bs_account(const std::string& ep,
         }
     }
 
+    // A non-default tenant must be a known, active tenant; its dm.uri (when set)
+    // overrides the global one. A default deployment has no cloud.tenants.
+    {
+        auto t = find_tenant(tenants_json, p.tenant);
+        if (p.tenant != kDefaultTenant && (!t.has_value() || !t->active))
+            return p;                                        // ok stays false
+        if (t.has_value() && !t->dm_uri.empty()) p.dm_uri = t->dm_uri;
+    }
+
     // Zero-touch (HKDF) tier: no stored row but a master is available → derive
-    // statelessly. The device presents its raw serial as the BS identity here
-    // (override path), matching the legacy zero-touch behaviour.
+    // statelessly from the bare serial.
     if ((p.dm_key.empty() || p.dm_identity.empty()) && !master_hex.empty()) {
         p.bs_key      = derive_bs_psk_hex(master_hex, p.serial);
         p.dm_key      = derive_dm_psk_hex(master_hex, p.serial);
-        p.dm_identity = dm_identity(p.tenant, p.serial);
+        p.dm_identity = format_dm_identity(p.serial);        // bare
         p.zero_touch  = true;
     }
 
-    if (p.dm_identity.empty())
-        p.dm_identity = dm_identity(p.tenant, p.serial);
+    if (p.dm_identity.empty()) p.dm_identity = format_dm_identity(p.serial);
 
-    // BS DTLS identity written to the device's Security /0/0. Commissioned tier
-    // uses the tenant-qualified canonical identity (default ⇒ sha256(serial)[:32]
-    // byte-for-byte); zero-touch keeps the raw serial the device presents.
-    p.bs_identity = p.zero_touch ? p.serial : bs_identity(p.tenant, p.serial);
+    // BS DTLS identity written to the device's Security /0/0 — the bare canonical
+    // sha256(serial)[:32] (zero-touch keeps the raw serial the device presents).
+    p.bs_identity = p.zero_touch ? p.serial
+                                 : sha256_hex(p.serial).substr(0, 32);
 
     p.ok = !p.dm_identity.empty() && !p.dm_key.empty() && !p.dm_uri.empty();
     return p;

--- a/apps/test/provisioning_policy_test.cpp
+++ b/apps/test/provisioning_policy_test.cpp
@@ -210,129 +210,75 @@ TEST(ResolveDmPsk, NoMasterOrUnparseableYieldsEmpty) {
     EXPECT_EQ("", iot::resolve_dm_psk("[]", "", kMaster));
 }
 
-// ── Multi-tenant resolution (tdd-multi-tenant-cloud.md) ──────────────────────
+// ── Multi-tenant resolution — Option B: device-agnostic (tdd §3) ─────────────
+// The device presents its BARE serial regardless of tenant; the tenant lives
+// only in the matched cred row's "tenant" tag (serials are globally unique).
 
-TEST(ResolveBsPskTenant, UntaggedRowIsByteIdenticalToLegacy) {
-    // The whole backward-compat guarantee: an untagged row resolves under the
-    // device's legacy sha256(serial)[:32] identity exactly as before — a fielded
-    // device stays online after the cloud gains tenant awareness.
-    const std::string creds =
+TEST(ResolveBsPskTenant, BareIdentityMatchesRegardlessOfTag) {
+    // Untagged AND tenant-tagged rows both resolve under the device's bare
+    // sha256(serial)[:32] — the device never sends its tenant.
+    const std::string def =
         R"([{"serial":"100000003d1f9c2e","bs.psk.key":"feedface"}])";
-    EXPECT_EQ(iot::bs_identity("default", kSerial), std::string(kSha256Id));
-    EXPECT_EQ("feedface", iot::resolve_bs_psk(creds, kSha256Id, kMaster));
-}
+    EXPECT_EQ("feedface", iot::resolve_bs_psk(def, kSha256Id, kMaster));
 
-TEST(ResolveBsPskTenant, TenantRowMatchesTenantIdentityOnly) {
-    // A tenant-tagged row authenticates only against its tenant-qualified
-    // identity, never the bare-serial (default) one.
-    const std::string creds =
+    const std::string acme =
         R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"acmekey"}])";
-    EXPECT_EQ("acmekey",
-              iot::resolve_bs_psk(creds, iot::bs_identity("acme", kSerial), ""));
-    // The default identity for the same serial must NOT resolve the acme row.
-    EXPECT_EQ("", iot::resolve_bs_psk(creds, kSha256Id, ""));
+    EXPECT_EQ("acmekey", iot::resolve_bs_psk(acme, kSha256Id, ""));
 }
 
-TEST(ResolveBsPskTenant, NoCrossTenantAuthOnDuplicateSerial) {
-    // Two tenants, same serial, different keys. Each identity resolves only its
-    // own tenant's key.
-    const std::string creds =
-        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"acmekey"},)"
-        R"({"serial":"100000003d1f9c2e","tenant":"globex","bs.psk.key":"globexkey"}])";
-    EXPECT_EQ("acmekey",
-              iot::resolve_bs_psk(creds, iot::bs_identity("acme", kSerial), ""));
-    EXPECT_EQ("globexkey",
-              iot::resolve_bs_psk(creds, iot::bs_identity("globex", kSerial), ""));
-}
+// ── plan_bs_account (Option B) ──────────────────────────────────────────────
 
-TEST(ResolveDmPskTenant, DerivesFromTenantQualifiedDmIdentity) {
-    // The derive path parses both legacy and tenant DM identities to the same
-    // serial, so the derived DM key is identical regardless of tenant suffix.
-    EXPECT_EQ(kDerivedDm,
-              iot::resolve_dm_psk("[]", iot::dm_identity("default", kSerial), kMaster));
-    EXPECT_EQ(kDerivedDm,
-              iot::resolve_dm_psk("[]", iot::dm_identity("acme", kSerial), kMaster));
-}
-
-// ── plan_bs_account ─────────────────────────────────────────────────────────
-
-TEST(PlanBsAccount, DefaultCommissionedIsLegacy) {
+TEST(PlanBsAccount, DefaultCommissionedIsBareLegacy) {
     const std::string creds =
         R"([{"serial":"100000003d1f9c2e","bs.psk.key":"bs","dm.psk.id":)"
         R"("rpi100000003d1f9c2e@cloud.local","dm.psk.key":"dm"}])";
     auto p = iot::plan_bs_account(/*ep*/kSerial, creds, /*tenants*/"[]",
-                                  /*global dm.uri*/"coaps://h:5683", /*master*/"");
+                                  "coaps://h:5683", /*master*/"");
     EXPECT_TRUE(p.ok);
     EXPECT_EQ(p.tenant, "default");
     EXPECT_EQ(p.serial, kSerial);
-    EXPECT_EQ(p.bs_identity, std::string(kSha256Id));           // legacy
-    EXPECT_EQ(p.dm_identity, "rpi100000003d1f9c2e@cloud.local"); // legacy
-    EXPECT_EQ(p.dm_uri, "coaps://h:5683");
-    EXPECT_FALSE(p.zero_touch);
-}
-
-TEST(PlanBsAccount, DefaultZeroTouchWhenNoRow) {
-    auto p = iot::plan_bs_account(kSerial, "[]", "[]", "coaps://h:5683", kMaster);
-    EXPECT_TRUE(p.ok);
-    EXPECT_TRUE(p.zero_touch);
-    EXPECT_EQ(p.bs_identity, std::string(kSerial));   // raw serial (override path)
+    EXPECT_EQ(p.bs_identity, std::string(kSha256Id));
     EXPECT_EQ(p.dm_identity, "rpi100000003d1f9c2e@cloud.local");
-    EXPECT_EQ(p.dm_key, kDerivedDm);
+    EXPECT_EQ(p.dm_uri, "coaps://h:5683");
 }
 
-TEST(PlanBsAccount, RejectsWhenNoRowNoMasterOrNoDmUri) {
-    EXPECT_FALSE(iot::plan_bs_account(kSerial, "[]", "[]", "coaps://h:5683", "").ok);
-    EXPECT_FALSE(iot::plan_bs_account(kSerial, "[]", "[]", /*no dm.uri*/"", kMaster).ok);
-}
-
-TEST(PlanBsAccount, TenantCommissionedScopedAndQualified) {
-    const std::string tenants =
-        R"([{"id":"acme","vpn.subnet":"10.9.16.0/24","status":"active"}])";
-    const std::string creds =
-        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
-        R"("dm.psk.id":"rpi100000003d1f9c2e@acme.cloud.local","dm.psk.key":"adm"}])";
-    auto p = iot::plan_bs_account("acme:100000003d1f9c2e", creds, tenants,
-                                  "coaps://h:5683", "");
-    EXPECT_TRUE(p.ok);
-    EXPECT_EQ(p.tenant, "acme");
-    EXPECT_EQ(p.serial, kSerial);
-    EXPECT_EQ(p.bs_identity, iot::bs_identity("acme", kSerial));   // tenant-qualified
-    EXPECT_EQ(p.dm_identity, "rpi100000003d1f9c2e@acme.cloud.local");
-    EXPECT_EQ(p.dm_key, "adm");
-    EXPECT_EQ(p.dm_uri, "coaps://h:5683");                          // global fallback
-}
-
-TEST(PlanBsAccount, TenantDmUriOverride) {
+TEST(PlanBsAccount, TenantFromRowBareIdentitiesPerTenantUri) {
+    // The device still sends the BARE serial; the tenant is the row's tag, and
+    // identities stay bare. The tenant only selects the per-tenant dm.uri.
     const std::string tenants =
         R"([{"id":"acme","dm.uri":"coaps://acme.example:5683","status":"active"}])";
     const std::string creds =
         R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
-        R"("dm.psk.id":"rpi100000003d1f9c2e@acme.cloud.local","dm.psk.key":"adm"}])";
-    auto p = iot::plan_bs_account("acme:100000003d1f9c2e", creds, tenants,
+        R"("dm.psk.id":"rpi100000003d1f9c2e@cloud.local","dm.psk.key":"adm"}])";
+    auto p = iot::plan_bs_account(/*ep=bare serial*/kSerial, creds, tenants,
                                   "coaps://global:5683", "");
-    ASSERT_TRUE(p.ok);
-    EXPECT_EQ(p.dm_uri, "coaps://acme.example:5683");
+    EXPECT_TRUE(p.ok);
+    EXPECT_EQ(p.tenant, "acme");                       // from the row's tag
+    EXPECT_EQ(p.bs_identity, std::string(kSha256Id));  // bare, not tenant-qualified
+    EXPECT_EQ(p.dm_identity, "rpi100000003d1f9c2e@cloud.local");  // bare
+    EXPECT_EQ(p.dm_key, "adm");
+    EXPECT_EQ(p.dm_uri, "coaps://acme.example:5683");  // per-tenant override
 }
 
-TEST(PlanBsAccount, RejectsUnknownOrSuspendedTenant) {
+TEST(PlanBsAccount, RejectsUnknownOrSuspendedTenantOnRow) {
     const std::string creds =
         R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
-        R"("dm.psk.id":"x","dm.psk.key":"adm"}])";
-    // Unknown tenant (empty registry).
-    EXPECT_FALSE(iot::plan_bs_account("acme:100000003d1f9c2e", creds, "[]",
-                                      "coaps://h:5683", "").ok);
-    // Suspended tenant.
-    const std::string suspended =
-        R"([{"id":"acme","status":"suspended"}])";
-    EXPECT_FALSE(iot::plan_bs_account("acme:100000003d1f9c2e", creds, suspended,
-                                      "coaps://h:5683", "").ok);
+        R"("dm.psk.id":"rpi100000003d1f9c2e@cloud.local","dm.psk.key":"adm"}])";
+    EXPECT_FALSE(iot::plan_bs_account(kSerial, creds, "[]",
+                                      "coaps://h:5683", "").ok);       // unknown
+    EXPECT_FALSE(iot::plan_bs_account(kSerial, creds,
+                 R"([{"id":"acme","status":"suspended"}])",
+                 "coaps://h:5683", "").ok);                            // suspended
 }
 
-TEST(PlanBsAccount, TenantRowNotVisibleToDefault) {
-    // A tenant-tagged row must not satisfy a default-tenant (legacy) bootstrap.
-    const std::string creds =
-        R"([{"serial":"100000003d1f9c2e","tenant":"acme","bs.psk.key":"abs",)"
-        R"("dm.psk.id":"x","dm.psk.key":"adm"}])";
-    auto p = iot::plan_bs_account(kSerial, creds, "[]", "coaps://h:5683", "");
-    EXPECT_FALSE(p.ok);   // no default row, no master
+TEST(PlanBsAccount, DefaultZeroTouchAndRejects) {
+    auto z = iot::plan_bs_account(kSerial, "[]", "[]", "coaps://h:5683", kMaster);
+    EXPECT_TRUE(z.ok);
+    EXPECT_TRUE(z.zero_touch);
+    EXPECT_EQ(z.bs_identity, std::string(kSerial));   // raw serial (override path)
+    EXPECT_EQ(z.dm_identity, "rpi100000003d1f9c2e@cloud.local");
+    EXPECT_EQ(z.dm_key, kDerivedDm);
+
+    EXPECT_FALSE(iot::plan_bs_account(kSerial, "[]", "[]", "coaps://h:5683", "").ok);
+    EXPECT_FALSE(iot::plan_bs_account(kSerial, "[]", "[]", /*no dm.uri*/"", kMaster).ok);
 }

--- a/modules/server/lwm2m/inc/cloud_credentials.hpp
+++ b/modules/server/lwm2m/inc/cloud_credentials.hpp
@@ -27,13 +27,9 @@ struct CredPair {
 };
 
 /// Cloud canonical identity for a raw device serial: rpi<serial>@cloud.local.
+/// Device-agnostic tenancy (Option B): always bare — the device never sends its
+/// tenant; the tenant lives only as a credential-row tag.
 std::string format_identity(const std::string& serial);
-
-/// Tenant-qualified identity (multi-tenant cloud): the default/empty tenant
-/// gives the legacy rpi<serial>@cloud.local; any other tenant gives
-/// rpi<serial>@<tenant>.cloud.local. Matches tenant_policy::dm_identity.
-std::string format_identity(const std::string& serial,
-                            const std::string& tenant);
 
 /// Mint a cryptographically-random `nbytes` (default 32) DM PSK, lowercase
 /// hex-encoded (2*nbytes chars). Throws std::runtime_error if no entropy

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -171,6 +171,16 @@ return {
       type    = "string",
       default = "",
     },
+    -- Target tenant for the next provision (multi-tenant, Option B). The device
+    -- is tenant-agnostic — it bootstraps with its bare serial — so the operator
+    -- console sets this alongside cloud.provision.request to tag the new cred
+    -- row + registry row. Empty ⇒ default tenant (single-tenant legacy).
+    -- iot-cloudd clears it after each provision.
+    ["cloud.provision.tenant"] = {
+        access  = "Admin",
+      type    = "string",
+      default = "",
+    },
     -- Deprovision request: iot-httpd writes the endpoint name here;
     -- iot-cloudd watches this key and calls deprovision().
     ["cloud.deprovision.request"] = {

--- a/modules/server/lwm2m/src/cloud_credentials.cpp
+++ b/modules/server/lwm2m/src/cloud_credentials.cpp
@@ -42,12 +42,6 @@ std::string format_identity(const std::string& serial) {
     return "rpi" + serial + "@cloud.local";
 }
 
-std::string format_identity(const std::string& serial,
-                            const std::string& tenant) {
-    if (tenant.empty() || tenant == "default") return format_identity(serial);
-    return "rpi" + serial + "@" + tenant + ".cloud.local";
-}
-
 std::string generate_psk_hex(std::size_t nbytes) {
     std::vector<unsigned char> buf(nbytes);
     std::ifstream urandom("/dev/urandom", std::ios::binary);
@@ -90,7 +84,10 @@ std::string upsert_credential(const std::string& array_json,
                               const std::string& dm_psk_hex,
                               const std::string& tenant) {
     json arr = parse_array(array_json);
-    const std::string identity = format_identity(serial, tenant);
+    // Device-agnostic tenancy (Option B): the identity is BARE
+    // (rpi<serial>@cloud.local) regardless of tenant — the device never sends
+    // its tenant. The tenant is recorded only as a row tag (below).
+    const std::string identity = format_identity(serial);
 
     // JSON field names follow the dotted convention (dm.psk.id, …).
     json rec = {

--- a/modules/server/lwm2m/test/cloud_credentials_test.cpp
+++ b/modules/server/lwm2m/test/cloud_credentials_test.cpp
@@ -18,16 +18,16 @@ TEST(CloudCredentials, FormatsIdentity) {
     EXPECT_EQ("rpi100000abcd@cloud.local", format_identity("100000abcd"));
 }
 
-TEST(CloudCredentials, TenantQualifiedUpsert) {
-    // Tenant row: identity/dm.psk.id are tenant-qualified + a "tenant" tag.
+TEST(CloudCredentials, TenantTaggedUpsertKeepsBareIdentity) {
+    // Option B: a tenant row carries a "tenant" tag but keeps the BARE identity
+    // (the device never sends its tenant).
     auto out = upsert_credential("[]", "SER1", "bbbb", "dddd", "acme");
     auto j = json::parse(out);
     ASSERT_EQ(j.size(), 1u);
     EXPECT_EQ(j[0]["serial"],    "SER1");
     EXPECT_EQ(j[0]["tenant"],    "acme");
-    EXPECT_EQ(j[0]["identity"],  "rpiSER1@acme.cloud.local");
-    EXPECT_EQ(j[0]["dm.psk.id"], "rpiSER1@acme.cloud.local");
-    EXPECT_EQ(format_identity("SER1", "acme"), "rpiSER1@acme.cloud.local");
+    EXPECT_EQ(j[0]["identity"],  "rpiSER1@cloud.local");   // bare
+    EXPECT_EQ(j[0]["dm.psk.id"], "rpiSER1@cloud.local");   // bare
 }
 
 TEST(CloudCredentials, DefaultTenantUpsertIsLegacyUntagged) {
@@ -39,7 +39,6 @@ TEST(CloudCredentials, DefaultTenantUpsertIsLegacyUntagged) {
     auto j = json::parse(def5);
     EXPECT_EQ(j[0]["identity"], "rpiSER1@cloud.local");
     EXPECT_FALSE(j[0].contains("tenant"));
-    EXPECT_EQ(format_identity("SER1", "default"), "rpiSER1@cloud.local");
 }
 
 TEST(CloudCredentials, UpsertAppendsNewRecord) {


### PR DESCRIPTION
## Why

Per design review: the device should **not** carry its tenant. The original
multi-tenant slices encoded the tenant into the device identity
(`ep=<tenant>:<serial>`, `sha256("tenant:serial")[:32]`). That existed solely to
disambiguate duplicate serials at the DTLS-PSK layer — at the cost of coupling
the device to cloud org structure and forcing device re-provisioning on tenant
transfer.

**Option B (this PR):** require globally-unique device serials; keep the device
**fully tenant-agnostic** — it bootstraps with its bare serial exactly as
single-tenant. The tenant lives only in the matched `cloud.endpoint.credentials`
row's `tenant` tag, derived cloud-side. Decouples the device, makes tenant
transfer a pure cloud-side row edit, and keeps the **default tenant
byte-identical** automatically.

## Changes
- **`resolve_bs_psk`** — match the **bare** `sha256(serial)[:32]` for every row
  regardless of tenant tag (reverts the tenant-qualified match).
- **`plan_bs_account`** — endpoint **is** the bare serial; tenant comes from the
  matched row; identities stay bare; the tenant only selects the per-tenant
  `dm.uri` + validates active/known.
- **`cloud_credentials`** — drop `format_identity(serial,tenant)`; upsert tags
  the row with `tenant` but keeps the **bare** identity/CN.
- **iot-cloudd provision watcher** — read the target tenant from a new
  `cloud.provision.tenant` carrier (not an `ep` prefix); key the registry/DNAT
  and heal by the **bare serial** (globally unique == device `/rd`).
- **`cloud.lua`** — add the `cloud.provision.tenant` carrier key.
- **bench loadgen** — present the bare serial/identity; keep the cred-row tenant
  tag (still exercises tenant scoping end to end).
- **TDD** — record the A→B switch (D3 + §4.3 + progress table).

## Net effect
−49 LOC. A simplification: most of the device-coupling from #485/#486/#490/#494
reverts to bare-serial behaviour; the tenant survives only as a cred-row tag for
cloud-side scoping.

## Testing
Standalone harness compiled over the **real** `provisioning_policy` +
`cloud_credentials` sources (`-lcrypto`) — bare-identity resolve (tagged +
untagged rows), tenant-from-row plan, per-tenant `dm.uri`, unknown/suspended
tenant reject, bare-identity tagged upsert — **all pass**. The gtest suites
(`provisioning_policy_test`, `cloud_credentials_test`) are updated to match;
full image compile of iot-cloudd/lwm2m/loadgen is covered by CI on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)