### PR TITLE
fix(lwm2m): pump DTLS handshake retransmission on the server tick (self-heal dm-connecting)

### DIFF
--- a/apps/src/main.cpp
+++ b/apps/src/main.cpp
@@ -693,6 +693,20 @@ ServerPlumbing wire_server(std::shared_ptr<App>& app,
         if (!a) return;
         const auto now = Clock::now();
 
+        // Pump tinydtls' handshake retransmission on the SERVER side too. The
+        // client tick does this (on_tick_client), but the server never did — so a
+        // lost cloud→device handshake flight (e.g. ServerHelloDone) was NEVER
+        // retransmitted. The device would retransmit its earlier flight, the
+        // server would reject it as a duplicate ("message sequence number too
+        // small, expected 2, got 1"), and the DM handshake deadlocked until the
+        // device restarted onto a fresh source port (a new peer). Pumping it here
+        // makes the handshake self-heal on packet loss — symmetric with the
+        // client, and covers EVERY peer in the server's DTLS context at once.
+        for (auto& kv : a->udpAdapter()->services()) {
+            if (kv.second && kv.second->dtlsAdapter())
+                kv.second->dtlsAdapter()->check_retransmit();
+        }
+
         auto expired = registry->expire(now);
         if (!expired.empty()) {
             ACE_DEBUG((LM_INFO,


### PR DESCRIPTION
## Why a device could sit in `dm-connecting` and not self-heal

You were right: it must recover on its own, and "lossy CGNAT" isn't the
explanation (both devices are on the same ISP). The manual
`systemctl restart iot-lwm2m-client` only "worked" because it opens a **new UDP
source port** — i.e. a fresh peer that sidesteps a deadlocked handshake.

**Root cause — asymmetric DTLS retransmission.** `on_tick_client` pumps
`dtls->check_retransmit()`, so a lost **device→cloud** handshake flight is
retried. But **`on_tick_server` never did.** When a **cloud→device** flight (e.g.
`ServerHelloDone`) was lost, the server never retransmitted it; the device kept
retransmitting its previous flight; the server rejected each as a duplicate —
`message sequence number too small, expected 2, got 1` — and the handshake
**deadlocked forever**. HW-observed: a device bootstrapped fine (`/bs` succeeded)
but never reached `registered`; only a peer restart (new source port) recovered it.

## Fix

`on_tick_server` now calls `check_retransmit()` for every service context's DTLS
adapter each tick — one call covers all peers in the server's DTLS context. A
lost server flight is retransmitted on its DTLS timer, so the handshake completes
on its own. **Symmetric with the client, ISP-independent, no device change.**

Reaches the fleet via a **cloud-iot redeploy** (`lwm2m-dm` + `lwm2m-bs` run this
binary in `role=server`).

## Testing
`apps/src/main.cpp` compiles clean against the real tinydtls config
(`-fsyntax-only`, rc=0). Behavioural validation: after the cloud redeploy, a
device that loses a server handshake flight should recover **without** a manual
restart (the `expected 2, got 1` deadlock no longer persists).

🤖 Generated with [Claude Code](https://claude.com/claude-code)