### PR TITLE
feat(cloud): P4e — scope device provisioning to the operator's own tenant

### DIFF
--- a/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
+++ b/apps/cloud/ui/src/app/endpoint-list/endpoint-list.component.ts
@@ -48,13 +48,19 @@ interface EpCred {
                      placeholder="paste BS PSK from device-ui" />
               <clr-control-helper *dsDebug><app-ds-hint key="cloud.provision.bs.psk"></app-ds-hint></clr-control-helper>
             </clr-input-container>
-            <clr-select-container *ngIf="tenantIds.length > 1 && !editing">
+            <!-- Platform operator: free choice. Tenant-scoped operator: pinned. -->
+            <clr-select-container *ngIf="isOperator && tenantIds.length > 1 && !editing">
               <label>Tenant</label>
               <select clrSelect [(ngModel)]="provTenant">
                 <option *ngFor="let t of tenantIds" [value]="t">{{ t }}</option>
               </select>
               <clr-control-helper *dsDebug><app-ds-hint key="cloud.provision.tenant"></app-ds-hint></clr-control-helper>
             </clr-select-container>
+            <clr-input-container *ngIf="!isOperator && !editing">
+              <label>Tenant</label>
+              <input clrInput [value]="provTenant" readonly />
+              <clr-control-helper>Provisions into your tenant.</clr-control-helper>
+            </clr-input-container>
             <div></div>
           </div>
           <button class="btn btn-primary" style="margin-top:16px;"
@@ -220,6 +226,9 @@ export class EndpointListComponent implements OnInit, OnDestroy {
   private sub = new Subscription(); private active = true;
 
   get isAdmin(): boolean { return this.session.isAdmin; }
+  /// Platform operator ("*") can provision into any tenant; a tenant-scoped
+  /// operator is PINNED to their own tenant (can't provision elsewhere).
+  get isOperator(): boolean { return this.session.isPlatformOperator; }
 
   /** Same-origin path-scoped device-UI URL (reverse-proxied by iot-httpd over
    *  the VPN tun). The endpoint is URL-encoded so urn:dev:* names are path-safe.
@@ -286,14 +295,23 @@ export class EndpointListComponent implements OnInit, OnDestroy {
             const arr = JSON.parse(String(d['cloud.endpoint.credentials'] || '[]'));
             this.creds = Array.isArray(arr) ? arr : [];
           } catch { this.creds = []; }
-          // Tenant dropdown options: "default" + every active tenant.
-          try {
-            const ts = JSON.parse(String(d['cloud.tenants'] || '[]'));
-            const ids = (Array.isArray(ts) ? ts : [])
-              .filter((t) => (t?.status || 'active') === 'active' && t?.id)
-              .map((t) => String(t.id));
-            this.tenantIds = ['default', ...ids.filter((id) => id !== 'default')];
-          } catch { this.tenantIds = ['default']; }
+          // Tenant options. A platform operator ("*") picks any tenant; a
+          // tenant-scoped operator is PINNED to their own — the dropdown then
+          // collapses to one option so they can only provision into their tenant
+          // (the server also enforces this — see the db/set handler).
+          if (!this.isOperator) {
+            const t = this.session.tenant || 'default';
+            this.tenantIds = [t];
+            this.provTenant = t;
+          } else {
+            try {
+              const ts = JSON.parse(String(d['cloud.tenants'] || '[]'));
+              const ids = (Array.isArray(ts) ? ts : [])
+                .filter((t) => (t?.status || 'active') === 'active' && t?.id)
+                .map((t) => String(t.id));
+              this.tenantIds = ['default', ...ids.filter((id) => id !== 'default')];
+            } catch { this.tenantIds = ['default']; }
+          }
         }
       },
       error: () => {}
@@ -339,7 +357,7 @@ export class EndpointListComponent implements OnInit, OnDestroy {
         if (r.ok) {
           this.toast.success((this.editing ? 'Updated PSK for ' : 'Provisioning ') + serial);
           this.provSerial = ''; this.provBsPsk = ''; this.editing = false;
-          this.provTenant = 'default';
+          this.provTenant = this.pinnedTenant();
         }
         else this.toast.error(r.err || 'Provision failed');
       },
@@ -368,7 +386,13 @@ export class EndpointListComponent implements OnInit, OnDestroy {
     this.editing = false;
     this.provSerial = '';
     this.provBsPsk = '';
-    this.provTenant = 'default';
+    this.provTenant = this.pinnedTenant();
+  }
+
+  /// The tenant a fresh provision defaults to: any ("default") for a platform
+  /// operator, else the operator's own tenant (they can't provision elsewhere).
+  private pinnedTenant(): string {
+    return this.isOperator ? 'default' : (this.session.tenant || 'default');
   }
 
   private startLongPoll(): void {

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -29,7 +29,8 @@ instance).
 | P4c | Operator console UI: **Tenants CRUD page** + Endpoints **tenant selector** (`provision.tenant`) | _this_ | 🟡 needs node build/validation |
 | P5b | Per-tenant CA / cert namespace | — | ⏭️ needs tun validation |
 | P5c | **Audit log** of operator + provisioning actions (`cloud.audit.log`, iot-httpd db/set hook + read-only UI) | _this_ | 🟢 gtest + ng-build |
-| P4d | **User↔tenant (D6 finish):** Users page tenant field + column; `/api/v1/users` GET/POST carry `tenant`; login returns tenant → session `isPlatformOperator`; built-in admin defaults to `*`; Tenants/Audit pages gated to the operator | _this_ | 🟢 compile + ng-build |
+| P4d | **User↔tenant (D6 finish):** Users page tenant field + column; `/api/v1/users` GET/POST carry `tenant`; login returns tenant → session `isPlatformOperator`; built-in admin defaults to `*`; Tenants/Audit pages gated to the operator | #503 | ✅ merged |
+| P4e | **Provision tenant-scoping (D7 finish):** a tenant-scoped operator can only provision into their own tenant — UI pins the selector to `session.tenant`; db/set force-pins `cloud.provision.tenant` server-side (defence-in-depth) | _this_ | 🟢 compile + ng-build |
 
 **P3b/P3c split:** P3b applies the inter-tenant **nft drop** table
 (`build_tenant_isolation_rules` over the tenant subnets) via the same

--- a/modules/http-server/src/handler.cpp
+++ b/modules/http-server/src/handler.cpp
@@ -209,6 +209,26 @@ void install_handlers(Router& router,
                     r.body = R"({"ok":false,"err":"forbidden: read-only access"})";
                     return r;
                 }
+                // Multi-tenant (D7): a tenant-scoped operator can only provision
+                // into THEIR OWN tenant. Pin cloud.provision.tenant to the
+                // session tenant (overriding any value the caller sent), and if a
+                // provision request comes in without one, inject it — so a crafted
+                // API call can't tag a device into another tenant. The platform
+                // operator ("*") is unrestricted.
+                if (auth && auth->enabled() && actor_tenant != "*") {
+                    bool hasTenantPair = false, hasRequest = false;
+                    for (auto& p : pairs) {
+                        if (p.first == "cloud.provision.tenant") {
+                            p.second = data_store::Value{actor_tenant};
+                            hasTenantPair = true;
+                        } else if (p.first == "cloud.provision.request") {
+                            hasRequest = true;
+                        }
+                    }
+                    if (hasRequest && !hasTenantPair)
+                        pairs.emplace_back("cloud.provision.tenant",
+                                           data_store::Value{actor_tenant});
+                }
                 auto rs = ds->set(pairs);
                 if (!rs.ok) {
                     r.status = 400;


### PR DESCRIPTION
## What

Completes console isolation (the follow-up flagged in #503): a **tenant-scoped
operator can only provision devices into their own tenant**; only the platform
operator (`*`) chooses freely.

### UI (Endpoints provision form)
- **Platform operator (`*`)**: Tenant dropdown = default + every active tenant (unchanged).
- **Tenant-scoped operator**: the dropdown is replaced by a **read-only Tenant
  field pinned to `session.tenant`**; `provTenant` and the reset/cancel defaults
  follow it, so every provision (fresh or re-provision) targets their tenant.

### Backend (defence-in-depth — a crafted API call can't bypass the UI)
In the `db/set` handler, for a non-platform-operator session:
- any `cloud.provision.tenant` pair is **force-overridden** to the session's tenant;
- if a `cloud.provision.request` arrives **without** a tenant pair, one is
  **injected** = the session tenant.

So a tenant-scoped user physically cannot tag a device into another tenant, UI or not.

## Testing
`handler.cpp` compiles clean (`-fsyntax-only`, rc=0); `ng build --configuration
production` (node:18) succeeds, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)