### PR TITLE
feat(cloud): P3c-ii — iot-cloudd per-tenant VPN IP wiring (opt-in)

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -47,6 +47,8 @@
 #include <unordered_map>
 
 #include <sys/stat.h>
+#include <dirent.h>
+#include <unistd.h>
 
 #include <nlohmann/json.hpp>
 
@@ -225,6 +227,71 @@ void rebuild_device_dnat(data_store::Client& ds, const std::string& tun_dev) {
                    static_cast<unsigned>(in.devices.size()),
                    static_cast<int>(in.ui_port)));
     }
+}
+
+// Multi-tenant (P3c): reconcile the OpenVPN client-config-dir from the current
+// fleet. One file per tenant device, named by its cert CN (rpi<serial>@cloud.
+// local — what OpenVPN matches CCD entries against), pinning it to its tenant
+// /24 IP via ifconfig-push. NO-OP when ccd_dir is empty (single-tenant) so the
+// default deployment never touches the filesystem. Idempotent (full rewrite +
+// prune of stale files), same discipline as rebuild_device_dnat. The whole dir
+// is ours, so any file not in the current plan (deprovisioned / de-tenanted
+// device) is removed. `server_pool_cidr` (the /16) supplies the ifconfig-push
+// netmask under `topology subnet`.
+void rebuild_tenant_ccd(data_store::Client& ds, const std::string& ccd_dir,
+                        const std::string& server_pool_cidr) {
+    if (ccd_dir.empty()) return;            // multi-tenant VPN not enabled
+    ::mkdir(ccd_dir.c_str(), 0750);         // ensure it exists (ignore EEXIST)
+
+    const auto plan = server::openvpn::plan_ccd_files(
+        ds_str(ds, "cloud.endpoints", "[]"), server_pool_cidr);
+
+    std::set<std::string> wanted;
+    for (const auto& f : plan) {
+        const std::string cn = server::lwm2m::format_identity(f.serial);
+        wanted.insert(cn);
+        std::ofstream out(ccd_dir + "/" + cn, std::ios::trunc);
+        if (out) out << f.contents;
+    }
+    // Prune stale entries.
+    if (DIR* d = ::opendir(ccd_dir.c_str())) {
+        while (dirent* e = ::readdir(d)) {
+            const std::string name = e->d_name;
+            if (name == "." || name == "..") continue;
+            if (!wanted.count(name)) ::unlink((ccd_dir + "/" + name).c_str());
+        }
+        ::closedir(d);
+    }
+    ACE_DEBUG((LM_DEBUG,
+               ACE_TEXT("%D cloudd:thread:%t %M %N:%l tenant CCD reconciled "
+                        "(%u file(s)) in %C\n"),
+               static_cast<unsigned>(plan.size()), ccd_dir.c_str()));
+}
+
+// Multi-tenant (P3c): the VPN /24 assigned to `tenant` (from cloud.tenants), or
+// "" for the default/empty tenant or when multi-tenant VPN is off — the caller
+// then falls back to the base-pool allocation. Empty result == legacy behaviour.
+std::string tenant_subnet_of(data_store::Client& ds, const std::string& tenant) {
+    if (tenant.empty() || tenant == "default") return {};
+    if (ds_str(ds, "cloud.vpn.ccd.dir", "").empty()) return {};   // VPN MT off
+    try {
+        auto arr = nlohmann::json::parse(ds_str(ds, "cloud.tenants", "[]"));
+        if (arr.is_array()) for (const auto& t : arr) {
+            if (t.is_object() && t.value("id", std::string()) == tenant)
+                return t.value("vpn.subnet", std::string());
+        }
+    } catch (const std::exception&) { /* fall through to "" */ }
+    return {};
+}
+
+// Device-routing reconcile: the per-device UI DNAT + the per-tenant OpenVPN CCD,
+// which must track the SAME endpoint changes. Callers use this everywhere the
+// DNAT was rebuilt before. The CCD half is a no-op unless multi-tenant VPN
+// (cloud.vpn.ccd.dir) is enabled, so single-tenant behaviour is unchanged.
+void reconcile_routing(data_store::Client& ds, const std::string& tun_dev) {
+    rebuild_device_dnat(ds, tun_dev);
+    rebuild_tenant_ccd(ds, ds_str(ds, "cloud.vpn.ccd.dir", ""),
+                       ds_str(ds, "cloud.vpn.subnet", "10.9.0.0/24"));
 }
 
 // Merge lwm2m-dm's registration status into the EndpointRegistry. lwm2m-dm
@@ -461,7 +528,9 @@ std::size_t rehydrate_registry(data_store::Client& ds,
                 // /rd as, regardless of tenant. The tenant is only a row tag,
                 // carried into cloud.endpoints for the console.
                 if (reg.lookup_by_ep(serial)) continue;
-                if (prov.provision(serial)) {
+                // P3c: a tenant device draws its tunnel IP from its tenant /24
+                // (when multi-tenant VPN is on); default tenant uses the base pool.
+                if (prov.provision(serial, tenant_subnet_of(ds, tenant))) {
                     reg.update_tenant(serial, tenant);
                     ++healed;
                 }
@@ -664,6 +733,13 @@ int main(int argc, char** argv) {
         // DNS resolver pushed to devices (so the device surfaces vpn.assigned.dns).
         // Empty disables the push; default 1.1.1.1 so the field is populated.
         c.dns       = ds_str(ds, "cloud.vpn.dns", "1.1.1.1");
+        // Multi-tenant (P3c): per-client static IPs via OpenVPN client-config-dir.
+        // EMPTY by default → no client-config-dir line → single-tenant config is
+        // byte-identical. To enable multi-tenant VPN the operator sets
+        // cloud.vpn.ccd.dir (e.g. /etc/iot/vpn/ccd) AND widens cloud.vpn.subnet
+        // to a /16 covering the default /24 + the tenant pool (10.9.0.0/16); then
+        // each tenant device is pinned into its tenant /24 by a CCD file.
+        c.ccd_dir   = ds_str(ds, "cloud.vpn.ccd.dir", "");
         return c;
     };
     server::openvpn::OpenVpnServerConfig ovpn_cfg = load_ovpn_cfg();
@@ -680,6 +756,7 @@ int main(int argc, char** argv) {
         {"cloud.vpn.mgmt.port",   data_store::Value{static_cast<std::int32_t>(ovpn_cfg.mgmt_port)}},
         {"cloud.vpn.verb",        data_store::Value{static_cast<std::int32_t>(ovpn_cfg.verb)}},
         {"cloud.vpn.dns",         data_store::Value{ovpn_cfg.dns}},
+        {"cloud.vpn.ccd.dir",     data_store::Value{ovpn_cfg.ccd_dir}},
     });
     // Live hot-reload of the VPN server config: watch the knobs that feed
     // build_server_config so an operator changing proto/port/cipher/etc. in the
@@ -690,7 +767,7 @@ int main(int argc, char** argv) {
     auto ws_vpncfg = ds.watch(std::vector<std::string>{
         "cloud.vpn.proto", "cloud.vpn.listen.port", "cloud.vpn.cipher",
         "cloud.vpn.dev", "cloud.vpn.subnet", "cloud.vpn.dns",
-        "cloud.vpn.verb", "cloud.vpn.mgmt.port",
+        "cloud.vpn.verb", "cloud.vpn.mgmt.port", "cloud.vpn.ccd.dir",
         "cloud.vpn.ca.crt", "cloud.vpn.server.crt", "cloud.vpn.server.key",
     }, 1000);
     if (!ws_vpncfg.ok) {
@@ -883,7 +960,7 @@ int main(int argc, char** argv) {
     }
     // Reconstruct the full rule set from the persisted cloud.endpoints so a
     // restart restores every device's mapping atomically before any sync.
-    rebuild_device_dnat(ds, tun_dev);
+    reconcile_routing(ds, tun_dev);
 
     ACE_DEBUG((LM_INFO,
                ACE_TEXT("%D cloudd:thread:%t %M %N:%l started, ds=%C vpn-subnet=%C"
@@ -1182,7 +1259,12 @@ int main(int argc, char** argv) {
 
                     // Provision keyed by the (possibly tenant-qualified)
                     // bare serial — globally unique, == the device's /rd ep.
-                    auto result = provisioner.provision(p_serial);
+                    // P3c: a tenant device draws its tunnel IP from its tenant /24
+                    // (when multi-tenant VPN is on); default tenant uses the base
+                    // pool. The CCD reconcile below pins it; the loop's routing
+                    // reconcile (DNAT + CCD) also re-runs on the registry change.
+                    auto result = provisioner.provision(
+                        p_serial, tenant_subnet_of(ds, p_tenant));
                     if (result.has_value()) {
                         // Tag the registry row with the tenant so cloud.endpoints
                         // carries it ("" == default).
@@ -1404,7 +1486,7 @@ int main(int argc, char** argv) {
             // provision/deprovision/online-change may have added/removed a
             // device → its cloud:<proxy_port> mapping must follow).
             sync_endpoints_to_ds(ds, ep_reg);
-            rebuild_device_dnat(ds, tun_dev);
+            reconcile_routing(ds, tun_dev);
             sync_tick = 0;
         } else {
             // recv_event timed out — periodic housekeeping
@@ -1445,7 +1527,7 @@ int main(int argc, char** argv) {
                 }
                 if (ip_changed) {
                     sync_endpoints_to_ds(ds, ep_reg);
-                    rebuild_device_dnat(ds, tun_dev);
+                    reconcile_routing(ds, tun_dev);
                 }
             }
 
@@ -1456,7 +1538,7 @@ int main(int argc, char** argv) {
                 sync_endpoints_to_ds(ds, ep_reg);
                 // Safety-net DNAT rebuild — also picks up a live
                 // cloud.proxy.device.ui.port change.
-                rebuild_device_dnat(ds, tun_dev);
+                reconcile_routing(ds, tun_dev);
                 ds.set("cloud.vpn.port.next",
                        data_store::Value{static_cast<std::uint32_t>(proxy_port_start)});
                 g_log.apply_level(ds);

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -20,7 +20,7 @@ instance).
 | P1e | `db/get cloud.endpoints` tenant scoping (**live UI isolation**) | _this_ | 🔵 |
 | P3b | Apply inter-tenant nft isolation table (compile-verified) | _this_ | 🔵 needs tun validation |
 | P3c-i | **Integration foundation** (gtest): `VpnRegistry::allocate_in_subnet` (tenant-/24 IP + base-pool guard) + `plan_ccd_files` (per-device CCD plan) | _this_ | 🟢 gtest |
-| P3c-ii | iot-cloudd glue: server `/16` + `ccd_dir`, allocate tenant IPs in provision/heal, write CCD files | — | ⏭️ needs tun validation |
+| P3c-ii | iot-cloudd glue: `ccd_dir` opt-in knob, allocate tenant IPs in provision/heal, write+prune CCD files (reconcile_routing) | _this_ | 🟡 compile-clean, needs tun validation |
 | P4a | Tenant registry: auto VPN-subnet assignment (`cloud.tenants` watch) | _this_ | 🔵 |
 | P4b | Tenant-aware provision *watcher* + cred minting | #494 | ✅ merged |
 | P5a | Per-tenant device **quota** (`max.devices`), enforced at provision | #495 | ✅ merged |

--- a/modules/server/lwm2m/inc/bootstrap.hpp
+++ b/modules/server/lwm2m/inc/bootstrap.hpp
@@ -30,9 +30,16 @@ class BootstrapProvisioner {
 public:
     BootstrapProvisioner(EndpointRegistry& ep_reg, openvpn::VpnRegistry& vpn_reg);
 
-    /// Provision a new endpoint.  Returns nullopt when the endpoint
-    /// already exists or subnet/port pool is exhausted.
-    std::optional<BootstrapResult> provision(const std::string& ep);
+    /// Provision a new endpoint.  Returns nullopt when the subnet/port pool is
+    /// exhausted (an already-provisioned endpoint reuses its allocation).
+    ///
+    /// Multi-tenant (P3c): when `tenant_subnet` is non-empty (the device's
+    /// tenant /24, e.g. "10.9.16.0/24"), the tunnel IP is allocated from THAT
+    /// subnet via VpnRegistry::allocate_in_subnet instead of the base pool, so
+    /// the device lands in its tenant's address range (pinned by an OpenVPN CCD
+    /// file). Empty ⇒ the legacy base-pool allocation (default tenant).
+    std::optional<BootstrapResult> provision(const std::string& ep,
+                                             const std::string& tenant_subnet = "");
 
     /// Remove a previously provisioned endpoint.
     bool deprovision(const std::string& ep);

--- a/modules/server/lwm2m/schemas/cloud.lua
+++ b/modules/server/lwm2m/schemas/cloud.lua
@@ -363,6 +363,19 @@ return {
       default = "10.9.16.0/20",
     },
 
+    -- Multi-tenant VPN enable knob (P3c). EMPTY by default → no
+    -- client-config-dir line in the OpenVPN config, no CCD files written →
+    -- single-tenant deployments are byte-identical. To turn on per-tenant static
+    -- IPs the operator sets this to a directory (e.g. /etc/iot/vpn/ccd) AND
+    -- widens cloud.vpn.subnet to a /16 covering the default /24 + the tenant pool
+    -- (10.9.0.0/16); iot-cloudd then pins each tenant device into its tenant /24
+    -- via a CCD file and allocates its tunnel IP from that /24.
+    ["cloud.vpn.ccd.dir"] = {
+        access  = "Admin",
+      type    = "string",
+      default = "",
+    },
+
     -- JSON array of device serials with a live VPN tunnel right now, written
     -- by iot-cloudd from the openvpn management interface. lwm2m-dm reads it to
     -- stop pushing the cert once the device's tunnel is up.

--- a/modules/server/lwm2m/src/bootstrap.cpp
+++ b/modules/server/lwm2m/src/bootstrap.cpp
@@ -8,7 +8,7 @@ BootstrapProvisioner::BootstrapProvisioner(EndpointRegistry& ep_reg,
     : m_ep_reg(ep_reg), m_vpn_reg(vpn_reg) {}
 
 std::optional<BootstrapResult> BootstrapProvisioner::provision(
-    const std::string& ep) {
+    const std::string& ep, const std::string& tenant_subnet) {
 
     const std::string server_uri = "coaps://cloud:5684";
 
@@ -29,9 +29,12 @@ std::optional<BootstrapResult> BootstrapProvisioner::provision(
         return result;
     }
 
-    // New endpoint: allocate tunnel IP + proxy port.
-    auto alloc = m_vpn_reg.allocate(ep);
-    if (!alloc.has_value()) return std::nullopt;   // ports exhausted
+    // New endpoint: allocate tunnel IP + proxy port. A tenant device draws its
+    // IP from its tenant /24 (P3c); the default tenant uses the base pool.
+    auto alloc = tenant_subnet.empty()
+                     ? m_vpn_reg.allocate(ep)
+                     : m_vpn_reg.allocate_in_subnet(ep, tenant_subnet);
+    if (!alloc.has_value()) return std::nullopt;   // subnet / ports exhausted
 
     // Register in the endpoint registry
     EndpointInfo info;


### PR DESCRIPTION
## What

Wires the P3c-i building blocks (#500) into iot-cloudd so a tenant device lands
in its tenant's `/24` and is pinned there by an OpenVPN CCD file. **Gated behind
`cloud.vpn.ccd.dir` (empty by default)** → single-tenant deployments are
**byte-identical** (no `client-config-dir`, no CCD files, base-pool allocation
unchanged).

## Changes
- **`BootstrapProvisioner::provision(ep, tenant_subnet="")`** — a tenant device
  allocates its tunnel IP from its tenant `/24` (`allocate_in_subnet`); empty =
  legacy base pool.
- **`load_ovpn_cfg`** — `c.ccd_dir = cloud.vpn.ccd.dir` (seeded + on the
  `cloud.vpn.*` hot-reload watch); `build_server_config` emits `client-config-dir`
  when set.
- **`rebuild_tenant_ccd`** — one CCD file per tenant device (`plan_ccd_files`),
  named by its cert CN (`rpi<serial>@cloud.local`); prunes stale files. No-op
  when `ccd_dir` is empty.
- **`reconcile_routing`** = `rebuild_device_dnat` + `rebuild_tenant_ccd`; the 4
  DNAT call sites now go through it, so the CCD tracks the same endpoint changes.
- **`tenant_subnet_of`** — the tenant's `/24` from `cloud.tenants` (used by the
  provision watcher + startup heal).
- **`cloud.lua`** — `cloud.vpn.ccd.dir` (Admin, default `""`).

## Enabling
Operator sets `cloud.vpn.ccd.dir` (e.g. `/etc/iot/vpn/ccd`) **and** widens
`cloud.vpn.subnet` to `10.9.0.0/16` (covers the default `/24` + the
`10.9.16.0/20` tenant pool). Then P3b's nft inter-tenant drops finally bite.

## Testing
`apps/cloud/server/main.cpp` + `bootstrap.cpp` compile clean (`-fsyntax-only`,
rc=0). The pure helpers (`allocate_in_subnet`, `plan_ccd_files`) are gtested in
P3c-i. **Live tun/OpenVPN/nft behaviour is the remaining HW validation** — do not
deploy blind.

🤖 Generated with [Claude Code](https://claude.com/claude-code)