### PR TITLE
feat(cloud): P5c — operator audit log

### DIFF
--- a/apps/cloud/ui/src/app/app.module.ts
+++ b/apps/cloud/ui/src/app/app.module.ts
@@ -35,6 +35,7 @@ import { ServicesListComponent } from './services/services-list/services-list.co
 import { HttpConfigComponent } from './http-config/http-config.component';
 import { UsersComponent } from './users/users.component';
 import { TenantsComponent } from './tenants/tenants.component';
+import { AuditComponent } from './audit/audit.component';
 import { SoftwareUpdateComponent } from './software-update/software-update.component';
 
 import { SsoAuthInterceptor } from '../common/sso-auth.interceptor';
@@ -51,7 +52,7 @@ import { DsDebugDirective } from '../common/ds-debug.directive';
     RoutingSubmenuComponent, CustomRulesComponent, DeviceForwardingComponent,
     Lwm2mSubmenuComponent, Lwm2mConfigComponent, BsConfigComponent,
     ServicesSubmenuComponent, ServicesListComponent, HttpConfigComponent,
-    UsersComponent, TenantsComponent, SoftwareUpdateComponent,
+    UsersComponent, TenantsComponent, AuditComponent, SoftwareUpdateComponent,
     DsHintComponent, DsDebugDirective,
   ],
   imports: [

--- a/apps/cloud/ui/src/app/audit/audit.component.ts
+++ b/apps/cloud/ui/src/app/audit/audit.component.ts
@@ -1,0 +1,96 @@
+import { Component, OnInit } from '@angular/core';
+import { HttpsvcService } from '../../common/httpsvc.service';
+import { SessionService } from '../../common/session.service';
+
+/// One cloud.audit.log record (newest-first array written by iot-httpd, P5c).
+interface AuditRow {
+  ts: number;        // unix epoch seconds
+  actor: string;     // session username, or "system"
+  tenant: string;    // actor's tenant ("*" = platform operator)
+  action: string;    // e.g. "device.provision", "tenant.update"
+  target?: string;   // serial / tenant id acted on
+  detail?: string;
+}
+
+/// Operator audit log (P5c). Read-only view of cloud.audit.log — who did what,
+/// when. iot-httpd is the sole writer (appends in the db/set handler for tenant
+/// + device lifecycle actions); this page just renders the capped array.
+@Component({
+  selector: 'app-audit',
+  template: `
+    <div class="page">
+      <h3>Audit Log
+        <button class="btn btn-sm btn-link" (click)="reload()" [disabled]="loading">Refresh</button>
+      </h3>
+
+      <ng-container *ngIf="isAdmin; else noAccess">
+        <p class="hint">
+          Tenant &amp; device lifecycle actions (provision, deprovision, tenant
+          changes), newest first. Recorded by the cloud at the point of action.
+        </p>
+        <clr-datagrid [clrDgLoading]="loading" style="margin-top:12px;">
+          <clr-dg-column>Time</clr-dg-column>
+          <clr-dg-column>Actor</clr-dg-column>
+          <clr-dg-column>Tenant</clr-dg-column>
+          <clr-dg-column>Action</clr-dg-column>
+          <clr-dg-column>Target</clr-dg-column>
+
+          <clr-dg-row *clrDgItems="let e of rows">
+            <clr-dg-cell>{{ fmt(e.ts) }}</clr-dg-cell>
+            <clr-dg-cell>{{ e.actor || '—' }}</clr-dg-cell>
+            <clr-dg-cell><code>{{ e.tenant || 'default' }}</code></clr-dg-cell>
+            <clr-dg-cell><span class="action">{{ e.action }}</span></clr-dg-cell>
+            <clr-dg-cell>
+              <code *ngIf="e.target">{{ e.target }}</code>
+              <span *ngIf="!e.target" class="hint">—</span>
+              <span *ngIf="e.detail" class="hint"> ({{ e.detail }})</span>
+            </clr-dg-cell>
+          </clr-dg-row>
+
+          <clr-dg-footer>{{ rows.length }} event{{ rows.length===1?'':'s' }}</clr-dg-footer>
+        </clr-datagrid>
+      </ng-container>
+
+      <ng-template #noAccess>
+        <p class="hint">You need Admin access to view the audit log.</p>
+      </ng-template>
+    </div>
+  `,
+  styles: [`
+    .page { padding: 24px; }
+    h3 { color: #333; margin: 0 0 12px 0; font-size: 16px; font-weight: 600; }
+    .hint { color: #888; font-size: 12px; }
+    .action { font-family: monospace; font-size: 12px; color: #0072a3; }
+  `]
+})
+export class AuditComponent implements OnInit {
+  rows: AuditRow[] = [];
+  loading = false;
+
+  get isAdmin(): boolean { return this.session.isAdmin; }
+
+  constructor(private http: HttpsvcService, private session: SessionService) {}
+
+  ngOnInit(): void { if (this.isAdmin) this.reload(); }
+
+  fmt(ts: number): string {
+    if (!ts) return '—';
+    try { return new Date(ts * 1000).toLocaleString(); } catch { return String(ts); }
+  }
+
+  reload(): void {
+    this.loading = true;
+    this.http.dbGet(['cloud.audit.log']).subscribe({
+      next: (r) => {
+        this.loading = false;
+        if (r.ok && r.data) {
+          try {
+            const arr = JSON.parse(String(r.data['cloud.audit.log'] ?? '[]'));
+            this.rows = Array.isArray(arr) ? arr : [];
+          } catch { this.rows = []; }
+        }
+      },
+      error: () => { this.loading = false; }
+    });
+  }
+}

--- a/apps/cloud/ui/src/app/main/main.component.html
+++ b/apps/cloud/ui/src/app/main/main.component.html
@@ -83,6 +83,9 @@
       <!-- Tenants (multi-tenant operator console) -->
       <app-tenants *ngIf="selectedMenu==='tenants'"></app-tenants>
 
+      <!-- Audit log (operator/provisioning actions) -->
+      <app-audit *ngIf="selectedMenu==='audit'"></app-audit>
+
       <!-- Software Update -->
       <app-software-update *ngIf="selectedMenu==='software'"></app-software-update>
     </div>

--- a/apps/cloud/ui/src/app/main/main.component.ts
+++ b/apps/cloud/ui/src/app/main/main.component.ts
@@ -29,6 +29,7 @@ export class MainComponent implements OnInit {
     { id: 'logs',      label: 'Logs',      svg: 'assets/icons/logs.svg' },
     { id: 'users',     label: 'Users',     svg: 'assets/icons/users.svg' },
     { id: 'tenants',   label: 'Tenants',   svg: 'assets/icons/tenants.svg' },
+    { id: 'audit',     label: 'Audit',     svg: 'assets/icons/audit.svg' },
     { id: 'software',  label: 'Software',  svg: 'assets/icons/software.svg' },
   ];
   menus = [...this.DEFAULT_MENUS];

--- a/apps/cloud/ui/src/assets/icons/audit.svg
+++ b/apps/cloud/ui/src/assets/icons/audit.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+  <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"/>
+  <path d="M14 2v6h6"/>
+  <path d="M9 13l2 2 4-4"/>
+</svg>

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -27,7 +27,7 @@ instance).
 | **PB** | **Adopt Option B (device-agnostic tenancy): bare identities, tenant from cred-row tag, `cloud.provision.tenant` carrier; revert qualified `ep`/identity** | _this_ | 🔵 gtest |
 | P4c | Operator console UI: **Tenants CRUD page** + Endpoints **tenant selector** (`provision.tenant`) | _this_ | 🟡 needs node build/validation |
 | P5b | Per-tenant CA / cert namespace | — | ⏭️ needs tun validation |
-| P5c | Audit log of platform-operator + provisioning actions | — | ⏭️ |
+| P5c | **Audit log** of operator + provisioning actions (`cloud.audit.log`, iot-httpd db/set hook + read-only UI) | _this_ | 🟢 gtest + ng-build |
 
 **P3b/P3c split:** P3b applies the inter-tenant **nft drop** table
 (`build_tenant_isolation_rules` over the tenant subnets) via the same

--- a/modules/http-server/CMakeLists.txt
+++ b/modules/http-server/CMakeLists.txt
@@ -43,6 +43,7 @@ add_library(http_server_lib STATIC
     src/handler.cpp
     src/handler_cloud.cpp
     src/tenant_scope.cpp
+    src/audit.cpp
     src/handler_proxy.cpp
     src/handler_shell.cpp
     src/shell.cpp
@@ -169,6 +170,13 @@ if(BUILD_HTTP_SERVER_TESTS)
             GTest::gtest_main GTest::gtest)
         add_test(NAME http-cloud-api-tests COMMAND http-cloud-api-tests)
     endif()
+
+    # Audit-log helpers (P5c) — pure JSON math, no ds/HTTP.
+    add_executable(http-audit-tests
+        test/audit_test.cpp
+        src/audit.cpp)
+    target_link_libraries(http-audit-tests GTest::gtest_main GTest::gtest)
+    add_test(NAME http-audit-tests COMMAND http-audit-tests)
 endif()
 
 # ─────────────────────────── Install ───────────────────────────

--- a/modules/http-server/inc/audit.hpp
+++ b/modules/http-server/inc/audit.hpp
@@ -1,0 +1,41 @@
+#ifndef __iot_http_audit_hpp__
+#define __iot_http_audit_hpp__
+
+/// Operator audit log (multi-tenant cloud, tdd-multi-tenant-cloud.md P5c).
+///
+/// A capped, newest-first JSON array (`cloud.audit.log`) recording who did
+/// what: platform-operator + provisioning actions captured at the iot-httpd
+/// db/set layer, where the session (actor + tenant) is known. Pure helpers so
+/// the array math is unit-testable with no ds/HTTP.
+
+#include <cstddef>
+#include <string>
+
+namespace http_server {
+
+/// One audit record. `ts` is a unix epoch (seconds); the caller stamps it
+/// (handlers may use std::time) so this stays pure/testable.
+struct AuditEntry {
+    long        ts = 0;
+    std::string actor;    ///< session username, or "system" when unauthenticated
+    std::string tenant;   ///< actor's tenant ("*" = platform operator)
+    std::string action;   ///< e.g. "device.provision", "tenant.update"
+    std::string target;   ///< the thing acted on (serial, tenant id, …)
+    std::string detail;   ///< optional extra context
+};
+
+/// Map a mutated ds key to an audit action label. Returns "" when the key is
+/// not auditable (the common case — most db/set writes aren't operator actions).
+/// Used by the db/set handler to decide whether to record an entry.
+std::string audit_action_for_key(const std::string& key);
+
+/// Prepend `e` to the `cloud.audit.log` JSON array string (newest-first) and
+/// trim to at most `cap` entries. A non-array / unparseable input is treated as
+/// an empty log (so a first write or a corrupt value self-heals). Returns the
+/// new array as a compact JSON string.
+std::string append_audit(const std::string& array_json, const AuditEntry& e,
+                         std::size_t cap = 500);
+
+}  // namespace http_server
+
+#endif  // __iot_http_audit_hpp__

--- a/modules/http-server/src/audit.cpp
+++ b/modules/http-server/src/audit.cpp
@@ -1,0 +1,45 @@
+#include "audit.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace http_server {
+
+using nlohmann::json;
+
+std::string audit_action_for_key(const std::string& key) {
+    // The auditable operator/provisioning keys (db/set-driven). Anything else
+    // (config tweaks, log levels, …) is intentionally not recorded — this log
+    // is for tenant + device lifecycle, not every form save.
+    if (key == "cloud.provision.request")          return "device.provision";
+    if (key == "cloud.deprovision.request")        return "device.deprovision";
+    if (key == "cloud.transfer.release.request")   return "device.transfer";
+    if (key == "cloud.tenants")                    return "tenant.update";
+    if (key == "cloud.bs.master.key")              return "bs.master.update";
+    return {};
+}
+
+std::string append_audit(const std::string& array_json, const AuditEntry& e,
+                         std::size_t cap) {
+    json arr = json::parse(array_json, /*cb*/nullptr, /*allow_exceptions*/false);
+    if (!arr.is_array()) arr = json::array();
+
+    json rec = {
+        {"ts",     e.ts},
+        {"actor",  e.actor},
+        {"tenant", e.tenant},
+        {"action", e.action},
+        {"target", e.target},
+    };
+    if (!e.detail.empty()) rec["detail"] = e.detail;
+
+    // Newest-first: insert at the front.
+    arr.insert(arr.begin(), std::move(rec));
+
+    // Ring-buffer cap: keep the newest `cap` entries.
+    if (cap > 0 && arr.size() > cap)
+        arr.erase(arr.begin() + static_cast<long>(cap), arr.end());
+
+    return arr.dump();
+}
+
+}  // namespace http_server

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -1,3 +1,4 @@
+#include "audit.hpp"
 #include "auth.hpp"
 #include "handler.hpp"
 #include "tenant_scope.hpp"
@@ -13,6 +14,7 @@
 
 #include <cctype>
 #include <chrono>
+#include <ctime>
 #include <condition_variable>
 #include <fstream>
 #include <iterator>
@@ -160,14 +162,19 @@ void install_handlers(Router& router,
                 r.body = R"({"ok":false,"err":"data store not connected"})";
                 return r;
             }
-            // ── Access control ─────────────────────────────────
+            // ── Access control + actor attribution (P5c audit) ──
             std::string access_level = "Admin";  // default: full access
+            std::string actor = "system", actor_tenant = "default";
             if (auth && auth->enabled()) {
                 std::string token = extract_session_cookie(req.headers,
                                                            auth->cookie_name());
                 if (!token.empty()) {
                     const auto* session = auth->validate(token);
-                    if (session) access_level = session->access;
+                    if (session) {
+                        access_level = session->access;
+                        actor        = session->username;
+                        actor_tenant = session->tenant;
+                    }
                 }
             }
             try {
@@ -207,6 +214,43 @@ void install_handlers(Router& router,
                     r.status = 400;
                     r.body = R"({"ok":false,"err":")" + rs.err + "\"}";
                     return r;
+                }
+                // ── P5c: record operator/provisioning actions in the audit log.
+                // Only a small watchlist of keys is auditable (tenant + device
+                // lifecycle); the actor comes from the session above. Best-effort
+                // — a failed audit write never fails the operator's set.
+                {
+                    std::vector<http_server::AuditEntry> events;
+                    const long now = static_cast<long>(std::time(nullptr));
+                    for (const auto& p : pairs) {
+                        const std::string action =
+                            http_server::audit_action_for_key(p.first);
+                        if (action.empty()) continue;
+                        std::string target;
+                        if (auto s = data_store::to_string(p.second)) target = *s;
+                        // Skip iot-cloudd's clear-to-"" of the request carriers
+                        // (a system step, not an operator action).
+                        if (target.empty() && action.rfind("device.", 0) == 0)
+                            continue;
+                        http_server::AuditEntry e;
+                        e.ts = now; e.actor = actor; e.tenant = actor_tenant;
+                        e.action = action;
+                        // tenant.update / bs.master.update carry no per-row
+                        // target; the others log their serial.
+                        e.target = (action == "tenant.update" ||
+                                    action == "bs.master.update") ? "" : target;
+                        events.push_back(std::move(e));
+                    }
+                    if (!events.empty()) {
+                        std::vector<data_store::Client::GetResult> got;
+                        std::string log = "[]";
+                        if (ds->get({"cloud.audit.log"}, got).ok &&
+                            !got.empty() && got[0].has_value) {
+                            if (auto s = data_store::to_string(got[0].value)) log = *s;
+                        }
+                        for (const auto& e : events) log = http_server::append_audit(log, e);
+                        ds->set({{ "cloud.audit.log", data_store::Value{log} }});
+                    }
                 }
                 json resp;
                 resp["ok"] = true;

--- a/modules/http-server/test/audit_test.cpp
+++ b/modules/http-server/test/audit_test.cpp
@@ -1,0 +1,71 @@
+/// Unit tests for the operator audit-log helpers (audit.{hpp,cpp}). Pure JSON.
+
+#include <gtest/gtest.h>
+#include <nlohmann/json.hpp>
+
+#include "audit.hpp"
+
+using http_server::AuditEntry;
+using http_server::append_audit;
+using http_server::audit_action_for_key;
+using nlohmann::json;
+
+static AuditEntry mk(long ts, const std::string& actor, const std::string& action,
+                     const std::string& target) {
+    AuditEntry e; e.ts = ts; e.actor = actor; e.tenant = "acme";
+    e.action = action; e.target = target; return e;
+}
+
+TEST(AuditActionForKey, MapsOnlyAuditableKeys) {
+    EXPECT_EQ(audit_action_for_key("cloud.provision.request"),   "device.provision");
+    EXPECT_EQ(audit_action_for_key("cloud.deprovision.request"), "device.deprovision");
+    EXPECT_EQ(audit_action_for_key("cloud.tenants"),             "tenant.update");
+    EXPECT_EQ(audit_action_for_key("cloud.transfer.release.request"), "device.transfer");
+    EXPECT_EQ(audit_action_for_key("cloud.bs.master.key"),       "bs.master.update");
+    // Non-auditable keys → "".
+    EXPECT_EQ(audit_action_for_key("log.level"), "");
+    EXPECT_EQ(audit_action_for_key("cloud.vpn.subnet"), "");
+}
+
+TEST(AppendAudit, NewestFirstWithFields) {
+    std::string log = "[]";
+    log = append_audit(log, mk(100, "alice", "device.provision", "ser1"));
+    log = append_audit(log, mk(200, "bob",   "tenant.update",     "acme"));
+    auto j = json::parse(log);
+    ASSERT_EQ(j.size(), 2u);
+    // Newest (ts=200) is at the front.
+    EXPECT_EQ(j[0]["ts"], 200);
+    EXPECT_EQ(j[0]["actor"], "bob");
+    EXPECT_EQ(j[0]["action"], "tenant.update");
+    EXPECT_EQ(j[1]["ts"], 100);
+    EXPECT_EQ(j[1]["target"], "ser1");
+    EXPECT_EQ(j[1]["tenant"], "acme");
+}
+
+TEST(AppendAudit, OmitsEmptyDetailKeepsNonEmpty) {
+    auto plain = json::parse(append_audit("[]", mk(1, "a", "x", "t")));
+    EXPECT_FALSE(plain[0].contains("detail"));
+    AuditEntry e = mk(2, "a", "x", "t"); e.detail = "quota=5";
+    auto withd = json::parse(append_audit("[]", e));
+    EXPECT_EQ(withd[0]["detail"], "quota=5");
+}
+
+TEST(AppendAudit, RingBufferCaps) {
+    std::string log = "[]";
+    for (long i = 0; i < 10; ++i)
+        log = append_audit(log, mk(i, "a", "device.provision", "s"), /*cap*/3);
+    auto j = json::parse(log);
+    ASSERT_EQ(j.size(), 3u);
+    // Only the 3 newest survive (ts 9,8,7), newest-first.
+    EXPECT_EQ(j[0]["ts"], 9);
+    EXPECT_EQ(j[1]["ts"], 8);
+    EXPECT_EQ(j[2]["ts"], 7);
+}
+
+TEST(AppendAudit, CorruptOrNonArrayInputSelfHeals) {
+    // A non-array / unparseable existing value is treated as an empty log.
+    auto a = json::parse(append_audit("not json", mk(1, "a", "x", "t")));
+    EXPECT_EQ(a.size(), 1u);
+    auto b = json::parse(append_audit("{\"oops\":1}", mk(1, "a", "x", "t")));
+    EXPECT_EQ(b.size(), 1u);
+}

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -188,6 +188,15 @@ return {
       type    = "string",
       default = "",
     },
+    -- Operator audit log (multi-tenant P5c). A capped, newest-first JSON array
+    -- of {ts,actor,tenant,action,target} records. iot-httpd appends an entry in
+    -- the db/set handler for tenant + device lifecycle actions (sole writer);
+    -- the cloud-ui Audit page reads it. Admin-only.
+    ["cloud.audit.log"] = {
+        access  = "Admin",
+      type    = "string",
+      default = "[]",
+    },
 
     -- ── OTA software update (LwM2M Firmware Update Object 5) ──────────
     -- Operator-curated catalogue of artifacts in the cloud firmware feed


### PR DESCRIPTION
## What

Records **who did what, when** — tenant + device lifecycle actions — completing
the multi-tenant operator console. Captured at the iot-httpd `db/set` layer
(where the session = actor + tenant is known), plus a read-only cloud-ui Audit
page.

### Pieces
- **`modules/http-server/audit.{hpp,cpp}`** — pure helpers:
  - `audit_action_for_key()` — the watchlist: `cloud.provision.request` →
    `device.provision`, `cloud.deprovision.request`, `cloud.transfer.release.request`,
    `cloud.tenants` → `tenant.update`, `cloud.bs.master.key`. Everything else is
    not audited.
  - `append_audit()` — newest-first, **capped ring buffer** (default 500),
    self-heals a corrupt/non-array value. gtest: `http-audit-tests`.
- **`handler.cpp` db/set** — after a successful set, stamp an `AuditEntry`
  `{ts, actor, tenant, action, target}` for each watched key → append to
  `cloud.audit.log`. iot-httpd is the **sole writer**; actor/tenant from the
  validated session (`system`/`default` when unauthenticated). Skips iot-cloudd's
  clear-to-`""` of the request carriers (a system step). Best-effort — a failed
  audit write never fails the operator's set.
- **`cloud.lua`** — `cloud.audit.log` (Admin, default `"[]"`).
- **cloud-ui** — read-only Audit page (`clr-datagrid`: time / actor / tenant /
  action / target, newest-first, Refresh) + sidebar entry + `audit.svg`.

## Testing
- Standalone harness over the **real** `audit.cpp` — action mapping, newest-first
  ordering, ring-buffer cap, corrupt-input self-heal — **all pass**.
- `handler.cpp` **`-fsyntax-only` clean** against ACE/datastore includes.
- `ng build --configuration production` (node:18) **succeeds, no errors**.

## Notes / scope
- Single-writer (iot-httpd) keeps it race-free for human-paced operator actions;
  two near-simultaneous audited sets could in theory clobber (acceptable + noted).
- Captures operator **intent** at the REST layer. Auditing the async **outcome**
  (iot-cloudd provision result) is a possible follow-up.

This is the last non-infra multi-tenant slice. Remaining: P3c integration +
P5b (per-tenant CA) — both need a real tun/OpenVPN host.

🤖 Generated with [Claude Code](https://claude.com/claude-code)