### PR TITLE
feat(cloud): P4d — associate users with tenants + tenant-aware login

### DIFF
--- a/apps/cloud/ui/src/app/audit/audit.component.ts
+++ b/apps/cloud/ui/src/app/audit/audit.component.ts
@@ -23,7 +23,7 @@ interface AuditRow {
         <button class="btn btn-sm btn-link" (click)="reload()" [disabled]="loading">Refresh</button>
       </h3>
 
-      <ng-container *ngIf="isAdmin; else noAccess">
+      <ng-container *ngIf="isOperator; else noAccess">
         <p class="hint">
           Tenant &amp; device lifecycle actions (provision, deprovision, tenant
           changes), newest first. Recorded by the cloud at the point of action.
@@ -52,7 +52,7 @@ interface AuditRow {
       </ng-container>
 
       <ng-template #noAccess>
-        <p class="hint">You need Admin access to view the audit log.</p>
+        <p class="hint">Only the platform operator (tenant <code>*</code>) can view the audit log.</p>
       </ng-template>
     </div>
   `,
@@ -67,11 +67,11 @@ export class AuditComponent implements OnInit {
   rows: AuditRow[] = [];
   loading = false;
 
-  get isAdmin(): boolean { return this.session.isAdmin; }
+  get isOperator(): boolean { return this.session.isPlatformOperator; }
 
   constructor(private http: HttpsvcService, private session: SessionService) {}
 
-  ngOnInit(): void { if (this.isAdmin) this.reload(); }
+  ngOnInit(): void { if (this.isOperator) this.reload(); }
 
   fmt(ts: number): string {
     if (!ts) return '—';

--- a/apps/cloud/ui/src/app/login/login.component.ts
+++ b/apps/cloud/ui/src/app/login/login.component.ts
@@ -19,7 +19,7 @@ export class LoginComponent {
     this.http.login({ id: this.id, password: this.password }).subscribe({
       next: (r) => {
         this.loggingIn = false;
-        if (r.ok) { this.session.setFromLogin(r.access); this.router.navigate(['/main']); }
+        if (r.ok) { this.session.setFromLogin(r.access, r.tenant); this.router.navigate(['/main']); }
         else { this.error = r.err || 'Login failed'; }
       },
       error: () => { this.loggingIn = false; this.error = 'Connection failed'; }

--- a/apps/cloud/ui/src/app/tenants/tenants.component.ts
+++ b/apps/cloud/ui/src/app/tenants/tenants.component.ts
@@ -25,7 +25,7 @@ interface TenantRow {
     <div class="page">
       <h3>Tenants</h3>
 
-      <ng-container *ngIf="isAdmin; else noAccess">
+      <ng-container *ngIf="isOperator; else noAccess">
         <!-- Create / update -->
         <div class="form-grid" style="align-items:end;">
           <clr-input-container>
@@ -93,7 +93,7 @@ interface TenantRow {
       </ng-container>
 
       <ng-template #noAccess>
-        <p class="hint">You need Admin access to manage tenants.</p>
+        <p class="hint">Only the platform operator (tenant <code>*</code>) can manage tenants.</p>
       </ng-template>
     </div>
   `,
@@ -116,12 +116,12 @@ export class TenantsComponent implements OnInit {
   loading = false;
   saving = false;
 
-  get isAdmin(): boolean { return this.session.isAdmin; }
+  get isOperator(): boolean { return this.session.isPlatformOperator; }
 
   constructor(private http: HttpsvcService, private session: SessionService,
               private toast: ToastService) {}
 
-  ngOnInit(): void { if (this.isAdmin) this.reload(); }
+  ngOnInit(): void { if (this.isOperator) this.reload(); }
 
   reload(): void {
     this.loading = true;

--- a/apps/cloud/ui/src/app/users/users.component.ts
+++ b/apps/cloud/ui/src/app/users/users.component.ts
@@ -30,6 +30,13 @@ import { UserAccount } from '../../common/app-globals';
             </select>
             <clr-control-helper *dsDebug><app-ds-hint key="auth.users.accounts"></app-ds-hint></clr-control-helper>
           </clr-select-container>
+          <clr-select-container>
+            <label>Tenant</label>
+            <select clrSelect [(ngModel)]="newTenant">
+              <option *ngFor="let t of tenantIds" [value]="t">{{ t === '*' ? '* (platform operator)' : t }}</option>
+            </select>
+            <clr-control-helper *dsDebug><app-ds-hint key="auth.users.accounts (tenant)"></app-ds-hint></clr-control-helper>
+          </clr-select-container>
           <div class="btn-cell">
             <button class="btn btn-primary" (click)="create()" [disabled]="saving">
               {{ saving ? 'Saving…' : 'Add / Update' }}
@@ -42,12 +49,16 @@ import { UserAccount } from '../../common/app-globals';
         <clr-datagrid [clrDgLoading]="loading" style="margin-top:20px;">
           <clr-dg-column>User ID</clr-dg-column>
           <clr-dg-column>Access</clr-dg-column>
+          <clr-dg-column>Tenant</clr-dg-column>
           <clr-dg-column>Actions</clr-dg-column>
 
           <clr-dg-row *clrDgItems="let u of users">
             <clr-dg-cell>{{ u.id }}</clr-dg-cell>
             <clr-dg-cell>
               <app-status-badge [label]="u.access" [state]="u.access==='Admin' ? 'connected' : 'idle'"></app-status-badge>
+            </clr-dg-cell>
+            <clr-dg-cell>
+              <code>{{ u.tenant === '*' ? '* (operator)' : (u.tenant || 'default') }}</code>
             </clr-dg-cell>
             <clr-dg-cell>
               <button class="btn btn-sm btn-danger" *ngIf="u.id !== 'admin'" (click)="remove(u.id)">Delete</button>
@@ -78,6 +89,9 @@ export class UsersComponent implements OnInit {
   newPassword = '';
   newAccess = 'Viewer';
   accessLevels = ['Admin', 'Viewer'];
+  // Tenant options: default + platform-operator (*) + every active tenant.
+  newTenant = 'default';
+  tenantIds: string[] = ['default', '*'];
   loading = false;
   saving = false;
 
@@ -86,7 +100,7 @@ export class UsersComponent implements OnInit {
   constructor(private http: HttpsvcService, private session: SessionService,
               private toast: ToastService) {}
 
-  ngOnInit(): void { if (this.isAdmin) this.reload(); }
+  ngOnInit(): void { if (this.isAdmin) { this.reload(); this.loadTenants(); } }
 
   reload(): void {
     this.loading = true;
@@ -96,15 +110,36 @@ export class UsersComponent implements OnInit {
     });
   }
 
+  /// Populate the Tenant dropdown: default + "*" (platform operator) + the
+  /// active tenants from cloud.tenants.
+  loadTenants(): void {
+    this.http.dbGet(['cloud.tenants']).subscribe({
+      next: (r) => {
+        const ids: string[] = ['default', '*'];
+        if (r.ok && r.data) {
+          try {
+            const arr = JSON.parse(String(r.data['cloud.tenants'] ?? '[]'));
+            (Array.isArray(arr) ? arr : [])
+              .filter((t) => (t?.status || 'active') === 'active' && t?.id && t.id !== 'default')
+              .forEach((t) => ids.push(String(t.id)));
+          } catch { /* keep defaults */ }
+        }
+        this.tenantIds = ids;
+      },
+      error: () => {}
+    });
+  }
+
   create(): void {
     if (!this.newId || !this.newPassword) { this.toast.error('ID and password required'); return; }
     this.saving = true;
-    this.http.createUser({ id: this.newId, password: this.newPassword, access: this.newAccess }).subscribe({
+    this.http.createUser({ id: this.newId, password: this.newPassword,
+                           access: this.newAccess, tenant: this.newTenant }).subscribe({
       next: (r) => {
         this.saving = false;
         if (r.ok) {
           this.toast.success('User ' + r.id + ' saved');
-          this.newId = ''; this.newPassword = ''; this.newAccess = 'Viewer';
+          this.newId = ''; this.newPassword = ''; this.newAccess = 'Viewer'; this.newTenant = 'default';
           this.reload();
         } else { this.toast.error(r.err || 'Failed to save user'); }
       },

--- a/apps/cloud/ui/src/common/app-globals.ts
+++ b/apps/cloud/ui/src/common/app-globals.ts
@@ -77,12 +77,14 @@ export interface LoginResponse {
   ok: boolean;
   role?: string;
   access?: string;   // "Admin" | "Viewer"
+  tenant?: string;   // owning tenant ("*" = platform operator, sees all)
   err?: string;
 }
 
 export interface SessionInfo {
   role: string;
   access: string;    // "Admin" | "Viewer"
+  tenant: string;    // "*" = platform operator, else a tenant slug
 }
 
 // ── User accounts (managed via /api/v1/users) ───────────────────────
@@ -90,6 +92,7 @@ export interface SessionInfo {
 export interface UserAccount {
   id: string;
   access: string;    // "Admin" | "Viewer"
+  tenant?: string;   // owning tenant ("*" = platform operator)
 }
 
 export interface UserListResponse {
@@ -102,6 +105,7 @@ export interface UserCreateRequest {
   id: string;
   password: string;
   access: string;    // "Admin" | "Viewer"
+  tenant?: string;   // owning tenant ("*" = platform operator)
 }
 
 export interface UserMutateResponse {

--- a/apps/cloud/ui/src/common/session.service.ts
+++ b/apps/cloud/ui/src/common/session.service.ts
@@ -16,23 +16,37 @@ export class SessionService {
   get role(): string | undefined { return this.session?.role; }
   get access(): string { return this.session?.access || 'Viewer'; }
   get isAdmin(): boolean { return this.access === 'Admin'; }
+  /// The session's owning tenant ("*" = platform operator, sees all tenants).
+  get tenant(): string { return this.session?.tenant || 'default'; }
+  /// Platform operator — the only role that manages tenants / sees every tenant.
+  get isPlatformOperator(): boolean { return this.tenant === '*'; }
 
-  clear(): void { this.session = null; }
+  clear(): void { this.session = null; localStorage.removeItem('iot-session'); }
 
-  /// Probe /api/v1/status — 401 when unauthenticated.
+  /// Probe /api/v1/status — 401 when unauthenticated. The tenant/access aren't
+  /// in /status, so restore them from the login-persisted copy (falls back to
+  /// platform-operator admin, the legacy single-tenant assumption).
   loadSession(): Observable<SessionInfo | null> {
     return this.http.getStatus().pipe(
       map(() => {
-        this.session = { role: 'admin', access: 'Admin' };
+        this.session = this.restore() || { role: 'admin', access: 'Admin', tenant: '*' };
         return this.session;
       }),
       catchError(() => { this.session = null; return of(null); })
     );
   }
 
-  /// Cache session after login with the access level from the server.
-  setFromLogin(access?: string): void {
-    this.session = { role: 'admin', access: access || 'Viewer' };
+  /// Cache + persist session after login (access + owning tenant from server).
+  setFromLogin(access?: string, tenant?: string): void {
+    this.session = { role: 'admin', access: access || 'Viewer', tenant: tenant || 'default' };
+    try { localStorage.setItem('iot-session', JSON.stringify(this.session)); } catch { /* noop */ }
+  }
+
+  private restore(): SessionInfo | null {
+    try {
+      const s = JSON.parse(localStorage.getItem('iot-session') || 'null');
+      return (s && s.access && s.tenant) ? s as SessionInfo : null;
+    } catch { return null; }
   }
 }
 

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -29,6 +29,7 @@ instance).
 | P4c | Operator console UI: **Tenants CRUD page** + Endpoints **tenant selector** (`provision.tenant`) | _this_ | 🟡 needs node build/validation |
 | P5b | Per-tenant CA / cert namespace | — | ⏭️ needs tun validation |
 | P5c | **Audit log** of operator + provisioning actions (`cloud.audit.log`, iot-httpd db/set hook + read-only UI) | _this_ | 🟢 gtest + ng-build |
+| P4d | **User↔tenant (D6 finish):** Users page tenant field + column; `/api/v1/users` GET/POST carry `tenant`; login returns tenant → session `isPlatformOperator`; built-in admin defaults to `*`; Tenants/Audit pages gated to the operator | _this_ | 🟢 compile + ng-build |
 
 **P3b/P3c split:** P3b applies the inter-tenant **nft drop** table
 (`build_tenant_isolation_rules` over the tenant subnets) via the same

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -410,6 +410,9 @@ void install_handlers(Router& router,
                     access = CredentialStore::load_user_access(*ds, id);
                     tenant = CredentialStore::load_user_tenant(*ds, id);
                 }
+                // Built-in admin is the platform operator ("*" = all tenants)
+                // unless explicitly scoped via auth.users.admin.tenant.
+                if (tenant.empty() || tenant == "default") tenant = "*";
             } else {
                 role = "user";
                 bool found = false;
@@ -441,6 +444,7 @@ void install_handlers(Router& router,
             resp["ok"]     = true;
             resp["role"]   = role;
             resp["access"] = access;
+            resp["tenant"] = tenant;   // owning tenant ("*" = platform operator)
             r.body = resp.dump();
             if (!token.empty()) {
                 r.headers["Set-Cookie"] = make_set_cookie(
@@ -1543,11 +1547,18 @@ void install_handlers(Router& router,
             json admin;
             admin["id"]     = "admin";
             admin["access"] = CredentialStore::load_user_access(*ds, "admin");
+            // Built-in admin is the platform operator ("*" = sees all tenants)
+            // unless explicitly scoped via auth.users.admin.tenant.
+            {
+                std::string at = CredentialStore::load_user_tenant(*ds, "admin");
+                admin["tenant"] = (at.empty() || at == "default") ? "*" : at;
+            }
             users.push_back(admin);
             for (const auto& u : load_accounts(ds)) {
                 json e;
                 e["id"]     = u.value("id", "");
                 e["access"] = u.value("access", "Viewer");
+                e["tenant"] = u.value("tenant", "default");
                 users.push_back(e);
             }
             json resp;
@@ -1587,6 +1598,7 @@ void install_handlers(Router& router,
             std::string uid      = doc.value("id", "");
             std::string password = doc.value("password", "");
             std::string uaccess  = doc.value("access", "Viewer");
+            std::string utenant  = doc.value("tenant", "default");
             if (uid.empty() || password.empty()) {
                 r.status = 400;
                 r.body = R"({"ok":false,"err":"id and password required"})";
@@ -1598,6 +1610,27 @@ void install_handlers(Router& router,
                 return r;
             }
             if (uaccess != "Admin" && uaccess != "Viewer") uaccess = "Viewer";
+            // Multi-tenant (D6): the user's owning tenant — "*" (platform
+            // operator, sees all), "default", or a known cloud.tenants id. Reject
+            // an unknown tenant so a typo can't orphan a user outside isolation.
+            if (utenant.empty()) utenant = "default";
+            if (utenant != "*" && utenant != "default") {
+                bool known = false;
+                std::string tenants_json = "[]";
+                {
+                    std::vector<data_store::Client::GetResult> g;
+                    if (ds->get({"cloud.tenants"}, g).ok && !g.empty() && g[0].has_value)
+                        if (auto s = data_store::to_string(g[0].value)) tenants_json = *s;
+                }
+                auto ts = nlohmann::json::parse(tenants_json, nullptr, false);
+                if (ts.is_array()) for (const auto& t : ts)
+                    if (t.is_object() && t.value("id", std::string()) == utenant) { known = true; break; }
+                if (!known) {
+                    r.status = 400;
+                    r.body = R"({"ok":false,"err":"unknown tenant"})";
+                    return r;
+                }
+            }
 
             auto accounts = load_accounts(ds);
             std::string hash = sha256_hex(password);
@@ -1606,6 +1639,7 @@ void install_handlers(Router& router,
                 if (u.value("id", "") == uid) {
                     u["hash"]   = hash;
                     u["access"] = uaccess;
+                    u["tenant"] = utenant;
                     updated = true;
                     break;
                 }
@@ -1615,6 +1649,7 @@ void install_handlers(Router& router,
                 e["id"]     = uid;
                 e["hash"]   = hash;
                 e["access"] = uaccess;
+                e["tenant"] = utenant;
                 accounts.push_back(e);
             }
             json resp;


### PR DESCRIPTION
## What

Closes the console-authz gap you spotted: the server already scoped **reads** by
the session's tenant (P1c), but there was **no way to set a user's tenant**, so
every account silently defaulted to `default`. Now the loop is complete.

### Backend (iot-httpd)
- `POST /api/v1/users` accepts + persists **`tenant`** (validated: `*`,
  `default`, or a known `cloud.tenants` id — unknown → rejected, so a typo can't
  orphan a user outside isolation). `GET` returns each user's tenant.
- **Login response returns `tenant`**; the built-in **admin defaults to `*`**
  (platform operator, sees all) unless explicitly scoped via
  `auth.users.admin.tenant`.

### Frontend (cloud-ui)
- **Users page**: Tenant dropdown (default + `*` platform-operator + active
  tenants) on create/update + a **Tenant column** in the list.
- **Session** carries `tenant`; `SessionService` exposes `tenant` +
  `isPlatformOperator` (`tenant === "*"`), persisted to `localStorage` so it
  survives a refresh (the `/status` probe can't return it).
- **Login** passes the server tenant into the session.
- **Tenants + Audit pages are gated to the platform operator** (was Admin) — a
  tenant-scoped admin can no longer manage all tenants or read the global audit log.

## On "the login page needs modification"
Login intentionally takes **no tenant input** — the tenant is bound to the
account (set here in the Users page) and resolved **server-side**, then carried
in the session. That's the cleaner multi-tenant model (no confusing org field, no
way to log into the wrong tenant). What changed is that login now *surfaces* the
tenant into the session so the UI can gate operator-only pages.

## Testing
`handler.cpp` compiles clean (`-fsyntax-only`, rc=0); `ng build --configuration
production` (node:18) succeeds, no errors.

## Related (your provisioning question)
Provisioning **already** carries a tenant — the Endpoints page has a Tenant
dropdown that sets `cloud.provision.tenant` (P4c). Follow-up worth doing: for a
**tenant-scoped** operator, *pin* the provision tenant to their own
(`session.tenant`) instead of a free choice, so a tenant admin can only provision
into their own tenant. Not in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)