### PR TITLE
feat(cloud): P3c-i — integration foundation for per-tenant VPN IPs

### DIFF
--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -19,7 +19,8 @@ instance).
 | P3a | Per-tenant VPN **subnet math + nft isolation rules** (pure, gtest) | _this_ | 🔵 |
 | P1e | `db/get cloud.endpoints` tenant scoping (**live UI isolation**) | _this_ | 🔵 |
 | P3b | Apply inter-tenant nft isolation table (compile-verified) | _this_ | 🔵 needs tun validation |
-| P3c | OpenVPN `/16` + per-client CCD static IP from tenant `/24` | — | ⏭️ needs tun validation |
+| P3c-i | **Integration foundation** (gtest): `VpnRegistry::allocate_in_subnet` (tenant-/24 IP + base-pool guard) + `plan_ccd_files` (per-device CCD plan) | _this_ | 🟢 gtest |
+| P3c-ii | iot-cloudd glue: server `/16` + `ccd_dir`, allocate tenant IPs in provision/heal, write CCD files | — | ⏭️ needs tun validation |
 | P4a | Tenant registry: auto VPN-subnet assignment (`cloud.tenants` watch) | _this_ | 🔵 |
 | P4b | Tenant-aware provision *watcher* + cred minting | #494 | ✅ merged |
 | P5a | Per-tenant device **quota** (`max.devices`), enforced at provision | #495 | ✅ merged |

--- a/modules/http-server/CMakeLists.txt
+++ b/modules/http-server/CMakeLists.txt
@@ -164,7 +164,8 @@ if(BUILD_HTTP_SERVER_TESTS)
             test/cloud_api_test.cpp
             ${HTTP_MODULE_DIR}/../server/lwm2m/src/endpoint_registry.cpp
             ${HTTP_MODULE_DIR}/../server/lwm2m/src/bootstrap.cpp
-            ${HTTP_MODULE_DIR}/../server/openvpn/src/vpn_registry.cpp)
+            ${HTTP_MODULE_DIR}/../server/openvpn/src/vpn_registry.cpp
+            ${HTTP_MODULE_DIR}/../server/openvpn/src/tenant_subnet.cpp)
         target_link_libraries(http-cloud-api-tests
             http_server_lib
             GTest::gtest_main GTest::gtest)

--- a/modules/server/lwm2m/CMakeLists.txt
+++ b/modules/server/lwm2m/CMakeLists.txt
@@ -51,7 +51,8 @@ if(BUILD_SERVER_LWM2M_TESTS)
         test/bootstrap_test.cpp
         src/bootstrap.cpp
         src/endpoint_registry.cpp
-        ../openvpn/src/vpn_registry.cpp)
+        ../openvpn/src/vpn_registry.cpp
+        ../openvpn/src/tenant_subnet.cpp)
     target_include_directories(bootstrap-tests
         PRIVATE ${LWM2M_SERVER_DIR}/inc
         PRIVATE ${LWM2M_SERVER_DIR}/../openvpn/inc)

--- a/modules/server/openvpn/CMakeLists.txt
+++ b/modules/server/openvpn/CMakeLists.txt
@@ -14,6 +14,7 @@ include_directories(${OVPN_SERVER_DIR}/inc ${ACE_ROOT}/include)
 
 add_library(server_openvpn STATIC
     src/vpn_registry.cpp
+    src/tenant_subnet.cpp
     src/openvpn_server.cpp
     src/cert_authority.cpp)
 
@@ -28,7 +29,8 @@ if(BUILD_SERVER_OPENVPN_TESTS)
 
     add_executable(vpn-registry-tests
         test/vpn_registry_test.cpp
-        src/vpn_registry.cpp)
+        src/vpn_registry.cpp
+        src/tenant_subnet.cpp)
     target_include_directories(vpn-registry-tests
         PRIVATE ${OVPN_SERVER_DIR}/inc)
     target_link_libraries(vpn-registry-tests

--- a/modules/server/openvpn/inc/tenant_subnet.hpp
+++ b/modules/server/openvpn/inc/tenant_subnet.hpp
@@ -74,6 +74,22 @@ std::string allocate_ip_in_subnet(const std::string& subnet_cidr,
 std::string build_ccd_entry(const std::string& ip,
                             const std::string& server_cidr);
 
+/// One planned OpenVPN client-config-dir file for a tenant device.
+struct CcdFile {
+    std::string serial;    ///< the endpoint serial (caller maps it → the cert CN
+                           ///< filename, e.g. rpi<serial>@cloud.local)
+    std::string contents;  ///< the file body (a build_ccd_entry line)
+};
+
+/// Plan the CCD files for the current fleet: one entry per `cloud.endpoints` row
+/// that has a non-default tenant tag AND a `tun_ip`, pinning that device to its
+/// tenant IP via build_ccd_entry(tun_ip, server_pool_cidr). Default-tenant rows
+/// get NO file (they draw dynamically from the base pool). Pure — the caller
+/// writes <ccd_dir>/<cn> = contents (and prunes stale files). Returns empty on a
+/// non-array `endpoints_json` or an invalid `server_pool_cidr`.
+std::vector<CcdFile> plan_ccd_files(const std::string& endpoints_json,
+                                    const std::string& server_pool_cidr);
+
 }} // namespace server::openvpn
 
 #endif /* __iot_tenant_subnet_hpp__ */

--- a/modules/server/openvpn/inc/vpn_registry.hpp
+++ b/modules/server/openvpn/inc/vpn_registry.hpp
@@ -40,6 +40,15 @@ public:
     /// the subnet or port range is exhausted.
     std::optional<VpnAllocation> allocate(const std::string& ep);
 
+    /// Multi-tenant (P3c): allocate a tunnel IP from `subnet_cidr` (a tenant's
+    /// /24, which lies OUTSIDE this registry's base pool) plus a proxy port,
+    /// avoiding any IP already handed out. Returns nullopt when the tenant
+    /// subnet or the port range is exhausted. The tenant IP is tracked as
+    /// allocated but is never returned to the base free pool on release (it is
+    /// re-derivable from the tenant subnet on demand).
+    std::optional<VpnAllocation> allocate_in_subnet(const std::string& ep,
+                                                    const std::string& subnet_cidr);
+
     /// Restore a previously-persisted allocation at startup (rehydration).
     /// Marks `ip` / `port` as in-use for `ep` so the pools never hand them
     /// out again — unlike allocate(), the caller supplies the exact values

--- a/modules/server/openvpn/src/tenant_subnet.cpp
+++ b/modules/server/openvpn/src/tenant_subnet.cpp
@@ -9,6 +9,7 @@
 #include <set>
 #include <sstream>
 #include <utility>
+#include <vector>
 
 #include <nlohmann/json.hpp>
 
@@ -191,6 +192,30 @@ std::string build_ccd_entry(const std::string& ip,
     in_addr a{};
     if (::inet_pton(AF_INET, ip.c_str(), &a) != 1) return {};   // bad ip
     return "ifconfig-push " + ip + " " + u32_to_ip(mask_of(sprefix)) + "\n";
+}
+
+std::vector<CcdFile> plan_ccd_files(const std::string& endpoints_json,
+                                    const std::string& server_pool_cidr) {
+    std::vector<CcdFile> out;
+    // Bail early on an invalid pool (build_ccd_entry would reject each row too).
+    if (parse_cidr(server_pool_cidr).second < 0) return out;
+
+    auto arr = nlohmann::json::parse(endpoints_json, /*cb*/nullptr,
+                                     /*allow_exceptions*/false);
+    if (!arr.is_array()) return out;
+
+    for (const auto& e : arr) {
+        if (!e.is_object()) continue;
+        const std::string tenant = e.value("tenant", std::string());
+        if (tenant.empty() || tenant == "default") continue;  // base pool → no pin
+        const std::string serial = e.value("endpoint", std::string());
+        const std::string tun_ip = e.value("tun_ip", std::string());
+        if (serial.empty() || tun_ip.empty()) continue;
+        const std::string body = build_ccd_entry(tun_ip, server_pool_cidr);
+        if (body.empty()) continue;
+        out.push_back(CcdFile{serial, body});
+    }
+    return out;
 }
 
 }} // namespace server::openvpn

--- a/modules/server/openvpn/src/vpn_registry.cpp
+++ b/modules/server/openvpn/src/vpn_registry.cpp
@@ -1,8 +1,11 @@
 #include "vpn_registry.hpp"
 
+#include "tenant_subnet.hpp"   // allocate_ip_in_subnet (multi-tenant P3c)
+
 #include <algorithm>
 #include <arpa/inet.h>
 #include <cstring>
+#include <vector>
 
 namespace server {
 namespace openvpn {
@@ -86,6 +89,35 @@ std::optional<VpnAllocation> VpnRegistry::allocate(const std::string& ep) {
     return a;
 }
 
+std::optional<VpnAllocation>
+VpnRegistry::allocate_in_subnet(const std::string& ep,
+                                const std::string& subnet_cidr) {
+    std::lock_guard<std::mutex> lk(m_mutex);
+
+    if (m_free_ports.empty()) return std::nullopt;
+
+    // Pick a host IP from the tenant subnet, avoiding every IP this registry has
+    // already handed out (base pool + all tenants) so two tenants whose /24s
+    // were mis-configured to overlap still never collide.
+    std::vector<std::string> used(m_allocated_ips.begin(), m_allocated_ips.end());
+    const std::string ip = allocate_ip_in_subnet(subnet_cidr, used);
+    if (ip.empty()) return std::nullopt;
+
+    auto port_it = m_free_ports.begin();
+
+    VpnAllocation a;
+    a.ep         = ep;
+    a.tun_ip     = ip;            // from the tenant /24, NOT the base free pool
+    a.proxy_port = *port_it;
+
+    m_free_ports.erase(port_it);
+    m_allocated_ips.insert(ip);   // tracked as in-use; not drawn from m_free_ips
+    m_allocated_ports.insert(a.proxy_port);
+    m_ep_to_alloc[ep] = a;
+
+    return a;
+}
+
 void VpnRegistry::reserve(const std::string& ep, const std::string& ip,
                           std::uint16_t port) {
     std::lock_guard<std::mutex> lk(m_mutex);
@@ -141,9 +173,22 @@ void VpnRegistry::release(const std::string& ep) {
 }
 
 void VpnRegistry::release_ip_locked(const std::string& ip) {
-    if (m_allocated_ips.erase(ip)) {
-        m_free_ips.insert(ip);
+    if (!m_allocated_ips.erase(ip)) return;
+    // Only return it to the base free pool if it belongs to THIS registry's own
+    // subnet. A tenant IP (handed out by allocate_in_subnet from a tenant /24
+    // outside the base pool) must NOT pollute the base allocator — dropping it
+    // from m_allocated_ips is enough (it's re-derivable from the tenant subnet).
+    const auto cidr = parse_cidr(m_subnet_cidr);
+    const int prefix = cidr.second;
+    if (prefix > 0 && prefix < 32) {
+        const std::uint32_t mask  = ~0u << (32 - prefix);
+        const std::uint32_t net   = cidr.first & mask;
+        const std::uint32_t bcast = net | ~mask;
+        const std::uint32_t v     = ip_to_u32(ip);
+        if (v > net && v < bcast) m_free_ips.insert(ip);   // base host range
+        return;
     }
+    m_free_ips.insert(ip);   // unusual prefix → preserve legacy behaviour
 }
 
 void VpnRegistry::release_port_locked(std::uint16_t port) {

--- a/modules/server/openvpn/test/tenant_subnet_test.cpp
+++ b/modules/server/openvpn/test/tenant_subnet_test.cpp
@@ -186,3 +186,31 @@ TEST(BuildCcdEntry, BadInput) {
     EXPECT_EQ(build_ccd_entry("not-an-ip", "10.9.0.0/16"), "");
     EXPECT_EQ(build_ccd_entry("10.9.16.2", "garbage"), "");
 }
+
+// ── plan_ccd_files ──────────────────────────────────────────────────────────
+
+TEST(PlanCcdFiles, OnlyTenantRowsWithTunIp) {
+    // default/untagged rows and rows without a tun_ip get NO CCD file; only
+    // tenant-tagged rows with a tun_ip are pinned, using the server pool mask.
+    const std::string eps = R"([
+        {"endpoint":"ser-acme","tenant":"acme","tun_ip":"10.9.16.2"},
+        {"endpoint":"ser-def","tun_ip":"10.9.0.5"},
+        {"endpoint":"ser-glx","tenant":"globex","tun_ip":"10.9.17.2"},
+        {"endpoint":"ser-noip","tenant":"acme"},
+        {"endpoint":"ser-defx","tenant":"default","tun_ip":"10.9.0.9"}
+    ])";
+    auto plan = plan_ccd_files(eps, "10.9.0.0/16");
+    ASSERT_EQ(plan.size(), 2u);                       // acme + globex only
+    EXPECT_EQ(plan[0].serial, "ser-acme");
+    EXPECT_EQ(plan[0].contents, "ifconfig-push 10.9.16.2 255.255.0.0\n");
+    EXPECT_EQ(plan[1].serial, "ser-glx");
+    EXPECT_EQ(plan[1].contents, "ifconfig-push 10.9.17.2 255.255.0.0\n");
+}
+
+TEST(PlanCcdFiles, BadInputs) {
+    EXPECT_TRUE(plan_ccd_files("not json", "10.9.0.0/16").empty());
+    EXPECT_TRUE(plan_ccd_files("{}", "10.9.0.0/16").empty());          // not array
+    EXPECT_TRUE(plan_ccd_files(
+        R"([{"endpoint":"a","tenant":"acme","tun_ip":"10.9.16.2"}])",
+        "garbage").empty());                                          // bad pool
+}

--- a/modules/server/openvpn/test/vpn_registry_test.cpp
+++ b/modules/server/openvpn/test/vpn_registry_test.cpp
@@ -132,4 +132,54 @@ TEST(VpnRegistryTest, ContainsIp) {
     EXPECT_FALSE(reg.contains_ip("10.9.0.255"));   // broadcast
 }
 
+// ── 13. Multi-tenant: allocate_in_subnet (P3c) ──────────────────────
+
+TEST(VpnRegistryTest, AllocateInTenantSubnet) {
+    // Base pool is the legacy /24; a tenant device draws from its own /24
+    // (10.9.16.0/24, OUTSIDE the base pool) but shares the proxy-port range.
+    VpnRegistry reg("10.9.0.0/24", 5001, 5003);
+    auto a = reg.allocate_in_subnet("dev-a", "10.9.16.0/24");
+    ASSERT_TRUE(a.has_value());
+    EXPECT_EQ(a->tun_ip, "10.9.16.2");        // .0 net, .1 gw → first host .2
+    EXPECT_EQ(a->proxy_port, 5001U);          // port from the shared range
+    // A second tenant device gets the next free IP in its /24 + next port.
+    auto b = reg.allocate_in_subnet("dev-b", "10.9.16.0/24");
+    ASSERT_TRUE(b.has_value());
+    EXPECT_EQ(b->tun_ip, "10.9.16.3");
+    EXPECT_EQ(b->proxy_port, 5002U);
+}
+
+TEST(VpnRegistryTest, AllocateInSubnetReDerivesAfterRelease) {
+    // release() frees the tenant IP; the next allocate_in_subnet re-derives the
+    // same first host (it's tracked while in use, re-derivable once freed).
+    VpnRegistry reg("10.9.0.0/24");
+    auto a = reg.allocate_in_subnet("dev", "10.9.16.0/24");
+    ASSERT_TRUE(a.has_value());
+    EXPECT_EQ(a->tun_ip, "10.9.16.2");
+    reg.release("dev");
+    auto b = reg.allocate_in_subnet("dev2", "10.9.16.0/24");
+    ASSERT_TRUE(b.has_value());
+    EXPECT_EQ(b->tun_ip, "10.9.16.2");        // freed → re-derived
+}
+
+TEST(VpnRegistryTest, TenantIpNotReturnedToBasePool) {
+    // Releasing a tenant IP must not pollute the base /24 free pool: a later
+    // base allocate() yields a base-subnet IP, never the released tenant IP.
+    VpnRegistry reg("10.9.0.0/24");
+    auto t = reg.allocate_in_subnet("dev", "10.9.16.0/24");
+    ASSERT_TRUE(t.has_value());
+    EXPECT_EQ(t->tun_ip, "10.9.16.2");
+    reg.release("dev");
+    auto base = reg.allocate("base");
+    ASSERT_TRUE(base.has_value());
+    EXPECT_NE(base->tun_ip, "10.9.16.2");                 // not the tenant IP
+    EXPECT_EQ(base->tun_ip.rfind("10.9.0.", 0), 0u);      // a base-subnet IP
+}
+
+TEST(VpnRegistryTest, AllocateInSubnetPortExhaustion) {
+    VpnRegistry reg("10.9.0.0/24", 5001, 5001);   // exactly one port
+    EXPECT_TRUE(reg.allocate_in_subnet("a", "10.9.16.0/24").has_value());
+    EXPECT_FALSE(reg.allocate_in_subnet("b", "10.9.16.0/24").has_value()); // no port
+}
+
 } // namespace


### PR DESCRIPTION
## What

The **tested, inert foundation** the iot-cloudd P3c wiring will build on — the
allocator + CCD planner that make per-tenant VPN IPs possible. No running code
calls these yet, so this is behaviour-preserving (same discipline as #496's
building blocks). The live glue (provision path + OpenVPN server config) is
**P3c-ii**, which needs a real `tun`/OpenVPN host to validate.

## Changes
- **`VpnRegistry::allocate_in_subnet(ep, subnet_cidr)`** — allocate a tunnel IP
  from a tenant's `/24` (outside the base pool) + a proxy port, avoiding every IP
  already handed out. Reuses the tested `allocate_ip_in_subnet`.
- **`release_ip_locked` guard** — a released tenant IP is dropped from
  `m_allocated_ips` but **not** re-pooled into the base `m_free_ips`. Base IPs
  re-pool exactly as before.
- **`plan_ccd_files(endpoints_json, server_pool_cidr)`** — pure planner: one CCD
  entry per `cloud.endpoints` row with a non-default tenant tag + a `tun_ip`.
  Default rows get no file.
- **CMake** — link `tenant_subnet.cpp` wherever `vpn_registry.cpp` is compiled.

## Testing
Standalone harnesses over the real sources — all pass. gtest:
`vpn-registry-tests` (+4), `tenant-subnet-tests` (+2). (Documented a pre-existing
lexicographic base-pool ordering quirk; tests are robust to it.)

## Next — P3c-ii (needs tun)
Wire these into iot-cloudd: serve the `/16` + set `ccd_dir`, allocate tenant IPs
in provision/heal, write the planned CCD files. Validate on real infra before
merge (parked on the worktree).

🤖 Generated with [Claude Code](https://claude.com/claude-code)