### PR TITLE
feat(cloud-ui): P4c — multi-tenant operator console

### DIFF
--- a/apps/cloud/ui/src/app/app.module.ts
+++ b/apps/cloud/ui/src/app/app.module.ts
@@ -34,6 +34,7 @@ import { ServicesSubmenuComponent } from './services/services-submenu/services-s
 import { ServicesListComponent } from './services/services-list/services-list.component';
 import { HttpConfigComponent } from './http-config/http-config.component';
 import { UsersComponent } from './users/users.component';
+import { TenantsComponent } from './tenants/tenants.component';
 import { SoftwareUpdateComponent } from './software-update/software-update.component';
 
 import { SsoAuthInterceptor } from '../common/sso-auth.interceptor';
@@ -50,7 +51,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     RoutingSubmenuComponent, CustomRulesComponent, DeviceForwardingComponent,
     Lwm2mSubmenuComponent, Lwm2mConfigComponent, BsConfigComponent,
     ServicesSubmenuComponent, ServicesListComponent, HttpConfigComponent,
-    UsersComponent, SoftwareUpdateComponent,
+    UsersComponent, TenantsComponent, SoftwareUpdateComponent,
     DsHintComponent, DsDebugDirective,
   ],
   imports: [

--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -48,7 +48,13 @@ interface EpCred {
                      placeholder="paste BS PSK from device-ui" />
               <clr-control-helper *dsDebug><app-ds-hint key="cloud.provision.bs.psk"></app-ds-hint></clr-control-helper>
             </clr-input-container>
-            <div></div>
+            <clr-select-container *ngIf="tenantIds.length > 1 && !editing">
+              <label>Tenant</label>
+              <select clrSelect [(ngModel)]="provTenant">
+                <option *ngFor="let t of tenantIds" [value]="t">{{ t }}</option>
+              </select>
+              <clr-control-helper *dsDebug><app-ds-hint key="cloud.provision.tenant"></app-ds-hint></clr-control-helper>
+            </clr-select-container>
             <div></div>
           </div>
           <button class="btn btn-primary" style="margin-top:16px;"
@@ -204,6 +210,11 @@ export class EndpointListComponent implements OnInit, OnDestroy {
   serverTunIp = '';
   // PSK provisioning (task O).
   provSerial = ''; provBsPsk = ''; provisioning = false; devMode = false;
+  // Multi-tenant (P4c): which tenant the device is provisioned into. The device
+  // stays tenant-agnostic — this only tags the cred/registry rows cloud-side via
+  // the cloud.provision.tenant carrier. "default" = single-tenant (legacy).
+  provTenant = 'default';
+  tenantIds: string[] = ['default'];
   // Edit mode: re-provision an existing endpoint to update its BS PSK in place.
   editing = false;
   private sub = new Subscription(); private active = true;
@@ -262,7 +273,8 @@ export class EndpointListComponent implements OnInit, OnDestroy {
     this.ticker = setInterval(() => { this.now = Math.floor(Date.now() / 1000); }, 1000);
     this.startLongPoll();
     this.http.dbGet(['cloud.dev.mode', 'cloud.endpoint.credentials',
-                     'cloud.proxy.device.ui.port', 'cloud.vpn.subnet']).subscribe({
+                     'cloud.proxy.device.ui.port', 'cloud.vpn.subnet',
+                     'cloud.tenants']).subscribe({
       next: (r) => {
         if (r.ok && r.data) {
           const d = r.data as Record<string, unknown>;
@@ -274,6 +286,14 @@ export class EndpointListComponent implements OnInit, OnDestroy {
             const arr = JSON.parse(String(d['cloud.endpoint.credentials'] || '[]'));
             this.creds = Array.isArray(arr) ? arr : [];
           } catch { this.creds = []; }
+          // Tenant dropdown options: "default" + every active tenant.
+          try {
+            const ts = JSON.parse(String(d['cloud.tenants'] || '[]'));
+            const ids = (Array.isArray(ts) ? ts : [])
+              .filter((t) => (t?.status || 'active') === 'active' && t?.id)
+              .map((t) => String(t.id));
+            this.tenantIds = ['default', ...ids.filter((id) => id !== 'default')];
+          } catch { this.tenantIds = ['default']; }
         }
       },
       error: () => {}
@@ -305,7 +325,12 @@ export class EndpointListComponent implements OnInit, OnDestroy {
     if (!serial) { this.toast.error('Serial number required'); return; }
     if (!/^[0-9a-f]{32}$/.test(psk)) { this.toast.error('BS PSK must be 32 hex chars'); return; }
     this.provisioning = true;
+    // Order matters: the tenant carrier + BS PSK must be in place before the
+    // request key fires iot-cloudd's watcher. The device stays tenant-agnostic;
+    // this only tags the cred/registry rows (Option B). Editing keeps the
+    // existing tenant (the form hides the selector), so re-send the current one.
     this.http.dbSet([
+      { key: 'cloud.provision.tenant', value: this.provTenant || 'default' },
       { key: 'cloud.provision.bs.psk', value: psk },
       { key: 'cloud.provision.request', value: serial },
     ]).subscribe({
@@ -314,6 +339,7 @@ export class EndpointListComponent implements OnInit, OnDestroy {
         if (r.ok) {
           this.toast.success((this.editing ? 'Updated PSK for ' : 'Provisioning ') + serial);
           this.provSerial = ''; this.provBsPsk = ''; this.editing = false;
+          this.provTenant = 'default';
         }
         else this.toast.error(r.err || 'Provision failed');
       },
@@ -330,6 +356,11 @@ export class EndpointListComponent implements OnInit, OnDestroy {
     this.provSerial = ep;
     this.provBsPsk = '';
     this.editing = true;
+    // Preserve the device's existing tenant on re-provision (the selector is
+    // hidden in edit mode) so the in-place update never silently re-tenants it.
+    const c = this.creds.find((x) => x.serial === ep || x.identity === ep) as
+      (EpCred & { tenant?: string }) | undefined;
+    this.provTenant = c?.tenant || 'default';
     try { window.scrollTo({ top: 0, behavior: 'smooth' }); } catch { /* noop */ }
   }
 
@@ -337,6 +368,7 @@ export class EndpointListComponent implements OnInit, OnDestroy {
     this.editing = false;
     this.provSerial = '';
     this.provBsPsk = '';
+    this.provTenant = 'default';
   }
 
   private startLongPoll(): void {

--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -80,6 +80,9 @@
       <!-- Users -->
       <app-users *ngIf="selectedMenu==='users'"></app-users>
 
+      <!-- Tenants (multi-tenant operator console) -->
+      <app-tenants *ngIf="selectedMenu==='tenants'"></app-tenants>
+
       <!-- Software Update -->
       <app-software-update *ngIf="selectedMenu==='software'"></app-software-update>
     </div>

--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -28,6 +28,7 @@ export class MainComponent implements OnInit {
     { id: 'services',  label: 'Services',  svg: 'assets/icons/services.svg' },
     { id: 'logs',      label: 'Logs',      svg: 'assets/icons/logs.svg' },
     { id: 'users',     label: 'Users',     svg: 'assets/icons/users.svg' },
+    { id: 'tenants',   label: 'Tenants',   svg: 'assets/icons/tenants.svg' },
     { id: 'software',  label: 'Software',  svg: 'assets/icons/software.svg' },
   ];
   menus = [...this.DEFAULT_MENUS];

--- a/apps/cloud/ui/src/app/tenants/tenants.component.ts
+++ b/apps/cloud/ui/src/app/tenants/tenants.component.ts
@@ -1,0 +1,202 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+import { ToastService } from '../../common/toast.service';
+
+/// One row of the cloud.tenants JSON array. Keys use the dotted ds convention.
+interface TenantRow {
+  id: string;
+  name?: string;
+  'vpn.subnet'?: string;     // auto-assigned by iot-cloudd (P4a) from the pool
+  'dm.uri'?: string;         // optional per-tenant DM URI override
+  'max.devices'?: number;    // optional per-tenant quota (P5a; 0/absent = unlimited)
+  status?: string;           // "active" | "suspended"
+}
+
+/// Multi-tenant operator console (P4c). Platform-operator CRUD over the
+/// cloud.tenants registry, driven through the generic /api/v1/db surface — the
+/// same pattern as every other cloud-ui config page. iot-cloudd watches
+/// cloud.tenants and auto-carves a non-overlapping /24 (P4a) for any tenant
+/// lacking one, so the add form only needs id + name (+ optional quota/DM URI);
+/// vpn.subnet is shown read-only once assigned.
+@Component({
+  selector: 'app-tenants',
+  template: `
+    <div class="page">
+      <h3>Tenants</h3>
+
+      <ng-container *ngIf="isAdmin; else noAccess">
+        <!-- Create / update -->
+        <div class="form-grid" style="align-items:end;">
+          <clr-input-container>
+            <label>Tenant ID</label>
+            <input clrInput [(ngModel)]="newId" [readonly]="editing" placeholder="acme" />
+            <clr-control-helper *dsDebug><app-ds-hint key="cloud.tenants"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>Display name</label>
+            <input clrInput [(ngModel)]="newName" placeholder="Acme Corp" />
+          </clr-input-container>
+          <clr-input-container>
+            <label>Max devices</label>
+            <input clrInput type="number" min="0" [(ngModel)]="newMax" placeholder="0 = unlimited" />
+            <clr-control-helper *dsDebug><app-ds-hint key="cloud.tenants (max.devices)"></app-ds-hint></clr-control-helper>
+          </clr-input-container>
+          <clr-input-container>
+            <label>DM URI (optional)</label>
+            <input clrInput [(ngModel)]="newDmUri" placeholder="coaps://cloud.example:5683" />
+          </clr-input-container>
+          <div class="btn-cell">
+            <button class="btn btn-primary" (click)="save()" [disabled]="saving">
+              {{ saving ? 'Saving…' : (editing ? 'Update' : 'Add tenant') }}
+            </button>
+            <button *ngIf="editing" class="btn btn-link" (click)="cancelEdit()">Cancel</button>
+          </div>
+        </div>
+        <p class="hint">
+          The VPN subnet is auto-assigned by the cloud from the tenant pool — no
+          need to enter it. <code>default</code> is the built-in single-tenant
+          bucket and can't be deleted.
+        </p>
+
+        <!-- Tenant list -->
+        <clr-datagrid [clrDgLoading]="loading" style="margin-top:20px;">
+          <clr-dg-column>ID</clr-dg-column>
+          <clr-dg-column>Name</clr-dg-column>
+          <clr-dg-column>VPN subnet</clr-dg-column>
+          <clr-dg-column>Max devices</clr-dg-column>
+          <clr-dg-column>Status</clr-dg-column>
+          <clr-dg-column>Actions</clr-dg-column>
+
+          <clr-dg-row *clrDgItems="let t of tenants">
+            <clr-dg-cell><code>{{ t.id }}</code></clr-dg-cell>
+            <clr-dg-cell>{{ t.name || '—' }}</clr-dg-cell>
+            <clr-dg-cell>{{ t['vpn.subnet'] || '(assigning…)' }}</clr-dg-cell>
+            <clr-dg-cell>{{ t['max.devices'] ? t['max.devices'] : 'unlimited' }}</clr-dg-cell>
+            <clr-dg-cell>
+              <app-status-badge [label]="t.status || 'active'"
+                [state]="(t.status || 'active')==='active' ? 'connected' : 'idle'"></app-status-badge>
+            </clr-dg-cell>
+            <clr-dg-cell>
+              <button class="btn btn-sm btn-outline" (click)="edit(t)">Edit</button>
+              <button class="btn btn-sm btn-outline" (click)="toggleStatus(t)">
+                {{ (t.status || 'active')==='active' ? 'Suspend' : 'Activate' }}
+              </button>
+              <button class="btn btn-sm btn-danger" *ngIf="t.id !== 'default'"
+                      (click)="remove(t.id)">Delete</button>
+              <span *ngIf="t.id === 'default'" class="hint">built-in</span>
+            </clr-dg-cell>
+          </clr-dg-row>
+
+          <clr-dg-footer>{{ tenants.length }} tenant{{ tenants.length===1?'':'s' }}</clr-dg-footer>
+        </clr-datagrid>
+      </ng-container>
+
+      <ng-template #noAccess>
+        <p class="hint">You need Admin access to manage tenants.</p>
+      </ng-template>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; }
+    h3 { color: #333; margin: 0 0 20px 0; font-size: 16px; font-weight: 600; }
+    .hint { color: #888; font-size: 12px; margin-top: 8px; }
+    .btn-cell { display: flex; align-items: flex-end; gap: 8px; }
+    .btn-cell .btn-primary { white-space: nowrap; }
+    .btn-sm { margin-right: 6px; }
+  `]
+})
+export class TenantsComponent implements OnInit {
+  tenants: TenantRow[] = [];
+  newId = '';
+  newName = '';
+  newMax: number | null = null;
+  newDmUri = '';
+  editing = false;
+  loading = false;
+  saving = false;
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpsvcService, private session: SessionService,
+              private toast: ToastService) {}
+
+  ngOnInit(): void { if (this.isAdmin) this.reload(); }
+
+  reload(): void {
+    this.loading = true;
+    this.http.dbGet(['cloud.tenants']).subscribe({
+      next: (r) => {
+        this.loading = false;
+        if (r.ok && r.data) {
+          try {
+            const arr = JSON.parse(String(r.data['cloud.tenants'] ?? '[]'));
+            this.tenants = Array.isArray(arr) ? arr : [];
+          } catch { this.tenants = []; }
+        }
+      },
+      error: () => { this.loading = false; }
+    });
+  }
+
+  edit(t: TenantRow): void {
+    this.editing = true;
+    this.newId = t.id;
+    this.newName = t.name || '';
+    this.newMax = t['max.devices'] ?? null;
+    this.newDmUri = t['dm.uri'] || '';
+  }
+
+  cancelEdit(): void {
+    this.editing = false;
+    this.newId = ''; this.newName = ''; this.newMax = null; this.newDmUri = '';
+  }
+
+  save(): void {
+    const id = this.newId.trim().toLowerCase();
+    if (!/^[a-z0-9-]{3,32}$/.test(id)) {
+      this.toast.error('Tenant ID must be 3–32 chars of [a-z0-9-]'); return;
+    }
+    // Merge into the array: update an existing row in place (preserving its
+    // auto-assigned vpn.subnet / port range), else append a fresh one.
+    const next = this.tenants.map((t) => ({ ...t }));
+    const idx = next.findIndex((t) => t.id === id);
+    if (!this.editing && idx >= 0) {
+      this.toast.error('Tenant ' + id + ' already exists'); return;
+    }
+    const row: TenantRow = idx >= 0 ? next[idx] : { id, status: 'active' };
+    row.name = this.newName.trim();
+    if (this.newMax && this.newMax > 0) row['max.devices'] = Number(this.newMax);
+    else delete row['max.devices'];
+    if (this.newDmUri.trim()) row['dm.uri'] = this.newDmUri.trim();
+    else delete row['dm.uri'];
+    if (idx < 0) next.push(row);
+    this.commit(next, (this.editing ? 'Updated ' : 'Added ') + id);
+  }
+
+  toggleStatus(t: TenantRow): void {
+    const next = this.tenants.map((x) =>
+      x.id === t.id ? { ...x, status: (x.status || 'active') === 'active' ? 'suspended' : 'active' } : x);
+    this.commit(next, t.id + ' ' + ((t.status || 'active') === 'active' ? 'suspended' : 'activated'));
+  }
+
+  remove(id: string): void {
+    if (id === 'default') return;
+    const next = this.tenants.filter((t) => t.id !== id);
+    this.commit(next, 'Deleted ' + id);
+  }
+
+  /// Write the whole array back; iot-cloudd's cloud.tenants watch reconciles
+  /// (subnet carve, nft isolation rebuild). Reload to pick up the assigned subnet.
+  private commit(next: TenantRow[], msg: string): void {
+    this.saving = true;
+    this.http.dbSet([{ key: 'cloud.tenants', value: JSON.stringify(next) }]).subscribe({
+      next: (r) => {
+        this.saving = false;
+        if (r.ok) { this.toast.success(msg); this.cancelEdit(); this.reload(); }
+        else this.toast.error(r.err || 'Save failed');
+      },
+      error: (e) => { this.saving = false; this.toast.error(e?.error?.err || 'Save failed'); }
+    });
+  }
+}

--- a/apps/cloud/ui/src/assets/icons/tenants.svg
+++ b/apps/cloud/ui/src/assets/icons/tenants.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M3 21h18"/>
+  <path d="M5 21V7l8-4v18"/>
+  <path d="M19 21V11l-6-4"/>
+  <path d="M9 9h0M9 13h0M9 17h0"/>
+</svg>

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -25,7 +25,7 @@ instance).
 | P5a | Per-tenant device **quota** (`max.devices`), enforced at provision | #495 | ✅ merged |
 | P3c-bb | P3c building blocks: per-tenant IP alloc + OpenVPN CCD (inert) | #496 | ✅ merged |
 | **PB** | **Adopt Option B (device-agnostic tenancy): bare identities, tenant from cred-row tag, `cloud.provision.tenant` carrier; revert qualified `ep`/identity** | _this_ | 🔵 gtest |
-| P4c | Operator console UI (tenant CRUD + `provision.tenant` selector) | — | ⏭️ needs node |
+| P4c | Operator console UI: **Tenants CRUD page** + Endpoints **tenant selector** (`provision.tenant`) | _this_ | 🟡 needs node build/validation |
 | P5b | Per-tenant CA / cert namespace | — | ⏭️ needs tun validation |
 | P5c | Audit log of platform-operator + provisioning actions | — | ⏭️ |
 


### PR DESCRIPTION
## What

The operator-facing console for multi-tenancy (Option B), driven through the
generic `/api/v1/db` surface — the same pattern as every other cloud-ui config
page (no new REST needed; iot-cloudd's `cloud.tenants` watch does the rest).

### Tenants page (new — sidebar **Tenants**, Admin-gated)
- `clr-datagrid` over `cloud.tenants`: **id / name / VPN subnet / max devices / status**.
- **Add / update** (id `3–32 [a-z0-9-]`, display name, optional `max.devices`
  quota + `dm.uri`), **suspend/activate** toggle, **delete** (the built-in
  `default` tenant is protected).
- Writes the whole `cloud.tenants` array back; **iot-cloudd's P4a watch
  auto-carves a non-overlapping `/24`** + rebuilds nft isolation, so the form
  never asks for a subnet (shown read-only once assigned).

### Endpoints page — tenant selector
- When ≥1 non-default tenant exists, the provision form shows a **Tenant**
  dropdown (default + active tenants). `provision()` sets the
  **`cloud.provision.tenant` carrier before `cloud.provision.request`** so the
  watcher tags the cred/registry rows. Option B: the device stays
  tenant-agnostic — bare serial on the wire.
- **Edit/re-provision preserves the device's existing tenant** (selector hidden
  in edit mode) so an in-place PSK update never silently re-tenants it.

Wiring: `app.module` declaration, main sidebar menu + page switch, `tenants.svg`.

## Testing
`ng build --configuration production` (node:18-alpine) **succeeds** — no errors;
only pre-existing warnings in unrelated components (`software-update`,
`wifi-scan`, leaflet/clr CommonJS, bundle budget). Live click-through on a real
cloud deployment is the remaining manual validation.

## Remaining multi-tenant work
P5b (per-tenant CA — needs tun), P5c (audit log), and the P3c integration
(per-tenant VPN IP wiring — needs tun).

🤖 Generated with [Claude Code](https://claude.com/claude-code)