### PR TITLE
fix(client): keep DM identity on DM switch (OTA stuck-at-90% / dm-connecting regression)

### DIFF
--- a/apps/inc/dtls_adapter.hpp
+++ b/apps/inc/dtls_adapter.hpp
@@ -174,7 +174,16 @@ class DTLSAdapter {
         /// a known-suspect session (e.g. a bootstrap that never completed over a
         /// stale "connected" peer) gets a fresh ClientHello instead of a doomed
         /// renegotiation. Use when the session must be assumed dead.
-        void reset_and_connect(const std::string& ip, const std::uint16_t& port);
+        ///
+        /// `toBootstrapIdentity` (default true) restores the BS identity before
+        /// the handshake — correct when re-establishing the *bootstrap* session.
+        /// Pass FALSE when switching to the *DM* server after a successful
+        /// bootstrap: the caller has just pinned the DM identity via
+        /// active_identity(), and resetting to the BS identity would make the DM
+        /// handshake present sha256(serial) — which the DM server has no PSK for
+        /// (the device then wedges at dm-connecting, never registering).
+        void reset_and_connect(const std::string& ip, const std::uint16_t& port,
+                               bool toBootstrapIdentity = true);
         /// Nuke and recreate the whole tinydtls context (empty peer table), the
         /// in-process equivalent of restarting iot-lwm2m-client. connect()/
         /// reset_and_connect() reset the peer matched by dtls_get_peer(&m_session),

--- a/apps/src/dtls_adapter.cpp
+++ b/apps/src/dtls_adapter.cpp
@@ -333,12 +333,15 @@ void DTLSAdapter::hard_reset() {
     dtls_debug("DTLSAdapter::hard_reset recreated dtls context (peer table cleared)\n");
 }
 
-void DTLSAdapter::reset_and_connect(const std::string& ip, const std::uint16_t& port) {
-    // reset_and_connect is only ever used to (re)establish the BS bootstrap
-    // session. If a prior successful bootstrap pinned the DM identity, restore
-    // the BS identity so this fresh handshake presents BS creds, not the DM
-    // identity+key the BS server cannot resolve.
-    reset_to_bootstrap_identity();
+void DTLSAdapter::reset_and_connect(const std::string& ip, const std::uint16_t& port,
+                                   bool toBootstrapIdentity) {
+    // For a BS re-handshake, restore the BS identity so this fresh handshake
+    // presents BS creds, not the DM identity+key the BS server cannot resolve.
+    // For the DM switch (toBootstrapIdentity=false) the caller has just pinned
+    // the DM identity via active_identity(); resetting it here would make the DM
+    // handshake present the BS identity (sha256(serial)), which the DM server
+    // has no PSK for — the device would wedge at dm-connecting forever.
+    if (toBootstrapIdentity) reset_to_bootstrap_identity();
     session(ip, port);
     m_peerSession = m_session;
     isClient(true);

--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -1575,7 +1575,15 @@ ClientPlumbing wire_client(std::shared_ptr<App>& app,
             // tears the stale peer down first so a PLAINTEXT ClientHello starts a
             // clean handshake the restarted DM accepts — auto-recovery after any
             // cloud bounce/upgrade.
-            dtls->reset_and_connect(dmHost, dmPort);
+            //
+            // toBootstrapIdentity=FALSE: keep the DM identity pinned just above.
+            // reset_and_connect() defaults to restoring the BS identity (it was
+            // built for the BS re-handshake); using that default here made the DM
+            // handshake present sha256(serial) — the DM server has no PSK for it,
+            // so the device wedged at dm-connecting AND never registered (the OTA
+            // "stuck at 90%" + offline regression from the reset_and_connect-on-
+            // DM-switch fix). Keeping the DM identity is the whole point here.
+            dtls->reset_and_connect(dmHost, dmPort, /*toBootstrapIdentity=*/false);
         }
         // Apply the bootstrap-delivered registration lifetime (Server Object
         // RID 1) — the client uses this, sourced by the BS from


### PR DESCRIPTION
## Critical — fixes the OTA "stuck at 90%" + offline regression

**Root cause.** `d1b1ae6a` (the #481 "reset_and_connect on DM switch" wedge fix)
reused `reset_and_connect()` for the DM switch. That function was built **only**
for the bootstrap re-handshake — it unconditionally calls
`reset_to_bootstrap_identity()`. So `on_done` did:

```
active_identity(rpi<serial>@cloud.local)        // pin the DM identity
reset_and_connect(DM) → reset_to_bootstrap_identity()  // clobbers it to the BS identity
```

→ the DM handshake presents `sha256(serial)[:32]` (the **BS** identity), which the
DM server has **no PSK for** → `PSK for unknown identity requested` → the device
never registers.

**HW-confirmed:** the cloud-logged DM identity `990c19d624178d7e11f134989079044c`
== `sha256("000000006556e041")[:32]` exactly (both fielded devices).

**Impact.** Any device on a build containing `d1b1ae6a` (e.g. `1.3.6+ae3a150`)
bootstraps fine but **wedges at `dm-connecting` and never registers**. It surfaces
as OTA **stuck at 90%** + **offline** (the device can't send its Object 5 success
report). A restart can't fix it; OTA-rollback can't reach an unregistered device →
**reflash required**.

## Fix
`reset_and_connect(ip, port, bool toBootstrapIdentity = true)`:
- The two **BS** re-handshake callers (main.cpp:1863, 2000) keep the default →
  restore the BS identity (unchanged).
- The **DM switch** (main.cpp:1578) passes **`false`** → keeps the DM identity
  pinned by `active_identity()`, while still getting the fresh-handshake wedge
  recovery (peer teardown + plaintext ClientHello).

So DM auth **and** the original cloud-restart wedge fix both hold.

## Testing
`dtls_adapter.cpp` compiles clean (`-fsyntax-only`, rc=0) against the real
generated tinydtls config; the DM-switch caller just passes a bool literal. The
full device image is built by CI on merge.

## Deploy note
This is on the device image — it reaches fielded devices only via reflash/OTA.
The two stuck devices must be **reflashed** with an image containing this fix
(they can't be OTA'd while unregistered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)