### PR TITLE
feat(cloud): P5b — namespace VPN client certs by tenant (/OU=<tenant>)

### DIFF
--- a/apps/cloud/server/src/main.cpp
+++ b/apps/cloud/server/src/main.cpp
@@ -1226,11 +1226,12 @@ int main(int argc, char** argv) {
                     // Mint a per-device VPN client cert (Phase 2) signed by
                     // the runtime CA and stash it in the credential record for
                     // LwM2M Object-2048 delivery (Phase 3). CN = the cloud
-                    // formatted identity, for traceability.
+                    // formatted identity (bare); the tenant is stamped into the
+                    // cert OU (P5b) for namespacing + revocation scoping.
                     if (cert_ca.have_ca()) {
                         const std::string cn =
                             server::lwm2m::format_identity(p_serial);
-                        if (auto mc = cert_ca.mint_client(cn)) {
+                        if (auto mc = cert_ca.mint_client(cn, p_tenant)) {
                             try {
                                 const std::string cur =
                                     ds_str(ds, "cloud.endpoint.credentials", "[]");

--- a/apps/docs/tdd-multi-tenant-cloud.md
+++ b/apps/docs/tdd-multi-tenant-cloud.md
@@ -27,7 +27,7 @@ instance).
 | P3c-bb | P3c building blocks: per-tenant IP alloc + OpenVPN CCD (inert) | #496 | ✅ merged |
 | **PB** | **Adopt Option B (device-agnostic tenancy): bare identities, tenant from cred-row tag, `cloud.provision.tenant` carrier; revert qualified `ep`/identity** | _this_ | 🔵 gtest |
 | P4c | Operator console UI: **Tenants CRUD page** + Endpoints **tenant selector** (`provision.tenant`) | _this_ | 🟡 needs node build/validation |
-| P5b | Per-tenant CA / cert namespace | — | ⏭️ needs tun validation |
+| P5b | **Cert namespace by tenant (D5):** `mint_client` stamps the tenant into the VPN client cert's `/OU=<tenant>` (one CA; CN stays bare for CCD/device compat). iot-cloudd passes the tenant when minting | _this_ | 🟢 gtest + openssl-verified |
 | P5c | **Audit log** of operator + provisioning actions (`cloud.audit.log`, iot-httpd db/set hook + read-only UI) | _this_ | 🟢 gtest + ng-build |
 | P4d | **User↔tenant (D6 finish):** Users page tenant field + column; `/api/v1/users` GET/POST carry `tenant`; login returns tenant → session `isPlatformOperator`; built-in admin defaults to `*`; Tenants/Audit pages gated to the operator | #503 | ✅ merged |
 | P4e | **Provision tenant-scoping (D7 finish):** a tenant-scoped operator can only provision into their own tenant — UI pins the selector to `session.tenant`; db/set force-pins `cloud.provision.tenant` server-side (defence-in-depth) | _this_ | 🟢 compile + ng-build |

--- a/modules/server/openvpn/inc/cert_authority.hpp
+++ b/modules/server/openvpn/inc/cert_authority.hpp
@@ -70,7 +70,15 @@ public:
     /// Mint a client cert + key signed by the CA, CN = sanitized `cn`. Signed
     /// via `openssl ca` so the cert is recorded in the CA database and is
     /// revocable later. Returns std::nullopt on failure (no CA, openssl/IO).
-    std::optional<MintedCert> mint_client(const std::string& cn);
+    ///
+    /// Multi-tenant (P5b): when `tenant` is non-empty/non-default it is stamped
+    /// into the cert's Organizational Unit (/OU=<tenant>) — one CA, certs
+    /// namespaced + traceable by tenant. The CN stays BARE (rpi<serial>@cloud.
+    /// local) so OpenVPN's client-config-dir lookup + the device flow are
+    /// unaffected. Network isolation remains the nft subnet boundary (D4/D5), not
+    /// the CA; the OU is for traceability + revocation scoping.
+    std::optional<MintedCert> mint_client(const std::string& cn,
+                                          const std::string& tenant = "");
 
     /// Ensure the CRL/CA-database scaffolding exists (openssl.cnf, index.txt,
     /// serial, crlnumber, newcerts/, and an initial empty CRL). Idempotent and

--- a/modules/server/openvpn/src/cert_authority.cpp
+++ b/modules/server/openvpn/src/cert_authority.cpp
@@ -237,7 +237,8 @@ std::optional<std::string> CertAuthority::revoke(const std::string& client_cert_
     return result;
 }
 
-std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn) {
+std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn,
+                                                     const std::string& tenant) {
     if (!have_ca()) {
         ACE_ERROR((LM_ERROR,
                    ACE_TEXT("%D cloudd:thread:%t %M %N:%l mint_client(%C): no CA "
@@ -246,6 +247,12 @@ std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn) {
         return std::nullopt;
     }
     const std::string safe = sanitize_cn(cn);
+    // Tenant → /OU=<tenant> (P5b). Sanitised like the CN and single-quoted in the
+    // -subj arg, so no shell/DN metacharacter can escape. Default/empty ⇒ no OU
+    // (byte-identical single-tenant subject).
+    std::string ou;
+    if (!tenant.empty() && tenant != "default")
+        ou = "/OU=" + sanitize_cn(tenant);
 
     // Work in a private temp dir so concurrent/repeated mints don't collide
     // and nothing leaks into the persistent volume.
@@ -277,7 +284,7 @@ std::optional<MintedCert> CertAuthority::mint_client(const std::string& cn) {
         ensure_crl() &&
         run_openssl("genrsa -out '" + key + "' 2048") &&
         run_openssl("req -new -key '" + key + "' -out '" + csr +
-                    "' -subj '/O=IoT Cloud/CN=" + safe + "'") &&
+                    "' -subj '/O=IoT Cloud" + ou + "/CN=" + safe + "'") &&
         run_openssl("ca -batch -notext -rand_serial -config '" + m_p.ca_cnf + "' -days " +
                     std::to_string(m_p.days) + " -in '" + csr + "' -out '" + crt + "'");
 

--- a/modules/server/openvpn/test/cert_authority_test.cpp
+++ b/modules/server/openvpn/test/cert_authority_test.cpp
@@ -121,6 +121,39 @@ TEST(CertAuthority, mint_client_returns_family_that_chains_to_ca) {
                               "' '" + p.srv_crt + "' >/dev/null 2>&1").c_str()));
 }
 
+TEST(CertAuthority, mint_client_stamps_tenant_ou) {
+    if (!have_openssl()) GTEST_SKIP() << "openssl CLI not available";
+    const std::string dir = scratch();
+    if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";
+    CaPaths p = paths_under(dir);
+
+    CertAuthority ca(p);
+    ASSERT_TRUE(ca.ensure());
+
+    // grep the cert subject. Case-sensitive "OU" matches only the field label
+    // (the org "IoT Cloud" contains lowercase "ou", not "OU").
+    auto subj_has = [](const std::string& file, const std::string& pat) {
+        return std::system(("/usr/bin/openssl x509 -subject -noout -in '" + file +
+                            "' | grep -q '" + pat + "'").c_str());
+    };
+
+    // Tenant device: /OU=acme stamped; CN stays BARE.
+    auto acme = ca.mint_client("rpi100000abcd@cloud.local", "acme");
+    ASSERT_TRUE(acme.has_value());
+    const std::string acrt = dir + "/acme.crt";
+    std::ofstream(acrt, std::ios::binary) << acme->client_crt;
+    EXPECT_EQ(0, subj_has(acrt, "OU"));                          // OU field present
+    EXPECT_EQ(0, subj_has(acrt, "acme"));                        // = the tenant
+    EXPECT_EQ(0, subj_has(acrt, "rpi100000abcd@cloud.local"));   // CN unchanged
+
+    // Default tenant: NO OU — byte-identical to the single-tenant subject.
+    auto def = ca.mint_client("rpi200000dcba@cloud.local", "default");
+    ASSERT_TRUE(def.has_value());
+    const std::string dcrt = dir + "/def.crt";
+    std::ofstream(dcrt, std::ios::binary) << def->client_crt;
+    EXPECT_NE(0, subj_has(dcrt, "OU"));                          // no OU field
+}
+
 TEST(CertAuthority, mint_without_ca_fails) {
     const std::string dir = scratch();
     if (dir.empty()) GTEST_SKIP() << "no writable scratch dir";


### PR DESCRIPTION
## What

Implements the D5 decision — **one runtime CA, the tenant stamped into the client
cert** (not a per-tenant CA: under a single OpenVPN server a separate CA wouldn't
isolate anyway; the **nft subnet boundary** is the isolation).

- **`CertAuthority::mint_client(cn, tenant="")`** — when `tenant` is
  non-empty/non-default, the subject gains **`/OU=<tenant>`** (sanitized like the
  CN, single-quoted in `-subj`). The **CN stays BARE** (`rpi<serial>@cloud.local`)
  so OpenVPN's `client-config-dir` lookup + the tenant-agnostic device flow are
  unaffected. Default/empty ⇒ **no OU** (byte-identical single-tenant subject).
- **iot-cloudd** passes the provision tenant when minting the per-device cert.
- The OU is for **namespacing / traceability / revocation scoping** — isolation
  stays the nft boundary (D4/D5), not the CA.

## Testing
- Reproduced end-to-end that the OU **survives `openssl ca`** under the
  `policy_any` config (`organizationalUnitName = optional`):
  - tenant → `subject=CN = rpi100000abcd@cloud.local, O = IoT Cloud, OU = acme`
  - default → `subject=CN = rpi200000dcba@cloud.local, O = IoT Cloud` (no OU)
- gtest **`mint_client_stamps_tenant_ou`** asserts both (OU present + bare CN for a
  tenant; no OU for default).
- `cert_authority.cpp` + iot-cloudd `main.cpp` compile clean (`-fsyntax-only`, rc=0).

## Scope note
This is the cert-namespacing half of "P5b — per-tenant CA". A truly separate CA
per tenant was deferred in D5 as a later hardening option and doesn't add
isolation under the single-server topology.

🤖 Generated with [Claude Code](https://claude.com/claude-code)